### PR TITLE
Fixed error installation on non standard postgres db port

### DIFF
--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -270,7 +270,8 @@ ${EndIf}
       LogEx::Write "PostgresPath=$PostgresPath"
 
 
-    # set postgres username and password in environment
+    # set postgres port, username and password in environment
+    System::Call 'kernel32::SetEnvironmentVariable(t "PGPORT", t "$DbPort")i.r0'
     System::Call 'kernel32::SetEnvironmentVariable(t "PGUSER", t "$DbAdminUser")i.r0'
     System::Call 'kernel32::SetEnvironmentVariable(t "PGPASSWORD", t "$DbAdminPassword")i.r0'
 


### PR DESCRIPTION
Installation script are missing from `PGPORT` environment setup. That's why it's can't install bareos on systems with non standard postgres port. User gets error about connection problem and can't continue to install. That's PR will fix that error.