### PR TITLE
Fix link to documentation and bconsole typo

### DIFF
--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1030,7 +1030,7 @@ static void DoEnDisableCmd(UaContext *ua, bool setting)
       }
 
       if (!sched) {
-         ua->ErrorMsg(_("Client \"%s\" not found.\n"), ua->argv[i]);
+         ua->ErrorMsg(_("Schedule \"%s\" not found.\n"), ua->argv[i]);
          return;
       }
    } else {


### PR DESCRIPTION
First commit fixes #727: wrong error message in disable schedule
Description: Disabling a non-existent schedule over bconsole no longer
throws "Client not found" error, now it is "Schedule not found"

Second commit fixes a documentation link mentioned [here](https://groups.google.com/forum/#!topic/bareos-users/0EIy1hCJcac), where a fuzzy directory structure would throw a non-existent link.