### PR TITLE
fix bashisms

### DIFF
--- a/debian/bareos-director.bareos-dir.init.in
+++ b/debian/bareos-director.bareos-dir.init.in
@@ -45,7 +45,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 . /lib/lsb/init-functions
 
 # workaround, if status_of_proc is not defined (Ubuntu 8.04)
-if ! type status_of_proc >/dev/null; then
+if ! command -v status_of_proc >/dev/null; then
 status_of_proc ()
 {
     local pidfile daemon name status OPTIND

--- a/debian/bareos-director.postinst.in
+++ b/debian/bareos-director.postinst.in
@@ -45,7 +45,7 @@ case "$1" in
         fi
         permissions
         # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && type ucr >/dev/null 2>&1; then
+        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
             ucr set \
                 security/packetfilter/package/bareos-director/tcp/@dir_port@/all="ACCEPT" \
                 security/packetfilter/package/bareos-director/tcp/@dir_port@/all/en="bareos-dir"

--- a/debian/bareos-filedaemon.bareos-fd.init.in
+++ b/debian/bareos-filedaemon.bareos-fd.init.in
@@ -46,7 +46,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 . /lib/lsb/init-functions
 
 # workaround, if status_of_proc is not defined (Ubuntu 8.04)
-if ! type status_of_proc >/dev/null; then
+if ! command -v status_of_proc >/dev/null; then
 status_of_proc ()
 {
     local pidfile daemon name status OPTIND

--- a/debian/bareos-filedaemon.postinst.in
+++ b/debian/bareos-filedaemon.postinst.in
@@ -47,7 +47,7 @@ case "$1" in
         fi
         permissions
         # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && type ucr >/dev/null 2>&1; then
+        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
             ucr set \
                 security/packetfilter/package/bareos-filedaemon/tcp/@fd_port@/all="ACCEPT" \
                 security/packetfilter/package/bareos-filedaemon/tcp/@fd_port@/all/en="bareos-fd"

--- a/debian/bareos-storage.bareos-sd.init.in
+++ b/debian/bareos-storage.bareos-sd.init.in
@@ -43,7 +43,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 . /lib/lsb/init-functions
 
 # workaround, if status_of_proc is not defined (Ubuntu 8.04)
-if ! type status_of_proc >/dev/null; then
+if ! command -v status_of_proc >/dev/null; then
 status_of_proc ()
 {
     local pidfile daemon name status OPTIND

--- a/debian/bareos-storage.postinst.in
+++ b/debian/bareos-storage.postinst.in
@@ -50,7 +50,7 @@ case "$1" in
         permissions
         /usr/lib/bareos/scripts/bareos-config setup_sd_user
         # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && type ucr >/dev/null 2>&1; then
+        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
             ucr set \
                 security/packetfilter/package/bareos-storage/tcp/@sd_port@/all="ACCEPT" \
                 security/packetfilter/package/bareos-storage/tcp/@sd_port@/all/en="bareos-sd"

--- a/scripts/bareos-config-lib.sh.in
+++ b/scripts/bareos-config-lib.sh.in
@@ -37,7 +37,7 @@ os_type=`uname -s`
 is_function()
 {
     func=${1-}
-    test "$func" && type "$func" > /dev/null 2>&1
+    test "$func" && command -v "$func" > /dev/null 2>&1
     return $?
 }
 


### PR DESCRIPTION
[`type` is only a XSI extension in the current POSIX standard](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/type.html), which means it is optional and may be not present in a pure POSIX shell.

`command -v` is part of the standard, though. so let's use it to identify shell functions.
`which` is usually present as either a shell built-in or `/bin/which` so it can be used to identify binaries.