### PR TITLE
File size change should be treated as warning, not error.

### DIFF
--- a/src/findlib/attribs.c
+++ b/src/findlib/attribs.c
@@ -416,7 +416,7 @@ bool set_attributes(JCR *jcr, ATTR *attr, BFILE *ofd)
           fsize > 0 &&
           attr->statp.st_size > 0 &&
           fsize != (boffset_t)attr->statp.st_size) {
-         Jmsg3(jcr, M_ERROR, 0, _("File size of restored file %s not correct. Original %s, restored %s.\n"),
+         Jmsg3(jcr, M_WARNING, 0, _("File size of restored file %s not correct. Original %s, restored %s.\n"),
                attr->ofname, edit_uint64(attr->statp.st_size, ec1), edit_uint64(fsize, ec2));
       }
    } else {


### PR DESCRIPTION
File size change is treated as warning during backup, but as an error during restore. Backing up a live filesytem rather than a snapshot is often going to result in this behaviour and whilst not ideal, it isn't an error. I believe this should also be true for restore.