### PR TITLE
Finally fix LDFLAGS position.

### DIFF
--- a/src/cats/Makefile.in
+++ b/src/cats/Makefile.in
@@ -147,35 +147,35 @@ libbareoscats.a: $(LIBBAREOSCATS_OBJS)
 
 libbareoscats.la: Makefile $(LIBBAREOSCATS_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(LIBBAREOSCATS_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSCATS_LT_RELEASE) -lbareos
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(LIBBAREOSCATS_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSCATS_LT_RELEASE) -lbareos
 
 libbareossql.la: Makefile $(LIBBAREOSSQL_LOBJS) libbareoscats.la
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(LIBBAREOSSQL_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSSQL_LT_RELEASE) $(DB_LIBS) -lbareos -lbareoscats
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(LIBBAREOSSQL_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSSQL_LT_RELEASE) $(DB_LIBS) -lbareos -lbareoscats
 
 libbareoscats-mysql.la: Makefile $(MYSQL_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(MYSQL_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(MYSQL_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
 							   -soname libbareoscats-$(LIBBAREOSCATS_LT_RELEASE).so $(MYSQL_LIBS)
 
 libbareoscats-postgresql.la: Makefile $(POSTGRESQL_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(POSTGRESQL_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(POSTGRESQL_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
 							   -soname libbareoscats-$(LIBBAREOSCATS_LT_RELEASE).so $(POSTGRESQL_LIBS)
 
 libbareoscats-sqlite3.la: Makefile $(SQLITE_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(SQLITE_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(SQLITE_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
 							   -soname libbareoscats-$(LIBBAREOSCATS_LT_RELEASE).so $(SQLITE_LIBS)
 
 #libbareoscats-ingres.la: Makefile $(INGRES_LOBJS)
 #	 @echo "Making $@ ..."
-#	 $(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(INGRES_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
+#	 $(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(INGRES_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
 #							    -soname libbareoscats-$(LIBBAREOSCATS_LT_RELEASE).so $(INGRES_LIBS)
 
 #libbareoscats-dbi.la: Makefile $(DBI_LOBJS)
 #	 @echo "Making $@ ..."
-#	 $(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(DBI_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
+#	 $(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(DBI_LOBJS) -export-dynamic -rpath $(backenddir) -release $(LIBBAREOSCATS_LT_RELEASE) \
 #							    -soname libbareoscats-$(LIBBAREOSCATS_LT_RELEASE).so $(DBI_LIBS)
 
 Makefile: $(srcdir)/Makefile.in $(topdir)/config.status

--- a/src/console/Makefile.in
+++ b/src/console/Makefile.in
@@ -50,12 +50,12 @@ console_conf.o: console_conf.c
 	$(NO_ECHO)$(CXX) $(DEFS) $(DEBUG) -c $(CPPFLAGS) $(CONS_INC) $(JANSSON_CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) $<
 
 bconsole: Makefile $(CONSOBJS) ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE)
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) $(CONS_LDFLAGS) -L../lib -L../cats -o $@ $(CONSOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../cats $(CONS_LDFLAGS) $(LDFLAGS) -o $@ $(CONSOBJS) \
 	      $(DLIB) $(CONS_LIBS) -lbareoscfg -lbareos -lm $(LIBS) $(GETTEXT_LIBS) \
 	      $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 static-bconsole: Makefile $(CONSOBJS) ../lib/libbareos.a ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE)
-	$(LIBTOOL_LINK) $(CXX) -static $(LDFLAGS) $(CONS_LDFLAGS) -L../lib -L../cats -o $@ $(CONSOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -static -L../lib -L../cats $(CONS_LDFLAGS) $(LDFLAGS) -o $@ $(CONSOBJS) \
 	      $(DLIB) $(CONS_LIBS) -lbareoscfg -lbareos -lm $(LIBS) $(GETTEXT_LIBS) \
 	      $(OPENSSL_LIBS) $(GNUTLS_LIBS)
 	strip $@

--- a/src/dird/Makefile.in
+++ b/src/dird/Makefile.in
@@ -76,7 +76,7 @@ bareos-dir: Makefile $(SVROBJS) \
 	    ../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE) \
 	    @NDMP_DEPS@
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(WLDFLAGS) $(LDFLAGS) -L../lib -L../cats -L../findlib -o $@ $(SVROBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../cats -L../findlib $(WLDFLAGS) $(LDFLAGS) -o $@ $(SVROBJS) \
 	      $(NDMP_LIBS) -lbareosfind -lbareossql -lbareoscats -lbareoscfg -lbareos -lm $(DLIB) \
 	      $(DB_LIBS) $(LIBS) $(WRAPLIBS) $(GETTEXT_LIBS) $(CAP_LIBS) \
 	      $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
@@ -88,7 +88,7 @@ bareos-dbcheck: Makefile $(DBCHKOBJS) \
 	 ../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE) \
 	 ../cats/libbareoscats$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -L../findlib -L../cats -o $@ $(DBCHKOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../findlib -L../cats $(LDFLAGS) -o $@ $(DBCHKOBJS) \
 	      -lbareoscats -lbareossql -lbareoscfg -lbareosfind -lbareos -lm $(DB_LIBS) $(LIBS) $(GETTEXT_LIBS) \
 	      $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 

--- a/src/filed/Makefile.in
+++ b/src/filed/Makefile.in
@@ -74,7 +74,7 @@ bareos-fd: Makefile $(SVROBJS) \
 	   ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE) \
 	   ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(WLDFLAGS) $(LDFLAGS) -L../lib -L../findlib -o $@ $(SVROBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../findlib $(WLDFLAGS) $(LDFLAGS) -o $@ $(SVROBJS) \
 	  $(FDLIBS) -lbareosfind -lbareoscfg -lbareos -lm $(LIBS) \
 	  $(DLIB) $(WRAPLIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
@@ -83,7 +83,7 @@ static-bareos-fd: Makefile $(SVROBJS) \
 		  ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE) \
 		  ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(WLDFLAGS) $(LDFLAGS) -static -L../lib -L../findlib -o $@ $(SVROBJS) \
+	$(LIBTOOL_LINK) $(CXX) -static -L../lib -L../findlib $(WLDFLAGS) $(LDFLAGS) -o $@ $(SVROBJS) \
 	   $(FDLIBS) -lbareosfind -lbareoscfg -lbareos -lm $(LIBS) \
 	   $(DLIB) $(WRAPLIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS) $(GNUTLS_LIBS)
 	strip $@

--- a/src/findlib/Makefile.in
+++ b/src/findlib/Makefile.in
@@ -77,7 +77,7 @@ libbareosfind.a: $(LIBBAREOSFIND_OBJS)
 
 libbareosfind.la: Makefile $(LIBBAREOSFIND_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(LIBBAREOSFIND_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSFIND_LT_RELEASE) $(ACL_LIBS) $(XATTR_LIBS) $(AFS_LIBS) -lbareos
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(LIBBAREOSFIND_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSFIND_LT_RELEASE) $(ACL_LIBS) $(XATTR_LIBS) $(AFS_LIBS) -lbareos
 
 Makefile: $(srcdir)/Makefile.in $(topdir)/config.status
 	cd $(topdir) \

--- a/src/plugins/dird/Makefile.in
+++ b/src/plugins/dird/Makefile.in
@@ -47,7 +47,7 @@ python-dir.la: Makefile \
 plugtest: Makefile dir_plugins.c \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../dird/dir_plugins.c
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -L../../findlib -o $@ dir_plugins.o -lbareos $(DLIB) -lm $(LIBS)
+	$(LIBTOOL_LINK) $(CXX) -L../../lib -L../../findlib $(LDFLAGS) -o $@ dir_plugins.o -lbareos $(DLIB) -lm $(LIBS)
 
 install: all
 	$(MKDIR) $(DESTDIR)$(plugindir)

--- a/src/plugins/filed/Makefile.in
+++ b/src/plugins/filed/Makefile.in
@@ -89,7 +89,7 @@ plugtest: Makefile fd_plugins.c fileset.c \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fd_plugins.c
 	$(CXX) $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../filed/fileset.c
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -L../../findlib -o $@ fd_plugins.o fileset.o -lbareosfind -lbareos $(DLIB) -lm $(LIBS)
+	$(LIBTOOL_LINK) $(CXX) -L../../lib -L../../findlib $(LDFLAGS) -o $@ fd_plugins.o fileset.o -lbareosfind -lbareos $(DLIB) -lm $(LIBS)
 
 install: all
 	$(MKDIR) $(DESTDIR)$(plugindir)

--- a/src/plugins/stored/Makefile.in
+++ b/src/plugins/stored/Makefile.in
@@ -40,7 +40,7 @@ autoxflate-sd.lo: autoxflate-sd.c
 autoxflate-sd.la: Makefile \
 		  autoxflate-sd$(DEFAULT_OBJECT_TYPE) \
 		  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared autoxflate-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -L../../lib -lbareos
+	$(LIBTOOL_LINK) $(CXX) -L../../lib $(LDFLAGS) -shared autoxflate-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -lbareos
 
 example-plugin-sd.la: Makefile example-plugin-sd$(DEFAULT_OBJECT_TYPE)
 	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared example-plugin-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version
@@ -57,17 +57,17 @@ python-sd.la: Makefile \
 scsicrypto-sd.la: Makefile \
 		  scsicrypto-sd$(DEFAULT_OBJECT_TYPE) \
 		  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared scsicrypto-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -L../../lib -lbareos
+	$(LIBTOOL_LINK) $(CXX) -L../../lib $(LDFLAGS) -shared scsicrypto-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -lbareos
 
 scsitapealert-sd.la: Makefile \
 		     scsitapealert-sd$(DEFAULT_OBJECT_TYPE) \
 		     ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -shared scsitapealert-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -L../../lib -lbareos
+	$(LIBTOOL_LINK) $(CXX) -L../../lib $(LDFLAGS) -shared scsitapealert-sd.lo -o $@ -rpath $(plugindir) -module -export-dynamic -avoid-version -lbareos
 
 plugtest: Makefile sd_plugins.c \
 	  ../../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	$(CXX) -DTEST_PROGRAM $(DEFS) $(DEBUG) -c $(CXXFLAGS) $(CPPFLAGS) $(INCLUDES) $(DINCLUDE) $(CXXFLAGS) ../../stored/sd_plugins.c
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../../lib -o $@ sd_plugins.o -lbareos $(DLIB) -lm $(LIBS)
+	$(LIBTOOL_LINK) $(CXX) -L../../lib $(LDFLAGS) -o $@ sd_plugins.o -lbareos $(DLIB) -lm $(LIBS)
 
 install: all
 	$(MKDIR) $(DESTDIR)$(plugindir)

--- a/src/stored/Makefile.in
+++ b/src/stored/Makefile.in
@@ -127,7 +127,7 @@ libbareossd.a: $(LIBBAREOSSD_OBJS)
 
 libbareossd.la: Makefile $(LIBBAREOSSD_LOBJS)
 	@echo "Making $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) $(LDFLAGS) -L../lib -o $@ $(LIBBAREOSSD_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSSD_LT_RELEASE) -lbareos -lbareoscfg
+	$(LIBTOOL_LINK) $(CXX) $(DEFS) $(DEBUG) -L../lib $(LDFLAGS) -o $@ $(LIBBAREOSSD_LOBJS) -export-dynamic -rpath $(libdir) -release $(LIBBAREOSSD_LT_RELEASE) -lbareos -lbareoscfg
 
 dev.lo: dev.c
 	@echo "Compiling $<"
@@ -166,7 +166,7 @@ bareos-sd: Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(SDOBJS) \
 	   ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
 	   @NDMP_DEPS@
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(WLDFLAGS) $(LDFLAGS) -L. -L../lib -o $@ $(SDOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(WLDFLAGS) $(LDFLAGS) -o $@ $(SDOBJS) \
 	   $(NDMP_LIBS) -lbareossd -lbareoscfg -lbareos -lm $(DLIB) $(LIBS) $(WRAPLIBS) \
 	   $(SD_LIBS) $(GETTEXT_LIBS) $(COMPRESS_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
@@ -175,7 +175,7 @@ static-bareos-sd: Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(SDOBJS) \
 	          ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
 	          @NDMP_DEPS@
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(WLDFLAGS) $(LDFLAGS) -static -L. -L../lib -o $@ $(SDOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(WLDFLAGS) $(LDFLAGS) -static -o $@ $(SDOBJS) \
 	   $(NDMP_LIBS) -lbareossd -lbareoscfg -lbareos -lm $(DLIB) $(LIBS) $(WRAPLIBS) \
 	   $(SD_LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS) $(GNUTLS_LIBS) $(COMPRESS_LIBS)
 	strip $@
@@ -188,7 +188,7 @@ btape: Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(TAPEOBJS) \
        ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
        ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(TTOOL_LDFLAGS) $(LDFLAGS) -L. -L../lib -o $@ $(TAPEOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(TTOOL_LDFLAGS) $(LDFLAGS) -o $@ $(TAPEOBJS) \
 	   -lbareossd -lbareoscfg -lbareos $(DLIB) -lm $(LIBS) $(GETTEXT_LIBS) \
 	   $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
@@ -197,7 +197,7 @@ bls: Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(BLSOBJS) \
      ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE) \
      ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(TTOOL_LDFLAGS) $(LDFLAGS) -L. -L../lib -L../findlib -o $@ $(BLSOBJS) $(DLIB) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib -L../findlib $(TTOOL_LDFLAGS) $(LDFLAGS) -o $@ $(BLSOBJS) $(DLIB) \
 	   -lbareossd -lbareosfind -lbareoscfg -lbareos -lm $(LIBS) $(GETTEXT_LIBS) \
 	   $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
@@ -206,7 +206,7 @@ bextract: Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(BEXTOBJS) \
 	  ../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE) \
           ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(TTOOL_LDFLAGS) $(LDFLAGS) -L. -L../lib -L../findlib -o $@ $(BEXTOBJS) $(DLIB) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib -L../findlib $(TTOOL_LDFLAGS) $(LDFLAGS) -o $@ $(BEXTOBJS) $(DLIB) \
 	   -lbareossd -lbareosfind -lbareoscfg -lbareos -lm $(LIBS) $(SD_LIBS) $(BEXTRACT_LIBS) \
 	   $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
@@ -216,14 +216,14 @@ bscan:	Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(SCNOBJS) \
 	../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE) \
 	../cats/libbareoscats$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(TTOOL_LDFLAGS) $(LDFLAGS) -L. -L../lib -L../cats -L../findlib -o $@ $(SCNOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib -L../cats -L../findlib $(TTOOL_LDFLAGS) $(LDFLAGS) -o $@ $(SCNOBJS) \
 	   -lbareossql -lbareoscats $(DB_LIBS) -lbareossd -lbareosfind -lbareoscfg -lbareos -lm $(LIBS) $(SD_LIBS) \
 	   $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 bcopy:	Makefile libbareossd$(DEFAULT_ARCHIVE_TYPE) $(COPYOBJS) \
 	../lib/libbareoscfg$(DEFAULT_ARCHIVE_TYPE) ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(TTOOL_LDFLAGS) $(LDFLAGS) -L. -L../lib -o $@ $(COPYOBJS) \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(TTOOL_LDFLAGS) $(LDFLAGS) -o $@ $(COPYOBJS) \
 	   -lbareossd -lbareoscfg -lbareos -lm $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 Makefile: $(srcdir)/Makefile.in $(topdir)/config.status

--- a/src/tests/Makefile.in
+++ b/src/tests/Makefile.in
@@ -44,13 +44,13 @@ all: Makefile $(TESTS) gigaslam grow
 bregtest: Makefile bregtest.o \
 	  ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -o $@ bregtest.o -lbareos -lm $(DLIB) $(LIBS) $(GETTEXT_LIBS)
+	$(LIBTOOL_LINK) $(CXX) -L../lib $(LDFLAGS) -o $@ bregtest.o -lbareos -lm $(DLIB) $(LIBS) $(GETTEXT_LIBS)
 
 testls: Makefile testls.o \
 	../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE) \
 	../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) -g $(LDFLAGS) -L. -L../lib -L../findlib -o $@ testls.o \
+	$(LIBTOOL_LINK) $(CXX) -g -L. -L../lib -L../findlib $(LDFLAGS) -o $@ testls.o \
 	  $(DLIB) -lbareosfind -lbareos -lm $(LIBS) $(GETTEXT_LIBS)
 
 bbatch.o: bbatch.c
@@ -62,7 +62,7 @@ bbatch: Makefile bbatch.o \
 	../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE) \
 	../cats/libbareoscats$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) -g $(LDFLAGS) -L../cats -L. -L../lib -o $@ bbatch.o \
+	$(LIBTOOL_LINK) $(CXX) -g -L../cats -L. -L../lib $(LDFLAGS) -o $@ bbatch.o \
 	  -lbareoscats -lbareossql -lbareos -lm $(DB_LIBS) $(LIBS) $(GETTEXT_LIBS)
 
 bvfs_test: Makefile bvfs_test.o \
@@ -71,7 +71,7 @@ bvfs_test: Makefile bvfs_test.o \
 	   ../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE) \
 	   ../cats/libbareoscats$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) -g $(LDFLAGS) -L../cats -L. -L../lib -L../findlib -o $@ bvfs_test.o  \
+	$(LIBTOOL_LINK) $(CXX) -g -L../cats -L. -L../lib -L../findlib $(LDFLAGS) -o $@ bvfs_test.o  \
 	  -lbareoscats -lbareossql -lbareosfind -lbareos -lm $(DB_LIBS) $(LIBS) $(GETTEXT_LIBS)
 
 ing_test: Makefile ing_test.o \
@@ -80,7 +80,7 @@ ing_test: Makefile ing_test.o \
 	  ../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE) \
 	  ../cats/libbareoscats$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) -g $(LDFLAGS) -L../cats -L. -L../lib -L../findlib -o $@ ing_test.o  \
+	$(LIBTOOL_LINK) $(CXX) -g -L../cats -L. -L../lib -L../findlib $(LDFLAGS) -o $@ ing_test.o  \
 	  -lbareoscats -lbareossql -lbareosfind -lbareos -lm $(DB_LIBS) $(LIBS) $(GETTEXT_LIBS)
 
 cats_test: Makefile cats_test.o \
@@ -88,7 +88,7 @@ cats_test: Makefile cats_test.o \
 	   ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
 	   ../cats/libbareossql$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) -g $(LDFLAGS) -L../cats -L. -L../lib -L../findlib -o $@ cats_test.o  \
+	$(LIBTOOL_LINK) $(CXX) -g -L../cats -L. -L../lib -L../findlib $(LDFLAGS) -o $@ cats_test.o  \
 	  -lbareoscats -lbareossql -lbareosfind -lbareos -lm $(DB_LIBS) $(LIBS) $(GETTEXT_LIBS)
 
 gigaslam.o: gigaslam.c
@@ -101,7 +101,7 @@ gigaslam: gigaslam.o
 
 grow: Makefile grow.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -o $@ grow.o -lbareos -lm $(DLIB) $(LIBS) $(GETTEXT_LIBS)
+	$(LIBTOOL_LINK) $(CXX) -L../lib $(LDFLAGS) -o $@ grow.o -lbareos -lm $(DLIB) $(LIBS) $(GETTEXT_LIBS)
 
 Makefile: $(srcdir)/Makefile.in $(topdir)/config.status
 	cd $(topdir) \

--- a/src/tools/Makefile.in
+++ b/src/tools/Makefile.in
@@ -46,38 +46,38 @@ all: Makefile $(TOOLS)
 
 bsmtp: Makefile bsmtp.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -o $@ bsmtp.o -lbareos -lm $(DLIB) $(LIBS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib $(LDFLAGS) -o $@ bsmtp.o -lbareos -lm $(DLIB) $(LIBS) \
 	$(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 fstype: Makefile fstype.o \
 	../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
 	../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -L../findlib -o $@ fstype.o -lbareosfind -lbareos -lm \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../findlib $(LDFLAGS) -o $@ fstype.o -lbareosfind -lbareos -lm \
 	  $(DLIB) $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 drivetype: Makefile drivetype.o \
 	../lib/libbareos$(DEFAULT_ARCHIVE_TYPE) \
 	../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -L../findlib -o $@ drivetype.o -lbareosfind -lbareos -lm \
+	$(LIBTOOL_LINK) $(CXX) -L../lib -L../findlib $(LDFLAGS) -o $@ drivetype.o -lbareosfind -lbareos -lm \
 	  $(DLIB) $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 bregex: Makefile bregex.o \
 	../findlib/libbareosfind$(DEFAULT_ARCHIVE_TYPE) \
 	../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L. -L../lib -o $@ bregex.o \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(LDFLAGS) -o $@ bregex.o \
 	  $(DLIB) -lbareos -lm $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 bwild:	Makefile bwild.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L. -L../lib -o $@ bwild.o \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(LDFLAGS) -o $@ bwild.o \
 	  $(DLIB) -lbareos -lm $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 bscrypto: Makefile bscrypto.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L. -L../lib -o $@ bscrypto.o \
+	$(LIBTOOL_LINK) $(CXX) -L. -L../lib $(LDFLAGS) -o $@ bscrypto.o \
 	  $(DLIB) -lbareos -lm $(LIBS) $(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 bpluginfo.o: bpluginfo.c
@@ -86,7 +86,7 @@ bpluginfo.o: bpluginfo.c
 
 bpluginfo: Makefile bpluginfo.o ../lib/libbareos$(DEFAULT_ARCHIVE_TYPE)
 	@echo "Linking $@ ..."
-	$(LIBTOOL_LINK) $(CXX) $(LDFLAGS) -L../lib -o $@ bpluginfo.o -lbareos $(LIBS) \
+	$(LIBTOOL_LINK) $(CXX) -L../lib $(LDFLAGS) -o $@ bpluginfo.o -lbareos $(LIBS) \
 	$(GETTEXT_LIBS) $(OPENSSL_LIBS_NONSHARED) $(GNUTLS_LIBS_NONSHARED)
 
 timelimit.o: timelimit.c


### PR DESCRIPTION
The Makefiles for most binaries had put $(LDFLAGS) /before/ all of the local includes, giving /usr/local/lib more priority over ../libs, etc. This causes the compiler to try to link the programs with libs from the currently installed version, not the version being built.

This is a problem inherited from bacula - see the following bug reports in FreeBSD's ports:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=192526
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=193641