### PR TITLE
Dependency cannot be resolved

### DIFF
--- a/platforms/systemd/Makefile.in
+++ b/platforms/systemd/Makefile.in
@@ -16,7 +16,7 @@ nothing:
 
 install: install-dir install-conf install-autostart
 
-install-dir: $(DESTDIR)/$(SYSTEMD_UNITDIR)
+install-dir:
 	@$(MKDIR) $(DESTDIR)/$(SYSTEMD_UNITDIR)
 	@$(MKDIR) $(DESTDIR)/$(SYSTEMD_TMPFILES)
 


### PR DESCRIPTION
Hi there,

this line needs to be changed to build bareos successfully with 

```
make DISTNAME='systemd' install
```

on arch linux. As a hint "-j2" breaks `make install`.
