### PR TITLE
stored: do not treat read error as EoT by default

### DIFF
--- a/src/stored/backends/generic_tape_device.c
+++ b/src/stored/backends/generic_tape_device.c
@@ -1402,7 +1402,7 @@ bool generic_tape_device::reposition(DCR *dcr, uint32_t rfile, uint32_t rblock)
       return fsr(rblock-block_num);
    } else {
       while (rblock > block_num) {
-         if (!dcr->read_block_from_dev(NO_BLOCK_NUMBER_CHECK)) {
+         if (Ok != dcr->read_block_from_dev(NO_BLOCK_NUMBER_CHECK)) {
             berrno be;
             dev_errno = errno;
             Dmsg2(30, "Failed to find requested block on %s: ERR=%s", prt_name, be.bstrerror());

--- a/src/stored/bls.c
+++ b/src/stored/bls.c
@@ -291,13 +291,15 @@ static void do_blocks(char *infname)
    DEV_BLOCK *block = dcr->block;
    char buf1[100], buf2[100];
    for ( ;; ) {
-      if (!dcr->read_block_from_device(NO_BLOCK_NUMBER_CHECK)) {
-         Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
-         if (dev->at_eot()) {
+      switch(dcr->read_block_from_device(NO_BLOCK_NUMBER_CHECK)) {
+         case Ok:
+            // no special handling required
+            break;
+         case EndOfTape:
             if (!mount_next_read_volume(dcr)) {
                Jmsg(jcr, M_INFO, 0, _("Got EOM at file %u on device %s, Volume \"%s\"\n"),
                   dev->file, dev->print_name(), dcr->VolumeName);
-               break;
+               return;
             }
             /* Read and discard Volume label */
             DEV_RECORD *record;
@@ -307,19 +309,22 @@ static void do_blocks(char *infname)
             get_session_record(dev, record, &sessrec);
             free_record(record);
             Jmsg(jcr, M_INFO, 0, _("Mounted Volume \"%s\".\n"), dcr->VolumeName);
-         } else if (dev->at_eof()) {
+            break;
+         case EndOfFile:
             Jmsg(jcr, M_INFO, 0, _("End of file %u on device %s, Volume \"%s\"\n"),
                dev->file, dev->print_name(), dcr->VolumeName);
             Dmsg0(20, "read_record got eof. try again\n");
             continue;
-         } else if (dev->is_short_block()) {
-            Jmsg(jcr, M_INFO, 0, "%s", dev->errmsg);
-            continue;
-         } else {
-            /* I/O error */
-            display_tape_error_status(jcr, dev);
-            break;
-         }
+         default:
+            Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
+            if (dev->is_short_block()) {
+               Jmsg(jcr, M_INFO, 0, "%s", dev->errmsg);
+               continue;
+            } else {
+               /* I/O error */
+               display_tape_error_status(jcr, dev);
+               return;
+            }
       }
       if (!match_bsr_block(bsr, block)) {
          Dmsg5(100, "reject Blk=%u blen=%u bVer=%d SessId=%u SessTim=%u\n",

--- a/src/stored/dev.h
+++ b/src/stored/dev.h
@@ -75,6 +75,16 @@ enum {
 };
 
 /**
+ * Return values for read_block_from_device()
+ */
+enum ReadStatus {
+   Error = 0,
+   Ok,
+   EndOfFile,
+   EndOfTape,
+};
+
+/**
  * Arguments to open_dev()
  */
 enum {
@@ -753,8 +763,8 @@ public:
     */
    bool write_block_to_device();
    bool write_block_to_dev();
-   bool read_block_from_device(bool check_block_numbers);
-   bool read_block_from_dev(bool check_block_numbers);
+   ReadStatus read_block_from_device(bool check_block_numbers);
+   ReadStatus read_block_from_dev(bool check_block_numbers);
 
    /*
     * Methods in label.c

--- a/src/stored/label.c
+++ b/src/stored/label.c
@@ -140,7 +140,7 @@ int read_dev_volume_label(DCR *dcr)
    empty_block(dcr->block);
 
    Dmsg0(130, "Big if statement in read_volume_label\n");
-   if (!dcr->read_block_from_dev(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->read_block_from_dev(NO_BLOCK_NUMBER_CHECK)) {
       Mmsg(jcr->errmsg, _("Requested Volume \"%s\" on %s is not a Bareos "
            "labeled Volume, because: ERR=%s"), NPRT(VolName),
            dev->print_name(), dev->print_errmsg());

--- a/src/stored/read_record.c
+++ b/src/stored/read_record.c
@@ -178,7 +178,7 @@ void read_context_set_record(DCR *dcr, READ_CTX *rctx)
  *
  * Returns:  true on success
  *           false on error
- *
+ e
  * Any fatal error sets the status bool to false.
  */
 bool read_next_block_from_device(DCR *dcr,
@@ -191,8 +191,11 @@ bool read_next_block_from_device(DCR *dcr,
    DEV_RECORD *trec;
 
    while (1) {
-      if (!dcr->read_block_from_device(CHECK_BLOCK_NUMBERS)) {
-         if (dcr->dev->at_eot()) {
+      switch(dcr->read_block_from_device(CHECK_BLOCK_NUMBERS)) {
+         case Ok:
+            // no handling required if read was successful
+            break;
+         case EndOfTape:
             Jmsg(jcr, M_INFO, 0, _("End of Volume at file %u on device %s, Volume \"%s\"\n"),
                  dcr->dev->file, dcr->dev->print_name(), dcr->VolumeName);
 
@@ -239,26 +242,27 @@ bool read_next_block_from_device(DCR *dcr,
              * After reading label, we must read first data block
              */
             continue;
-         } else if (dcr->dev->at_eof()) {
+         case EndOfFile:
             Dmsg3(200, "End of file %u on device %s, Volume \"%s\"\n",
                   dcr->dev->file, dcr->dev->print_name(), dcr->VolumeName);
             continue;
-         } else if (dcr->dev->is_short_block()) {
-            Jmsg1(jcr, M_ERROR, 0, "%s", dcr->dev->errmsg);
-            continue;
-         } else {
-            /*
-             * I/O error or strange end of tape
-             */
-            display_tape_error_status(jcr, dcr->dev);
-            if (forge_on || jcr->ignore_label_errors) {
-               dcr->dev->fsr(1);           /* try skipping bad record */
-               Pmsg0(000, _("Did fsr in attemp to skip bad record.\n"));
+         default:
+            if (dcr->dev->is_short_block()) {
+               Jmsg1(jcr, M_ERROR, 0, "%s", dcr->dev->errmsg);
                continue;
+            } else {
+               /*
+                * I/O error or strange end of tape
+                */
+               display_tape_error_status(jcr, dcr->dev);
+               if (forge_on || jcr->ignore_label_errors) {
+                  dcr->dev->fsr(1);           /* try skipping bad record */
+                  Pmsg0(000, _("Did fsr in attemp to skip bad record.\n"));
+                  continue;
+               }
+               *status = false;
+               return false;
             }
-            *status = false;
-            return false;
-         }
       }
 
       Dmsg2(dbglvl, "Read new block at pos=%u:%u\n", dcr->dev->file, dcr->dev->block_num);

--- a/src/stored/read_record.c
+++ b/src/stored/read_record.c
@@ -178,7 +178,7 @@ void read_context_set_record(DCR *dcr, READ_CTX *rctx)
  *
  * Returns:  true on success
  *           false on error
- e
+ *
  * Any fatal error sets the status bool to false.
  */
 bool read_next_block_from_device(DCR *dcr,

--- a/src/stored/stored_conf.c
+++ b/src/stored/stored_conf.c
@@ -205,7 +205,9 @@ static RES_ITEM dev_items[] = {
    { "AutoDeflateLevel", CFG_TYPE_PINT16, ITEM(res_dev.autodeflate_level), 0, CFG_ITEM_DEFAULT, "6", "13.4.0-", NULL },
    { "AutoInflate", CFG_TYPE_IODIRECTION, ITEM(res_dev.autoinflate), 0, 0, NULL, "13.4.0-", NULL },
    { "CollectStatistics", CFG_TYPE_BOOL, ITEM(res_dev.collectstats), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL },
-   { "EofOnErrorIsEot", CFG_TYPE_BOOL, ITEM(res_dev.eof_on_error_is_eot), 0, CFG_ITEM_DEFAULT, NULL, NULL, NULL },
+   { "EofOnErrorIsEot", CFG_TYPE_BOOL, ITEM(res_dev.eof_on_error_is_eot), 0, CFG_ITEM_DEFAULT, NULL, "17.2.8-",
+     "If Yes, Bareos will treat any read error at an end-of-file mark as end-of-tape. You should only set"
+     "this option if your tape-drive fails to detect end-of-tape while reading." },
    { NULL, 0, { 0 }, 0, 0, NULL, NULL, NULL }
 };
 

--- a/src/stored/stored_conf.c
+++ b/src/stored/stored_conf.c
@@ -205,6 +205,7 @@ static RES_ITEM dev_items[] = {
    { "AutoDeflateLevel", CFG_TYPE_PINT16, ITEM(res_dev.autodeflate_level), 0, CFG_ITEM_DEFAULT, "6", "13.4.0-", NULL },
    { "AutoInflate", CFG_TYPE_IODIRECTION, ITEM(res_dev.autoinflate), 0, 0, NULL, "13.4.0-", NULL },
    { "CollectStatistics", CFG_TYPE_BOOL, ITEM(res_dev.collectstats), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL },
+   { "EofOnErrorIsEot", CFG_TYPE_BOOL, ITEM(res_dev.eof_on_error_is_eot), 0, CFG_ITEM_DEFAULT, NULL, NULL, NULL },
    { NULL, 0, { 0 }, 0, 0, NULL, NULL, NULL }
 };
 

--- a/src/stored/stored_conf.h
+++ b/src/stored/stored_conf.h
@@ -138,6 +138,7 @@ public:
    bool drive_crypto_enabled;         /**< Enable hardware crypto */
    bool query_crypto_status;          /**< Query device for crypto status */
    bool collectstats;                 /**< Set if statistics should be collected */
+   bool eof_on_error_is_eot;          /**< Interpret EOF during read error as EOT */
    drive_number_t drive;              /**< Autochanger logical drive number */
    drive_number_t drive_index;        /**< Autochanger physical drive index */
    char cap_bits[CAP_BYTES];          /**< Capabilities of this device */


### PR DESCRIPTION
Fixes #1034: Read error on tape may be misinterpreted as end-of-tape
Previously stored treated a read-error immediately
following an end-of-file mark on a tape as end-of-tape
instead of an error.
This patch makes stored raise an error in this case,
but allows to switch back to the previous behaviour on
a per-device basis using the new configuration option
"Eof On Error Is Eot".