### PR TITLE
remove duplicate index identified by pt-duplicate-key-checker

### DIFF
--- a/src/cats/ddl/creates/mysql.sql
+++ b/src/cats/ddl/creates/mysql.sql
@@ -369,8 +369,6 @@ CREATE TABLE PathVisibility
    Files int4 DEFAULT 0,
    CONSTRAINT pathvisibility_pkey PRIMARY KEY (JobId, PathId)
 );
-CREATE INDEX pathvisibility_jobid
-	     ON PathVisibility (JobId);
 
 CREATE TABLE Version (
    VersionId INTEGER UNSIGNED NOT NULL

--- a/src/cats/ddl/updates/mysql.11_12.sql
+++ b/src/cats/ddl/updates/mysql.11_12.sql
@@ -33,8 +33,6 @@ CREATE TABLE PathVisibility
       Files int4 DEFAULT 0,
       CONSTRAINT pathvisibility_pkey PRIMARY KEY (JobId, PathId)
 );
-CREATE INDEX pathvisibility_jobid
-	     ON PathVisibility (JobId);
 
 CREATE INDEX basefiles_jobid_idx ON BaseFiles ( JobId );
 


### PR DESCRIPTION
identified by Percona Toolkit:

```
pathvisibility_jobid is a left-prefix of PRIMARY
 Key definitions:
   KEY `pathvisibility_jobid` (`JobId`)
   PRIMARY KEY (`JobId`,`PathId`),
 Column types:
	  `jobid` int(11) not null
	  `pathid` int(11) not null
```