### PR TITLE
fix bug that bregex command cannot recongnise -l option

### DIFF
--- a/src/tools/bregex.c
+++ b/src/tools/bregex.c
@@ -87,7 +87,7 @@ int main(int argc, char *const *argv)
    bindtextdomain("bareos", LOCALEDIR);
    textdomain("bareos");
 
-   while ((ch = getopt(argc, argv, "d:f:n?")) != -1) {
+   while ((ch = getopt(argc, argv, "d:f:n:l?")) != -1) {
       switch (ch) {
       case 'd':                       /* set debug level */
          if (*optarg == 't') {

--- a/src/tools/bregex.c
+++ b/src/tools/bregex.c
@@ -87,7 +87,7 @@ int main(int argc, char *const *argv)
    bindtextdomain("bareos", LOCALEDIR);
    textdomain("bareos");
 
-   while ((ch = getopt(argc, argv, "d:f:n:l?")) != -1) {
+   while ((ch = getopt(argc, argv, "d:f:nl?")) != -1) {
       switch (ch) {
       case 'd':                       /* set debug level */
          if (*optarg == 't') {


### PR DESCRIPTION
recently I'm write document of bareos for my boss
before modify run bregex with -l option would got "./bregex: invalid option -- 'l'"
because of getopt(argc, argv, "d:f:n?") forgot the :l
thinks