### PR TITLE
stored: fix corner-case crash during job cancel

### DIFF
--- a/src/dird/sd_cmds.c
+++ b/src/dird/sd_cmds.c
@@ -668,8 +668,10 @@ bool cancel_storage_daemon_job(UAContext *ua, JCR *jcr, bool interactive)
    if (!interactive) {
       jcr->sd_canceled = true;
    }
-   jcr->store_bsock->set_timed_out();
-   jcr->store_bsock->set_terminated();
+   if (jcr->store_bsock) {
+     jcr->store_bsock->set_timed_out();
+     jcr->store_bsock->set_terminated();
+   }
    sd_msg_thread_send_signal(jcr, TIMEOUT_SIGNAL);
 
    /*


### PR DESCRIPTION
When jcr->store_bsock was null during job cancellation
the director would crash.

This patch was backported from commit d0d1ccb9.