### PR TITLE
docs: make diagrams work with newer plantuml

### DIFF
--- a/docs/manuals/en/new_main_reference/source/bareos-18.2.rst
+++ b/docs/manuals/en/new_main_reference/source/bareos-18.2.rst
@@ -15,6 +15,7 @@ that are virtually usable. See the chapters :ref:`below for specific diagrams <C
 .. uml::
   :caption: Sequence diagram of a Bareos File Daemon connection
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -81,6 +82,7 @@ Named Console and Default Console
 .. uml::
   :caption: Diagram of Console to Director connection
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -121,6 +123,7 @@ Default Backup/Restore
 .. uml::
   :caption: Diagram of a default Backup or Restore operation
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -161,6 +164,7 @@ Client Initiated Backup/Restore
 .. uml::
   :caption: Diagram of a **client initiated** Backup or Restore operation
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -201,6 +205,7 @@ Passive Client Backup/Restore
 .. uml::
   :caption: Diagram of a **passive client** Backup or Restore operation
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -241,6 +246,7 @@ Storage-Storage Migration
 .. uml::
   :caption: Diagram of a Storage to Storage copy or migrate operation
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con
@@ -281,6 +287,7 @@ Tray-Monitor
 .. uml::
   :caption: Diagram of all Tray Monitor Connections
 
+  left to right direction
   skinparam shadowing false
 
   (Console\nPython\nWebUI) as Con

--- a/docs/manuals/en/new_main_reference/source/developers/releasenotes.rst
+++ b/docs/manuals/en/new_main_reference/source/developers/releasenotes.rst
@@ -163,6 +163,7 @@ For a detailed explanation of all connection modes see :ref:`ConnectionOverviewR
 .. uml::
   :caption: Full overview of all Bareos connections possible with Bareos 18.2
 
+  left to right direction
   skinparam shadowing false
 
   (Python 17,18) as Py1718


### PR DESCRIPTION
Previously the diagrams for docs.bareos.org have
been built using plantuml 8033 (which even
predates the modern versioning scheme). This patch
updates some of the diagrams to still look nice
when built using plantuml 1.2019.2 (which is the
latest version as of now).

Applying this pull-request should be coordinated with an upgrade of plantuml on docs.bareos.org. The new JAR is already in place, but the configuration has not been changed yet.