### PR TITLE
stored: do not treat read error as EoT by default

### DIFF
--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -1406,7 +1406,7 @@ bool generic_tape_device::Reposition(DeviceControlRecord *dcr, uint32_t rfile, u
       return fsr(rblock-block_num);
    } else {
       while (rblock > block_num) {
-         if (!dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
+         if (Ok != dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
             BErrNo be;
             dev_errno = errno;
             Dmsg2(30, "Failed to find requested block on %s: ERR=%s", prt_name, be.bstrerror());

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -306,13 +306,15 @@ static void DoBlocks(char *infname)
    DeviceBlock *block = dcr->block;
    char buf1[100], buf2[100];
    for ( ;; ) {
-      if (!dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
-         Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
-         if (dev->AtEot()) {
+      switch(dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
+         case Ok:
+            // no special handling required
+            break;
+         case EndOfTape:
             if (!MountNextReadVolume(dcr)) {
                Jmsg(jcr, M_INFO, 0, _("Got EOM at file %u on device %s, Volume \"%s\"\n"),
                   dev->file, dev->print_name(), dcr->VolumeName);
-               break;
+               return;
             }
             /* Read and discard Volume label */
             DeviceRecord *record;
@@ -322,19 +324,22 @@ static void DoBlocks(char *infname)
             GetSessionRecord(dev, record, &sessrec);
             FreeRecord(record);
             Jmsg(jcr, M_INFO, 0, _("Mounted Volume \"%s\".\n"), dcr->VolumeName);
-         } else if (dev->AtEof()) {
+            break;
+         case EndOfFile:
             Jmsg(jcr, M_INFO, 0, _("End of file %u on device %s, Volume \"%s\"\n"),
                dev->file, dev->print_name(), dcr->VolumeName);
             Dmsg0(20, "read_record got eof. try again\n");
             continue;
-         } else if (dev->IsShortBlock()) {
-            Jmsg(jcr, M_INFO, 0, "%s", dev->errmsg);
-            continue;
-         } else {
-            /* I/O error */
-            DisplayTapeErrorStatus(jcr, dev);
-            break;
-         }
+         default:
+            Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
+            if (dev->IsShortBlock()) {
+               Jmsg(jcr, M_INFO, 0, "%s", dev->errmsg);
+               continue;
+            } else {
+               /* I/O error */
+               DisplayTapeErrorStatus(jcr, dev);
+               return;
+            }
       }
       if (!MatchBsrBlock(bsr, block)) {
          Dmsg5(100, "reject Blk=%u blen=%u bVer=%d SessId=%u SessTim=%u\n",

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -878,7 +878,7 @@ static bool re_read_block_test()
       goto bail_out;
    }
    Pmsg0(0, _("Backspace record OK.\n"));
-   if (!dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
       BErrNo be;
       Pmsg1(0, _("Read block failed! ERR=%s\n"), be.bstrerror(dev->dev_errno));
       goto bail_out;
@@ -1251,7 +1251,7 @@ static bool write_read_test()
     */
    for (uint32_t i = 1; i <= 2 * num_recs; i++) {
 read_again:
-      if (!dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
+      if (Ok != dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
          BErrNo be;
          if (dev->AtEof()) {
             Pmsg0(-1, _("Got EOF on tape.\n"));
@@ -1369,7 +1369,7 @@ static bool position_test()
          goto bail_out;
       }
 read_again:
-      if (!dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
+      if (Ok != dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
          BErrNo be;
          if (dev->AtEof()) {
             Pmsg0(-1, _("Got EOF on tape.\n"));
@@ -2081,9 +2081,11 @@ static void scan_blocks()
    dev->UpdatePos(dcr);
    tot_files = dev->file;
    for (;;) {
-      if (!dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
-         Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
-         if (dev->AtEot()) {
+      switch(dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
+         case Ok:
+            // no special handling required
+            break;
+         case EndOfTape:
             if (blocks > 0) {
                if (blocks==1) {
                   printf(_("1 block of %d bytes in file %d\n"), block_size, dev->file);
@@ -2094,8 +2096,7 @@ static void scan_blocks()
                blocks = 0;
             }
             goto bail_out;
-         }
-         if (dev->AtEof()) {
+         case EndOfFile:
             if (blocks > 0) {
                if (blocks==1) {
                   printf(_("1 block of %d bytes in file %d\n"), block_size, dev->file);
@@ -2107,22 +2108,23 @@ static void scan_blocks()
             }
             printf(_("End of File mark.\n"));
             continue;
-         }
-         if (BitIsSet(ST_SHORT, dev->state)) {
-            if (blocks > 0) {
-               if (blocks==1) {
-                  printf(_("1 block of %d bytes in file %d\n"), block_size, dev->file);
+         default:
+            Dmsg1(100, "!read_block(): ERR=%s\n", dev->bstrerror());
+            if (BitIsSet(ST_SHORT, dev->state)) {
+               if (blocks > 0) {
+                  if (blocks==1) {
+                     printf(_("1 block of %d bytes in file %d\n"), block_size, dev->file);
+                  }
+                  else {
+                     printf(_("%d blocks of %d bytes in file %d\n"), blocks, block_size, dev->file);
+                  }
+                  blocks = 0;
                }
-               else {
-                  printf(_("%d blocks of %d bytes in file %d\n"), blocks, block_size, dev->file);
-               }
-               blocks = 0;
+               printf(_("Short block read.\n"));
+               continue;
             }
-            printf(_("Short block read.\n"));
-            continue;
-         }
-         printf(_("Error reading block. ERR=%s\n"), dev->bstrerror());
-         goto bail_out;
+            printf(_("Error reading block. ERR=%s\n"), dev->bstrerror());
+            goto bail_out;
       }
       if (block->block_len != block_size) {
          if (blocks > 0) {
@@ -2615,7 +2617,7 @@ static bool do_unfill()
       goto bail_out;
    }
    Pmsg1(-1, _("Reading block %u.\n"), last_block_num);
-   if (!dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
       Pmsg1(-1, _("Error reading block: ERR=%s\n"), dev->bstrerror());
       goto bail_out;
    }
@@ -2667,7 +2669,7 @@ static bool do_unfill()
       goto bail_out;
    }
    Pmsg1(-1, _("Reading block %d.\n"), dev->block_num);
-   if (!dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
       Pmsg1(-1, _("Error reading block: ERR=%s\n"), dev->bstrerror());
       goto bail_out;
    }
@@ -2683,7 +2685,7 @@ static bool do_unfill()
       goto bail_out;
    }
    Pmsg1(-1, _("Reading block %d.\n"), dev->block_num);
-   if (!dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->ReadBlockFromDevice(NO_BLOCK_NUMBER_CHECK)) {
       Pmsg1(-1, _("Error reading block: ERR=%s\n"), dev->bstrerror());
       goto bail_out;
    }

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -83,6 +83,16 @@ enum {
 };
 
 /**
+ * Return values for ReadBlockFromDevice()
+ */
+enum ReadStatus {
+   Error = 0,
+   Ok,
+   EndOfFile,
+   EndOfTape,
+};
+
+/**
  * Arguments to open_dev()
  */
 enum {
@@ -755,8 +765,8 @@ public:
     */
    bool WriteBlockToDevice();
    bool WriteBlockToDev();
-   bool ReadBlockFromDevice(bool check_block_numbers);
-   bool ReadBlockFromDev(bool check_block_numbers);
+   ReadStatus ReadBlockFromDevice(bool check_block_numbers);
+   ReadStatus ReadBlockFromDev(bool check_block_numbers);
 
    /*
     * Methods in label.c

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -148,7 +148,7 @@ int ReadDevVolumeLabel(DeviceControlRecord *dcr)
    EmptyBlock(dcr->block);
 
    Dmsg0(130, "Big if statement in ReadVolumeLabel\n");
-   if (!dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
+   if (Ok != dcr->ReadBlockFromDev(NO_BLOCK_NUMBER_CHECK)) {
       Mmsg(jcr->errmsg, _("Requested Volume \"%s\" on %s is not a Bareos "
            "labeled Volume, because: ERR=%s"), NPRT(VolName),
            dev->print_name(), dev->print_errmsg());

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -260,6 +260,7 @@ static ResourceItem dev_items[] = {
      NULL},
     {"AutoInflate", CFG_TYPE_IODIRECTION, ITEM(res_dev.autoinflate), 0, 0, NULL, "13.4.0-", NULL},
     {"CollectStatistics", CFG_TYPE_BOOL, ITEM(res_dev.collectstats), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL},
+    {"EofOnErrorIsEot", CFG_TYPE_BOOL, ITEM(res_dev.eof_on_error_is_eot), 0, CFG_ITEM_DEFAULT, NULL, NULL, NULL},
     {NULL, 0, {0}, 0, 0, NULL, NULL, NULL}};
 
 /**

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -148,6 +148,7 @@ public:
    bool drive_crypto_enabled;         /**< Enable hardware crypto */
    bool query_crypto_status;          /**< Query device for crypto status */
    bool collectstats;                 /**< Set if statistics should be collected */
+   bool eof_on_error_is_eot;          /**< Interpret EOF during read error as EOT */
    drive_number_t drive;              /**< Autochanger logical drive number */
    drive_number_t drive_index;        /**< Autochanger physical drive index */
    char cap_bits[CAP_BYTES];          /**< Capabilities of this device */


### PR DESCRIPTION
Fixes #1034: Read error on tape may be misinterpreted as end-of-tape
Previously stored treated a read-error immediately
following an end-of-file mark on a tape as end-of-tape
instead of an error.
This patch makes stored raise an error in this case,
but allows to switch back to the previous behaviour on
a per-device basis using the new configuration option
"Eof On Error Is Eot".