### PR TITLE
Update bareos-dir.conf.in

### DIFF
--- a/src/defaultconfigs/diskonly/bareos-dir.conf.in
+++ b/src/defaultconfigs/diskonly/bareos-dir.conf.in
@@ -54,6 +54,10 @@ Director {                            # define myself
   Password = "@dir_password@"         # Console password
   Messages = Daemon
   Auditing = yes
+  
+  # Not all installations need heartbeat, but most do, and it won't hurt
+  Heartbeat Interval = 1m
+
 
   # remove comment in next line to load dynamic backends from specified directory
   # Backend Directory = @backenddir@


### PR DESCRIPTION
Add heartbeat = 1m in default config
While this isn't strictly needed on fast, low-latency networks, I see it's needed on our 10Gbps network over 20km distance, although I'm not exactly sure why