### PR TITLE
fix cannot recongnition-l option

### DIFF
--- a/src/tools/bregex.c
+++ b/src/tools/bregex.c
@@ -87,7 +87,7 @@ int main(int argc, char *const *argv)
    bindtextdomain("bareos", LOCALEDIR);
    textdomain("bareos");
 
-   while ((ch = getopt(argc, argv, "d:f:n?")) != -1) {
+   while ((ch = getopt(argc, argv, "d:f:nl?")) != -1) {
       switch (ch) {
       case 'd':                       /* set debug level */
          if (*optarg == 't') {


### PR DESCRIPTION
before fix run bregex -l -f filename will got -----./bregex: invalid option -- 'l'
I'm sure the getopt function's parm has some mistake.
"d:f:nl?" option would work properly.