### PR TITLE
 stored: fix crash in status command 

### DIFF
--- a/src/stored/status.c
+++ b/src/stored/status.c
@@ -253,7 +253,7 @@ static void get_device_specific_status(DEVRES *device,
    dst.status = get_pool_memory(PM_MESSAGE);
    dst.status_length = 0;
 
-   if (device->dev->device_status(&dst)) {
+   if (device && device->dev && device->dev->device_status(&dst)) {
       if (dst.status_length > 0) {
          sendit(dst.status, dst.status_length, sp);
       }


### PR DESCRIPTION
this patch fixes a crash in the storage daemon that happened when status information was generated and one of the sd devices could not be opened.