### PR TITLE
self.jobType in BareosDirPluginBaseclass should be a char, not int

### DIFF
--- a/src/plugins/dird/BareosDirPluginBaseclass.py
+++ b/src/plugins/dird/BareosDirPluginBaseclass.py
@@ -49,7 +49,7 @@ class BareosDirPluginBaseclass(object):
         # get some static Bareos values
         self.jobName = bareosdir.GetValue(context, brDirVariable['bDirVarJobName'])
         self.jobLevel = chr(bareosdir.GetValue(context, brDirVariable['bDirVarLevel']))
-        self.jobType = bareosdir.GetValue(context, brDirVariable['bDirVarType'])
+        self.jobType = chr(bareosdir.GetValue(context, brDirVariable['bDirVarType']))
         self.jobId = int(bareosdir.GetValue(context, brDirVariable['bDirVarJobId']))
         self.jobClient = bareosdir.GetValue(context, brDirVariable['bDirVarClient'])
         self.jobStatus = bareosdir.GetValue(context, brDirVariable['bDirVarJobStatus'])


### PR DESCRIPTION
Example:
for restore jobs self.jobType is 82, chr(82) is 'R'. It looks like bareosdir.GetValue(context, brDirVariable['bDirVarType']) should be chr'ed