### PR TITLE
dird: redesign GetNdmpEnvironmentString() API

### DIFF
--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -35,8 +35,6 @@
 #ifndef BAREOS_CATS_CATS_H_
 #define BAREOS_CATS_CATS_H_ 1
 
-#include "lib/volume_session_info.h"
-
 /* import automatically generated SQL_QUERY_ENUM */
 #include "bdb_query_enum_class.h"
 
@@ -48,6 +46,8 @@
  */
 
 #define faddr_t long
+
+struct VolumeSessionInfo;
 
 /**
  * Generic definitions of list types, list handlers and result handlers.
@@ -823,7 +823,7 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
-  bool GetNdmpEnvironmentString(const VolumeSessionInfo vsi,
+  bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                 const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -35,6 +35,8 @@
 #ifndef BAREOS_CATS_CATS_H_
 #define BAREOS_CATS_CATS_H_ 1
 
+#include "lib/volume_session_info.h"
+
 /* import automatically generated SQL_QUERY_ENUM */
 #include "bdb_query_enum_class.h"
 
@@ -821,12 +823,15 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
-  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
-                                JobDbRecord* jr,
+  bool GetNdmpEnvironmentString(const VolumeSessionInfo vsi,
+                                const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
-                                JobId_t JobId,
+  bool GetNdmpEnvironmentString(const JobId_t JobId,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
+  bool GetNdmpEnvironmentString(const JobId_t JobId,
+                                const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool PrepareMediaSqlQuery(JobControlRecord* jcr,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -827,14 +827,14 @@ class BareosDb
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
-                                const int32_t FileIndex,
+                                int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(const JobId_t JobId,
+  bool GetNdmpEnvironmentString(JobId_t JobId,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(const JobId_t JobId,
-                                const int32_t FileIndex,
+  bool GetNdmpEnvironmentString(JobId_t JobId,
+                                int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool PrepareMediaSqlQuery(JobControlRecord* jcr,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -823,6 +823,9 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
+  bool GetNdmpEnvironmentString(const std::string& query,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
   bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                 const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -1322,6 +1322,8 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
   char esc_envname[MAX_ESCAPE_NAME_LENGTH];
   char esc_envvalue[MAX_ESCAPE_NAME_LENGTH];
 
+  Jmsg(jcr, M_INFO, 0, "NDMP Environment: %s=%s\n", name, value);
+
   DbLock(this);
 
   EscapeString(jcr, esc_envname, name, strlen(name));

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1757,7 +1757,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
+bool BareosDb::GetNdmpEnvironmentString(JobId_t JobId,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
@@ -1774,8 +1774,8 @@ bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
-                                        const int32_t FileIndex,
+bool BareosDb::GetNdmpEnvironmentString(JobId_t JobId,
+                                        int32_t FileIndex,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
@@ -1795,7 +1795,7 @@ bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
  *         true: on success
  */
 bool BareosDb::GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
-                                        const int32_t FileIndex,
+                                        int32_t FileIndex,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1712,17 +1712,17 @@ bail_out:
 }
 
 /**
- * CountingHandler() with a count_context* can be used to count the number of
+ * CountingHandler() with a CountContext* can be used to count the number of
  * times that SqlQueryWithHandler() calls the handler.
  * This is not neccesarily the number of rows, because the ResultHandler can
  * stop processing of further rows by returning non-zero.
  */
-struct count_context {
+struct CountContext {
   DB_RESULT_HANDLER* handler;
   void* ctx;
   int count;
 
-  count_context(DB_RESULT_HANDLER* t_handler, void* t_ctx)
+  CountContext(DB_RESULT_HANDLER* t_handler, void* t_ctx)
       : handler(t_handler), ctx(t_ctx), count(0)
   {
   }
@@ -1730,7 +1730,7 @@ struct count_context {
 
 static int CountingHandler(void* counting_ctx, int num_fields, char** rows)
 {
-  auto* c = static_cast<struct count_context*>(counting_ctx);
+  auto* c = static_cast<struct CountContext*>(counting_ctx);
   c->count++;
   return c->handler(c->ctx, num_fields, rows);
 }
@@ -1744,7 +1744,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
-  auto myctx = std::make_unique<count_context>(ResultHandler, ctx);
+  auto myctx = std::make_unique<CountContext>(ResultHandler, ctx);
   bool status =
       SqlQueryWithHandler(query.c_str(), CountingHandler, myctx.get());
   Dmsg3(150, "Got %d NDMP environment records\n", myctx->count);

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1730,7 +1730,7 @@ struct count_context {
 
 static int CountingHandler(void* counting_ctx, int num_fields, char** rows)
 {
-  auto* c = (struct count_context*)counting_ctx;
+  auto* c = static_cast<struct count_context*>(counting_ctx);
   c->count++;
   return c->handler(c->ctx, num_fields, rows);
 }
@@ -1747,7 +1747,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
   auto myctx = std::make_unique<count_context>(ResultHandler, ctx);
   bool status =
       SqlQueryWithHandler(query.c_str(), CountingHandler, myctx.get());
-  Dmsg3(150, "Got %d NDMP environment records", myctx->count);
+  Dmsg3(150, "Got %d NDMP environment records\n", myctx->count);
   return status && myctx->count > 0;  // no rows means no environment was found
 }
 
@@ -1811,9 +1811,10 @@ bool BareosDb::GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                       ctx);
     }
   }
-  Dmsg3(100,
-        "Got %d JobIds for VolSessionTime=%lld VolSessionId=%lld instead of 1",
-        lctx.count, vsi.time, vsi.id);
+  Dmsg3(
+      100,
+      "Got %d JobIds for VolSessionTime=%lld VolSessionId=%lld instead of 1\n",
+      lctx.count, vsi.time, vsi.id);
   return false;
 }
 

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -212,6 +212,8 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
      * the database when its either expired or when an old NDMP backup is
      * restored where the whole environment was not saved.
      */
+    Jmsg(jcr, M_WARNING, 0,
+         _("Could not load NDMP environment. Using fallback.\n"));
 
     if (!nbf_options || nbf_options->uses_file_history) {
       /*

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -36,6 +36,7 @@
 #include "dird/storage.h"
 
 #include "lib/parse_bsr.h"
+#include "lib/volume_session_info.h"
 
 #if HAVE_NDMP
 #include "dird/ndmp_dma_generic.h"
@@ -159,6 +160,7 @@ static inline int set_files_to_restore(JobControlRecord* jcr,
  */
 static inline bool fill_restore_environment(JobControlRecord* jcr,
                                             int32_t current_fi,
+                                            VolumeSessionInfo current_session,
                                             struct ndm_job_param* job)
 {
   int i;
@@ -202,8 +204,8 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
   /*
    * Lookup the environment stack saved during the backup so we can restore it.
    */
-  if (!jcr->db->GetNdmpEnvironmentString(jcr, &jcr->jr, NdmpEnvHandler,
-                                         &job->env_tab)) {
+  if (!jcr->db->GetNdmpEnvironmentString(current_session, current_fi,
+                                         NdmpEnvHandler, &job->env_tab)) {
     /*
      * Fallback code try to build a environment stack that is good enough to
      * restore this NDMP backup. This is used when the data is not available in
@@ -540,14 +542,13 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
     bool next_fi = true;
     int first_fi = jcr->bsr->FileIndex->findex;
     int last_fi = jcr->bsr->FileIndex->findex2;
-    uint32_t current_sessionid = jcr->bsr->sessid->sessid;
-    uint32_t current_sessiontime = jcr->bsr->sesstime->sesstime;
+    VolumeSessionInfo current_session{jcr->bsr->sessid->sessid,
+                                      jcr->bsr->sesstime->sesstime};
     cnt = 0;
 
     for (bsr = jcr->bsr; bsr; bsr = bsr->next) {
-      if (current_sessionid != bsr->sessid->sessid) {
-        current_sessionid = bsr->sessid->sessid;
-        current_sessiontime = bsr->sesstime->sesstime;
+      if (current_session.id != bsr->sessid->sessid) {
+        current_session = {bsr->sessid->sessid, bsr->sesstime->sesstime};
         first_run = true;
         next_sessid = true;
       }
@@ -568,7 +569,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
           }
         }
         Dmsg4(20, "sessionid:sesstime : first_fi/last_fi : %d:%d %d/%d \n",
-              current_sessionid, current_sessiontime, first_fi, last_fi);
+              current_session.id, current_session.time, first_fi, last_fi);
       }
 
       if (next_sessid | next_fi) {
@@ -580,8 +581,8 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
         Jmsg(
             jcr, M_INFO, 0,
             _("Run restore for sesstime %s (%d), sessionid %d, fileindex %d\n"),
-            bstrftime(dt, sizeof(dt), current_sessiontime, NULL),
-            current_sessiontime, current_sessionid, current_fi);
+            bstrftime(dt, sizeof(dt), current_session.time, NULL),
+            current_session.time, current_session.id, current_fi);
 
 
         /*
@@ -630,7 +631,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
 
         memcpy(&ndmp_sess.control_acb->job, &ndmp_job,
                sizeof(struct ndm_job_param));
-        if (!fill_restore_environment(jcr, current_fi,
+        if (!fill_restore_environment(jcr, current_fi, current_session,
                                       &ndmp_sess.control_acb->job)) {
           Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
           goto cleanup_ndmp;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -98,6 +98,9 @@ static inline bool fill_restore_environment_ndmp_native(
      * the database when its either expired or when an old NDMP backup is
      * restored where the whole environment was not saved.
      */
+    Jmsg(jcr, M_WARNING, 0,
+         _("Could not load NDMP environment. Using fallback.\n"));
+
 
     if (!nbf_options || nbf_options->uses_file_history) {
       /*
@@ -117,6 +120,7 @@ static inline bool fill_restore_environment_ndmp_native(
 
     /*
      * Tell the data engine what was backuped.
+     * As we have no idea without an environment, just set to a nullstring.
      */
     pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
     pv.value = ndmp_filesystem;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -73,7 +73,7 @@ static inline bool fill_restore_environment_ndmp_native(
    * We use the first jobid to get the environment string
    */
 
-  JobId_t JobId = (JobId_t)str_to_int32(jcr->JobIds);
+  JobId_t JobId{str_to_uint32(jcr->JobIds)};
   if (JobId <= 0) {
     Jmsg(jcr, M_FATAL, 0, "Impossible JobId: %d", JobId);
     return false;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -55,12 +55,9 @@ static inline bool fill_restore_environment_ndmp_native(
     struct ndm_job_param* job)
 {
   ndmp9_pval pv;
-  char *ndmp_filesystem, *restore_prefix;
   PoolMem tape_device;
   PoolMem destination_path;
   ndmp_backup_format_option* nbf_options;
-
-  ndmp_filesystem = NULL;
 
   /*
    * See if we know this backup format and get it options.
@@ -79,59 +76,33 @@ static inline bool fill_restore_environment_ndmp_native(
     return false;
   }
 
-  if (jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler, &job->env_tab)) {
-    /*
-     * extract ndmp_filesystem from environment
-     */
-    for (struct ndm_env_entry* entry = job->env_tab.head; entry;
-         entry = entry->next) {
-      if (bstrcmp(entry->pval.name,
-                  ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
-        ndmp_filesystem = entry->pval.value;
-        break;
-      }
-    }
-  } else {
-    /*
-     * Fallback code try to build a environment stack that is good enough to
-     * restore this NDMP backup. This is used when the data is not available in
-     * the database when its either expired or when an old NDMP backup is
-     * restored where the whole environment was not saved.
-     */
-    Jmsg(jcr, M_WARNING, 0,
-         _("Could not load NDMP environment. Using fallback.\n"));
-
-
-    if (!nbf_options || nbf_options->uses_file_history) {
-      /*
-       * We asked during the NDMP backup to receive file history info.
-       */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
-      pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
-      ndma_store_env_list(&job->env_tab, &pv);
-    }
-
-    /*
-     * Tell the data agent what type of restore stream to expect.
-     */
-    pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
-    pv.value = job->bu_type;
-    ndma_store_env_list(&job->env_tab, &pv);
-
-    /*
-     * Tell the data engine what was backuped.
-     * As we have no idea without an environment, just set to a nullstring.
-     */
-    pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
-    pv.value = ndmp_filesystem;
-    ndma_store_env_list(&job->env_tab, &pv);
+  if (!jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler,
+                                         &job->env_tab)) {
+    Jmsg(jcr, M_FATAL, 0,
+         _("Could not load NDMP environment. Cannot continue without one.\n"));
+    return false;
   }
 
+  /* try to extract ndmp_filesystem from environment */
+  char *ndmp_filesystem = nullptr;
+  for (struct ndm_env_entry* entry = job->env_tab.head; entry;
+       entry = entry->next) {
+    if (bstrcmp(entry->pval.name, ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
+      ndmp_filesystem = entry->pval.value;
+      break;
+    }
+  }
+
+  if (!ndmp_filesystem) {
+    Jmsg(jcr, M_FATAL, 0, _("No %s in NDMP environment. Cannot continue.\n"),
+         ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM]);
+    return false;
+  }
 
   /*
    * See where to restore the data.
    */
-  restore_prefix = NULL;
+  char* restore_prefix = nullptr;
   if (jcr->where) {
     restore_prefix = jcr->where;
   } else {

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -73,11 +73,13 @@ static inline bool fill_restore_environment_ndmp_native(
    * We use the first jobid to get the environment string
    */
 
-  JobId_t JobId = str_to_int32(jcr->JobIds);
-  // TODO: Check if JobId is Zero as this indicates error
+  JobId_t JobId = (JobId_t)str_to_int32(jcr->JobIds);
+  if (JobId <= 0) {
+    Jmsg(jcr, M_FATAL, 0, "Impossible JobId: %d", JobId);
+    return false;
+  }
 
-  if (jcr->db->GetNdmpEnvironmentString(jcr, JobId, NdmpEnvHandler,
-                                        &job->env_tab)) {
+  if (jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler, &job->env_tab)) {
     /*
      * extract ndmp_filesystem from environment
      */

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -22,6 +22,8 @@
 #define BAREOS_LIB_EDIT_H_
 
 uint64_t str_to_uint64(const char* str);
+#define str_to_uint16(str) ((uint16_t)str_to_uint64(str))
+#define str_to_uint32(str) ((uint32_t)str_to_uint64(str))
 int64_t str_to_int64(const char* str);
 #define str_to_int16(str) ((int16_t)str_to_int64(str))
 #define str_to_int32(str) ((int32_t)str_to_int64(str))

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -1,0 +1,35 @@
+/*
+ * BAREOS® - Backup Archiving REcovery Open Sourced
+ *
+ * Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+ *
+ * This program is Free Software; you can redistribute it and/or modify
+ * it under the terms of version three of the GNU Affero General Public License
+ * as published by the Free Software Foundation and included in the file
+ * LICENSE.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details. You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ *
+ */
+
+/*
+ * provides a struct to wrap a pair of VolumeSessionId and VolumeSessionTime
+ */
+
+#ifndef BAREOS_LIB_VOLUME_SESSION_INFO_H_
+#define BAREOS_LIB_VOLUME_SESSION_INFO_H_ 1
+
+struct VolumeSessionInfo {
+  uint32_t id;
+  uint32_t time;
+
+  /* explicit constructor disables default construction */
+  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
+};
+
+#endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -29,10 +29,7 @@ struct VolumeSessionInfo {
   uint32_t time;
 
   /* explicit constructor disables default construction */
-  VolumeSessionInfo(const uint32_t t_id, const uint32_t t_time)
-      : id(t_id), time(t_time)
-  {
-  }
+  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
 };
 
 #endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -29,7 +29,10 @@ struct VolumeSessionInfo {
   uint32_t time;
 
   /* explicit constructor disables default construction */
-  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
+  VolumeSessionInfo(const uint32_t t_id, const uint32_t t_time)
+      : id(t_id), time(t_time)
+  {
+  }
 };
 
 #endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/ndmp/ndmos.h
+++ b/core/src/ndmp/ndmos.h
@@ -329,9 +329,6 @@
 #define NDMOS_OPTION_ROBOT_SIMULATOR 1
 #define NDMOS_OPTION_GAP_SIMULATOR 1
 
-/* Convert IP to human readable string instead of HEX String */
-/* #define NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP 1 */
-
 /*
  * Constants
  */

--- a/core/src/ndmp/ndmp4_pp.c
+++ b/core/src/ndmp/ndmp4_pp.c
@@ -74,15 +74,12 @@ int ndmp4_pp_addr(char* buf, ndmp4_addr* ma)
     for (i = 0; i < ma->ndmp4_addr_u.tcp_addr.tcp_addr_len; i++) {
       tcp = &ma->ndmp4_addr_u.tcp_addr.tcp_addr_val[i];
 
-#ifndef NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP
-      sprintf(NDMOS_API_STREND(buf), " #%d(%lx,%d", i, tcp->ip_addr, tcp->port);
-#else
       char ip_addr[100];
       ip_in_host_order = ntohl(tcp->ip_addr);
       sprintf(NDMOS_API_STREND(buf), "%d(%s:%u", i,
               inet_ntop(AF_INET, &ip_in_host_order, ip_addr, sizeof(ip_addr)),
               tcp->port);
-#endif /* NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP */
+
       for (j = 0; j < tcp->addr_env.addr_env_len; j++) {
         sprintf(NDMOS_API_STREND(buf), ",%s=%s",
                 tcp->addr_env.addr_env_val[j].name,


### PR DESCRIPTION
Fixes #1056: NDMP restore on 16.2.5 and above does not fill NDMP environment correctly

Previously one overload of the function GetNdmpEnvironmentString() wanted a JobDbRecord* and expected jr->VolSessionId and jr->VolSessionTime to contain the values for the volume from which the
restore happens. These had to be filled manually before calling GetNdmlEnvironmentString() which had not been done since 16.2.5 resulting in #1056.

This patch now redesigns the API for all overloads of GetNdmpEnviromentString() to make it harder
to misuse.

We also add a new struct VolumeSessionInfo to wrap a pair of VolumeSessionId and VolumeSessionTime. These two numbers are only meaningful together, so they now have their own container.