### PR TITLE
bconsole: Add '/' to the list of acceptable volume name characters

### DIFF
--- a/src/lib/edit.c
+++ b/src/lib/edit.c
@@ -482,7 +482,7 @@ bool is_name_valid(const char *name, POOLMEM **msg)
    int len;
    const char *p;
    /* Special characters to accept */
-   const char *accept = ":.-_ ";
+   const char *accept = ":.-_/ ";
 
    /* No name is invalid */
    if (!name) {


### PR DESCRIPTION
Bareos accepts slashes in volume names since commit 7969af665ad5b38e88763b6456b0b13b564dbbc3, but when running a command such as `update volume="Foo/Bar"`, `bconsole` says: `Illegal character "/" in name.`