### PR TITLE
webui: fix invalid url generated in first job

### DIFF
--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -359,7 +359,8 @@ class JobController extends AbstractActionController
                $this->bsock->disconnect();
                $s = strrpos($result, "=") + 1;
                $jobid = rtrim( substr( $result, $s ) );
-               return $this->redirect()->toRoute('job', array('action' => 'details', 'id' => $jobid));
+	       preg_match("'\d{1,99}(?=%)?'", $jobid, $filtered);
+               return $this->redirect()->toRoute('job', array('action' => 'details', 'id' => $filtered[0]));
             }
             catch(Exception $e) {
                echo $e->getMessage();


### PR DESCRIPTION
When you start the first job over the webui, a wrong-formatted URL was generated. By filtering for a number, preceded by a slash as well as optional trailing characters, we make sure that only the job id makes it into the URL.

Fixes #974: Submitting job jumps to invalid site