### PR TITLE
Fix Univention bareos-dir-restart script

### DIFF
--- a/platforms/univention/bareos-dir-restart
+++ b/platforms/univention/bareos-dir-restart
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-su - bareos -s /bin/sh -c "/usr/sbin/bareos-dir -t" && service bareos-dir restart
+su - bareos -s /bin/sh -c "/usr/sbin/bareos-dir -t" && /usr/sbin/service bareos-dir restart
 exit $?
 


### PR DESCRIPTION
Add missing absolute path to service command. Otherwise it fails with
/usr/share/univention-bareos/bareos-dir-restart: 3: /usr/share/univention-bareos/bareos-dir-restart: service: not found