### PR TITLE
Fix compilation with MariaDB 10.2

### DIFF
--- a/src/cats/mysql.c
+++ b/src/cats/mysql.c
@@ -156,6 +156,7 @@ bool B_DB_MYSQL::open_database(JCR *jcr)
 {
    bool retval = false;
    int errstat;
+   my_bool reconnect = 1;
 
    P(mutex);
    if (m_connected) {
@@ -200,7 +201,7 @@ bool B_DB_MYSQL::open_database(JCR *jcr)
       bmicrosleep(5,0);
    }
 
-   m_instance.reconnect = 1;             /* so connection does not timeout */
+   mysql_options(&m_instance, MYSQL_OPT_RECONNECT, &reconnect);    /* so connection does not timeout */
    Dmsg0(50, "mysql_real_connect done\n");
    Dmsg3(50, "db_user=%s db_name=%s db_password=%s\n", m_db_user, m_db_name,
         (m_db_password == NULL) ? "(NULL)" : m_db_password);


### PR DESCRIPTION
Hi,

bareos does not seem to compile with MariaDB 10.2 on Fedora 27 because of

```
mysql.c: In member function 'virtual bool B_DB_MYSQL::db_open_database(JCR*)':
mysql.c:194:15: error: 'MYSQL {aka struct st_mysql}' has no member named 'reconnect'
    m_instance.reconnect = 1;             /* so connection does not timeout */
               ^~~~~~~~~
make[1]: *** [Makefile:205: mysql.lo] Error 1
```
It looks like the same bug as described here: https://bugzilla.redhat.com/show_bug.cgi?id=1467706

Please have a look at the commit. With the new mysql.c file bareos compiles fine on Fedora 27 with MariaDB 10.2 for me.

Thank you!

Best regards,
Paul



