### PR TITLE
webui: fix restore tree for directories without subdirs

### DIFF
--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -358,7 +358,7 @@ class RestoreController extends AbstractActionController
             }
          }
 
-         if($fnum > 0) {
+         if($tmp > 0 && $fnum > 0) {
             $items .= ",";
          }
 


### PR DESCRIPTION
Fixes the generation of a bad JSON if a directory has no subdirs or is completely empty.
The bad JSON would break the JTree, forcing the user to reload.

Fixes #973: WEBUI Restore Too Many Files error caused by bad JSON [issue present at least from 17.2.4]