### PR TITLE
dbcheck: do not find empty path as bad.

### DIFF
--- a/src/dird/dbcheck.c
+++ b/src/dird/dbcheck.c
@@ -1298,7 +1298,7 @@ static void repair_bad_paths()
 
    printf(_("Checking for Paths without a trailing slash\n"));
    query = "SELECT PathId,Path from Path "
-           "WHERE Path NOT LIKE '%/'";
+           "WHERE Path NOT LIKE '%/' AND NOT NULL";
    if (verbose > 1) {
       printf("%s\n", query);
    }


### PR DESCRIPTION
In file src/cats/bvfs.c function bvfs_parent_dir return '\0' as root
path, but in file src/dird/dbcheck.c function repair_bad_paths check
is "WHERE Path NOT LIKE '%/'". That query always find "root" = NULL
as bad and always fix that.

Current patch change that query to "WHERE Path NOT LIKE '%/' AND NOT
NULL", which solves the problem.