### PR TITLE
ignore running- and canceled-jobs when looking for failed jobs

### DIFF
--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -209,7 +209,7 @@ bool BareosDb::FindFailedJobSince(JobControlRecord *jcr, JobDbRecord *jr, POOLME
 
    /* Differential is since last Full backup */
    Mmsg(cmd,
-"SELECT Level FROM Job WHERE JobStatus NOT IN ('T','W') AND "
+"SELECT Level FROM Job WHERE JobStatus NOT IN ('T','W','A','R') AND "
 "Type='%c' AND Level IN ('%c','%c') AND Name='%s' AND ClientId=%s "
 "AND FileSetId=%s AND StartTime>'%s' "
 "ORDER BY StartTime DESC LIMIT 1",


### PR DESCRIPTION
I have an issue with backup jobs constantly being upgraded from INC to FULL even if an actual successful FULL backup is available.

My setup is the following - a backup job that is:

* basically performed hourly (INCs)
* at 1:05 a FULL is in the schedule as shown below

```
Schedule {
  Name = "JobCycleSql"
  run = Full at 01:05
  run = Incremental at 00:05
at 01:05
at 02:05
...
at 23:05
}
```

* Additionally I have configured canceling of duplicate and/or lower-level jobs:

```
Cancel Lower Level Duplicates = yes
Cancel Queued Duplicates = yes
```

---

Considering the following situation:

* The FULL backup starts as planed at 1:05. Because of out-of-scope circumstances, the FULL backup takes longer than one hour.
* The scheduler kicks another backup job at 2:05. According to the schedule it should be an INC, but gets upgraded to a FULL,
  because no previous, successful FULL backup is available (in cases of the very first FULL backup or there was an issue with the last FULL backup).
  Before the 2:05 job gets actually run, it's canceled because of Cancel-Queued-Duplicates is enabled - as the 1:05 FULL backup job has not yet finished. The canceled job remains in the Job table as FULL with state 'A'.

```
| 3,254 | db-sql | db-fd | 2018-10-07 02:05:00 | B    | F     |        0 |              0 | A         |
```

* Between 2:05 and 3:05 the 1:05 FULL job at some time finishes successfully.

```
| 3,251 | db-sql | db-fd | 2018-10-07 01:05:01 | B    | F     |       17 | 37,341,086,992 | T         |
```

* At 3:05, the scheduler triggers another backup job that should be an INC.
  The director checks, if there has been a successful FULL backup before.

```
bareos-dir (100): cats/sql_query.cc:124-0 called: bool BareosDb::SqlQuery(const char*, int) with query SELECT StartTime, Job FROM Job WHERE JobStatus IN ('T','W') AND Type='B' AND Level IN ('I','D','F') AND Name='db-sql' AND ClientId=13 AND FileSetId=3 ORDER BY StartTime DESC LIMIT 1
# this will return the successful FULL from 1:05

bareos-dir (100): cats/sql_find.cc:130-0 Got start time: 2018-10-07 01:05:00, job: db-sql.2018-10-07_01.05.00_14
bareos-dir (100): cats/sql_query.cc:124-0 called: bool BareosDb::SqlQuery(const char*, int) with query SELECT StartTime, Job FROM Job WHERE JobStatus IN ('T','W') AND Type='B' AND Level='F' AND Name='db-sql' AND ClientId=13 AND FileSetId=3 ORDER BY StartTime DESC LIMIT 1
# this will return the successful  FULL from 1:05

bareos-dir (100): cats/sql_find.cc:180-0 Got start time: 2018-10-07 01:05:00
bareos-dir (50): dird/job.cc:1136-0 have_full=1 do_full=0 now=1538874301 full_time=1538867100

bareos-dir (100): cats/sql_query.cc:124-0 called: bool BareosDb::SqlQuery(const char*, int) with query SELECT Level FROM Job WHERE JobStatus NOT IN ('T','W') AND Type='B' AND Level IN ('F','D') AND Name='db-sql' AND ClientId=13 AND FileSetId=3 AND StartTime>'2018-10-07 01:05:00' ORDER BY StartTime DESC LIMIT 1
# this will return the canceled job at 2:05 as it was upgraded to a FULL

bareos-dir (100): cats/sql_query.cc:124-0 called: bool BareosDb::SqlQuery(const char*, int) with query INSERT INTO Log (JobId, Time, LogText) VALUES (3268,'2018-10-07 08:56:09','bareos-dir JobId 3268: Prior failed job found in catalog. Upgrading to Full.')
# director has decided to upgrade the INC to FULL
```

As shown above the thing is, that the job from 2:05 - that was upgraded from INC to FULL but then **canceled** (state A) - is being taken into account and used to decide upgrading the 3:05 INC to a FULL - even if the 1:05 FULL has finished successfully - but as the query contains `ORDER BY StartTime DESC`, the 2:05 has been returned as the first result.

* Now again the upgraded 3:05 FULL backup takes longer than one hour.
* The scheduler trigger 4:05 INC, it detects that the last FULL backup (2:05, seen from `ORDER BY StartTime DESC`) was unsuccessful (state A) and the 3:05 FULL backup has not finished yet - so it upgrades the 4:05 INC to FULL, but cancels it because of Cancel-Queued-Duplicates.
* The 3:05 FULL finishes at some time before 5:05 successfully.
* The 5:05 job gets started, `BareosDb::FindFailedJobSince()` returns the canceled 4:05 FULL job - the 5:05 gets upgraded to a FULL backup as well.
* and so on


This leads then to the following job log

```
| 3,248 | db-sql | db-fd | 2018-10-07 00:05:01 | B    | I     |        2 |     68,891,904 | T         |
| 3,251 | db-sql | db-fd | 2018-10-07 01:05:01 | B    | F     |       17 | 37,341,086,992 | T         |
| 3,252 | db-sql | db-fd | 2018-10-07 01:05:01 | B    | I     |        0 |              0 | A         |
| 3,254 | db-sql | db-fd | 2018-10-07 02:05:00 | B    | F     |        0 |              0 | A         |
| 3,256 | db-sql | db-fd | 2018-10-07 03:05:01 | B    | F     |       17 | 37,343,171,360 | T         |
| 3,258 | db-sql | db-fd | 2018-10-07 04:05:00 | B    | F     |        0 |              0 | A         |
| 3,260 | db-sql | db-fd | 2018-10-07 05:05:00 | B    | F     |       17 | 37,341,096,448 | T         |
| 3,262 | db-sql | db-fd | 2018-10-07 06:05:00 | B    | F     |        0 |              0 | A         |
| 3,264 | db-sql | db-fd | 2018-10-07 07:05:00 | B    | F     |       17 | 37,342,472,704 | T         |
| 3,266 | db-sql | db-fd | 2018-10-07 08:05:00 | B    | F     |        0 |              0 | A         |
| 3,270 | db-sql | db-fd | 2018-10-07 09:05:01 | B    | F     |        0 |              0 | R         |
````


To get rid of this, I adapted the SQL query in `BareosDb::FindFailedJobSince()` as shown in this pull requests by filtering out running (R) and canceled (A) states.

I did this because for finding the latest failed backup neither a running- nor a canceled-job have a designated result.

It helps in my situation and fixes the above described issue. Obviously I do not have that deep insight into Bareos's internals and do not know if my change has side-effects.

Another solution could be ordering by `EndTime` instead of `StartTime`, so that the successful finished FULL backup precedes in the result before the canceled, upgraded one.