### PR TITLE
config-lib improvements

### DIFF
--- a/scripts/bareos-config-lib.sh.in
+++ b/scripts/bareos-config-lib.sh.in
@@ -700,6 +700,14 @@ apply_dbconfig_settings()
     # check if dbconfig is enabled
     [ $dbc_upgrade = 'true' ] || return 0
 
+    if [ -n "$dbc_dbuser" ]; then
+        set_config_param "${CFG_DIR}" "Catalog" "MyCatalog" "dbuser" "$dbc_dbuser"
+    fi
+
+    if [ -n "$dbc_dbname" ]; then
+        set_config_param "${CFG_DIR}" "Catalog" "MyCatalog" "dbname" "$dbc_dbname"
+    fi
+
     case "$dbc_dbtype" in
         pgsql)
             set_config_param "${CFG_DIR}" "Catalog" "MyCatalog" "dbdriver" "postgresql"

--- a/scripts/bareos-config-lib.sh.in
+++ b/scripts/bareos-config-lib.sh.in
@@ -810,7 +810,7 @@ initialize_passwords()
     if [ ! -f ${DIR_CFG}/.rndpwd ]; then
         for string in ${PASSWORD_SUBST}
         do
-           pass=`openssl rand -base64 33`
+           pass=`RANDFILE=/dev/urandom openssl rand -base64 33`
            echo "${string}=${pass}" >> ${DIR_CFG}/.rndpwd
         done
         chmod 400 ${DIR_CFG}/.rndpwd


### PR DESCRIPTION
Hi,

this brings two small fixes to your config library:

  *  set `dbuser` and `dbname` for `dbconfig-common`, previously the script (or actually the config template) would just assume that  `dbuser` and `dbname` are always `bareos`, which is obviously wrong
  * call `openssl rand` with an explicit `RANDFILE`, otherwise it will create `$HOME/.rnd` in the users home, which people might not like on automated installations