### PR TITLE
webui: rename selenium test, fix exception import

### DIFF
--- a/core/platforms/win32/winbareos-nsi.spec
+++ b/core/platforms/win32/winbareos-nsi.spec
@@ -212,7 +212,7 @@ for flavor in %{flavors}; do
       cp /etc/bareos-webui/*.ini install
       cp -av /etc/bareos install
       mkdir -p tests/selenium
-      cp /usr/share/doc/packages/bareos-webui/selenium/webui-selenium-test.py tests/selenium
+      cp /usr/share/doc/packages/bareos-webui/selenium/WebuiSeleniumTest.py tests/selenium
 
       echo "" >> %_sourcedir/LICENSE
       echo "##### LICENSE FILE OF BAREOS_WEBUI START #####" >> %_sourcedir/LICENSE

--- a/webui/tests/selenium/README.md
+++ b/webui/tests/selenium/README.md
@@ -36,11 +36,11 @@ BAREOS_CLIENT_NAME=bareos-fd
 BAREOS_RESTOREFILE=/etc/passwd
 BAREOS_LOG_PATH=/tmp/selenium-logs/
 BAREOS_DELAY=1
-python webui-selenium-test.py -v
+python WebuiSeleniumTest.py -v
 ```
 
 After setting the environment variables you can run the test. Use `-v`option of our test to show the progress and results of each test.
 
 ## Debugging
 
-After the test fails you will see an exception that was thrown. If this does not help you, take a look inside the generated log file, located in the same path as your `webui-selenium-test.py` file.
+After the test fails you will see an exception that was thrown. If this does not help you, take a look inside the generated log file, located in the same path as your `WebuiSeleniumTest.py` file.


### PR DESCRIPTION
Renames the selenium test to fix the import of exceptions in the same file. Python does not allow '-' dashes in import names.

Also enhances the test for available languages in login.
We used to test against a list of expected languages, now we iterate over the directories in public/js/locale and compare that counter against the present options while logging in.