### PR TITLE
catalog: make "Exit On Fatal" work as expected

### DIFF
--- a/core/src/cats/mysql.cc
+++ b/core/src/cats/mysql.cc
@@ -439,7 +439,7 @@ retry_query:
          /*
           * Any fatal error should result in the daemon exiting.
           */
-         Emsg0(M_FATAL, 0, "Fatal database error\n");
+         Emsg0(M_ERROR_TERM, 0, "Fatal database error\n");
       }
 
       if (try_reconnect_ && !transaction_) {
@@ -560,7 +560,7 @@ retry_query:
          /*
           * Any fatal error should result in the daemon exiting.
           */
-         Emsg0(M_FATAL, 0, "Fatal database error\n");
+         Emsg0(M_ERROR_TERM, 0, "Fatal database error\n");
       }
 
       if (try_reconnect_ && !transaction_) {

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -689,7 +689,7 @@ retry_query:
          /*
           * Any fatal error should result in the daemon exiting.
           */
-         Emsg0(M_FATAL, 0, "Fatal database error\n");
+         Emsg0(M_ERROR_TERM, 0, "Fatal database error\n");
       }
 
       if (try_reconnect_ && !transaction_) {


### PR DESCRIPTION
fixes #631: No DB-reconnect after connection lost
the catalog backends previously logged a fatal
error with the database with M_FATAL. This patch
changes the message to M_ERROR_TERM which will
also quit the director.