### PR TITLE
adjust manpage sections to match the file extensions

### DIFF
--- a/manpages/bconsole.1
+++ b/manpages/bconsole.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH CONSOLE 8 "4 December 2009" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
+.TH CONSOLE 1 "4 December 2009" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .SH NAME

--- a/manpages/bregex.1
+++ b/manpages/bregex.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH BREGEX 8 "30 October 2011" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
+.TH BREGEX 1 "30 October 2011" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:

--- a/manpages/btraceback.8
+++ b/manpages/btraceback.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH BTRACEBACK 1 "6 December 2009" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
+.TH BTRACEBACK 8 "6 December 2009" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .SH NAME

--- a/manpages/bwild.1
+++ b/manpages/bwild.1
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH BWILD 8 "30 October 2011" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
+.TH BWILD 1 "30 October 2011" "Kern Sibbald" "Backup Archiving REcovery Open Sourced"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:


### PR DESCRIPTION
some manpages had section 8 in the header but a .1 extension
and vice versa. fix these to match the extension.

thanks to Debian's Lintian tool for spotting the issue