### PR TITLE
add missing leading slash to logdir

### DIFF
--- a/core/cmake/BareosSetVariableDefaults.cmake
+++ b/core/cmake/BareosSetVariableDefaults.cmake
@@ -121,7 +121,7 @@ ENDIF()
 
 # logdir
 IF(NOT DEFINED logdir)
-   set(logdir "${CMAKE_INSTALL_LOCALSTATEDIR}/log/${CMAKE_PROJECT_NAME}")
+   set(logdir "/${CMAKE_INSTALL_LOCALSTATEDIR}/log/${CMAKE_PROJECT_NAME}")
 ENDIF()
 
 # datarootdir


### PR DESCRIPTION
This comment add a leading slash to the logdir-Path that is currently missing (cmake output will list only "var/log/bareos" instead of "/var/log/bareos" without the patch