### PR TITLE
Fix build flags handling

### DIFF
--- a/autoconf/configure.in
+++ b/autoconf/configure.in
@@ -4624,7 +4624,7 @@ if test "${support_bat}" = "yes" ; then
    touch bat
    chmod 755 bat
    rm -f Makefile
-   $QMAKE
+   $QMAKE QMAKE_CFLAGS_RELEASE="$CFLAGS $CPPFLAGS" QMAKE_CXXFLAGS_RELEASE="$CXXFLAGS $CPPFLAGS" QMAKE_LFLAGS_RELEASE="$LDFLAGS"
    ${MAKE:-make} clean
    cd ${BUILD_DIR}
 fi
@@ -4640,7 +4640,7 @@ if test "${support_traymonitor}" = "yes" ; then
    touch bareos-tray-monitor
    chmod 755 bareos-tray-monitor
    rm -f Makefile
-   $QMAKE
+   $QMAKE QMAKE_CFLAGS_RELEASE="$CFLAGS $CPPFLAGS" QMAKE_CXXFLAGS_RELEASE="$CXXFLAGS $CPPFLAGS" QMAKE_LFLAGS_RELEASE="$LDFLAGS"
    ${MAKE:-make} clean
    cd ${BUILD_DIR}
 fi

--- a/autoconf/configure.in
+++ b/autoconf/configure.in
@@ -1159,7 +1159,7 @@ if test "x$support_crypto" != "xno" -o "x$support_tls" != "xno"; then
 
       saved_LIBS="${LIBS}"
       saved_CFLAGS="${CFLAGS}"
-      saved_CPPFLAGS="${CFLAGS}"
+      saved_CPPFLAGS="${CPPFLAGS}"
       LIBS="${saved_LIBS} ${OPENSSL_LIBS}"
       CFLAGS="${saved_CFLAGS} ${OPENSSL_INC}"
       CPPFLAGS="${saved_CPPFLAGS} ${OPENSSL_INC}"
@@ -1291,7 +1291,7 @@ if test "x$support_crypto" != "xno" -o "x$support_tls" != "xno"; then
 
       saved_LIBS="${LIBS}"
       saved_CFLAGS="${CFLAGS}"
-      saved_CPPFLAGS="${CFLAGS}"
+      saved_CPPFLAGS="${CPPFLAGS}"
       LIBS="${saved_LIBS} ${GNUTLS_LIBS}"
       CFLAGS="${saved_CFLAGS} ${GNUTLS_INC}"
       CPPFLAGS="${saved_CPPFLAGS} ${GNUTLS_INC}"

--- a/src/plugins/dird/Makefile.in
+++ b/src/plugins/dird/Makefile.in
@@ -23,7 +23,7 @@ BUILD_PLUGINS = @BUILD_DIR_PLUGINS@
 
 # inference rules
 .c.lo:
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) -c $<
 
 all: Makefile $(BUILD_PLUGINS)
 
@@ -36,7 +36,7 @@ example-plugin-dir.la: Makefile \
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared example-plugin-dir.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version
 
 python-dir.lo: python-dir.c python-dir.h
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
 
 python-dir.la: Makefile \
 	       python-dir$(DEFAULT_OBJECT_TYPE) \
@@ -46,7 +46,7 @@ python-dir.la: Makefile \
 
 plugtest: Makefile dir_plugins.c \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../dird/dir_plugins.c
+	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../dird/dir_plugins.c
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -L../../findlib -o $@ dir_plugins.o -lbareos $(DLIB) -lm $(LIBS)
 
 install: all

--- a/src/plugins/filed/Makefile.in
+++ b/src/plugins/filed/Makefile.in
@@ -26,7 +26,7 @@ BUILD_PLUGINS = @BUILD_FD_PLUGINS@
 
 # inference rules
 .c.lo:
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) -c $<
 
 all: Makefile bpipe-fd.la test-plugin-fd.la test-deltaseq-fd.la $(BUILD_PLUGINS)
 
@@ -59,7 +59,7 @@ gfapi-fd.la: Makefile \
 	-L../../lib -lbareos @GLUSTER_LIBS@
 
 python-fd.lo: python-fd.c python-fd.h
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
 
 python-fd.la: Makefile \
 	      python-fd$(DEFAULT_OBJECT_TYPE) \
@@ -87,8 +87,8 @@ test-plugin-fd.la: Makefile test-plugin-fd$(DEFAULT_OBJECT_TYPE) ../../lib/libba
 plugtest: Makefile fd_plugins.c fileset.c \
 	  ../../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE) \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fd_plugins.c
-	$(CXX) $(DEFS) $(DEBUG) -c $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fileset.c
+	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fd_plugins.c
+	$(CXX) $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fileset.c
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -L../../findlib -o $@ fd_plugins.o fileset.o -lbareosfind -lbareos $(DLIB) -lm $(LIBS)
 
 install: all

--- a/src/plugins/stored/Makefile.in
+++ b/src/plugins/stored/Makefile.in
@@ -26,7 +26,7 @@ BUILD_PLUGINS = @BUILD_SD_PLUGINS@
 
 # inference rules
 .c.lo:
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) -c $<
 
 all: Makefile $(BUILD_PLUGINS)
 
@@ -35,7 +35,7 @@ Makefile: $(srcdir)/Makefile.in $(topdir)/config.status
 		&& CONFIG_FILES=$(thisdir)/$@ CONFIG_HEADERS= $(SHELL) ./config.status
 
 autoxflate-sd.lo: autoxflate-sd.c
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) $(COMPRESS_CPPFLAGS) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(COMPRESS_CPPFLAGS) -c $<
 
 autoxflate-sd.la: Makefile \
 		  autoxflate-sd$(DEFAULT_OBJECT_TYPE) \
@@ -46,7 +46,7 @@ example-plugin-sd.la: Makefile example-plugin-sd$(DEFAULT_OBJECT_TYPE)
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared example-plugin-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version
 
 python-sd.lo: python-sd.c python-sd.h
-	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
+	$(LIBTOOL_COMPILE) $(CXX) $(DEFS) $(DEBUG) $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(PYTHON_CPPFLAGS) -c $<
 
 python-sd.la: Makefile \
 	      python-sd$(DEFAULT_OBJECT_TYPE) \
@@ -66,7 +66,7 @@ scsitapealert-sd.la: Makefile \
 
 plugtest: Makefile sd_plugins.c \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../stored/sd_plugins.c
+	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../stored/sd_plugins.c
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -o $@ sd_plugins.o -lbareos $(DLIB) -lm $(LIBS)
 
 install: all

--- a/src/tools/Makefile.in
+++ b/src/tools/Makefile.in
@@ -91,7 +91,7 @@ bpluginfo: Makefile bpluginfo.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 
 timelimit.o: timelimit.c
 	@echo "Compiling $<"
-	${CC} ${DEFS} ${DEBUG} $(CFLAGS) -DHAVE_ERRNO_H -DHAVE_SETITIMER -DHAVE_SIGACTION -c timelimit.c
+	${CC} ${DEFS} ${DEBUG} $(CFLAGS) $(CPPFLAGS) -DHAVE_ERRNO_H -DHAVE_SETITIMER -DHAVE_SIGACTION -c timelimit.c
 
 timelimit: timelimit.o
 	@echo "Linking $@ ..."


### PR DESCRIPTION
$CFLAGS/$CPPFLAGS/$LDFLAGS weren't always passed to the compiler.
These commits fix all cases I could find.