### PR TITLE
plugins: Prevent segfault if plugin_list is null

### DIFF
--- a/src/lib/plugins.c
+++ b/src/lib/plugins.c
@@ -364,7 +364,10 @@ int list_plugins(alist *plugin_list, POOL_MEM &msg)
 {
    int i, len = 0;
    Plugin *plugin;
-
+   
+   if (!plugin_list) {
+      return 0;
+   }
    if (plugin_list->size() > 0) {
       pm_strcpy(msg, "Plugin Info:\n");
       foreach_alist_index(i, plugin, plugin_list) {


### PR DESCRIPTION
I admit I haven't taken the time to fully understand the code execution path around plugins.  I do not know if this is the correct fix to <>.  It does prevent bareos-sd from crashing on my system.

Fixes: https://bugs.bareos.org/view.php?id=662

Commit Message:
This storage daemon can call list_plugins when plugin_list is null.  This
commit adds a check to make sure the plugin_list variable is not null.