### PR TITLE
Don't initialize TLS library before daemonizing

### DIFF
--- a/src/dird/dird.c
+++ b/src/dird/dird.c
@@ -296,11 +296,6 @@ int main (int argc, char *argv[])
       goto bail_out;
    }
 
-   if (init_crypto() != 0) {
-      Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Cryptography library initialization failed.\n"));
-      goto bail_out;
-   }
-
    if (!check_resources()) {
       Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Please correct configuration file: %s\n"), configfile);
       goto bail_out;
@@ -316,6 +311,11 @@ int main (int argc, char *argv[])
                       get_first_port_host_order(me->DIRaddrs));
       read_state_file(me->working_directory, "bareos-dir",
                       get_first_port_host_order(me->DIRaddrs));
+   }
+
+   if (init_crypto() != 0) {
+      Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Cryptography library initialization failed.\n"));
+      goto bail_out;
    }
 
    set_jcr_in_tsd(INVALID_JCR);

--- a/src/filed/filed.c
+++ b/src/filed/filed.c
@@ -241,11 +241,6 @@ int main (int argc, char *argv[])
       goto bail_out;
    }
 
-   if (init_crypto() != 0) {
-      Emsg0(M_ERROR, 0, _("Cryptography library initialization failed.\n"));
-      terminate_filed(1);
-   }
-
    if (!check_resources()) {
       Emsg1(M_ERROR, 0, _("Please correct configuration file: %s\n"), configfile);
       terminate_filed(1);
@@ -268,6 +263,11 @@ int main (int argc, char *argv[])
    if (!foreground) {
       daemon_start();
       init_stack_dump();              /* set new pid */
+   }
+
+   if (init_crypto() != 0) {
+      Emsg0(M_ERROR, 0, _("Cryptography library initialization failed.\n"));
+      terminate_filed(1);
    }
 
    set_thread_concurrency(me->MaxConcurrentJobs + 10);

--- a/src/stored/stored.c
+++ b/src/stored/stored.c
@@ -242,10 +242,6 @@ int main (int argc, char *argv[])
       goto bail_out;
    }
 
-   if (init_crypto() != 0) {
-      Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Cryptography library initialization failed.\n"));
-   }
-
    if (!check_resources()) {
       Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Please correct configuration file: %s\n"), configfile);
    }
@@ -261,6 +257,10 @@ int main (int argc, char *argv[])
    if (!foreground) {
       daemon_start();                 /* become daemon */
       init_stack_dump();              /* pick up new pid */
+   }
+
+   if (init_crypto() != 0) {
+      Jmsg((JCR *)NULL, M_ERROR_TERM, 0, _("Cryptography library initialization failed.\n"));
    }
 
    create_pid_file(me->pid_directory, "bareos-sd",


### PR DESCRIPTION
GnuTLS [opens file descriptors (e.g., for `/dev/urandom`) during library initialization][1]. Such file descriptors are currently [closed during daemonization][2], so enabling TLS won't work when using GnuTLS (you get messages such as `TLS negotiation failed with SD` when trying to talk to the Storage Daemon via TLS).

This commit fixes the issue by initializing the TLS libraries _after_ daemonizing.

[1]: http://gnutls.org/manual/html_node/Initialization.html
[2]: https://github.com/bareos/bareos/blob/690e9ed29043443742b3c5c9a8ab13ad90f50b17/src/lib/daemon.c#L71