### PR TITLE
move bscrypto binary to bareos-storage-tape

### DIFF
--- a/debian/bareos-storage-tape.install.in
+++ b/debian/bareos-storage-tape.install.in
@@ -7,4 +7,5 @@
 @scriptdir@/mtx-changer
 /usr/share/man/man8/bscrypto.8.gz
 /usr/share/man/man8/btape.8.gz
+/usr/sbin/bscrypto
 /usr/sbin/btape

--- a/debian/bareos-storage.install.in
+++ b/debian/bareos-storage.install.in
@@ -1,4 +1,3 @@
-/usr/sbin/bscrypto
 @plugindir@/autoxflate-sd.so
 @scriptdir@/disk-changer
 @confdir@/bareos-sd.conf     @configtemplatedir@


### PR DESCRIPTION
in 10fe486549814c30dab4a6fc34ab9b84fdfe7bd6 the manpage and library were moved to b-s-t, but the actual binary was left in bareos-storage. finalize the move by placing the binary into b-s-t.