### PR TITLE
Fix d'tor out by one error

### DIFF
--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -137,7 +137,7 @@ ConfigurationParser::ConfigurationParser(
 }
 
 ConfigurationParser::~ConfigurationParser() {
-   for (int i = r_first_; i<= r_last_; i++) {
+   for (int i = r_first_; i< r_last_; i++) {
       FreeResource(res_head_[i-r_first_], i);
       res_head_[i-r_first_] = NULL;
    }


### PR DESCRIPTION
This corrects an out by one error that causes a crash at shutdown and at configuration reload. See bug #0000996