### PR TITLE
Start bareos-dir.service after mariadb.service

### DIFF
--- a/platforms/systemd/bareos-dir.service.in
+++ b/platforms/systemd/bareos-dir.service.in
@@ -15,7 +15,7 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=nss-lookup.target network.target remote-fs.target time-sync.target
-After=nss-lookup.target network.target remote-fs.target time-sync.target postgresql.service mysql.service
+After=nss-lookup.target network.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service


### PR DESCRIPTION
Fedora and RHEL are shipping mariadb.service rather mysql.service (at least by default)