### PR TITLE
Miss casts and zeroing of integers

### DIFF
--- a/src/dird/dir_plugins.c
+++ b/src/dird/dir_plugins.c
@@ -514,12 +514,12 @@ static bRC bareosGetValue(bpContext *ctx, brDirVariable var, void *value)
          Dmsg1(dbglvl, "BAREOS: return bDirVarLastRate=%d\n", jcr->LastRate);
          break;
       case bDirVarJobBytes:
-         *((int *)value) = jcr->JobBytes;
-         Dmsg1(dbglvl, "BAREOS: return bDirVarJobBytes=%d\n", jcr->JobBytes);
+         *((uint64_t *)value) = jcr->JobBytes;
+         Dmsg1(dbglvl, "BAREOS: return bDirVarJobBytes=%u\n", jcr->JobBytes);
          break;
       case bDirVarReadBytes:
-         *((int *)value) = jcr->ReadBytes;
-         Dmsg1(dbglvl, "BAREOS: return bDirVarReadBytes=%d\n", jcr->ReadBytes);
+         *((uint64_t *)value) = jcr->ReadBytes;
+         Dmsg1(dbglvl, "BAREOS: return bDirVarReadBytes=%u\n", jcr->ReadBytes);
          break;
       default:
          break;

--- a/src/plugins/dird/python-dir.c
+++ b/src/plugins/dird/python-dir.c
@@ -515,7 +515,7 @@ static PyObject *PyBareosGetValue(PyObject *self, PyObject *args)
    case bDirVarPriority:
    case bDirVarFDJobStatus:
    case bDirVarSDJobStatus: {
-      int value;
+      int value = 0;
 
       ctx = PyGetbpContext(pyCtx);
       if (bfuncs->getBareosValue(ctx, (brDirVariable)var, &value) == bRC_OK) {
@@ -530,7 +530,7 @@ static PyObject *PyBareosGetValue(PyObject *self, PyObject *args)
    case bDirVarLastRate:
    case bDirVarJobBytes:
    case bDirVarReadBytes: {
-      uint64_t value;
+      uint64_t value = 0;
 
       ctx = PyGetbpContext(pyCtx);
       if (bfuncs->getBareosValue(ctx, (brDirVariable)var, &value) == bRC_OK) {


### PR DESCRIPTION
Since JobBytes and ReadButes are unsigned 64 bits, they need to be casted as that and to avoid undeterminate/garbage value, initialize the integers to zero.
