### PR TITLE
define PATH_MAX if it is not present on the current OS

### DIFF
--- a/src/tools/bpluginfo.c
+++ b/src/tools/bpluginfo.c
@@ -41,6 +41,9 @@
 #ifndef __WIN32__
 #include <dlfcn.h>
 #endif
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
 
 extern "C" {
    typedef int (*loadPlugin) (void *binfo, void *bfuncs, void **pinfo,


### PR DESCRIPTION
GNU/Hurd does not have a `PATH_MAX` define and thus the compilation of `src/tools/bpluginfo.c` fails:

    bpluginfo.c:269:26: error: 'PATH_MAX' was not declared in this scope

The perfect solution would be not to need a `PATH_MAX` at all, but this part is left to the educated reader as an exercise.