### PR TITLE
fixed height in RunningJobs.phtml only shows 3 jobs

### DIFF
--- a/webui/module/Dashboard/view/partial/RunningJobs.phtml
+++ b/webui/module/Dashboard/view/partial/RunningJobs.phtml
@@ -33,7 +33,7 @@
          </h3>
       </div>
 
-      <div class="panel-body" style="height: 450px; overflow-y: scroll;">
+      <div class="panel-body">
          <div class="running-jobs-container"></div>
       </div>
 


### PR DESCRIPTION
Why does this panel had an fixed height?
Only 3 jobs fitted in there.
If you run more than 3 jobs you need to scroll...

I'd rather scroll the whole page than just the box.