### PR TITLE
if compiled with glusterfs support, link the gfapi-fd plugin to the gfapi library

### DIFF
--- a/core/src/plugins/filed/CMakeLists.txt
+++ b/core/src/plugins/filed/CMakeLists.txt
@@ -90,6 +90,7 @@ if(${HAVE_GLUSTERFS})
    add_library(gfapi-fd MODULE gfapi-fd.cc)
    set_target_properties(gfapi-fd PROPERTIES PREFIX "")
    INSTALL(TARGETS gfapi-fd DESTINATION ${plugindir})
+   target_link_libraries(gfapi-fd gfapi)
 endif()
 
 if (${HAVE_TEST_PLUGIN})


### PR DESCRIPTION
Linking the gfapi-fd plugin against Gluster's gfapi library on building Bareos must have been lost at some point. This MR adds it back to `src/plugins/filed/CMakeLists.txt` to make the plugin functional again - otherwise it fails with unresolved-symbol errors as soon as it gets loaded by the _filedaemon_.