### PR TITLE
Ceph Rados: added id argument to specify rados client id

### DIFF
--- a/src/plugins/filed/plugin-rados.conf
+++ b/src/plugins/filed/plugin-rados.conf
@@ -16,7 +16,7 @@ FileSet {
     # adapt this to your environment
     #   namespace: optional
     #   snapshotname: optional (a snapshot in any case)
-    Plugin = "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
+    Plugin = "rados:conffile=<ceph_conf_file>:clientid=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
   }
 }
 

--- a/src/plugins/filed/plugin-rados.conf
+++ b/src/plugins/filed/plugin-rados.conf
@@ -16,7 +16,7 @@ FileSet {
     # adapt this to your environment
     #   namespace: optional
     #   snapshotname: optional (a snapshot in any case)
-    Plugin = "rados:conffile=<ceph_conf_file>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
+    Plugin = "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
   }
 }
 

--- a/src/plugins/filed/rados-fd.c
+++ b/src/plugins/filed/rados-fd.c
@@ -36,9 +36,9 @@ static const int dbglvl = 150;
 #define PLUGIN_VERSION      "1"
 #define PLUGIN_DESCRIPTION  "Bareos CEPH rados File Daemon Plugin"
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
-#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
+#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
 #else
-#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:poolname=<pool_name>:snapshotname=<snapshot_name>:"
+#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:snapshotname=<snapshot_name>:"
 #endif
 
 /*
@@ -124,6 +124,7 @@ struct plugin_ctx {
    char *plugin_options;
    uint32_t JobId;
    char *rados_conffile;
+   char *rados_id;
    char *rados_poolname;
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    char *rados_namespace;
@@ -149,6 +150,7 @@ enum plugin_argument_type {
    argument_none,
    argument_conffile,
    argument_poolname,
+   argument_id,
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    argument_namespace,
 #endif
@@ -163,6 +165,7 @@ struct plugin_argument {
 static plugin_argument plugin_arguments[] = {
    { "conffile", argument_conffile },
    { "poolname", argument_poolname },
+   { "id", argument_id },
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    { "namespace", argument_namespace },
 #endif
@@ -277,6 +280,10 @@ static bRC freePlugin(bpContext *ctx)
 
    if (p_ctx->rados_poolname) {
       free(p_ctx->rados_poolname);
+   }
+
+   if (p_ctx->rados_id) {
+      free(p_ctx->rados_id);
    }
 
    if (p_ctx->rados_conffile) {
@@ -647,6 +654,9 @@ static bRC parse_plugin_definition(bpContext *ctx, void *value)
             case argument_conffile:
                str_destination = &p_ctx->rados_conffile;
                break;
+            case argument_id:
+               str_destination = &p_ctx->rados_id;
+               break;
             case argument_poolname:
                str_destination = &p_ctx->rados_poolname;
                break;
@@ -710,7 +720,7 @@ static bRC connect_to_rados(bpContext *ctx)
     * See if we need to initialize the cluster connection.
     */
    if (!p_ctx->cluster_initialized) {
-      status = rados_create(&p_ctx->cluster, NULL);
+      status = rados_create(&p_ctx->cluster, p_ctx->rados_id);
       if (status < 0) {
          berrno be;
 

--- a/src/plugins/filed/rados-fd.c
+++ b/src/plugins/filed/rados-fd.c
@@ -36,9 +36,9 @@ static const int dbglvl = 150;
 #define PLUGIN_VERSION      "1"
 #define PLUGIN_DESCRIPTION  "Bareos CEPH rados File Daemon Plugin"
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
-#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
+#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:clientid=<client_id>:poolname=<pool_name>:namespace=<name_space>:snapshotname=<snapshot_name>:"
 #else
-#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:id=<client_id>:poolname=<pool_name>:snapshotname=<snapshot_name>:"
+#define PLUGIN_USAGE        "rados:conffile=<ceph_conf_file>:clientid=<client_id>:poolname=<pool_name>:snapshotname=<snapshot_name>:"
 #endif
 
 /*
@@ -124,7 +124,7 @@ struct plugin_ctx {
    char *plugin_options;
    uint32_t JobId;
    char *rados_conffile;
-   char *rados_id;
+   char *rados_clientid;
    char *rados_poolname;
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    char *rados_namespace;
@@ -150,7 +150,7 @@ enum plugin_argument_type {
    argument_none,
    argument_conffile,
    argument_poolname,
-   argument_id,
+   argument_clientid,
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    argument_namespace,
 #endif
@@ -165,7 +165,7 @@ struct plugin_argument {
 static plugin_argument plugin_arguments[] = {
    { "conffile", argument_conffile },
    { "poolname", argument_poolname },
-   { "id", argument_id },
+   { "clientid", argument_clientid },
 #if defined(HAVE_RADOS_NAMESPACES) && defined(LIBRADOS_ALL_NSPACES)
    { "namespace", argument_namespace },
 #endif
@@ -282,8 +282,8 @@ static bRC freePlugin(bpContext *ctx)
       free(p_ctx->rados_poolname);
    }
 
-   if (p_ctx->rados_id) {
-      free(p_ctx->rados_id);
+   if (p_ctx->rados_clientid) {
+      free(p_ctx->rados_clientid);
    }
 
    if (p_ctx->rados_conffile) {
@@ -654,8 +654,8 @@ static bRC parse_plugin_definition(bpContext *ctx, void *value)
             case argument_conffile:
                str_destination = &p_ctx->rados_conffile;
                break;
-            case argument_id:
-               str_destination = &p_ctx->rados_id;
+            case argument_clientd:
+               str_destination = &p_ctx->rados_clientid;
                break;
             case argument_poolname:
                str_destination = &p_ctx->rados_poolname;
@@ -720,7 +720,7 @@ static bRC connect_to_rados(bpContext *ctx)
     * See if we need to initialize the cluster connection.
     */
    if (!p_ctx->cluster_initialized) {
-      status = rados_create(&p_ctx->cluster, p_ctx->rados_id);
+      status = rados_create(&p_ctx->cluster, p_ctx->rados_clientid);
       if (status < 0) {
          berrno be;
 

--- a/src/stored/backends/rados_device.c
+++ b/src/stored/backends/rados_device.c
@@ -38,6 +38,7 @@ enum device_option_type {
    argument_none = 0,
    argument_conffile,
    argument_poolname,
+   argument_id,
    argument_striped,
    argument_stripe_unit,
    argument_stripe_count
@@ -52,6 +53,7 @@ struct device_option {
 static device_option device_options[] = {
    { "conffile=", argument_conffile, 9 },
    { "poolname=", argument_poolname, 9 },
+   { "id=", argument_id, 9 },
 #ifdef HAVE_RADOS_STRIPER
    { "striped", argument_striped, 7 },
    { "stripe_unit=", argument_stripe_unit, 11 },
@@ -100,6 +102,10 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
                   m_rados_conffile = bp + device_options[i].compare_size;
                   done = true;
                   break;
+               case argument_id:
+                  m_rados_id = bp + device_options[i].compare_size;
+                  done = true;
+                  break;
                case argument_poolname:
                   m_rados_poolname = bp + device_options[i].compare_size;
                   done = true;
@@ -139,6 +145,11 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
          goto bail_out;
       }
 
+      if (!m_rados_id) {
+         Mmsg0(errmsg, _("No client id configured defaulting to admin\n"));
+         m_rados_id = bstrdup("admin");
+      }
+
       if (!m_rados_poolname) {
          Mmsg0(errmsg, _("No rados pool configured\n"));
          Emsg0(M_FATAL, 0, errmsg);
@@ -147,7 +158,7 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
    }
 
    if (!m_cluster_initialized) {
-      status = rados_create(&m_cluster, NULL);
+      status = rados_create(&m_cluster, m_rados_id);
       if (status < 0) {
          Mmsg1(errmsg, _("Unable to create RADOS cluster: ERR=%s\n"), be.bstrerror(-status));
          Emsg0(M_FATAL, 0, errmsg);
@@ -468,6 +479,7 @@ rados_device::rados_device()
    m_rados_configstring = NULL;
    m_rados_conffile = NULL;
    m_rados_poolname = NULL;
+   m_rados_id = NULL;
    m_cluster_initialized = false;
    m_ctx = NULL;
 #ifdef HAVE_RADOS_STRIPER

--- a/src/stored/backends/rados_device.c
+++ b/src/stored/backends/rados_device.c
@@ -38,7 +38,7 @@ enum device_option_type {
    argument_none = 0,
    argument_conffile,
    argument_poolname,
-   argument_id,
+   argument_clientid,
    argument_striped,
    argument_stripe_unit,
    argument_stripe_count
@@ -53,7 +53,7 @@ struct device_option {
 static device_option device_options[] = {
    { "conffile=", argument_conffile, 9 },
    { "poolname=", argument_poolname, 9 },
-   { "id=", argument_id, 9 },
+   { "clientid=", argument_clientid, 9 },
 #ifdef HAVE_RADOS_STRIPER
    { "striped", argument_striped, 7 },
    { "stripe_unit=", argument_stripe_unit, 11 },
@@ -102,8 +102,8 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
                   m_rados_conffile = bp + device_options[i].compare_size;
                   done = true;
                   break;
-               case argument_id:
-                  m_rados_id = bp + device_options[i].compare_size;
+               case argument_clientid:
+                  m_rados_clientid = bp + device_options[i].compare_size;
                   done = true;
                   break;
                case argument_poolname:
@@ -145,9 +145,9 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
          goto bail_out;
       }
 
-      if (!m_rados_id) {
+      if (!m_rados_clientid) {
          Mmsg0(errmsg, _("No client id configured defaulting to admin\n"));
-         m_rados_id = bstrdup("admin");
+         m_rados_clientid = bstrdup("admin");
       }
 
       if (!m_rados_poolname) {
@@ -158,7 +158,7 @@ int rados_device::d_open(const char *pathname, int flags, int mode)
    }
 
    if (!m_cluster_initialized) {
-      status = rados_create(&m_cluster, m_rados_id);
+      status = rados_create(&m_cluster, m_rados_clientid);
       if (status < 0) {
          Mmsg1(errmsg, _("Unable to create RADOS cluster: ERR=%s\n"), be.bstrerror(-status));
          Emsg0(M_FATAL, 0, errmsg);
@@ -479,7 +479,7 @@ rados_device::rados_device()
    m_rados_configstring = NULL;
    m_rados_conffile = NULL;
    m_rados_poolname = NULL;
-   m_rados_id = NULL;
+   m_rados_clientid = NULL;
    m_cluster_initialized = false;
    m_ctx = NULL;
 #ifdef HAVE_RADOS_STRIPER

--- a/src/stored/backends/rados_device.h
+++ b/src/stored/backends/rados_device.h
@@ -39,6 +39,7 @@ private:
    char *m_rados_configstring;
    char *m_rados_conffile;
    char *m_rados_poolname;
+   char *m_rados_id;
    bool m_cluster_initialized;
 #ifdef HAVE_RADOS_STRIPER
    bool m_stripe_volume;

--- a/src/stored/backends/rados_device.h
+++ b/src/stored/backends/rados_device.h
@@ -39,7 +39,7 @@ private:
    char *m_rados_configstring;
    char *m_rados_conffile;
    char *m_rados_poolname;
-   char *m_rados_id;
+   char *m_rados_clientid;
    bool m_cluster_initialized;
 #ifdef HAVE_RADOS_STRIPER
    bool m_stripe_volume;


### PR DESCRIPTION
Hi all,

thanks for adding ceph rados support to bareos! As it is right now, you have no other choice than to use the client.admin key on bareos, because there is no way to specify a client id for `rados_create()`. I've added a config option "id" where the user can specify a client id.

Since you are using `rados_create()` and not `rados_create2()` the value should be "admin", not "client.admin".

Cheers,
Christian