### PR TITLE
fix not enough arguments for shift

### DIFF
--- a/debian/bareos-database-common.config.in
+++ b/debian/bareos-database-common.config.in
@@ -30,12 +30,16 @@ if [ -r @scriptdir@/bareos-config-lib.sh ]; then
         dbc_dbtypes=`echo ${dbc_dbtypes} | sed 's/, *$//'`
 
         # action
-        param1="$1"
-        shift || true
+        if [ $# -gt 0 ]; then
+            param1="$1"
+            shift
+        fi
         # $2: when action is "configure": most-recently-configured-version
-        param2="$1"
-        param2_orig=$param2
-        shift || true
+        if [ $# -gt 0 ]; then
+            param2="$1"
+            param2_orig=$param2
+            shift
+        fi
 
         # When upgrading from an older version (param2),
         # do not pass the version number of the old package.

--- a/debian/bareos-database-common.postinst.in
+++ b/debian/bareos-database-common.postinst.in
@@ -25,11 +25,15 @@ if [ -r @scriptdir@/bareos-config-lib.sh ]; then
         . /usr/share/dbconfig-common/dpkg/postinst
 
         # action
-        param1="$1"
-        shift || true
+        if [ $# -gt 0 ]; then
+            param1="$1"
+            shift
+        fi
         # when action is "configure": most-recently-configured-version
-        param2="$1"
-        shift || true
+        if [ $# -gt 0 ]; then
+            param2="$1"
+            shift
+        fi
         if [ "$param2" ]; then
             case "$param1" in
                 configure|reconfigure)


### PR DESCRIPTION
I was trying to deploy bareos inside docker and for some reasons dbconfig-common wasn't working properly. So after looking inside the maintainer scripts I've found out a quickfix

```bash
root@8cf09d5b8649:/var/lib/dpkg# bash -x
info/bareos-database-common.postinst configure
+ set -e
+ . /usr/share/debconf/confmodule
++ '[' '!' '' ']'
++ PERL_DL_NONLAZY=1
++ export PERL_DL_NONLAZY
++ '[' '' ']'
++ exec /usr/share/debconf/frontend info/bareos-database-common.postinst
configure
(config) dbc_go() bareos-database-common configure.
dbc_config() bareos-database-common configure.
dbc_set_dbtype_defaults() .
dbc_register_debconf() .
dbc_read_package_config() .
dbc_preseed_package_debconf() .
dbc_detect_supported_dbtype() pgsql.
dbc_detect_installed_dbtype() pgsql.
_dbc_detect_installed_dbtype() pgsql.
dbc_config() bareos-database-common configure.
dbc_set_dbtype_defaults() pgsql.
dbc_get_app_pass() .
info/bareos-database-common.postinst: 33: shift: can't shift that many
```

##### Error cause:
The error comes from the fact that some shells (but not all) detect when there are not enough arguments for shift. In particular, dash considers it a fatal error.

##### Possible solution:
Test if there are enough remaining arguments:
```bash
if [ "$#" -gt 0 ]; then shift; fi
```