### PR TITLE
fix imperformant sql query for 'list jobs last'

### DIFF
--- a/src/cats/sql_cmds.c
+++ b/src/cats/sql_cmds.c
@@ -96,6 +96,26 @@ const char *list_jobs =
    "%s "
    "ORDER BY StartTime%s";
 
+const char *list_jobs_last =
+   "SELECT DISTINCT "
+   "Job.JobId,Job.Name, "
+   "Client.Name as Client, "
+   "Job.StartTime,Job.Type,Job.Level,Job.JobFiles,Job.JobBytes,Job.JobStatus "
+   "FROM Job "
+   "LEFT JOIN Client ON Client.ClientId=Job.ClientId "
+   "LEFT JOIN JobMedia ON JobMedia.JobId=Job.JobId "
+   "LEFT JOIN Media ON JobMedia.MediaId=Media.MediaId "
+   "LEFT JOIN FileSet ON FileSet.FileSetId=Job.FileSetId "
+   "INNER JOIN ( "
+      "SELECT MAX(JobId) as JobId "
+      "FROM Job "
+      "GROUP BY Name "
+   ") LastJob "
+   "ON Job.JobId = LastJob.JobId "
+   "WHERE Job.JobId > 0 "
+   "%s "
+   "ORDER BY StartTime%s";
+
 const char *list_jobs_count =
    "SELECT DISTINCT "
    "COUNT(DISTINCT Job.JobId) as count "
@@ -130,21 +150,33 @@ const char *list_jobs_long =
    "%s "
    "ORDER BY StartTime%s";
 
-/*
- * Get the last JobId of each Job.Name matching the given criteria.
- */
-const char *list_jobs_last =
+const char *list_jobs_long_last =
    "SELECT DISTINCT "
-   "MAX(DISTINCT Job.JobId) as MaxJobId "
+   "Job.JobId, Job.Job, Job.Name, "
+   "Job.PurgedFiles, Job.Type, Job.Level, "
+   "Job.ClientId, Client.Name as Client, "
+   "Job.JobStatus,"
+   "Job.SchedTime, Job.StartTime, Job.EndTime, Job.RealEndTime, Job.JobTDate, "
+   "Job.VolSessionId, Job.VolSessionTime, "
+   "Job.JobFiles, Job.JobBytes, Job.JobErrors, Job.JobMissingFiles, "
+   "Job.PoolId, Pool.Name as PoolName,"
+   "Job.PriorJobId, "
+   "Job.FileSetId, FileSet.FileSet "
    "FROM Job "
    "LEFT JOIN Client ON Client.ClientId=Job.ClientId "
+   "LEFT JOIN Pool ON Pool.PoolId=Job.PoolId "
    "LEFT JOIN JobMedia ON JobMedia.JobId=Job.JobId "
    "LEFT JOIN Media ON JobMedia.MediaId=Media.MediaId "
    "LEFT JOIN FileSet ON FileSet.FileSetId=Job.FileSetId "
+   "INNER JOIN ( "
+      "SELECT MAX(JobId) as JobId "
+      "FROM Job "
+      "GROUP BY Name "
+   ") LastJob "
+   "ON Job.JobId = LastJob.JobId "
    "WHERE Job.JobId > 0 "
    "%s "
-   "GROUP BY Job.Name "
-   "%s";
+   "ORDER BY StartTime%s";
 
 const char *get_jobstatus_details =
    "SELECT DISTINCT "

--- a/src/cats/sql_cmds.h
+++ b/src/cats/sql_cmds.h
@@ -27,6 +27,7 @@ extern const char CATS_IMP_EXP *list_jobs;
 extern const char CATS_IMP_EXP *list_jobs_count;
 extern const char CATS_IMP_EXP *list_jobs_long;
 extern const char CATS_IMP_EXP *list_jobs_last;
+extern const char CATS_IMP_EXP *list_jobs_long_last;
 extern const char CATS_IMP_EXP *get_jobstatus_details;
 extern const char CATS_IMP_EXP *list_pool;
 extern const char CATS_IMP_EXP *drop_deltabs[];

--- a/src/cats/sql_list.c
+++ b/src/cats/sql_list.c
@@ -450,31 +450,15 @@ void db_list_job_records(JCR *jcr, B_DB *mdb, JOB_DBR *jr, const char *range,
       pm_strcat(selection, temp.c_str());
    }
 
-   if (last > 0) {
-      /*
-       * Show only the last run of a job (Job.Name).
-       * Do a subquery to get a list of matching JobIds
-       * to be used in the main query later.
-       *
-       * range: while it might be more efficient,
-       *        to apply the range to the subquery,
-       *        at least mariadb 10 does not support this.
-       *        Therefore range is handled in the main query.
-       */
-      temp.bsprintf("AND Job.JobId IN (%s) ", list_jobs_last);
-      selection_last.bsprintf(temp.c_str(), selection.c_str(), "");
-
-      /*
-       * As the existing selection is handled in the subquery,
-       * overwrite the main query selection
-       * by the newly created selection_last.
-       */
-      pm_strcpy(selection, selection_last.c_str());
-   }
-
    db_lock(mdb);
    if (count > 0) {
       Mmsg(mdb->cmd, list_jobs_count, selection.c_str(), range);
+   } else if (last > 0) {
+      if (type == VERT_LIST) {
+         Mmsg(mdb->cmd, list_jobs_long_last, selection.c_str(), range);
+      } else {
+         Mmsg(mdb->cmd, list_jobs_last, selection.c_str(), range);
+      }
    } else {
       if (type == VERT_LIST) {
          Mmsg(mdb->cmd, list_jobs_long, selection.c_str(), range);


### PR DESCRIPTION
This pull request fixes a really imperformant sql query for 'list jobs last' which is executed every time the webui dashboard is loaded.
On our production servers with mysql the query process time goes down from 10 minutes to 0.03 seconds.