### PR TITLE
Updated compiler flags to correct spelling

### DIFF
--- a/core/debian/rules
+++ b/core/debian/rules
@@ -37,11 +37,11 @@ define CONFIGURE_COMMON
   -Dconfigtemplatedir=/usr/lib/bareos/defaultconfigs \
   -Dscriptdir=/usr/lib/bareos/scripts \
   -Dplugindir=/usr/lib/bareos/plugins \
-  -Dworking-dir=/var/lib/bareos \
-  -Dpid-dir=/var/lib/bareos \
+  -Dworkingdir=/var/lib/bareos \
+  -Dpiddir=/var/lib/bareos \
   -Dbsrdir=/var/lib/bareos \
   -Dlogdir=/var/log/bareos \
-  -Dsubsys-dir=/var/lock \
+  -Dsubsysdir=/var/lock \
   -Dsmartalloc=yes \
   -Ddisable-conio=yes \
   -Dreadline=yes \

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -743,12 +743,12 @@ cmake  .. \
   -Darchivedir=/var/lib/%{name}/storage \
   -Dbackenddir=%{backend_dir} \
   -Dscriptdir=%{script_dir} \
-  -Dworking-dir=%{working_dir} \
+  -Dworkingdir=%{working_dir} \
   -Dplugindir=%{plugin_dir} \
-  -Dpid-dir=%{pid_dir} \
+  -Dpiddir=%{pid_dir} \
   -Dbsrdir=%{bsr_dir} \
   -Dlogdir=/var/log/bareos \
-  -Dsubsys-dir=%{_subsysdir} \
+  -Dsubsysdir=%{_subsysdir} \
 %if 0%{?python_plugins}
   -Dpython=yes \
 %endif


### PR DESCRIPTION
Compiler flags were labelled incorrectly and thus not recognized by the compiler. This didn't show up as an error, as the installation was able to correctly finish anyway. However, specifying the directories was not possible in usecases where it was required.

Additional flags are not being used, although they might have to be:

```
[  192s] CMake Warning:
[  192s]   Manually-specified variables were not used by the project:
[  192s] 
[  192s]     CMAKE_EXPORT_NO_PACKAGE_REGISTRY
[  192s]     bat
[  192s]     disable-conio
[  192s]     includes
[  192s]     pid-dir
[  192s]     python
[  192s]     readline
[  192s]     rpath
[  192s]     sbin-perm
[  192s]     subsys-dir
[  192s]     tcp-wrappers
[  192s]     working-dir
[  192s]     xattr
```
(seen in our internal build log)


Further inspection of 
```
core/platforms/packaging/bareos.spec
core/debian/rules
core/cmake/BareosSetVariableDefaults.cmake
```
yielded:
```rpath``` is not mentioned in neither ```core/cmake/BareosSetVariableDefaults.cmake``` or ```core/platforms/packaging/bareos.spec```
