### PR TITLE
dird: redesign GetNdmpEnvironmentString() API (bareos-18.2)

### DIFF
--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -35,8 +35,6 @@
 #ifndef BAREOS_CATS_CATS_H_
 #define BAREOS_CATS_CATS_H_ 1
 
-#include "lib/volume_session_info.h"
-
 /* import automatically generated SQL_QUERY_ENUM */
 #include "bdb_query_enum_class.h"
 
@@ -48,6 +46,8 @@
  */
 
 #define faddr_t long
+
+struct VolumeSessionInfo;
 
 /**
  * Generic definitions of list types, list handlers and result handlers.
@@ -823,7 +823,7 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
-  bool GetNdmpEnvironmentString(const VolumeSessionInfo vsi,
+  bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                 const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -35,6 +35,8 @@
 #ifndef BAREOS_CATS_CATS_H_
 #define BAREOS_CATS_CATS_H_ 1
 
+#include "lib/volume_session_info.h"
+
 /* import automatically generated SQL_QUERY_ENUM */
 #include "bdb_query_enum_class.h"
 
@@ -821,12 +823,15 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
-  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
-                                JobDbRecord* jr,
+  bool GetNdmpEnvironmentString(const VolumeSessionInfo vsi,
+                                const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
-                                JobId_t JobId,
+  bool GetNdmpEnvironmentString(const JobId_t JobId,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
+  bool GetNdmpEnvironmentString(const JobId_t JobId,
+                                const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool PrepareMediaSqlQuery(JobControlRecord* jcr,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -827,14 +827,14 @@ class BareosDb
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
-                                const int32_t FileIndex,
+                                int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(const JobId_t JobId,
+  bool GetNdmpEnvironmentString(JobId_t JobId,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
-  bool GetNdmpEnvironmentString(const JobId_t JobId,
-                                const int32_t FileIndex,
+  bool GetNdmpEnvironmentString(JobId_t JobId,
+                                int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,
                                 void* ctx);
   bool PrepareMediaSqlQuery(JobControlRecord* jcr,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -50,11 +50,12 @@
 /**
  * Generic definitions of list types, list handlers and result handlers.
  */
-enum e_list_type {
-   NF_LIST,
-   RAW_LIST,
-   HORZ_LIST,
-   VERT_LIST
+enum e_list_type
+{
+  NF_LIST,
+  RAW_LIST,
+  HORZ_LIST,
+  VERT_LIST
 };
 
 /**
@@ -62,19 +63,19 @@ enum e_list_type {
  *  allows the subroutine to return a list of ids.
  */
 class dbid_list : public SmartAlloc {
-public:
-   DBId_t *DBId;                      /**< array of DBIds */
-   char *PurgedFiles;                 /**< Array of PurgedFile flags */
-   int num_ids;                       /**< num of ids actually stored */
-   int max_ids;                       /**< size of id array */
-   int num_seen;                      /**< number of ids processed */
-   int tot_ids;                       /**< total to process */
+ public:
+  DBId_t* DBId;      /**< array of DBIds */
+  char* PurgedFiles; /**< Array of PurgedFile flags */
+  int num_ids;       /**< num of ids actually stored */
+  int max_ids;       /**< size of id array */
+  int num_seen;      /**< number of ids processed */
+  int tot_ids;       /**< total to process */
 
-   dbid_list();                       /**< in sql.c */
-   ~dbid_list();                      /**< in sql.c */
+  dbid_list();  /**< in sql.c */
+  ~dbid_list(); /**< in sql.c */
 
-   int size() const { return num_ids; }
-   DBId_t get(int i) const;
+  int size() const { return num_ids; }
+  DBId_t get(int i) const;
 };
 
 /**
@@ -88,54 +89,54 @@ public:
  * Job record
  */
 struct JobDbRecord {
-   JobId_t JobId;
-   char Job[MAX_NAME_LENGTH];         /**< Job unique name */
-   char Name[MAX_NAME_LENGTH];        /**< Job base name */
-   int JobType;                       /**< actually char(1) */
-   int JobLevel;                      /**< actually char(1) */
-   int JobStatus;                     /**< actually char(1) */
-   DBId_t ClientId;                   /**< Id of client */
-   DBId_t PoolId;                     /**< Id of pool */
-   DBId_t FileSetId;                  /**< Id of FileSet */
-   DBId_t PriorJobId;                 /**< Id of migrated (prior) job */
-   time_t SchedTime;                  /**< Time job scheduled */
-   time_t StartTime;                  /**< Job start time */
-   time_t EndTime;                    /**< Job termination time of orig job */
-   time_t RealEndTime;                /**< Job termination time of this job */
-   utime_t JobTDate;                  /**< Backup time/date in seconds */
-   uint32_t VolSessionId;
-   uint32_t VolSessionTime;
-   uint32_t JobFiles;
-   uint32_t JobErrors;
-   uint32_t JobMissingFiles;
-   uint64_t JobBytes;
-   uint64_t ReadBytes;
-   uint64_t JobSumTotalBytes;         /**< Total sum in bytes of all jobs but this one */
-   int PurgedFiles;
-   int HasBase;
+  JobId_t JobId;
+  char Job[MAX_NAME_LENGTH];  /**< Job unique name */
+  char Name[MAX_NAME_LENGTH]; /**< Job base name */
+  int JobType;                /**< actually char(1) */
+  int JobLevel;               /**< actually char(1) */
+  int JobStatus;              /**< actually char(1) */
+  DBId_t ClientId;            /**< Id of client */
+  DBId_t PoolId;              /**< Id of pool */
+  DBId_t FileSetId;           /**< Id of FileSet */
+  DBId_t PriorJobId;          /**< Id of migrated (prior) job */
+  time_t SchedTime;           /**< Time job scheduled */
+  time_t StartTime;           /**< Job start time */
+  time_t EndTime;             /**< Job termination time of orig job */
+  time_t RealEndTime;         /**< Job termination time of this job */
+  utime_t JobTDate;           /**< Backup time/date in seconds */
+  uint32_t VolSessionId;
+  uint32_t VolSessionTime;
+  uint32_t JobFiles;
+  uint32_t JobErrors;
+  uint32_t JobMissingFiles;
+  uint64_t JobBytes;
+  uint64_t ReadBytes;
+  uint64_t JobSumTotalBytes; /**< Total sum in bytes of all jobs but this one */
+  int PurgedFiles;
+  int HasBase;
 
-   /* Note, FirstIndex, LastIndex, Start/End File and Block
-    * are only used in the JobMedia record.
-    */
-   uint32_t FirstIndex;               /**< First index this Volume */
-   uint32_t LastIndex;                /**< Last index this Volume */
-   uint32_t StartFile;
-   uint32_t EndFile;
-   uint32_t StartBlock;
-   uint32_t EndBlock;
+  /* Note, FirstIndex, LastIndex, Start/End File and Block
+   * are only used in the JobMedia record.
+   */
+  uint32_t FirstIndex; /**< First index this Volume */
+  uint32_t LastIndex;  /**< Last index this Volume */
+  uint32_t StartFile;
+  uint32_t EndFile;
+  uint32_t StartBlock;
+  uint32_t EndBlock;
 
-   char cSchedTime[MAX_TIME_LENGTH];
-   char cStartTime[MAX_TIME_LENGTH];
-   char cEndTime[MAX_TIME_LENGTH];
-   char cRealEndTime[MAX_TIME_LENGTH];
+  char cSchedTime[MAX_TIME_LENGTH];
+  char cStartTime[MAX_TIME_LENGTH];
+  char cEndTime[MAX_TIME_LENGTH];
+  char cRealEndTime[MAX_TIME_LENGTH];
 
-   /*
-    * Extra stuff not in DB
-    */
-   int limit;                         /**< limit records to display */
-   int offset;                        /**< offset records to display */
-   faddr_t rec_addr;
-   uint32_t FileIndex;                /**< added during Verify */
+  /*
+   * Extra stuff not in DB
+   */
+  int limit;  /**< limit records to display */
+  int offset; /**< offset records to display */
+  faddr_t rec_addr;
+  uint32_t FileIndex; /**< added during Verify */
 };
 
 /* Job Media information used to create the media records
@@ -145,16 +146,16 @@ struct JobDbRecord {
  * JobMedia record
  */
 struct JobMediaDbRecord {
-   DBId_t JobMediaId;                 /**< record id */
-   JobId_t  JobId;                    /**< JobId */
-   DBId_t MediaId;                    /**< MediaId */
-   uint32_t FirstIndex;               /**< First index this Volume */
-   uint32_t LastIndex;                /**< Last index this Volume */
-   uint32_t StartFile;                /**< File for start of data */
-   uint32_t EndFile;                  /**< End file on Volume */
-   uint32_t StartBlock;               /**< start block on tape */
-   uint32_t EndBlock;                 /**< last block */
-   uint64_t JobBytes;                 /**< job bytes */
+  DBId_t JobMediaId;   /**< record id */
+  JobId_t JobId;       /**< JobId */
+  DBId_t MediaId;      /**< MediaId */
+  uint32_t FirstIndex; /**< First index this Volume */
+  uint32_t LastIndex;  /**< Last index this Volume */
+  uint32_t StartFile;  /**< File for start of data */
+  uint32_t EndFile;    /**< End file on Volume */
+  uint32_t StartBlock; /**< start block on tape */
+  uint32_t EndBlock;   /**< last block */
+  uint64_t JobBytes;   /**< job bytes */
 };
 
 
@@ -162,19 +163,19 @@ struct JobMediaDbRecord {
  * Volume Parameter structure
  */
 struct VolumeParameters {
-   char VolumeName[MAX_NAME_LENGTH];  /**< Volume name */
-   char MediaType[MAX_NAME_LENGTH];   /**< Media Type */
-   char Storage[MAX_NAME_LENGTH];     /**< Storage name */
-   uint32_t VolIndex;                 /**< Volume seqence no. */
-   uint32_t FirstIndex;               /**< First index this Volume */
-   uint32_t LastIndex;                /**< Last index this Volume */
-   int32_t Slot;                      /**< Slot */
-   uint64_t StartAddr;                /**< Start address */
-   uint64_t EndAddr;                  /**< End address */
-   int32_t InChanger;                 /**< InChanger flag */
-   uint64_t JobBytes;                 /**< job bytes */
-// uint32_t Copy;                     /**< identical copy */
-// uint32_t Stripe;                   /**< RAIT strip number */
+  char VolumeName[MAX_NAME_LENGTH]; /**< Volume name */
+  char MediaType[MAX_NAME_LENGTH];  /**< Media Type */
+  char Storage[MAX_NAME_LENGTH];    /**< Storage name */
+  uint32_t VolIndex;                /**< Volume seqence no. */
+  uint32_t FirstIndex;              /**< First index this Volume */
+  uint32_t LastIndex;               /**< Last index this Volume */
+  int32_t Slot;                     /**< Slot */
+  uint64_t StartAddr;               /**< Start address */
+  uint64_t EndAddr;                 /**< End address */
+  int32_t InChanger;                /**< InChanger flag */
+  uint64_t JobBytes;                /**< job bytes */
+  // uint32_t Copy;                     /**< identical copy */
+  // uint32_t Stripe;                   /**< RAIT strip number */
 };
 
 /**
@@ -183,345 +184,361 @@ struct VolumeParameters {
  * records (e.g. pathname, filename, fileattributes).
  */
 struct AttributesDbRecord {
-   char *fname;                       /**< full path & filename */
-   char *link;                        /**< link if any */
-   char *attr;                        /**< attributes statp */
-   uint32_t FileIndex;
-   uint32_t Stream;
-   uint32_t FileType;
-   uint32_t DeltaSeq;
-   JobId_t  JobId;
-   DBId_t ClientId;
-   DBId_t PathId;
-   FileId_t FileId;
-   char *Digest;
-   int DigestType;
-   uint64_t Fhinfo;                  /**< NDMP fh_info for DAR*/
-   uint64_t Fhnode;                  /**< NDMP fh_node for DAR*/
+  char* fname; /**< full path & filename */
+  char* link;  /**< link if any */
+  char* attr;  /**< attributes statp */
+  uint32_t FileIndex;
+  uint32_t Stream;
+  uint32_t FileType;
+  uint32_t DeltaSeq;
+  JobId_t JobId;
+  DBId_t ClientId;
+  DBId_t PathId;
+  FileId_t FileId;
+  char* Digest;
+  int DigestType;
+  uint64_t Fhinfo; /**< NDMP fh_info for DAR*/
+  uint64_t Fhnode; /**< NDMP fh_node for DAR*/
 };
 
 /**
  * Restore object database record
  */
 struct RestoreObjectDbRecord {
-   char *object_name;
-   char *object;
-   char *plugin_name;
-   uint32_t object_len;
-   uint32_t object_full_len;
-   uint32_t object_index;
-   int32_t object_compression;
-   uint32_t FileIndex;
-   uint32_t Stream;
-   uint32_t FileType;
-   JobId_t JobId;
-   DBId_t RestoreObjectId;
+  char* object_name;
+  char* object;
+  char* plugin_name;
+  uint32_t object_len;
+  uint32_t object_full_len;
+  uint32_t object_index;
+  int32_t object_compression;
+  uint32_t FileIndex;
+  uint32_t Stream;
+  uint32_t FileType;
+  JobId_t JobId;
+  DBId_t RestoreObjectId;
 };
 
 /**
  * File record -- same format as database
  */
 struct FileDbRecord {
-   FileId_t FileId;
-   uint32_t FileIndex;
-   JobId_t JobId;
-   DBId_t PathId;
-   JobId_t MarkId;
-   uint32_t DeltaSeq;
-   char LStat[256];
-   char Digest[BASE64_SIZE(CRYPTO_DIGEST_MAX_SIZE)];
-   int DigestType;                    /**< NO_SIG/MD5_SIG/SHA1_SIG */
+  FileId_t FileId;
+  uint32_t FileIndex;
+  JobId_t JobId;
+  DBId_t PathId;
+  JobId_t MarkId;
+  uint32_t DeltaSeq;
+  char LStat[256];
+  char Digest[BASE64_SIZE(CRYPTO_DIGEST_MAX_SIZE)];
+  int DigestType; /**< NO_SIG/MD5_SIG/SHA1_SIG */
 };
 
 /**
  * Pool record -- same format as database
  */
 struct PoolDbRecord {
-   DBId_t PoolId;
-   char Name[MAX_NAME_LENGTH];        /**< Pool name */
-   uint32_t NumVols;                  /**< total number of volumes */
-   uint32_t MaxVols;                  /**< max allowed volumes */
-   int32_t LabelType;                 /**< BAREOS/ANSI/IBM */
-   int32_t UseOnce;                   /**< set to use once only */
-   int32_t UseCatalog;                /**< set to use catalog */
-   int32_t AcceptAnyVolume;           /**< set to accept any volume sequence */
-   int32_t AutoPrune;                 /**< set to prune automatically */
-   int32_t Recycle;                   /**< default Vol recycle flag */
-   uint32_t ActionOnPurge;            /**< action on purge, e.g. truncate the disk volume */
-   utime_t VolRetention;              /**< retention period in seconds */
-   utime_t VolUseDuration;            /**< time in secs volume can be used */
-   uint32_t MaxVolJobs;               /**< Max Jobs on Volume */
-   uint32_t MaxVolFiles;              /**< Max files on Volume */
-   uint64_t MaxVolBytes;              /**< Max bytes on Volume */
-   DBId_t RecyclePoolId;              /**< RecyclePool destination when media is purged */
-   DBId_t ScratchPoolId;              /**< ScratchPool source when media is needed */
-   char PoolType[MAX_NAME_LENGTH];
-   char LabelFormat[MAX_NAME_LENGTH];
-   uint32_t MinBlocksize;             /**< Minimum Block Size */
-   uint32_t MaxBlocksize;             /**< Maximum Block Size */
+  DBId_t PoolId;
+  char Name[MAX_NAME_LENGTH]; /**< Pool name */
+  uint32_t NumVols;           /**< total number of volumes */
+  uint32_t MaxVols;           /**< max allowed volumes */
+  int32_t LabelType;          /**< BAREOS/ANSI/IBM */
+  int32_t UseOnce;            /**< set to use once only */
+  int32_t UseCatalog;         /**< set to use catalog */
+  int32_t AcceptAnyVolume;    /**< set to accept any volume sequence */
+  int32_t AutoPrune;          /**< set to prune automatically */
+  int32_t Recycle;            /**< default Vol recycle flag */
+  uint32_t ActionOnPurge; /**< action on purge, e.g. truncate the disk volume */
+  utime_t VolRetention;   /**< retention period in seconds */
+  utime_t VolUseDuration; /**< time in secs volume can be used */
+  uint32_t MaxVolJobs;    /**< Max Jobs on Volume */
+  uint32_t MaxVolFiles;   /**< Max files on Volume */
+  uint64_t MaxVolBytes;   /**< Max bytes on Volume */
+  DBId_t RecyclePoolId;   /**< RecyclePool destination when media is purged */
+  DBId_t ScratchPoolId;   /**< ScratchPool source when media is needed */
+  char PoolType[MAX_NAME_LENGTH];
+  char LabelFormat[MAX_NAME_LENGTH];
+  uint32_t MinBlocksize; /**< Minimum Block Size */
+  uint32_t MaxBlocksize; /**< Maximum Block Size */
 
-   /*
-    * Extra stuff not in DB
-    */
-   faddr_t rec_addr;
+  /*
+   * Extra stuff not in DB
+   */
+  faddr_t rec_addr;
 };
 
 /**
  * Device record
  */
 struct DeviceDbRecord {
-   DBId_t DeviceId;
-   char Name[MAX_NAME_LENGTH];        /**< Device name */
-   DBId_t MediaTypeId;                /**< MediaType */
-   DBId_t StorageId;                  /**< Storage id if autochanger */
-   uint32_t DevMounts;                /**< Number of times mounted */
-   uint32_t DevErrors;                /**< Number of read/write errors */
-   uint64_t DevReadBytes;             /**< Number of bytes read */
-   uint64_t DevWriteBytes;            /**< Number of bytes written */
-   uint64_t DevReadTime;              /**< time spent reading volume */
-   uint64_t DevWriteTime;             /**< time spent writing volume */
-   uint64_t DevReadTimeSincCleaning;  /**< read time since cleaning */
-   uint64_t DevWriteTimeSincCleaning; /**< write time since cleaning */
-   time_t CleaningDate;               /**< time last cleaned */
-   utime_t CleaningPeriod;            /**< time between cleanings */
+  DBId_t DeviceId;
+  char Name[MAX_NAME_LENGTH];        /**< Device name */
+  DBId_t MediaTypeId;                /**< MediaType */
+  DBId_t StorageId;                  /**< Storage id if autochanger */
+  uint32_t DevMounts;                /**< Number of times mounted */
+  uint32_t DevErrors;                /**< Number of read/write errors */
+  uint64_t DevReadBytes;             /**< Number of bytes read */
+  uint64_t DevWriteBytes;            /**< Number of bytes written */
+  uint64_t DevReadTime;              /**< time spent reading volume */
+  uint64_t DevWriteTime;             /**< time spent writing volume */
+  uint64_t DevReadTimeSincCleaning;  /**< read time since cleaning */
+  uint64_t DevWriteTimeSincCleaning; /**< write time since cleaning */
+  time_t CleaningDate;               /**< time last cleaned */
+  utime_t CleaningPeriod;            /**< time between cleanings */
 };
 
 /**
  * Storage database record
  */
 struct StorageDbRecord {
-   DBId_t StorageId;
-   char Name[MAX_NAME_LENGTH];        /**< Device name */
-   int AutoChanger;                   /**< Set if autochanger */
+  DBId_t StorageId;
+  char Name[MAX_NAME_LENGTH]; /**< Device name */
+  int AutoChanger;            /**< Set if autochanger */
 
-   /*
-    * Extra stuff not in DB
-    */
-   bool created;                      /**< set if created by db_create ... */
+  /*
+   * Extra stuff not in DB
+   */
+  bool created; /**< set if created by db_create ... */
 };
 
 /**
  * mediatype database record
  */
 struct MediaTypeDbRecord {
-   DBId_t MediaTypeId;
-   char MediaType[MAX_NAME_LENGTH];   /**< MediaType string */
-   int ReadOnly;                      /**< Set if read-only */
+  DBId_t MediaTypeId;
+  char MediaType[MAX_NAME_LENGTH]; /**< MediaType string */
+  int ReadOnly;                    /**< Set if read-only */
 };
 
 /**
  * Media record -- same as the database
  */
 struct MediaDbRecord {
-   DBId_t MediaId;                    /**< Unique volume id */
-   char VolumeName[MAX_NAME_LENGTH];  /**< Volume name */
-   char MediaType[MAX_NAME_LENGTH];   /**< Media type */
-   char EncrKey[MAX_NAME_LENGTH];     /**< Encryption Key */
-   DBId_t PoolId;                     /**< Pool id */
-   time_t FirstWritten;               /**< Time Volume first written this usage */
-   time_t LastWritten;                /**< Time Volume last written */
-   time_t LabelDate;                  /**< Date/Time Volume labeled */
-   time_t InitialWrite;               /**< Date/Time Volume first written */
-   int32_t  LabelType;                /**< Label (BAREOS/ANSI/IBM) */
-   uint32_t VolJobs;                  /**< number of jobs on this medium */
-   uint32_t VolFiles;                 /**< Number of files */
-   uint32_t VolBlocks;                /**< Number of blocks */
-   uint32_t VolMounts;                /**< Number of times mounted */
-   uint32_t VolErrors;                /**< Number of read/write errors */
-   uint32_t VolWrites;                /**< Number of writes */
-   uint32_t VolReads;                 /**< Number of reads */
-   uint64_t VolBytes;                 /**< Number of bytes written */
-   uint64_t MaxVolBytes;              /**< Max bytes to write to Volume */
-   uint64_t VolCapacityBytes;         /**< capacity estimate */
-   uint64_t VolReadTime;              /**< time spent reading volume */
-   uint64_t VolWriteTime;             /**< time spent writing volume */
-   utime_t VolRetention;              /**< Volume retention in seconds */
-   utime_t VolUseDuration;            /**< time in secs volume can be used */
-   uint32_t ActionOnPurge;            /**< action on purge, e.g. truncate the disk volume */
-   uint32_t MaxVolJobs;               /**< Max Jobs on Volume */
-   uint32_t MaxVolFiles;              /**< Max files on Volume */
-   int32_t Recycle;                   /**< recycle yes/no */
-   int32_t Slot;                      /**< slot in changer */
-   int32_t Enabled;                   /**< 0=disabled, 1=enabled, 2=archived */
-   int32_t InChanger;                 /**< Volume currently in changer */
-   DBId_t StorageId;                  /**< Storage record Id */
-   uint32_t EndFile;                  /**< Last file on volume */
-   uint32_t EndBlock;                 /**< Last block on volume */
-   uint32_t RecycleCount;             /**< Number of times recycled */
-   uint32_t MinBlocksize;             /**< Minimum Block Size */
-   uint32_t MaxBlocksize;             /**< Maximum Block Size */
-   char VolStatus[20];                /**< Volume status */
-   DBId_t DeviceId;                   /**< Device where Vol last written */
-   DBId_t LocationId;                 /**< Where Volume is -- user defined */
-   DBId_t ScratchPoolId;              /**< Where to move if scratch */
-   DBId_t RecyclePoolId;              /**< Where to move when recycled */
+  DBId_t MediaId;                   /**< Unique volume id */
+  char VolumeName[MAX_NAME_LENGTH]; /**< Volume name */
+  char MediaType[MAX_NAME_LENGTH];  /**< Media type */
+  char EncrKey[MAX_NAME_LENGTH];    /**< Encryption Key */
+  DBId_t PoolId;                    /**< Pool id */
+  time_t FirstWritten;              /**< Time Volume first written this usage */
+  time_t LastWritten;               /**< Time Volume last written */
+  time_t LabelDate;                 /**< Date/Time Volume labeled */
+  time_t InitialWrite;              /**< Date/Time Volume first written */
+  int32_t LabelType;                /**< Label (BAREOS/ANSI/IBM) */
+  uint32_t VolJobs;                 /**< number of jobs on this medium */
+  uint32_t VolFiles;                /**< Number of files */
+  uint32_t VolBlocks;               /**< Number of blocks */
+  uint32_t VolMounts;               /**< Number of times mounted */
+  uint32_t VolErrors;               /**< Number of read/write errors */
+  uint32_t VolWrites;               /**< Number of writes */
+  uint32_t VolReads;                /**< Number of reads */
+  uint64_t VolBytes;                /**< Number of bytes written */
+  uint64_t MaxVolBytes;             /**< Max bytes to write to Volume */
+  uint64_t VolCapacityBytes;        /**< capacity estimate */
+  uint64_t VolReadTime;             /**< time spent reading volume */
+  uint64_t VolWriteTime;            /**< time spent writing volume */
+  utime_t VolRetention;             /**< Volume retention in seconds */
+  utime_t VolUseDuration;           /**< time in secs volume can be used */
+  uint32_t ActionOnPurge; /**< action on purge, e.g. truncate the disk volume */
+  uint32_t MaxVolJobs;    /**< Max Jobs on Volume */
+  uint32_t MaxVolFiles;   /**< Max files on Volume */
+  int32_t Recycle;        /**< recycle yes/no */
+  int32_t Slot;           /**< slot in changer */
+  int32_t Enabled;        /**< 0=disabled, 1=enabled, 2=archived */
+  int32_t InChanger;      /**< Volume currently in changer */
+  DBId_t StorageId;       /**< Storage record Id */
+  uint32_t EndFile;       /**< Last file on volume */
+  uint32_t EndBlock;      /**< Last block on volume */
+  uint32_t RecycleCount;  /**< Number of times recycled */
+  uint32_t MinBlocksize;  /**< Minimum Block Size */
+  uint32_t MaxBlocksize;  /**< Maximum Block Size */
+  char VolStatus[20];     /**< Volume status */
+  DBId_t DeviceId;        /**< Device where Vol last written */
+  DBId_t LocationId;      /**< Where Volume is -- user defined */
+  DBId_t ScratchPoolId;   /**< Where to move if scratch */
+  DBId_t RecyclePoolId;   /**< Where to move when recycled */
 
-   /*
-    * Extra stuff not in DB
-    */
-   faddr_t rec_addr;                  /**< found record address */
+  /*
+   * Extra stuff not in DB
+   */
+  faddr_t rec_addr; /**< found record address */
 
-   /*
-    * Since the database returns times as strings, this is how we pass them back.
-    */
-   char cFirstWritten[MAX_TIME_LENGTH]; /**< FirstWritten returned from DB */
-   char cLastWritten[MAX_TIME_LENGTH];  /**< LastWritten returned from DB */
-   char cLabelDate[MAX_TIME_LENGTH];    /**< LabelData returned from DB */
-   char cInitialWrite[MAX_TIME_LENGTH]; /**< InitialWrite returned from DB */
-   bool set_first_written;
-   bool set_label_date;
+  /*
+   * Since the database returns times as strings, this is how we pass them back.
+   */
+  char cFirstWritten[MAX_TIME_LENGTH]; /**< FirstWritten returned from DB */
+  char cLastWritten[MAX_TIME_LENGTH];  /**< LastWritten returned from DB */
+  char cLabelDate[MAX_TIME_LENGTH];    /**< LabelData returned from DB */
+  char cInitialWrite[MAX_TIME_LENGTH]; /**< InitialWrite returned from DB */
+  bool set_first_written;
+  bool set_label_date;
 };
 
 /**
  * Client record -- same as the database
  */
 struct ClientDbRecord {
-   DBId_t ClientId;                   /**< Unique Client id */
-   int AutoPrune;
-   utime_t GraceTime;                 /**< Time remaining on gracetime */
-   uint32_t QuotaLimit;               /**< The total softquota supplied if over grace */
-   utime_t FileRetention;
-   utime_t JobRetention;
-   char Name[MAX_NAME_LENGTH];        /**< Client name */
-   char Uname[256];                   /**< Uname for client */
+  DBId_t ClientId; /**< Unique Client id */
+  int AutoPrune;
+  utime_t GraceTime;   /**< Time remaining on gracetime */
+  uint32_t QuotaLimit; /**< The total softquota supplied if over grace */
+  utime_t FileRetention;
+  utime_t JobRetention;
+  char Name[MAX_NAME_LENGTH]; /**< Client name */
+  char Uname[256];            /**< Uname for client */
 };
 
 /**
  * Counter record -- same as in database
  */
 struct CounterDbRecord {
-   char Counter[MAX_NAME_LENGTH];
-   int32_t MinValue;
-   int32_t MaxValue;
-   int32_t CurrentValue;
-   char WrapCounter[MAX_NAME_LENGTH];
+  char Counter[MAX_NAME_LENGTH];
+  int32_t MinValue;
+  int32_t MaxValue;
+  int32_t CurrentValue;
+  char WrapCounter[MAX_NAME_LENGTH];
 };
 
 /**
  * FileSet record -- same as the database
  */
 struct FileSetDbRecord {
-   DBId_t FileSetId;                  /**< Unique FileSet id */
-   char FileSet[MAX_NAME_LENGTH];     /**< FileSet name */
-   char *FileSetText;                 /**< FileSet as Text */
-   char MD5[50];                      /**< MD5 signature of include/exclude */
-   time_t CreateTime;                 /**< Date created */
-   /*
-    * This is where we return CreateTime
-    */
-   char cCreateTime[MAX_TIME_LENGTH]; /**< CreateTime as returned from DB */
-   /*
-    * Not in DB but returned by db_create_fileset()
-    */
-   bool created;                      /**< set when record newly created */
+  DBId_t FileSetId;              /**< Unique FileSet id */
+  char FileSet[MAX_NAME_LENGTH]; /**< FileSet name */
+  char* FileSetText;             /**< FileSet as Text */
+  char MD5[50];                  /**< MD5 signature of include/exclude */
+  time_t CreateTime;             /**< Date created */
+  /*
+   * This is where we return CreateTime
+   */
+  char cCreateTime[MAX_TIME_LENGTH]; /**< CreateTime as returned from DB */
+  /*
+   * Not in DB but returned by db_create_fileset()
+   */
+  bool created; /**< set when record newly created */
 };
 
 /**
  * Device Statistics record -- same as in database
  */
 struct DeviceStatisticsDbRecord {
-   DBId_t DeviceId;                   /**< Device record id */
-   time_t SampleTime;                 /**< Timestamp statistic was captured */
-   uint64_t ReadTime;                 /**< Time spent reading volume */
-   uint64_t WriteTime;                /**< Time spent writing volume */
-   uint64_t ReadBytes;                /**< Number of bytes read */
-   uint64_t WriteBytes;               /**< Number of bytes written */
-   uint64_t SpoolSize;                /**< Number of bytes spooled */
-   uint32_t NumWaiting;               /**< Number of Jobs waiting for device */
-   uint32_t NumWriters;               /**< Number of writers to device */
-   DBId_t MediaId;                    /**< MediaId used */
-   uint64_t VolCatBytes;              /**< Volume Bytes */
-   uint64_t VolCatFiles;              /**< Volume Files */
-   uint64_t VolCatBlocks;             /**< Volume Blocks */
+  DBId_t DeviceId;       /**< Device record id */
+  time_t SampleTime;     /**< Timestamp statistic was captured */
+  uint64_t ReadTime;     /**< Time spent reading volume */
+  uint64_t WriteTime;    /**< Time spent writing volume */
+  uint64_t ReadBytes;    /**< Number of bytes read */
+  uint64_t WriteBytes;   /**< Number of bytes written */
+  uint64_t SpoolSize;    /**< Number of bytes spooled */
+  uint32_t NumWaiting;   /**< Number of Jobs waiting for device */
+  uint32_t NumWriters;   /**< Number of writers to device */
+  DBId_t MediaId;        /**< MediaId used */
+  uint64_t VolCatBytes;  /**< Volume Bytes */
+  uint64_t VolCatFiles;  /**< Volume Files */
+  uint64_t VolCatBlocks; /**< Volume Blocks */
 };
 
 /**
  * TapeAlert record -- same as in database
  */
 struct TapealertStatsDbRecord {
-   DBId_t DeviceId;                   /**< Device record id */
-   time_t SampleTime;                 /**< Timestamp statistic was captured */
-   uint64_t AlertFlags;               /**< Tape Alerts raised */
+  DBId_t DeviceId;     /**< Device record id */
+  time_t SampleTime;   /**< Timestamp statistic was captured */
+  uint64_t AlertFlags; /**< Tape Alerts raised */
 };
 
 /**
  * Job Statistics record -- same as in database
  */
 struct JobStatisticsDbRecord {
-   DBId_t DeviceId;                   /**< Device record id */
-   time_t SampleTime;                 /**< Timestamp statistic was captured */
-   JobId_t JobId;                     /**< Job record id */
-   uint32_t JobFiles;                 /**< Number of Files in Job */
-   uint64_t JobBytes;                 /**< Number of Bytes in Job */
+  DBId_t DeviceId;   /**< Device record id */
+  time_t SampleTime; /**< Timestamp statistic was captured */
+  JobId_t JobId;     /**< Job record id */
+  uint32_t JobFiles; /**< Number of Files in Job */
+  uint64_t JobBytes; /**< Number of Bytes in Job */
 };
 
 /**
  * Call back context for getting a 32/64 bit value from the database
  */
 class db_int64_ctx {
-public:
-   int64_t value;                     /**< value returned */
-   int count;                         /**< number of values seen */
+ public:
+  int64_t value; /**< value returned */
+  int count;     /**< number of values seen */
 
-   db_int64_ctx() : value(0), count(0) {}
-   ~db_int64_ctx() {}
-private:
-   db_int64_ctx(const db_int64_ctx&);            /**< prohibit pass by value */
-   db_int64_ctx &operator=(const db_int64_ctx&); /**< prohibit class assignment */
+  db_int64_ctx() : value(0), count(0) {}
+  ~db_int64_ctx() {}
+
+ private:
+  db_int64_ctx(const db_int64_ctx&); /**< prohibit pass by value */
+  db_int64_ctx& operator=(
+      const db_int64_ctx&); /**< prohibit class assignment */
 };
 
 /**
- * Call back context for getting a list of comma separated strings from the database
+ * Call back context for getting a list of comma separated strings from the
+ * database
  */
 class db_list_ctx {
-public:
-   POOLMEM *list;                     /* list */
-   int count;                         /* number of values seen */
+ public:
+  POOLMEM* list; /* list */
+  int count;     /* number of values seen */
 
-   db_list_ctx() { list = GetPoolMemory(PM_FNAME); reset(); }
-   ~db_list_ctx() { FreePoolMemory(list); list = NULL; }
-   void reset() { *list = 0; count = 0;}
-   void add(const db_list_ctx &str) {
-      if (str.count > 0) {
-         if (*list) {
-            PmStrcat(list, ",");
-         }
-         PmStrcat(list, str.list);
-         count += str.count;
-      }
-   }
-   void add(const char *str) {
-      if (count > 0) {
-         PmStrcat(list, ",");
-      }
-      PmStrcat(list, str);
-      count++;
-   }
-private:
-   db_list_ctx(const db_list_ctx&);            /**< prohibit pass by value */
-   db_list_ctx &operator=(const db_list_ctx&); /**< prohibit class assignment */
+  db_list_ctx()
+  {
+    list = GetPoolMemory(PM_FNAME);
+    reset();
+  }
+  ~db_list_ctx()
+  {
+    FreePoolMemory(list);
+    list = NULL;
+  }
+  void reset()
+  {
+    *list = 0;
+    count = 0;
+  }
+  void add(const db_list_ctx& str)
+  {
+    if (str.count > 0) {
+      if (*list) { PmStrcat(list, ","); }
+      PmStrcat(list, str.list);
+      count += str.count;
+    }
+  }
+  void add(const char* str)
+  {
+    if (count > 0) { PmStrcat(list, ","); }
+    PmStrcat(list, str);
+    count++;
+  }
+
+ private:
+  db_list_ctx(const db_list_ctx&);            /**< prohibit pass by value */
+  db_list_ctx& operator=(const db_list_ctx&); /**< prohibit class assignment */
 };
 
-typedef enum {
-   SQL_INTERFACE_TYPE_MYSQL      = 0,
-   SQL_INTERFACE_TYPE_POSTGRESQL = 1,
-   SQL_INTERFACE_TYPE_SQLITE3    = 2,
-   SQL_INTERFACE_TYPE_INGRES     = 3,
-   SQL_INTERFACE_TYPE_DBI        = 4
+typedef enum
+{
+  SQL_INTERFACE_TYPE_MYSQL = 0,
+  SQL_INTERFACE_TYPE_POSTGRESQL = 1,
+  SQL_INTERFACE_TYPE_SQLITE3 = 2,
+  SQL_INTERFACE_TYPE_INGRES = 3,
+  SQL_INTERFACE_TYPE_DBI = 4
 } SQL_INTERFACETYPE;
 
-typedef enum {
-   SQL_TYPE_MYSQL      = 0,
-   SQL_TYPE_POSTGRESQL = 1,
-   SQL_TYPE_SQLITE3    = 2,
-   SQL_TYPE_INGRES     = 3,
-   SQL_TYPE_UNKNOWN    = 99
+typedef enum
+{
+  SQL_TYPE_MYSQL = 0,
+  SQL_TYPE_POSTGRESQL = 1,
+  SQL_TYPE_SQLITE3 = 2,
+  SQL_TYPE_INGRES = 3,
+  SQL_TYPE_UNKNOWN = 99
 } SQL_DBTYPE;
 
-typedef void (DB_LIST_HANDLER)(void *, const char *);
-typedef int (DB_RESULT_HANDLER)(void *, int, char **);
+typedef void(DB_LIST_HANDLER)(void*, const char*);
+typedef int(DB_RESULT_HANDLER)(void*, int, char**);
 
-#define DbLock(mdb)   mdb->LockDb(__FILE__, __LINE__)
+#define DbLock(mdb) mdb->LockDb(__FILE__, __LINE__)
 #define DbUnlock(mdb) mdb->UnlockDb(__FILE__, __LINE__)
 
 class pathid_cache;
@@ -541,297 +558,486 @@ class pathid_cache;
 /*
  * Generic definition of a sql_row.
  */
-typedef char ** SQL_ROW;
+typedef char** SQL_ROW;
 
 /*
  * Generic definition of a a sql_field.
  */
 typedef struct sql_field {
-   char *name;                        /* name of column */
-   int max_length;                    /* max length */
-   uint32_t type;                     /* type */
-   uint32_t flags;                    /* flags */
+  char* name;     /* name of column */
+  int max_length; /* max length */
+  uint32_t type;  /* type */
+  uint32_t flags; /* flags */
 } SQL_FIELD;
 #endif
 
-class BareosDb: public SmartAlloc, public BareosDbQueryEnum {
-protected:
-   /*
-    * Members
-    */
-   brwlock_t lock_;                      /**< Transaction lock */
-   dlink link_;                          /**< Queue control */
-   SQL_INTERFACETYPE db_interface_type_; /**< Type of backend used */
-   SQL_DBTYPE db_type_;                  /**< Database type */
-   uint32_t ref_count_;                  /**< Reference count */
-   bool connected_;                      /**< Connection made to db */
-   bool have_batch_insert_;              /**< Have batch insert support ? */
-   bool try_reconnect_;                  /**< Try reconnecting DB connection ? */
-   bool exit_on_fatal_;                  /**< Exit on FATAL DB errors ? */
-   char *db_driver_;                     /**< Database driver */
-   char *db_driverdir_;                  /**< Database driver dir */
-   char *db_name_;                       /**< Database name */
-   char *db_user_;                       /**< Database user */
-   char *db_address_;                    /**< Host name address */
-   char *db_socket_;                     /**< Socket for local access */
-   char *db_password_;                   /**< Database password */
-   char *last_query_text_;               /**< Last query text obtained from query table */
-   int db_port_;                         /**< Port for host name address */
-   int cached_path_len;                   /**< Length of cached path */
-   int changes;                           /**< Changes during transaction */
-   int fnl;                               /**< File name length */
-   int pnl;                               /**< Path name length */
-   bool disabled_batch_insert_;          /**< Explicitly disabled batch insert mode ? */
-   bool is_private_;                     /**< Private connection ? */
-   uint32_t cached_path_id;               /**< Cached path id */
-   uint32_t last_hash_key_;              /**< Last hash key lookup on query table */
-   POOLMEM *fname;                        /**< Filename only */
-   POOLMEM *path;                         /**< Path only */
-   POOLMEM *cached_path;                  /**< Cached path name */
-   POOLMEM *esc_name;                     /**< Escaped file name */
-   POOLMEM *esc_path;                     /**< Escaped path name */
-   POOLMEM *esc_obj;                      /**< Escaped restore object */
-   POOLMEM *cmd;                          /**< SQL command string */
-   POOLMEM *errmsg;                       /**< Nicely edited error message */
-   const char **queries;                  /**< table of query texts */
-   static const char *query_names[];      /**< table of query names */
+class BareosDb
+    : public SmartAlloc
+    , public BareosDbQueryEnum {
+ protected:
+  /*
+   * Members
+   */
+  brwlock_t lock_;                      /**< Transaction lock */
+  dlink link_;                          /**< Queue control */
+  SQL_INTERFACETYPE db_interface_type_; /**< Type of backend used */
+  SQL_DBTYPE db_type_;                  /**< Database type */
+  uint32_t ref_count_;                  /**< Reference count */
+  bool connected_;                      /**< Connection made to db */
+  bool have_batch_insert_;              /**< Have batch insert support ? */
+  bool try_reconnect_;                  /**< Try reconnecting DB connection ? */
+  bool exit_on_fatal_;                  /**< Exit on FATAL DB errors ? */
+  char* db_driver_;                     /**< Database driver */
+  char* db_driverdir_;                  /**< Database driver dir */
+  char* db_name_;                       /**< Database name */
+  char* db_user_;                       /**< Database user */
+  char* db_address_;                    /**< Host name address */
+  char* db_socket_;                     /**< Socket for local access */
+  char* db_password_;                   /**< Database password */
+  char* last_query_text_;      /**< Last query text obtained from query table */
+  int db_port_;                /**< Port for host name address */
+  int cached_path_len;         /**< Length of cached path */
+  int changes;                 /**< Changes during transaction */
+  int fnl;                     /**< File name length */
+  int pnl;                     /**< Path name length */
+  bool disabled_batch_insert_; /**< Explicitly disabled batch insert mode ? */
+  bool is_private_;            /**< Private connection ? */
+  uint32_t cached_path_id;     /**< Cached path id */
+  uint32_t last_hash_key_;     /**< Last hash key lookup on query table */
+  POOLMEM* fname;              /**< Filename only */
+  POOLMEM* path;               /**< Path only */
+  POOLMEM* cached_path;        /**< Cached path name */
+  POOLMEM* esc_name;           /**< Escaped file name */
+  POOLMEM* esc_path;           /**< Escaped path name */
+  POOLMEM* esc_obj;            /**< Escaped restore object */
+  POOLMEM* cmd;                /**< SQL command string */
+  POOLMEM* errmsg;             /**< Nicely edited error message */
+  const char** queries;        /**< table of query texts */
+  static const char* query_names[]; /**< table of query names */
 
-private:
-   /*
-    * Methods
-    */
-   int GetFilenameRecord(JobControlRecord *jcr);
-   bool GetFileRecord(JobControlRecord *jcr, JobDbRecord *jr, FileDbRecord *fdbr);
-   bool CreateBatchFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CreateFilenameRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CreateFileRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   void CleanupBaseFile(JobControlRecord *jcr);
-   void BuildPathHierarchy(JobControlRecord *jcr, pathid_cache &ppathid_cache, char *org_pathid, char *path);
-   bool UpdatePathHierarchyCache(JobControlRecord *jcr, pathid_cache &ppathid_cache, JobId_t JobId);
-   void FillQueryVaList(POOLMEM *&query, BareosDb::SQL_QUERY_ENUM predefined_query, va_list arg_ptr);
-   void FillQueryVaList(PoolMem &query, BareosDb::SQL_QUERY_ENUM predefined_query, va_list arg_ptr);
+ private:
+  /*
+   * Methods
+   */
+  int GetFilenameRecord(JobControlRecord* jcr);
+  bool GetFileRecord(JobControlRecord* jcr,
+                     JobDbRecord* jr,
+                     FileDbRecord* fdbr);
+  bool CreateBatchFileAttributesRecord(JobControlRecord* jcr,
+                                       AttributesDbRecord* ar);
+  bool CreateFilenameRecord(JobControlRecord* jcr, AttributesDbRecord* ar);
+  bool CreateFileRecord(JobControlRecord* jcr, AttributesDbRecord* ar);
+  void CleanupBaseFile(JobControlRecord* jcr);
+  void BuildPathHierarchy(JobControlRecord* jcr,
+                          pathid_cache& ppathid_cache,
+                          char* org_pathid,
+                          char* path);
+  bool UpdatePathHierarchyCache(JobControlRecord* jcr,
+                                pathid_cache& ppathid_cache,
+                                JobId_t JobId);
+  void FillQueryVaList(POOLMEM*& query,
+                       BareosDb::SQL_QUERY_ENUM predefined_query,
+                       va_list arg_ptr);
+  void FillQueryVaList(PoolMem& query,
+                       BareosDb::SQL_QUERY_ENUM predefined_query,
+                       va_list arg_ptr);
 
-public:
-   /*
-    * Methods
-    */
-   BareosDb() {}
-   virtual ~BareosDb() {}
-   const char *get_db_name(void) { return db_name_; }
-   const char *get_db_user(void) { return db_user_; }
-   bool IsConnected(void) { return connected_; }
-   bool BatchInsertAvailable(void) { return have_batch_insert_; }
-   bool IsPrivate(void) { return is_private_; }
-   void SetPrivate(bool IsPrivate) { is_private_ = IsPrivate; }
-   void IncrementRefcount(void) { ref_count_++; }
+ public:
+  /*
+   * Methods
+   */
+  BareosDb() {}
+  virtual ~BareosDb() {}
+  const char* get_db_name(void) { return db_name_; }
+  const char* get_db_user(void) { return db_user_; }
+  bool IsConnected(void) { return connected_; }
+  bool BatchInsertAvailable(void) { return have_batch_insert_; }
+  bool IsPrivate(void) { return is_private_; }
+  void SetPrivate(bool IsPrivate) { is_private_ = IsPrivate; }
+  void IncrementRefcount(void) { ref_count_++; }
 
-   /* bvfs.c */
-   bool BvfsUpdatePathHierarchyCache(JobControlRecord *jcr, char *jobids);
-   void BvfsUpdateCache(JobControlRecord *jcr);
-   int BvfsLsDirs(PoolMem &query, void *ctx);
-   int BvfsBuildLsFileQuery(PoolMem &query, DB_RESULT_HANDLER *ResultHandler, void *ctx);
+  /* bvfs.c */
+  bool BvfsUpdatePathHierarchyCache(JobControlRecord* jcr, char* jobids);
+  void BvfsUpdateCache(JobControlRecord* jcr);
+  int BvfsLsDirs(PoolMem& query, void* ctx);
+  int BvfsBuildLsFileQuery(PoolMem& query,
+                           DB_RESULT_HANDLER* ResultHandler,
+                           void* ctx);
 
-   /* sql.c */
-   char *strerror();
-   bool CheckMaxConnections(JobControlRecord *jcr, uint32_t max_concurrent_jobs);
-   bool CheckTablesVersion(JobControlRecord *jcr);
-   bool QueryDB(const char *file, int line, JobControlRecord *jcr, const char *select_cmd);
-   bool InsertDB(const char *file, int line, JobControlRecord *jcr, const char *select_cmd);
-   int DeleteDB(const char *file, int line, JobControlRecord *jcr, const char *DeleteCmd);
-   bool UpdateDB(const char *file, int line, JobControlRecord *jcr, const char *UpdateCmd, int nr_afr);
-   int GetSqlRecordMax(JobControlRecord *jcr);
-   void SplitPathAndFile(JobControlRecord *jcr, const char *fname);
-   void ListDashes(OutputFormatter *send);
-   int ListResult(void *vctx, int nb_col, char **row);
-   int ListResult(JobControlRecord *jcr, OutputFormatter *send, e_list_type type);
-   bool OpenBatchConnection(JobControlRecord *jcr);
-   void DbDebugPrint(FILE *fp);
+  /* sql.c */
+  char* strerror();
+  bool CheckMaxConnections(JobControlRecord* jcr, uint32_t max_concurrent_jobs);
+  bool CheckTablesVersion(JobControlRecord* jcr);
+  bool QueryDB(const char* file,
+               int line,
+               JobControlRecord* jcr,
+               const char* select_cmd);
+  bool InsertDB(const char* file,
+                int line,
+                JobControlRecord* jcr,
+                const char* select_cmd);
+  int DeleteDB(const char* file,
+               int line,
+               JobControlRecord* jcr,
+               const char* DeleteCmd);
+  bool UpdateDB(const char* file,
+                int line,
+                JobControlRecord* jcr,
+                const char* UpdateCmd,
+                int nr_afr);
+  int GetSqlRecordMax(JobControlRecord* jcr);
+  void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
+  void ListDashes(OutputFormatter* send);
+  int ListResult(void* vctx, int nb_col, char** row);
+  int ListResult(JobControlRecord* jcr,
+                 OutputFormatter* send,
+                 e_list_type type);
+  bool OpenBatchConnection(JobControlRecord* jcr);
+  void DbDebugPrint(FILE* fp);
 
-   /* sql_create.c */
-   bool CreatePathRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CreateFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CreateJobRecord(JobControlRecord *jcr, JobDbRecord *jr);
-   bool CreateMediaRecord(JobControlRecord *jcr, MediaDbRecord *media_dbr);
-   bool CreateClientRecord(JobControlRecord *jcr, ClientDbRecord *cr);
-   bool CreateFilesetRecord(JobControlRecord *jcr, FileSetDbRecord *fsr);
-   bool CreatePoolRecord(JobControlRecord *jcr, PoolDbRecord *pool_dbr);
-   bool CreateJobmediaRecord(JobControlRecord *jcr, JobMediaDbRecord *jr);
-   bool CreateCounterRecord(JobControlRecord *jcr, CounterDbRecord *cr);
-   bool CreateDeviceRecord(JobControlRecord *jcr, DeviceDbRecord *dr);
-   bool CreateStorageRecord(JobControlRecord *jcr, StorageDbRecord *sr);
-   bool CreateMediatypeRecord(JobControlRecord *jcr, MediaTypeDbRecord *mr);
-   bool WriteBatchFileRecords(JobControlRecord *jcr);
-   bool CreateAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CreateRestoreObjectRecord(JobControlRecord *jcr, RestoreObjectDbRecord *ar);
-   bool CreateBaseFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar);
-   bool CommitBaseFileAttributesRecord(JobControlRecord *jcr);
-   bool CreateBaseFileList(JobControlRecord *jcr, char *jobids);
-   bool CreateQuotaRecord(JobControlRecord *jcr, ClientDbRecord *cr);
-   bool CreateNdmpLevelMapping(JobControlRecord *jcr, JobDbRecord *jr, char *filesystem);
-   bool CreateNdmpEnvironmentString(JobControlRecord *jcr, JobDbRecord *jr, char *name, char *value);
-   bool CreateJobStatistics(JobControlRecord *jcr, JobStatisticsDbRecord *jsr);
-   bool CreateDeviceStatistics(JobControlRecord *jcr, DeviceStatisticsDbRecord *dsr);
-   bool CreateTapealertStatistics(JobControlRecord *jcr, TapealertStatsDbRecord *tsr);
+  /* sql_create.c */
+  bool CreatePathRecord(JobControlRecord* jcr, AttributesDbRecord* ar);
+  bool CreateFileAttributesRecord(JobControlRecord* jcr,
+                                  AttributesDbRecord* ar);
+  bool CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr);
+  bool CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* media_dbr);
+  bool CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr);
+  bool CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr);
+  bool CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pool_dbr);
+  bool CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jr);
+  bool CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr);
+  bool CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr);
+  bool CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr);
+  bool CreateMediatypeRecord(JobControlRecord* jcr, MediaTypeDbRecord* mr);
+  bool WriteBatchFileRecords(JobControlRecord* jcr);
+  bool CreateAttributesRecord(JobControlRecord* jcr, AttributesDbRecord* ar);
+  bool CreateRestoreObjectRecord(JobControlRecord* jcr,
+                                 RestoreObjectDbRecord* ar);
+  bool CreateBaseFileAttributesRecord(JobControlRecord* jcr,
+                                      AttributesDbRecord* ar);
+  bool CommitBaseFileAttributesRecord(JobControlRecord* jcr);
+  bool CreateBaseFileList(JobControlRecord* jcr, char* jobids);
+  bool CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr);
+  bool CreateNdmpLevelMapping(JobControlRecord* jcr,
+                              JobDbRecord* jr,
+                              char* filesystem);
+  bool CreateNdmpEnvironmentString(JobControlRecord* jcr,
+                                   JobDbRecord* jr,
+                                   char* name,
+                                   char* value);
+  bool CreateJobStatistics(JobControlRecord* jcr, JobStatisticsDbRecord* jsr);
+  bool CreateDeviceStatistics(JobControlRecord* jcr,
+                              DeviceStatisticsDbRecord* dsr);
+  bool CreateTapealertStatistics(JobControlRecord* jcr,
+                                 TapealertStatsDbRecord* tsr);
 
-   /* sql_delete.c */
-   bool DeletePoolRecord(JobControlRecord *jcr, PoolDbRecord *pool_dbr);
-   bool DeleteMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr);
-   bool PurgeMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr);
+  /* sql_delete.c */
+  bool DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pool_dbr);
+  bool DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
+  bool PurgeMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
 
-   /* sql_find.c */
-   bool FindLastJobStartTime(JobControlRecord *jcr, JobDbRecord *jr, POOLMEM *&stime, char *job, int JobLevel);
-   bool FindJobStartTime(JobControlRecord *jcr, JobDbRecord *jr, POOLMEM *&stime, char *job);
-   bool FindLastJobid(JobControlRecord *jcr, const char *Name, JobDbRecord *jr);
-   int FindNextVolume(JobControlRecord *jcr, int index, bool InChanger, MediaDbRecord *mr, const char *unwanted_volumes);
-   bool FindFailedJobSince(JobControlRecord *jcr, JobDbRecord *jr, POOLMEM *stime, int &JobLevel);
+  /* sql_find.c */
+  bool FindLastJobStartTime(JobControlRecord* jcr,
+                            JobDbRecord* jr,
+                            POOLMEM*& stime,
+                            char* job,
+                            int JobLevel);
+  bool FindJobStartTime(JobControlRecord* jcr,
+                        JobDbRecord* jr,
+                        POOLMEM*& stime,
+                        char* job);
+  bool FindLastJobid(JobControlRecord* jcr, const char* Name, JobDbRecord* jr);
+  int FindNextVolume(JobControlRecord* jcr,
+                     int index,
+                     bool InChanger,
+                     MediaDbRecord* mr,
+                     const char* unwanted_volumes);
+  bool FindFailedJobSince(JobControlRecord* jcr,
+                          JobDbRecord* jr,
+                          POOLMEM* stime,
+                          int& JobLevel);
 
-   /* sql_get.c */
-   bool GetVolumeJobids(JobControlRecord *jcr, MediaDbRecord *mr, db_list_ctx *lst);
-   bool GetBaseFileList(JobControlRecord *jcr, bool use_md5, DB_RESULT_HANDLER *ResultHandler,void *ctx);
-   int GetPathRecord(JobControlRecord *jcr);
-   int GetPathRecord(JobControlRecord *jcr, const char *new_path);
-   bool GetPoolRecord(JobControlRecord *jcr, PoolDbRecord *pdbr);
-   bool GetStorageRecord(JobControlRecord *jcr, StorageDbRecord *sdbr);
-   bool GetJobRecord(JobControlRecord *jcr, JobDbRecord *jr);
-   int GetJobVolumeNames(JobControlRecord *jcr, JobId_t JobId, POOLMEM *&VolumeNames);
-   bool GetFileAttributesRecord(JobControlRecord *jcr, char *filename, JobDbRecord *jr, FileDbRecord *fdbr);
-   int GetFilesetRecord(JobControlRecord *jcr, FileSetDbRecord *fsr);
-   bool GetMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr);
-   int GetNumMediaRecords(JobControlRecord *jcr);
-   int GetNumPoolRecords(JobControlRecord *jcr);
-   int GetPoolIds(JobControlRecord *jcr, int *num_ids, DBId_t **ids);
-   bool GetClientIds(JobControlRecord *jcr, int *num_ids, DBId_t **ids);
-   int GetStorageIds(JobControlRecord *jcr, int *num_ids, DBId_t **ids);
-   bool PrepareMediaSqlQuery(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem &volumes);
-   bool GetMediaIds(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem &volumes, int *num_ids, DBId_t **ids);
-   int GetJobVolumeParameters(JobControlRecord *jcr, JobId_t JobId, VolumeParameters **VolParams);
-   bool GetClientRecord(JobControlRecord *jcr, ClientDbRecord *cdbr);
-   bool GetCounterRecord(JobControlRecord *jcr, CounterDbRecord *cr);
-   bool GetQueryDbids(JobControlRecord *jcr, PoolMem &query, dbid_list &ids);
-   bool GetFileList(JobControlRecord *jcr, char *jobids, bool use_md5, bool use_delta, DB_RESULT_HANDLER *ResultHandler, void *ctx);
-   bool GetBaseJobid(JobControlRecord *jcr, JobDbRecord *jr, JobId_t *jobid);
-   bool AccurateGetJobids(JobControlRecord *jcr, JobDbRecord *jr, db_list_ctx *jobids);
-   bool GetUsedBaseJobids(JobControlRecord *jcr, POOLMEM *jobids, db_list_ctx *result);
-   bool GetQuotaRecord(JobControlRecord *jcr, ClientDbRecord *cr);
-   bool get_quota_jobbytes(JobControlRecord *jcr, JobDbRecord *jr, utime_t JobRetention);
-   bool get_quota_jobbytes_nofailed(JobControlRecord *jcr, JobDbRecord *jr, utime_t JobRetention);
-   int GetNdmpLevelMapping(JobControlRecord *jcr, JobDbRecord *jr, char *filesystem);
-   bool GetNdmpEnvironmentString(JobControlRecord *jcr, JobDbRecord *jr, DB_RESULT_HANDLER *ResultHandler, void *ctx);
-   bool GetNdmpEnvironmentString(JobControlRecord *jcr, JobId_t JobId, DB_RESULT_HANDLER *ResultHandler, void *ctx);
-   bool PrepareMediaSqlQuery(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem *querystring, PoolMem &volumes);
-   bool VerifyMediaIdsFromSingleStorage(JobControlRecord *jcr, dbid_list &mediaIds);
+  /* sql_get.c */
+  bool GetVolumeJobids(JobControlRecord* jcr,
+                       MediaDbRecord* mr,
+                       db_list_ctx* lst);
+  bool GetBaseFileList(JobControlRecord* jcr,
+                       bool use_md5,
+                       DB_RESULT_HANDLER* ResultHandler,
+                       void* ctx);
+  int GetPathRecord(JobControlRecord* jcr);
+  int GetPathRecord(JobControlRecord* jcr, const char* new_path);
+  bool GetPoolRecord(JobControlRecord* jcr, PoolDbRecord* pdbr);
+  bool GetStorageRecord(JobControlRecord* jcr, StorageDbRecord* sdbr);
+  bool GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr);
+  int GetJobVolumeNames(JobControlRecord* jcr,
+                        JobId_t JobId,
+                        POOLMEM*& VolumeNames);
+  bool GetFileAttributesRecord(JobControlRecord* jcr,
+                               char* filename,
+                               JobDbRecord* jr,
+                               FileDbRecord* fdbr);
+  int GetFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr);
+  bool GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
+  int GetNumMediaRecords(JobControlRecord* jcr);
+  int GetNumPoolRecords(JobControlRecord* jcr);
+  int GetPoolIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids);
+  bool GetClientIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids);
+  int GetStorageIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids);
+  bool PrepareMediaSqlQuery(JobControlRecord* jcr,
+                            MediaDbRecord* mr,
+                            PoolMem& volumes);
+  bool GetMediaIds(JobControlRecord* jcr,
+                   MediaDbRecord* mr,
+                   PoolMem& volumes,
+                   int* num_ids,
+                   DBId_t** ids);
+  int GetJobVolumeParameters(JobControlRecord* jcr,
+                             JobId_t JobId,
+                             VolumeParameters** VolParams);
+  bool GetClientRecord(JobControlRecord* jcr, ClientDbRecord* cdbr);
+  bool GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr);
+  bool GetQueryDbids(JobControlRecord* jcr, PoolMem& query, dbid_list& ids);
+  bool GetFileList(JobControlRecord* jcr,
+                   char* jobids,
+                   bool use_md5,
+                   bool use_delta,
+                   DB_RESULT_HANDLER* ResultHandler,
+                   void* ctx);
+  bool GetBaseJobid(JobControlRecord* jcr, JobDbRecord* jr, JobId_t* jobid);
+  bool AccurateGetJobids(JobControlRecord* jcr,
+                         JobDbRecord* jr,
+                         db_list_ctx* jobids);
+  bool GetUsedBaseJobids(JobControlRecord* jcr,
+                         POOLMEM* jobids,
+                         db_list_ctx* result);
+  bool GetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr);
+  bool get_quota_jobbytes(JobControlRecord* jcr,
+                          JobDbRecord* jr,
+                          utime_t JobRetention);
+  bool get_quota_jobbytes_nofailed(JobControlRecord* jcr,
+                                   JobDbRecord* jr,
+                                   utime_t JobRetention);
+  int GetNdmpLevelMapping(JobControlRecord* jcr,
+                          JobDbRecord* jr,
+                          char* filesystem);
+  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
+                                JobDbRecord* jr,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
+  bool GetNdmpEnvironmentString(JobControlRecord* jcr,
+                                JobId_t JobId,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
+  bool PrepareMediaSqlQuery(JobControlRecord* jcr,
+                            MediaDbRecord* mr,
+                            PoolMem* querystring,
+                            PoolMem& volumes);
+  bool VerifyMediaIdsFromSingleStorage(JobControlRecord* jcr,
+                                       dbid_list& mediaIds);
 
-   /* sql_list.c */
-   void ListPoolRecords(JobControlRecord *jcr, PoolDbRecord *pr, OutputFormatter *sendit, e_list_type type);
-   void ListJobRecords(JobControlRecord *jcr, JobDbRecord *jr, const char *range, const char *clientname,
-                            int jobstatus, int joblevel, const char *volumename, const char *poolname, utime_t since_time, bool last,
-                            bool count, OutputFormatter *sendit, e_list_type type);
-   void ListJobTotals(JobControlRecord *jcr, JobDbRecord *jr, OutputFormatter *sendit);
-   void ListFilesForJob(JobControlRecord *jcr, uint32_t jobid, OutputFormatter *sendit);
-   void ListFilesets(JobControlRecord *jcr, JobDbRecord *jr, const char *range, OutputFormatter *sendit, e_list_type type);
-   void ListStorageRecords(JobControlRecord *jcr, OutputFormatter *sendit, e_list_type type);
-   void ListMediaRecords(JobControlRecord *jcr, MediaDbRecord *mdbr, const char *range, bool count, OutputFormatter *sendit, e_list_type type);
-   void ListJobmediaRecords(JobControlRecord *jcr, JobId_t JobId, OutputFormatter *sendit, e_list_type type);
-   void ListVolumesOfJobid(JobControlRecord *jcr, JobId_t JobId, OutputFormatter *sendit, e_list_type type);
-   void ListJoblogRecords(JobControlRecord *jcr, JobId_t JobId, const char *range, bool count, OutputFormatter *sendit, e_list_type type);
-   void ListLogRecords(JobControlRecord *jcr, const char *clientname, const char *range,
-                         bool reverse, OutputFormatter *sendit, e_list_type type);
-   void ListJobstatisticsRecords(JobControlRecord *jcr, uint32_t JobId, OutputFormatter *sendit, e_list_type type);
-   bool ListSqlQuery(JobControlRecord *jcr, const char *query, OutputFormatter *sendit, e_list_type type, bool verbose);
-   bool ListSqlQuery(JobControlRecord *jcr, SQL_QUERY_ENUM query, OutputFormatter *sendit, e_list_type type, bool verbose);
-   bool ListSqlQuery(JobControlRecord *jcr, const char *query, OutputFormatter *sendit, e_list_type type,
-                       const char *description, bool verbose = false);
-   bool ListSqlQuery(JobControlRecord *jcr, SQL_QUERY_ENUM query, OutputFormatter *sendit,
-                       e_list_type type, const char *description, bool verbose);
-   void ListClientRecords(JobControlRecord *jcr, char *clientname, OutputFormatter *sendit, e_list_type type);
-   void ListCopiesRecords(JobControlRecord *jcr, const char *range, const char *jobids, OutputFormatter *sendit, e_list_type type);
-   void ListBaseFilesForJob(JobControlRecord *jcr, JobId_t jobid, OutputFormatter *sendit);
+  /* sql_list.c */
+  void ListPoolRecords(JobControlRecord* jcr,
+                       PoolDbRecord* pr,
+                       OutputFormatter* sendit,
+                       e_list_type type);
+  void ListJobRecords(JobControlRecord* jcr,
+                      JobDbRecord* jr,
+                      const char* range,
+                      const char* clientname,
+                      int jobstatus,
+                      int joblevel,
+                      const char* volumename,
+                      const char* poolname,
+                      utime_t since_time,
+                      bool last,
+                      bool count,
+                      OutputFormatter* sendit,
+                      e_list_type type);
+  void ListJobTotals(JobControlRecord* jcr,
+                     JobDbRecord* jr,
+                     OutputFormatter* sendit);
+  void ListFilesForJob(JobControlRecord* jcr,
+                       uint32_t jobid,
+                       OutputFormatter* sendit);
+  void ListFilesets(JobControlRecord* jcr,
+                    JobDbRecord* jr,
+                    const char* range,
+                    OutputFormatter* sendit,
+                    e_list_type type);
+  void ListStorageRecords(JobControlRecord* jcr,
+                          OutputFormatter* sendit,
+                          e_list_type type);
+  void ListMediaRecords(JobControlRecord* jcr,
+                        MediaDbRecord* mdbr,
+                        const char* range,
+                        bool count,
+                        OutputFormatter* sendit,
+                        e_list_type type);
+  void ListJobmediaRecords(JobControlRecord* jcr,
+                           JobId_t JobId,
+                           OutputFormatter* sendit,
+                           e_list_type type);
+  void ListVolumesOfJobid(JobControlRecord* jcr,
+                          JobId_t JobId,
+                          OutputFormatter* sendit,
+                          e_list_type type);
+  void ListJoblogRecords(JobControlRecord* jcr,
+                         JobId_t JobId,
+                         const char* range,
+                         bool count,
+                         OutputFormatter* sendit,
+                         e_list_type type);
+  void ListLogRecords(JobControlRecord* jcr,
+                      const char* clientname,
+                      const char* range,
+                      bool reverse,
+                      OutputFormatter* sendit,
+                      e_list_type type);
+  void ListJobstatisticsRecords(JobControlRecord* jcr,
+                                uint32_t JobId,
+                                OutputFormatter* sendit,
+                                e_list_type type);
+  bool ListSqlQuery(JobControlRecord* jcr,
+                    const char* query,
+                    OutputFormatter* sendit,
+                    e_list_type type,
+                    bool verbose);
+  bool ListSqlQuery(JobControlRecord* jcr,
+                    SQL_QUERY_ENUM query,
+                    OutputFormatter* sendit,
+                    e_list_type type,
+                    bool verbose);
+  bool ListSqlQuery(JobControlRecord* jcr,
+                    const char* query,
+                    OutputFormatter* sendit,
+                    e_list_type type,
+                    const char* description,
+                    bool verbose = false);
+  bool ListSqlQuery(JobControlRecord* jcr,
+                    SQL_QUERY_ENUM query,
+                    OutputFormatter* sendit,
+                    e_list_type type,
+                    const char* description,
+                    bool verbose);
+  void ListClientRecords(JobControlRecord* jcr,
+                         char* clientname,
+                         OutputFormatter* sendit,
+                         e_list_type type);
+  void ListCopiesRecords(JobControlRecord* jcr,
+                         const char* range,
+                         const char* jobids,
+                         OutputFormatter* sendit,
+                         e_list_type type);
+  void ListBaseFilesForJob(JobControlRecord* jcr,
+                           JobId_t jobid,
+                           OutputFormatter* sendit);
 
-   /* SqlQuery.c */
-   const char *get_predefined_query_name(SQL_QUERY_ENUM query);
-   const char *get_predefined_query(SQL_QUERY_ENUM query);
+  /* SqlQuery.c */
+  const char* get_predefined_query_name(SQL_QUERY_ENUM query);
+  const char* get_predefined_query(SQL_QUERY_ENUM query);
 
-   void FillQuery(SQL_QUERY_ENUM predefined_query, ...);
-   void FillQuery(POOLMEM *&query, SQL_QUERY_ENUM predefined_query, ...);
-   void FillQuery(PoolMem &query, SQL_QUERY_ENUM predefined_query, ...);
+  void FillQuery(SQL_QUERY_ENUM predefined_query, ...);
+  void FillQuery(POOLMEM*& query, SQL_QUERY_ENUM predefined_query, ...);
+  void FillQuery(PoolMem& query, SQL_QUERY_ENUM predefined_query, ...);
 
-   bool SqlQuery(SQL_QUERY_ENUM query, ...);
-   bool SqlQuery(const char *query, int flags = 0);
-   bool SqlQuery(const char *query, DB_RESULT_HANDLER *ResultHandler, void *ctx);
+  bool SqlQuery(SQL_QUERY_ENUM query, ...);
+  bool SqlQuery(const char* query, int flags = 0);
+  bool SqlQuery(const char* query, DB_RESULT_HANDLER* ResultHandler, void* ctx);
 
-   /* sql_update.c */
-   bool UpdateJobStartRecord(JobControlRecord *jcr, JobDbRecord *jr);
-   bool UpdateJobEndRecord(JobControlRecord *jcr, JobDbRecord *jr);
-   bool UpdateClientRecord(JobControlRecord *jcr, ClientDbRecord *cr);
-   bool UpdatePoolRecord(JobControlRecord *jcr, PoolDbRecord *pr);
-   bool UpdateStorageRecord(JobControlRecord *jcr, StorageDbRecord *sr);
-   bool UpdateMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr);
-   bool UpdateMediaDefaults(JobControlRecord *jcr, MediaDbRecord *mr);
-   bool UpdateCounterRecord(JobControlRecord *jcr, CounterDbRecord *cr);
-   bool UpdateQuotaGracetime(JobControlRecord *jcr, JobDbRecord *jr);
-   bool UpdateQuotaSoftlimit(JobControlRecord *jcr, JobDbRecord *jr);
-   bool ResetQuotaRecord(JobControlRecord *jcr, ClientDbRecord *jr);
-   bool UpdateNdmpLevelMapping(JobControlRecord *jcr, JobDbRecord *jr, char *filesystem, int level);
-   bool AddDigestToFileRecord(JobControlRecord *jcr, FileId_t FileId, char *digest, int type);
-   bool MarkFileRecord(JobControlRecord *jcr, FileId_t FileId, JobId_t JobId);
-   void MakeInchangerUnique(JobControlRecord *jcr, MediaDbRecord *mr);
-   int UpdateStats(JobControlRecord *jcr, utime_t age);
+  /* sql_update.c */
+  bool UpdateJobStartRecord(JobControlRecord* jcr, JobDbRecord* jr);
+  bool UpdateJobEndRecord(JobControlRecord* jcr, JobDbRecord* jr);
+  bool UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr);
+  bool UpdatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr);
+  bool UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr);
+  bool UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
+  bool UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr);
+  bool UpdateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr);
+  bool UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr);
+  bool UpdateQuotaSoftlimit(JobControlRecord* jcr, JobDbRecord* jr);
+  bool ResetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* jr);
+  bool UpdateNdmpLevelMapping(JobControlRecord* jcr,
+                              JobDbRecord* jr,
+                              char* filesystem,
+                              int level);
+  bool AddDigestToFileRecord(JobControlRecord* jcr,
+                             FileId_t FileId,
+                             char* digest,
+                             int type);
+  bool MarkFileRecord(JobControlRecord* jcr, FileId_t FileId, JobId_t JobId);
+  void MakeInchangerUnique(JobControlRecord* jcr, MediaDbRecord* mr);
+  int UpdateStats(JobControlRecord* jcr, utime_t age);
 
-   /* Low level methods */
-   bool MatchDatabase(const char *db_driver, const char *db_name,
-                       const char *db_address, int db_port);
-   BareosDb *CloneDatabaseConnection(JobControlRecord *jcr,
-                                   bool mult_db_connections,
-                                   bool get_pooled_connection = true,
-                                   bool need_private = false);
-   int GetTypeIndex(void) { return db_type_; }
-   const char *GetType(void);
-   void LockDb(const char *file, int line);
-   void UnlockDb(const char *file, int line);
-   void PrintLockInfo(FILE *fp);
+  /* Low level methods */
+  bool MatchDatabase(const char* db_driver,
+                     const char* db_name,
+                     const char* db_address,
+                     int db_port);
+  BareosDb* CloneDatabaseConnection(JobControlRecord* jcr,
+                                    bool mult_db_connections,
+                                    bool get_pooled_connection = true,
+                                    bool need_private = false);
+  int GetTypeIndex(void) { return db_type_; }
+  const char* GetType(void);
+  void LockDb(const char* file, int line);
+  void UnlockDb(const char* file, int line);
+  void PrintLockInfo(FILE* fp);
 
-   /* Virtual low level methods */
-   virtual void ThreadCleanup(void) {}
-   virtual void EscapeString(JobControlRecord *jcr, char *snew, char *old, int len);
-   virtual char *EscapeObject(JobControlRecord *jcr, char *old, int len);
-   virtual void UnescapeObject(JobControlRecord *jcr, char *from, int32_t expected_len,
-                                POOLMEM *&dest, int32_t *len);
+  /* Virtual low level methods */
+  virtual void ThreadCleanup(void) {}
+  virtual void EscapeString(JobControlRecord* jcr,
+                            char* snew,
+                            char* old,
+                            int len);
+  virtual char* EscapeObject(JobControlRecord* jcr, char* old, int len);
+  virtual void UnescapeObject(JobControlRecord* jcr,
+                              char* from,
+                              int32_t expected_len,
+                              POOLMEM*& dest,
+                              int32_t* len);
 
-   /* Pure virtual low level methods */
-   virtual bool OpenDatabase(JobControlRecord *jcr) = 0;
-   virtual void CloseDatabase(JobControlRecord *jcr) = 0;
-   virtual bool ValidateConnection(void) = 0;
-   virtual void StartTransaction(JobControlRecord *jcr) = 0;
-   virtual void EndTransaction(JobControlRecord *jcr) = 0;
+  /* Pure virtual low level methods */
+  virtual bool OpenDatabase(JobControlRecord* jcr) = 0;
+  virtual void CloseDatabase(JobControlRecord* jcr) = 0;
+  virtual bool ValidateConnection(void) = 0;
+  virtual void StartTransaction(JobControlRecord* jcr) = 0;
+  virtual void EndTransaction(JobControlRecord* jcr) = 0;
 
-   /* By default, we use db_sql_query */
-   virtual bool BigSqlQuery(const char *query,
-                              DB_RESULT_HANDLER *ResultHandler, void *ctx) {
-      return SqlQuery(query, ResultHandler, ctx);
-   }
+  /* By default, we use db_sql_query */
+  virtual bool BigSqlQuery(const char* query,
+                           DB_RESULT_HANDLER* ResultHandler,
+                           void* ctx)
+  {
+    return SqlQuery(query, ResultHandler, ctx);
+  }
 
 #ifdef _BDB_PRIV_INTERFACE_
-   /*
-    * Backend methods
-    */
-private:
-   virtual int SqlNumRows(void) = 0;
-   virtual void SqlFieldSeek(int field) = 0;
-   virtual int SqlNumFields(void) = 0;
-   virtual void SqlFreeResult(void) = 0;
-   virtual SQL_ROW SqlFetchRow(void) = 0;
-   virtual bool SqlQueryWithoutHandler(const char *query, int flags = 0) = 0;
-   virtual bool SqlQueryWithHandler(const char *query, DB_RESULT_HANDLER *ResultHandler, void *ctx) = 0;
-   virtual const char *sql_strerror(void) = 0;
-   virtual void SqlDataSeek(int row) = 0;
-   virtual int SqlAffectedRows(void) = 0;
-   virtual uint64_t SqlInsertAutokeyRecord(const char *query, const char *table_name) = 0;
-   virtual SQL_FIELD *SqlFetchField(void) = 0;
-   virtual bool SqlFieldIsNotNull(int field_type) = 0;
-   virtual bool SqlFieldIsNumeric(int field_type) = 0;
-   virtual bool SqlBatchStart(JobControlRecord *jcr) = 0;
-   virtual bool SqlBatchEnd(JobControlRecord *jcr, const char *error) = 0;
-   virtual bool SqlBatchInsert(JobControlRecord *jcr, AttributesDbRecord *ar) = 0;
+  /*
+   * Backend methods
+   */
+ private:
+  virtual int SqlNumRows(void) = 0;
+  virtual void SqlFieldSeek(int field) = 0;
+  virtual int SqlNumFields(void) = 0;
+  virtual void SqlFreeResult(void) = 0;
+  virtual SQL_ROW SqlFetchRow(void) = 0;
+  virtual bool SqlQueryWithoutHandler(const char* query, int flags = 0) = 0;
+  virtual bool SqlQueryWithHandler(const char* query,
+                                   DB_RESULT_HANDLER* ResultHandler,
+                                   void* ctx) = 0;
+  virtual const char* sql_strerror(void) = 0;
+  virtual void SqlDataSeek(int row) = 0;
+  virtual int SqlAffectedRows(void) = 0;
+  virtual uint64_t SqlInsertAutokeyRecord(const char* query,
+                                          const char* table_name) = 0;
+  virtual SQL_FIELD* SqlFetchField(void) = 0;
+  virtual bool SqlFieldIsNotNull(int field_type) = 0;
+  virtual bool SqlFieldIsNumeric(int field_type) = 0;
+  virtual bool SqlBatchStart(JobControlRecord* jcr) = 0;
+  virtual bool SqlBatchEnd(JobControlRecord* jcr, const char* error) = 0;
+  virtual bool SqlBatchInsert(JobControlRecord* jcr,
+                              AttributesDbRecord* ar) = 0;
 #endif
 };
 
@@ -848,7 +1054,7 @@ private:
 /* Use for better error location printing */
 #define UPDATE_DB(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd, 1)
 #define UPDATE_DB_NO_AFR(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd, 0)
-#define INSERT_DB(jcr, cmd) InsertDB(__FILE__, __LINE__, jcr,  cmd)
+#define INSERT_DB(jcr, cmd) InsertDB(__FILE__, __LINE__, jcr, cmd)
 #define QUERY_DB(jcr, cmd) QueryDB(__FILE__, __LINE__, jcr, cmd)
 #define DELETE_DB(jcr, cmd) DeleteDB(__FILE__, __LINE__, jcr, cmd)
 
@@ -856,27 +1062,35 @@ private:
  * Pooled backend connection.
  */
 struct SqlPoolEntry {
-   int id;                                /**< Unique ID, connection numbering can have holes and the pool is not sorted on it */
-   int reference_count;                   /**< Reference count for this entry */
-   time_t last_update;                    /**< When was this connection last updated either used or put back on the pool */
-   BareosDb *db_handle;                       /**< Connection handle to the database */
-   dlink link;                            /**< list management */
+  int id; /**< Unique ID, connection numbering can have holes and the pool is
+             not sorted on it */
+  int reference_count; /**< Reference count for this entry */
+  time_t last_update;  /**< When was this connection last updated either used or
+                          put back on the pool */
+  BareosDb* db_handle; /**< Connection handle to the database */
+  dlink link;          /**< list management */
 };
 
 /**
  * Pooled backend list descriptor (one defined per backend defined in config)
  */
 struct SqlPoolDescriptor {
-   dlist *pool_entries;                   /**< Linked list of all pool entries */
-   bool active;                           /**< Is this an active pool, after a config reload an pool is made inactive */
-   time_t last_update;                    /**< When was this pool last updated */
-   int min_connections;                   /**< Minimum number of connections in the connection pool */
-   int max_connections;                   /**< Maximum number of connections in the connection pool */
-   int increment_connections;             /**< Increase/Decrease the number of connection in the pool with this value */
-   int idle_timeout;                      /**< Number of seconds to wait before tearing down a connection */
-   int validate_timeout;                  /**< Number of seconds after which an idle connection should be validated */
-   int nr_connections;                    /**< Number of active connections in the pool */
-   dlink link;                            /**< list management */
+  dlist* pool_entries; /**< Linked list of all pool entries */
+  bool active; /**< Is this an active pool, after a config reload an pool is
+                  made inactive */
+  time_t last_update;  /**< When was this pool last updated */
+  int min_connections; /**< Minimum number of connections in the connection pool
+                        */
+  int max_connections; /**< Maximum number of connections in the connection pool
+                        */
+  int increment_connections; /**< Increase/Decrease the number of connection in
+                                the pool with this value */
+  int idle_timeout;     /**< Number of seconds to wait before tearing down a
+                           connection */
+  int validate_timeout; /**< Number of seconds after which an idle connection
+                           should be validated */
+  int nr_connections;   /**< Number of active connections in the pool */
+  dlink link;           /**< list management */
 };
 
 #include "include/jcr.h"
@@ -885,41 +1099,48 @@ struct SqlPoolDescriptor {
  * Object used in db_list_xxx function
  */
 class ListContext {
-public:
-   char line[256];              /**< Used to print last dash line */
-   int32_t num_rows;
+ public:
+  char line[256]; /**< Used to print last dash line */
+  int32_t num_rows;
 
-   e_list_type type;            /**< Vertical/Horizontal */
-   OutputFormatter *send;      /**< send data back */
-   bool once;                   /**< Used to print header one time */
-   BareosDb *mdb;
-   JobControlRecord *jcr;
+  e_list_type type;      /**< Vertical/Horizontal */
+  OutputFormatter* send; /**< send data back */
+  bool once;             /**< Used to print header one time */
+  BareosDb* mdb;
+  JobControlRecord* jcr;
 
-   void empty() {
-      once = false;
-      line[0] = '\0';
-   }
+  void empty()
+  {
+    once = false;
+    line[0] = '\0';
+  }
 
-   void send_dashes() {
-      if (*line) {
-         send->Decoration(line);
-      }
-   }
+  void send_dashes()
+  {
+    if (*line) { send->Decoration(line); }
+  }
 
-   ListContext(JobControlRecord *j, BareosDb *m, OutputFormatter *h, e_list_type t) {
-      line[0] = '\0';
-      once = false;
-      num_rows = 0;
-      type = t;
-      send = h;
-      jcr = j;
-      mdb = m;
-   }
+  ListContext(JobControlRecord* j,
+              BareosDb* m,
+              OutputFormatter* h,
+              e_list_type t)
+  {
+    line[0] = '\0';
+    once = false;
+    num_rows = 0;
+    type = t;
+    send = h;
+    jcr = j;
+    mdb = m;
+  }
 };
 
 /**
  * Some functions exported by sql.c for use within the cats directory.
  */
-int ListResult(void *vctx, int cols, char **row);
-int ListResult(JobControlRecord *jcr, BareosDb *mdb, OutputFormatter *send, e_list_type type);
+int ListResult(void* vctx, int cols, char** row);
+int ListResult(JobControlRecord* jcr,
+               BareosDb* mdb,
+               OutputFormatter* send,
+               e_list_type type);
 #endif /* BAREOS_CATS_CATS_H_ */

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -823,6 +823,9 @@ class BareosDb
   int GetNdmpLevelMapping(JobControlRecord* jcr,
                           JobDbRecord* jr,
                           char* filesystem);
+  bool GetNdmpEnvironmentString(const std::string& query,
+                                DB_RESULT_HANDLER* ResultHandler,
+                                void* ctx);
   bool GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                 const int32_t FileIndex,
                                 DB_RESULT_HANDLER* ResultHandler,

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -53,53 +53,55 @@ static const int dbglevel = 100;
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::CreateJobRecord(JobControlRecord *jcr, JobDbRecord *jr)
+bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
 {
-   bool retval = false;;
-   PoolMem buf;
-   char dt[MAX_TIME_LENGTH];
-   time_t stime;
-   int len;
-   utime_t JobTDate;
-   char ed1[30], ed2[30];
-   char esc_ujobname[MAX_ESCAPE_NAME_LENGTH];
-   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  ;
+  PoolMem buf;
+  char dt[MAX_TIME_LENGTH];
+  time_t stime;
+  int len;
+  utime_t JobTDate;
+  char ed1[30], ed2[30];
+  char esc_ujobname[MAX_ESCAPE_NAME_LENGTH];
+  char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
+  DbLock(this);
 
-   stime = jr->SchedTime;
-   ASSERT(stime != 0);
+  stime = jr->SchedTime;
+  ASSERT(stime != 0);
 
-   bstrutime(dt, sizeof(dt), stime);
-   JobTDate = (utime_t)stime;
+  bstrutime(dt, sizeof(dt), stime);
+  JobTDate = (utime_t)stime;
 
-   len = strlen(jcr->comment);  /* TODO: use jr instead of jcr to get comment */
-   buf.check_size(len * 2 + 1);
+  len = strlen(jcr->comment); /* TODO: use jr instead of jcr to get comment */
+  buf.check_size(len * 2 + 1);
 
-   EscapeString(jcr, buf.c_str(), jcr->comment, len);
-   EscapeString(jcr, esc_ujobname, jr->Job, strlen(jr->Job));
-   EscapeString(jcr, esc_jobname, jr->Name, strlen(jr->Name));
+  EscapeString(jcr, buf.c_str(), jcr->comment, len);
+  EscapeString(jcr, esc_ujobname, jr->Job, strlen(jr->Job));
+  EscapeString(jcr, esc_jobname, jr->Name, strlen(jr->Name));
 
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Job (Job,Name,Type,Level,JobStatus,SchedTime,JobTDate,"
-        "ClientId,Comment) "
-        "VALUES ('%s','%s','%c','%c','%c','%s',%s,%s,'%s')",
-        esc_ujobname, esc_jobname, (char)(jr->JobType), (char)(jr->JobLevel),
-        (char)(jr->JobStatus), dt, edit_uint64(JobTDate, ed1),
-        edit_int64(jr->ClientId, ed2), buf.c_str());
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Job (Job,Name,Type,Level,JobStatus,SchedTime,JobTDate,"
+       "ClientId,Comment) "
+       "VALUES ('%s','%s','%c','%c','%c','%s',%s,%s,'%s')",
+       esc_ujobname, esc_jobname, (char)(jr->JobType), (char)(jr->JobLevel),
+       (char)(jr->JobStatus), dt, edit_uint64(JobTDate, ed1),
+       edit_int64(jr->ClientId, ed2), buf.c_str());
 
-   jr->JobId = SqlInsertAutokeyRecord(cmd, NT_("Job"));
-   if (jr->JobId == 0) {
-      Mmsg2(errmsg, _("Create DB Job record %s failed. ERR=%s\n"), cmd, sql_strerror());
-   } else {
-      retval = true;
-   }
-   DbUnlock(this);
+  jr->JobId = SqlInsertAutokeyRecord(cmd, NT_("Job"));
+  if (jr->JobId == 0) {
+    Mmsg2(errmsg, _("Create DB Job record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+  } else {
+    retval = true;
+  }
+  DbUnlock(this);
 
-   return retval;
+  return retval;
 }
 
 /**
@@ -107,56 +109,50 @@ bool BareosDb::CreateJobRecord(JobControlRecord *jcr, JobDbRecord *jr)
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::CreateJobmediaRecord(JobControlRecord *jcr, JobMediaDbRecord *jm)
+bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
 {
-   bool retval = false;
-   int count;
-   char ed1[50], ed2[50], ed3[50];
+  bool retval = false;
+  int count;
+  char ed1[50], ed2[50], ed3[50];
 
-   DbLock(this);
+  DbLock(this);
 
-   /*
-    * Now get count for VolIndex
-    */
-   Mmsg(cmd,
-        "SELECT count(*) from JobMedia WHERE JobId=%s",
-        edit_int64(jm->JobId, ed1));
-   count = GetSqlRecordMax(jcr);
-   if (count < 0) {
-      count = 0;
-   }
-   count++;
+  /*
+   * Now get count for VolIndex
+   */
+  Mmsg(cmd, "SELECT count(*) from JobMedia WHERE JobId=%s",
+       edit_int64(jm->JobId, ed1));
+  count = GetSqlRecordMax(jcr);
+  if (count < 0) { count = 0; }
+  count++;
 
-   Mmsg(cmd,
-        "INSERT INTO JobMedia (JobId,MediaId,FirstIndex,LastIndex,"
-        "StartFile,EndFile,StartBlock,EndBlock,VolIndex,JobBytes) "
-        "VALUES (%s,%s,%u,%u,%u,%u,%u,%u,%u,%s)",
-        edit_int64(jm->JobId, ed1),
-        edit_int64(jm->MediaId, ed2),
-        jm->FirstIndex, jm->LastIndex,
-        jm->StartFile, jm->EndFile,
-        jm->StartBlock, jm->EndBlock,
-        count,
-        edit_uint64(jm->JobBytes, ed3));
-   Dmsg0(300, cmd);
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create JobMedia record %s failed: ERR=%s\n"), cmd, sql_strerror());
-   } else {
-      /*
-       * Worked, now update the Media record with the EndFile and EndBlock
-       */
-      Mmsg(cmd,
-           "UPDATE Media SET EndFile=%u, EndBlock=%u WHERE MediaId=%u",
-           jm->EndFile, jm->EndBlock, jm->MediaId);
-      if (!UPDATE_DB(jcr, cmd)) {
-         Mmsg2(errmsg, _("Update Media record %s failed: ERR=%s\n"), cmd, sql_strerror());
-      } else {
-         retval = true;
-      }
-   }
-   DbUnlock(this);
-   Dmsg0(300, "Return from JobMedia\n");
-   return retval;
+  Mmsg(cmd,
+       "INSERT INTO JobMedia (JobId,MediaId,FirstIndex,LastIndex,"
+       "StartFile,EndFile,StartBlock,EndBlock,VolIndex,JobBytes) "
+       "VALUES (%s,%s,%u,%u,%u,%u,%u,%u,%u,%s)",
+       edit_int64(jm->JobId, ed1), edit_int64(jm->MediaId, ed2), jm->FirstIndex,
+       jm->LastIndex, jm->StartFile, jm->EndFile, jm->StartBlock, jm->EndBlock,
+       count, edit_uint64(jm->JobBytes, ed3));
+  Dmsg0(300, cmd);
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create JobMedia record %s failed: ERR=%s\n"), cmd,
+          sql_strerror());
+  } else {
+    /*
+     * Worked, now update the Media record with the EndFile and EndBlock
+     */
+    Mmsg(cmd, "UPDATE Media SET EndFile=%u, EndBlock=%u WHERE MediaId=%u",
+         jm->EndFile, jm->EndBlock, jm->MediaId);
+    if (!UPDATE_DB(jcr, cmd)) {
+      Mmsg2(errmsg, _("Update Media record %s failed: ERR=%s\n"), cmd,
+            sql_strerror());
+    } else {
+      retval = true;
+    }
+  }
+  DbUnlock(this);
+  Dmsg0(300, "Return from JobMedia\n");
+  return retval;
 }
 
 /**
@@ -164,67 +160,61 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord *jcr, JobMediaDbRecord *jm)
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::CreatePoolRecord(JobControlRecord *jcr, PoolDbRecord *pr)
+bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
 {
-   bool retval = false;
-   char ed1[30], ed2[30], ed3[50], ed4[50], ed5[50];
-   char esc_poolname[MAX_ESCAPE_NAME_LENGTH];
-   char esc_lf[MAX_ESCAPE_NAME_LENGTH];
-   int num_rows;
+  bool retval = false;
+  char ed1[30], ed2[30], ed3[50], ed4[50], ed5[50];
+  char esc_poolname[MAX_ESCAPE_NAME_LENGTH];
+  char esc_lf[MAX_ESCAPE_NAME_LENGTH];
+  int num_rows;
 
-   Dmsg0(200, "In create pool\n");
-   DbLock(this);
-   EscapeString(jcr, esc_poolname, pr->Name, strlen(pr->Name));
-   EscapeString(jcr, esc_lf, pr->LabelFormat, strlen(pr->LabelFormat));
-   Mmsg(cmd, "SELECT PoolId,Name FROM Pool WHERE Name='%s'", esc_poolname);
-   Dmsg1(200, "selectpool: %s\n", cmd);
+  Dmsg0(200, "In create pool\n");
+  DbLock(this);
+  EscapeString(jcr, esc_poolname, pr->Name, strlen(pr->Name));
+  EscapeString(jcr, esc_lf, pr->LabelFormat, strlen(pr->LabelFormat));
+  Mmsg(cmd, "SELECT PoolId,Name FROM Pool WHERE Name='%s'", esc_poolname);
+  Dmsg1(200, "selectpool: %s\n", cmd);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 0) {
-         Mmsg1(errmsg, _("pool record %s already exists\n"), pr->Name);
-         SqlFreeResult();
-         goto bail_out;
-      }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 0) {
+      Mmsg1(errmsg, _("pool record %s already exists\n"), pr->Name);
       SqlFreeResult();
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
 
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Pool (Name,NumVols,MaxVols,UseOnce,UseCatalog,"
-        "AcceptAnyVolume,AutoPrune,Recycle,VolRetention,VolUseDuration,"
-        "MaxVolJobs,MaxVolFiles,MaxVolBytes,PoolType,LabelType,LabelFormat,"
-        "RecyclePoolId,ScratchPoolId,ActionOnPurge,MinBlocksize,MaxBlocksize) "
-        "VALUES ('%s',%u,%u,%d,%d,%d,%d,%d,%s,%s,%u,%u,%s,'%s',%d,'%s',%s,%s,%d,%d,%d)",
-        esc_poolname,
-        pr->NumVols, pr->MaxVols,
-        pr->UseOnce, pr->UseCatalog,
-        pr->AcceptAnyVolume,
-        pr->AutoPrune, pr->Recycle,
-        edit_uint64(pr->VolRetention, ed1),
-        edit_uint64(pr->VolUseDuration, ed2),
-        pr->MaxVolJobs, pr->MaxVolFiles,
-        edit_uint64(pr->MaxVolBytes, ed3),
-        pr->PoolType, pr->LabelType, esc_lf,
-        edit_int64(pr->RecyclePoolId,ed4),
-        edit_int64(pr->ScratchPoolId,ed5),
-        pr->ActionOnPurge,
-        pr->MinBlocksize,
-        pr->MaxBlocksize);
-   Dmsg1(200, "Create Pool: %s\n", cmd);
-   pr->PoolId = SqlInsertAutokeyRecord(cmd, NT_("Pool"));
-   if (pr->PoolId == 0) {
-      Mmsg2(errmsg, _("Create db Pool record %s failed: ERR=%s\n"), cmd, sql_strerror());
-   } else {
-      retval = true;
-   }
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Pool (Name,NumVols,MaxVols,UseOnce,UseCatalog,"
+       "AcceptAnyVolume,AutoPrune,Recycle,VolRetention,VolUseDuration,"
+       "MaxVolJobs,MaxVolFiles,MaxVolBytes,PoolType,LabelType,LabelFormat,"
+       "RecyclePoolId,ScratchPoolId,ActionOnPurge,MinBlocksize,MaxBlocksize) "
+       "VALUES "
+       "('%s',%u,%u,%d,%d,%d,%d,%d,%s,%s,%u,%u,%s,'%s',%d,'%s',%s,%s,%d,%d,%d)",
+       esc_poolname, pr->NumVols, pr->MaxVols, pr->UseOnce, pr->UseCatalog,
+       pr->AcceptAnyVolume, pr->AutoPrune, pr->Recycle,
+       edit_uint64(pr->VolRetention, ed1), edit_uint64(pr->VolUseDuration, ed2),
+       pr->MaxVolJobs, pr->MaxVolFiles, edit_uint64(pr->MaxVolBytes, ed3),
+       pr->PoolType, pr->LabelType, esc_lf, edit_int64(pr->RecyclePoolId, ed4),
+       edit_int64(pr->ScratchPoolId, ed5), pr->ActionOnPurge, pr->MinBlocksize,
+       pr->MaxBlocksize);
+  Dmsg1(200, "Create Pool: %s\n", cmd);
+  pr->PoolId = SqlInsertAutokeyRecord(cmd, NT_("Pool"));
+  if (pr->PoolId == 0) {
+    Mmsg2(errmsg, _("Create db Pool record %s failed: ERR=%s\n"), cmd,
+          sql_strerror());
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   Dmsg0(500, "Create Pool: done\n");
-   return retval;
+  DbUnlock(this);
+  Dmsg0(500, "Create Pool: done\n");
+  return retval;
 }
 
 /**
@@ -232,71 +222,70 @@ bail_out:
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::CreateDeviceRecord(JobControlRecord *jcr, DeviceDbRecord *dr)
+bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[30], ed2[30];
-   char esc[MAX_ESCAPE_NAME_LENGTH];
-   int num_rows;
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[30], ed2[30];
+  char esc[MAX_ESCAPE_NAME_LENGTH];
+  int num_rows;
 
-   Dmsg0(200, "In create Device\n");
-   DbLock(this);
-   EscapeString(jcr, esc, dr->Name, strlen(dr->Name));
-   Mmsg(cmd,
-        "SELECT DeviceId,Name FROM Device WHERE Name='%s' AND StorageId = %s",
-        esc, edit_int64(dr->StorageId, ed1));
-   Dmsg1(200, "selectdevice: %s\n", cmd);
+  Dmsg0(200, "In create Device\n");
+  DbLock(this);
+  EscapeString(jcr, esc, dr->Name, strlen(dr->Name));
+  Mmsg(cmd,
+       "SELECT DeviceId,Name FROM Device WHERE Name='%s' AND StorageId = %s",
+       esc, edit_int64(dr->StorageId, ed1));
+  Dmsg1(200, "selectdevice: %s\n", cmd);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
 
-      /*
-       * If more than one, report error, but return first row
-       */
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Device!: %d\n"), num_rows);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    /*
+     * If more than one, report error, but return first row
+     */
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Device!: %d\n"), num_rows);
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    }
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching Device row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
       }
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching Device row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         }
-         dr->DeviceId = str_to_int64(row[0]);
-         if (row[1]) {
-            bstrncpy(dr->Name, row[1], sizeof(dr->Name));
-         } else {
-            dr->Name[0] = 0;         /* no name */
-         }
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
+      dr->DeviceId = str_to_int64(row[0]);
+      if (row[1]) {
+        bstrncpy(dr->Name, row[1], sizeof(dr->Name));
+      } else {
+        dr->Name[0] = 0; /* no name */
       }
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Device (Name,MediaTypeId,StorageId) VALUES ('%s',%s,%s)",
-        esc,
-        edit_uint64(dr->MediaTypeId, ed1),
-        edit_int64(dr->StorageId, ed2));
-   Dmsg1(200, "Create Device: %s\n", cmd);
-   dr->DeviceId = SqlInsertAutokeyRecord(cmd, NT_("Device"));
-   if (dr->DeviceId == 0) {
-      Mmsg2(errmsg, _("Create db Device record %s failed: ERR=%s\n"), cmd, sql_strerror());
-   } else {
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Device (Name,MediaTypeId,StorageId) VALUES ('%s',%s,%s)",
+       esc, edit_uint64(dr->MediaTypeId, ed1), edit_int64(dr->StorageId, ed2));
+  Dmsg1(200, "Create Device: %s\n", cmd);
+  dr->DeviceId = SqlInsertAutokeyRecord(cmd, NT_("Device"));
+  if (dr->DeviceId == 0) {
+    Mmsg2(errmsg, _("Create db Device record %s failed: ERR=%s\n"), cmd,
+          sql_strerror());
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -304,67 +293,68 @@ bail_out:
  * Returns: false on failure
  *          true  on success with id in sr->StorageId
  */
-bool BareosDb::CreateStorageRecord(JobControlRecord *jcr, StorageDbRecord *sr)
+bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
 {
-   SQL_ROW row;
-   bool retval = false;
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  SQL_ROW row;
+  bool retval = false;
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   EscapeString(jcr, esc, sr->Name, strlen(sr->Name));
-   Mmsg(cmd, "SELECT StorageId,AutoChanger FROM Storage WHERE Name='%s'", esc);
+  DbLock(this);
+  EscapeString(jcr, esc, sr->Name, strlen(sr->Name));
+  Mmsg(cmd, "SELECT StorageId,AutoChanger FROM Storage WHERE Name='%s'", esc);
 
-   sr->StorageId = 0;
-   sr->created = false;
-   /*
-    * Check if it already exists
-    */
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      /*
-       * If more than one, report error, but return first row
-       */
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Storage record!: %d\n"), num_rows);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      }
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching Storage row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         }
-         sr->StorageId = str_to_int64(row[0]);
-         sr->AutoChanger = atoi(row[1]);   /* bool */
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
-      }
-      SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Storage (Name,AutoChanger)"
-        " VALUES ('%s',%d)",
-        esc, sr->AutoChanger);
-
-   sr->StorageId = SqlInsertAutokeyRecord(cmd, NT_("Storage"));
-   if (sr->StorageId == 0) {
-      Mmsg2(errmsg, _("Create DB Storage record %s failed. ERR=%s\n"), cmd, sql_strerror());
+  sr->StorageId = 0;
+  sr->created = false;
+  /*
+   * Check if it already exists
+   */
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    /*
+     * If more than one, report error, but return first row
+     */
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Storage record!: %d\n"), num_rows);
       Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
-      sr->created = true;
+    }
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching Storage row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
+      }
+      sr->StorageId = str_to_int64(row[0]);
+      sr->AutoChanger = atoi(row[1]); /* bool */
+      SqlFreeResult();
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Storage (Name,AutoChanger)"
+       " VALUES ('%s',%d)",
+       esc, sr->AutoChanger);
+
+  sr->StorageId = SqlInsertAutokeyRecord(cmd, NT_("Storage"));
+  if (sr->StorageId == 0) {
+    Mmsg2(errmsg, _("Create DB Storage record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    sr->created = true;
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -372,48 +362,50 @@ bail_out:
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::CreateMediatypeRecord(JobControlRecord *jcr, MediaTypeDbRecord *mr)
+bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
+                                     MediaTypeDbRecord* mr)
 {
-   bool retval = false;
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   Dmsg0(200, "In create mediatype\n");
-   DbLock(this);
-   EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
-   Mmsg(cmd, "SELECT MediaTypeId,MediaType FROM MediaType WHERE MediaType='%s'", esc);
-   Dmsg1(200, "selectmediatype: %s\n", cmd);
+  Dmsg0(200, "In create mediatype\n");
+  DbLock(this);
+  EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
+  Mmsg(cmd, "SELECT MediaTypeId,MediaType FROM MediaType WHERE MediaType='%s'",
+       esc);
+  Dmsg1(200, "selectmediatype: %s\n", cmd);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 0) {
-         Mmsg1(errmsg, _("mediatype record %s already exists\n"), mr->MediaType);
-         SqlFreeResult();
-         goto bail_out;
-      }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 0) {
+      Mmsg1(errmsg, _("mediatype record %s already exists\n"), mr->MediaType);
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO MediaType (MediaType,ReadOnly) "
-        "VALUES ('%s',%d)",
-        mr->MediaType,
-        mr->ReadOnly);
-   Dmsg1(200, "Create mediatype: %s\n", cmd);
-   mr->MediaTypeId = SqlInsertAutokeyRecord(cmd, NT_("MediaType"));
-   if (mr->MediaTypeId == 0) {
-      Mmsg2(errmsg, _("Create db mediatype record %s failed: ERR=%s\n"), cmd, sql_strerror());
       goto bail_out;
-   } else {
-      retval = true;
-   }
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO MediaType (MediaType,ReadOnly) "
+       "VALUES ('%s',%d)",
+       mr->MediaType, mr->ReadOnly);
+  Dmsg1(200, "Create mediatype: %s\n", cmd);
+  mr->MediaTypeId = SqlInsertAutokeyRecord(cmd, NT_("MediaType"));
+  if (mr->MediaTypeId == 0) {
+    Mmsg2(errmsg, _("Create db mediatype record %s failed: ERR=%s\n"), cmd,
+          sql_strerror());
+    goto bail_out;
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -421,98 +413,88 @@ bail_out:
  * Returns: false on failure
  *          true on success with id in mr->MediaId
  */
-bool BareosDb::CreateMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr)
+bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 {
-   bool retval = false;
-   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50], ed7[50], ed8[50];
-   char ed9[50], ed10[50], ed11[50], ed12[50];
-   int num_rows;
-   char esc_medianame[MAX_ESCAPE_NAME_LENGTH];
-   char esc_mtype[MAX_ESCAPE_NAME_LENGTH];
-   char esc_status[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50], ed7[50], ed8[50];
+  char ed9[50], ed10[50], ed11[50], ed12[50];
+  int num_rows;
+  char esc_medianame[MAX_ESCAPE_NAME_LENGTH];
+  char esc_mtype[MAX_ESCAPE_NAME_LENGTH];
+  char esc_status[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   EscapeString(jcr, esc_medianame, mr->VolumeName, strlen(mr->VolumeName));
-   EscapeString(jcr, esc_mtype, mr->MediaType, strlen(mr->MediaType));
-   EscapeString(jcr, esc_status, mr->VolStatus, strlen(mr->VolStatus));
+  DbLock(this);
+  EscapeString(jcr, esc_medianame, mr->VolumeName, strlen(mr->VolumeName));
+  EscapeString(jcr, esc_mtype, mr->MediaType, strlen(mr->MediaType));
+  EscapeString(jcr, esc_status, mr->VolStatus, strlen(mr->VolStatus));
 
-   Mmsg(cmd, "SELECT MediaId FROM Media WHERE VolumeName='%s'", esc_medianame);
-   Dmsg1(500, "selectpool: %s\n", cmd);
+  Mmsg(cmd, "SELECT MediaId FROM Media WHERE VolumeName='%s'", esc_medianame);
+  Dmsg1(500, "selectpool: %s\n", cmd);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 0) {
-         Mmsg1(errmsg, _("Volume \"%s\" already exists.\n"), mr->VolumeName);
-         SqlFreeResult();
-         goto bail_out;
-      }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 0) {
+      Mmsg1(errmsg, _("Volume \"%s\" already exists.\n"), mr->VolumeName);
       SqlFreeResult();
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
 
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Media (VolumeName,MediaType,MediaTypeId,PoolId,MaxVolBytes,"
-        "VolCapacityBytes,Recycle,VolRetention,VolUseDuration,MaxVolJobs,MaxVolFiles,"
-        "VolStatus,Slot,VolBytes,InChanger,VolReadTime,VolWriteTime,"
-        "EndFile,EndBlock,LabelType,StorageId,DeviceId,LocationId,"
-        "ScratchPoolId,RecyclePoolId,Enabled,ActionOnPurge,EncryptionKey,"
-        "MinBlocksize,MaxBlocksize) "
-        "VALUES ('%s','%s',0,%u,%s,%s,%d,%s,%s,%u,%u,'%s',%d,%s,%d,%s,%s,0,0,%d,%s,"
-        "%s,%s,%s,%s,%d,%d,'%s',%d,%d)",
-        esc_medianame,
-        esc_mtype, mr->PoolId,
-        edit_uint64(mr->MaxVolBytes,ed1),
-        edit_uint64(mr->VolCapacityBytes, ed2),
-        mr->Recycle,
-        edit_uint64(mr->VolRetention, ed3),
-        edit_uint64(mr->VolUseDuration, ed4),
-        mr->MaxVolJobs,
-        mr->MaxVolFiles,
-        esc_status,
-        mr->Slot,
-        edit_uint64(mr->VolBytes, ed5),
-        mr->InChanger,
-        edit_int64(mr->VolReadTime, ed6),
-        edit_int64(mr->VolWriteTime, ed7),
-        mr->LabelType,
-        edit_int64(mr->StorageId, ed8),
-        edit_int64(mr->DeviceId, ed9),
-        edit_int64(mr->LocationId, ed10),
-        edit_int64(mr->ScratchPoolId, ed11),
-        edit_int64(mr->RecyclePoolId, ed12),
-        mr->Enabled, mr->ActionOnPurge,
-        mr->EncrKey, mr->MinBlocksize,
-        mr->MaxBlocksize);
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Media (VolumeName,MediaType,MediaTypeId,PoolId,MaxVolBytes,"
+       "VolCapacityBytes,Recycle,VolRetention,VolUseDuration,MaxVolJobs,"
+       "MaxVolFiles,"
+       "VolStatus,Slot,VolBytes,InChanger,VolReadTime,VolWriteTime,"
+       "EndFile,EndBlock,LabelType,StorageId,DeviceId,LocationId,"
+       "ScratchPoolId,RecyclePoolId,Enabled,ActionOnPurge,EncryptionKey,"
+       "MinBlocksize,MaxBlocksize) "
+       "VALUES "
+       "('%s','%s',0,%u,%s,%s,%d,%s,%s,%u,%u,'%s',%d,%s,%d,%s,%s,0,0,%d,%s,"
+       "%s,%s,%s,%s,%d,%d,'%s',%d,%d)",
+       esc_medianame, esc_mtype, mr->PoolId, edit_uint64(mr->MaxVolBytes, ed1),
+       edit_uint64(mr->VolCapacityBytes, ed2), mr->Recycle,
+       edit_uint64(mr->VolRetention, ed3), edit_uint64(mr->VolUseDuration, ed4),
+       mr->MaxVolJobs, mr->MaxVolFiles, esc_status, mr->Slot,
+       edit_uint64(mr->VolBytes, ed5), mr->InChanger,
+       edit_int64(mr->VolReadTime, ed6), edit_int64(mr->VolWriteTime, ed7),
+       mr->LabelType, edit_int64(mr->StorageId, ed8),
+       edit_int64(mr->DeviceId, ed9), edit_int64(mr->LocationId, ed10),
+       edit_int64(mr->ScratchPoolId, ed11), edit_int64(mr->RecyclePoolId, ed12),
+       mr->Enabled, mr->ActionOnPurge, mr->EncrKey, mr->MinBlocksize,
+       mr->MaxBlocksize);
 
-   Dmsg1(500, "Create Volume: %s\n", cmd);
-   mr->MediaId = SqlInsertAutokeyRecord(cmd, NT_("Media"));
-   if (mr->MediaId == 0) {
-      Mmsg2(errmsg, _("Create DB Media record %s failed. ERR=%s\n"), cmd, sql_strerror());
-   } else {
-      retval = true;
-      if (mr->set_label_date) {
-         char dt[MAX_TIME_LENGTH];
-         if (mr->LabelDate == 0) {
-            mr->LabelDate = time(NULL);
-         }
+  Dmsg1(500, "Create Volume: %s\n", cmd);
+  mr->MediaId = SqlInsertAutokeyRecord(cmd, NT_("Media"));
+  if (mr->MediaId == 0) {
+    Mmsg2(errmsg, _("Create DB Media record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+  } else {
+    retval = true;
+    if (mr->set_label_date) {
+      char dt[MAX_TIME_LENGTH];
+      if (mr->LabelDate == 0) { mr->LabelDate = time(NULL); }
 
-         bstrutime(dt, sizeof(dt), mr->LabelDate);
-         Mmsg(cmd, "UPDATE Media SET LabelDate='%s' "
-              "WHERE MediaId=%d", dt, mr->MediaId);
-         retval = UPDATE_DB(jcr, cmd);
-      }
-      /*
-       * Make sure that if InChanger is non-zero any other identical slot
-       * has InChanger zero.
-       */
-      MakeInchangerUnique(jcr, mr);
-   }
+      bstrutime(dt, sizeof(dt), mr->LabelDate);
+      Mmsg(cmd,
+           "UPDATE Media SET LabelDate='%s' "
+           "WHERE MediaId=%d",
+           dt, mr->MediaId);
+      retval = UPDATE_DB(jcr, cmd);
+    }
+    /*
+     * Make sure that if InChanger is non-zero any other identical slot
+     * has InChanger zero.
+     */
+    MakeInchangerUnique(jcr, mr);
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -520,72 +502,73 @@ bail_out:
  * Returns: false on failure
  *          true on success with id in cr->ClientId
  */
-bool BareosDb::CreateClientRecord(JobControlRecord *jcr, ClientDbRecord *cr)
+bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[50], ed2[50];
-   int num_rows;
-   char esc_clientname[MAX_ESCAPE_NAME_LENGTH];
-   char esc_uname[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[50], ed2[50];
+  int num_rows;
+  char esc_clientname[MAX_ESCAPE_NAME_LENGTH];
+  char esc_uname[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   EscapeString(jcr, esc_clientname, cr->Name, strlen(cr->Name));
-   EscapeString(jcr, esc_uname, cr->Uname, strlen(cr->Uname));
-   Mmsg(cmd, "SELECT ClientId,Uname FROM Client WHERE Name='%s'", esc_clientname);
+  DbLock(this);
+  EscapeString(jcr, esc_clientname, cr->Name, strlen(cr->Name));
+  EscapeString(jcr, esc_uname, cr->Uname, strlen(cr->Uname));
+  Mmsg(cmd, "SELECT ClientId,Uname FROM Client WHERE Name='%s'",
+       esc_clientname);
 
-   cr->ClientId = 0;
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      /*
-       * If more than one, report error, but return first row
-       */
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Client!: %d\n"), num_rows);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  cr->ClientId = 0;
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    /*
+     * If more than one, report error, but return first row
+     */
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Client!: %d\n"), num_rows);
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    }
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching Client row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
       }
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching Client row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         }
-         cr->ClientId = str_to_int64(row[0]);
-         if (row[1]) {
-            bstrncpy(cr->Uname, row[1], sizeof(cr->Uname));
-         } else {
-            cr->Uname[0] = 0;         /* no name */
-         }
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
+      cr->ClientId = str_to_int64(row[0]);
+      if (row[1]) {
+        bstrncpy(cr->Uname, row[1], sizeof(cr->Uname));
+      } else {
+        cr->Uname[0] = 0; /* no name */
       }
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Client (Name,Uname,AutoPrune,"
-        "FileRetention,JobRetention) VALUES "
-        "('%s','%s',%d,%s,%s)",
-        esc_clientname, esc_uname, cr->AutoPrune,
-        edit_uint64(cr->FileRetention, ed1),
-        edit_uint64(cr->JobRetention, ed2));
-
-   cr->ClientId = SqlInsertAutokeyRecord(cmd, NT_("Client"));
-   if (cr->ClientId == 0) {
-      Mmsg2(errmsg, _("Create DB Client record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Client (Name,Uname,AutoPrune,"
+       "FileRetention,JobRetention) VALUES "
+       "('%s','%s',%d,%s,%s)",
+       esc_clientname, esc_uname, cr->AutoPrune,
+       edit_uint64(cr->FileRetention, ed1), edit_uint64(cr->JobRetention, ed2));
+
+  cr->ClientId = SqlInsertAutokeyRecord(cmd, NT_("Client"));
+  if (cr->ClientId == 0) {
+    Mmsg2(errmsg, _("Create DB Client record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -593,83 +576,84 @@ bail_out:
  * Returns: false on failure
  *          true on success with id in cr->ClientId
  */
-bool BareosDb::CreatePathRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreatePathRecord(JobControlRecord* jcr, AttributesDbRecord* ar)
 {
-   bool retval = false;
-   SQL_ROW row;
-   int num_rows;
+  bool retval = false;
+  SQL_ROW row;
+  int num_rows;
 
-   errmsg[0] = 0;
-   esc_name = CheckPoolMemorySize(esc_name, 2 * pnl + 2);
-   EscapeString(jcr, esc_name, path, pnl);
+  errmsg[0] = 0;
+  esc_name = CheckPoolMemorySize(esc_name, 2 * pnl + 2);
+  EscapeString(jcr, esc_name, path, pnl);
 
-   if (cached_path_id != 0 &&
-       cached_path_len == pnl &&
-       bstrcmp(cached_path, path)) {
-      ar->PathId = cached_path_id;
-      return true;
-   }
+  if (cached_path_id != 0 && cached_path_len == pnl &&
+      bstrcmp(cached_path, path)) {
+    ar->PathId = cached_path_id;
+    return true;
+  }
 
-   Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
+  Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         char ed1[30];
-         Mmsg2(errmsg, _("More than one Path!: %s for path: %s\n"), edit_uint64(num_rows, ed1), path);
-         Jmsg(jcr, M_WARNING, 0, "%s", errmsg);
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      char ed1[30];
+      Mmsg2(errmsg, _("More than one Path!: %s for path: %s\n"),
+            edit_uint64(num_rows, ed1), path);
+      Jmsg(jcr, M_WARNING, 0, "%s", errmsg);
+    }
+    /*
+     * Even if there are multiple paths, take the first one
+     */
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        ar->PathId = 0;
+        ASSERT(ar->PathId);
+        goto bail_out;
       }
-      /*
-       * Even if there are multiple paths, take the first one
-       */
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            ar->PathId = 0;
-            ASSERT(ar->PathId);
-            goto bail_out;
-         }
-         ar->PathId = str_to_int64(row[0]);
-         SqlFreeResult();
-         /*
-          * Cache path
-          */
-         if (ar->PathId != cached_path_id) {
-            cached_path_id = ar->PathId;
-            cached_path_len = pnl;
-            PmStrcpy(cached_path, path);
-         }
-         ASSERT(ar->PathId);
-         retval = true;
-         goto bail_out;
-      }
+      ar->PathId = str_to_int64(row[0]);
       SqlFreeResult();
-   }
-
-   Mmsg(cmd, "INSERT INTO Path (Path) VALUES ('%s')", esc_name);
-
-   ar->PathId = SqlInsertAutokeyRecord(cmd, NT_("Path"));
-   if (ar->PathId == 0) {
-      Mmsg2(errmsg, _("Create db Path record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-      ar->PathId = 0;
+      /*
+       * Cache path
+       */
+      if (ar->PathId != cached_path_id) {
+        cached_path_id = ar->PathId;
+        cached_path_len = pnl;
+        PmStrcpy(cached_path, path);
+      }
+      ASSERT(ar->PathId);
+      retval = true;
       goto bail_out;
-   }
+    }
+    SqlFreeResult();
+  }
 
-   /*
-    * Cache path
-    */
-   if (ar->PathId != cached_path_id) {
-      cached_path_id = ar->PathId;
-      cached_path_len = pnl;
-      PmStrcpy(cached_path, path);
-   }
-   retval = true;
+  Mmsg(cmd, "INSERT INTO Path (Path) VALUES ('%s')", esc_name);
+
+  ar->PathId = SqlInsertAutokeyRecord(cmd, NT_("Path"));
+  if (ar->PathId == 0) {
+    Mmsg2(errmsg, _("Create db Path record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+    ar->PathId = 0;
+    goto bail_out;
+  }
+
+  /*
+   * Cache path
+   */
+  if (ar->PathId != cached_path_id) {
+    cached_path_id = ar->PathId;
+    cached_path_len = pnl;
+    PmStrcpy(cached_path, path);
+  }
+  retval = true;
 
 bail_out:
-   return retval;
+  return retval;
 }
 
 /**
@@ -677,37 +661,39 @@ bail_out:
  * Returns: false on failure
  *          true on success with counter filled in
  */
-bool BareosDb::CreateCounterRecord(JobControlRecord *jcr, CounterDbRecord *cr)
+bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
 {
-   bool retval = false;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
-   CounterDbRecord mcr;
+  bool retval = false;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
+  CounterDbRecord mcr;
 
-   DbLock(this);
-   memset(&mcr, 0, sizeof(mcr));
-   bstrncpy(mcr.Counter, cr->Counter, sizeof(mcr.Counter));
-   if (GetCounterRecord(jcr, &mcr)) {
-      memcpy(cr, &mcr, sizeof(CounterDbRecord));
-      retval = true;
-      goto bail_out;
-   }
-   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
+  DbLock(this);
+  memset(&mcr, 0, sizeof(mcr));
+  bstrncpy(mcr.Counter, cr->Counter, sizeof(mcr.Counter));
+  if (GetCounterRecord(jcr, &mcr)) {
+    memcpy(cr, &mcr, sizeof(CounterDbRecord));
+    retval = true;
+    goto bail_out;
+  }
+  EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
-   /*
-    * Must create it
-    */
-   FillQuery(SQL_QUERY_insert_counter_values, esc, cr->MinValue, cr->MaxValue, cr->CurrentValue, cr->WrapCounter);
+  /*
+   * Must create it
+   */
+  FillQuery(SQL_QUERY_insert_counter_values, esc, cr->MinValue, cr->MaxValue,
+            cr->CurrentValue, cr->WrapCounter);
 
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB Counters record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
-      retval = true;
-   }
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB Counters record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -716,171 +702,174 @@ bail_out:
  * Returns: false on failure
  *          true on success with FileSetId in record
  */
-bool BareosDb::CreateFilesetRecord(JobControlRecord *jcr, FileSetDbRecord *fsr)
+bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   int num_rows, len;
-   char esc_fs[MAX_ESCAPE_NAME_LENGTH];
-   char esc_md5[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  int num_rows, len;
+  char esc_fs[MAX_ESCAPE_NAME_LENGTH];
+  char esc_md5[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   fsr->created = false;
-   EscapeString(jcr, esc_fs, fsr->FileSet, strlen(fsr->FileSet));
-   EscapeString(jcr, esc_md5, fsr->MD5, strlen(fsr->MD5));
-   Mmsg(cmd,
-        "SELECT FileSetId,CreateTime FROM FileSet WHERE "
-        "FileSet='%s' AND MD5='%s'",
-        esc_fs, esc_md5);
+  DbLock(this);
+  fsr->created = false;
+  EscapeString(jcr, esc_fs, fsr->FileSet, strlen(fsr->FileSet));
+  EscapeString(jcr, esc_md5, fsr->MD5, strlen(fsr->MD5));
+  Mmsg(cmd,
+       "SELECT FileSetId,CreateTime FROM FileSet WHERE "
+       "FileSet='%s' AND MD5='%s'",
+       esc_fs, esc_md5);
 
-   fsr->FileSetId = 0;
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one FileSet!: %d\n"), num_rows);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  fsr->FileSetId = 0;
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one FileSet!: %d\n"), num_rows);
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    }
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching FileSet row: ERR=%s\n"),
+              sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
       }
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching FileSet row: ERR=%s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         }
-         fsr->FileSetId = str_to_int64(row[0]);
-         if (row[1] == NULL) {
-            fsr->cCreateTime[0] = 0;
-         } else {
-            bstrncpy(fsr->cCreateTime, row[1], sizeof(fsr->cCreateTime));
-         }
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
+      fsr->FileSetId = str_to_int64(row[0]);
+      if (row[1] == NULL) {
+        fsr->cCreateTime[0] = 0;
+      } else {
+        bstrncpy(fsr->cCreateTime, row[1], sizeof(fsr->cCreateTime));
       }
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   if (fsr->CreateTime == 0 && fsr->cCreateTime[0] == 0) {
-      fsr->CreateTime = time(NULL);
-   }
-
-   bstrutime(fsr->cCreateTime, sizeof(fsr->cCreateTime), fsr->CreateTime);
-   if (fsr->FileSetText) {
-      PoolMem esc_filesettext(PM_MESSAGE);
-
-      len = strlen(fsr->FileSetText);
-      esc_filesettext.check_size(len * 2 + 1);
-      EscapeString(jcr, esc_filesettext.c_str(), fsr->FileSetText, len);
-
-      Mmsg(cmd,
-           "INSERT INTO FileSet (FileSet,MD5,CreateTime,FileSetText) "
-           "VALUES ('%s','%s','%s','%s')",
-           esc_fs, esc_md5, fsr->cCreateTime, esc_filesettext.c_str());
-   } else {
-      Mmsg(cmd,
-           "INSERT INTO FileSet (FileSet,MD5,CreateTime,FileSetText) "
-           "VALUES ('%s','%s','%s','')",
-           esc_fs, esc_md5, fsr->cCreateTime);
-   }
-
-   fsr->FileSetId = SqlInsertAutokeyRecord(cmd, NT_("FileSet"));
-   if (fsr->FileSetId == 0) {
-      Mmsg2(errmsg, _("Create DB FileSet record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   } else {
-      fsr->created = true;
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  if (fsr->CreateTime == 0 && fsr->cCreateTime[0] == 0) {
+    fsr->CreateTime = time(NULL);
+  }
+
+  bstrutime(fsr->cCreateTime, sizeof(fsr->cCreateTime), fsr->CreateTime);
+  if (fsr->FileSetText) {
+    PoolMem esc_filesettext(PM_MESSAGE);
+
+    len = strlen(fsr->FileSetText);
+    esc_filesettext.check_size(len * 2 + 1);
+    EscapeString(jcr, esc_filesettext.c_str(), fsr->FileSetText, len);
+
+    Mmsg(cmd,
+         "INSERT INTO FileSet (FileSet,MD5,CreateTime,FileSetText) "
+         "VALUES ('%s','%s','%s','%s')",
+         esc_fs, esc_md5, fsr->cCreateTime, esc_filesettext.c_str());
+  } else {
+    Mmsg(cmd,
+         "INSERT INTO FileSet (FileSet,MD5,CreateTime,FileSetText) "
+         "VALUES ('%s','%s','%s','')",
+         esc_fs, esc_md5, fsr->cCreateTime);
+  }
+
+  fsr->FileSetId = SqlInsertAutokeyRecord(cmd, NT_("FileSet"));
+  if (fsr->FileSetId == 0) {
+    Mmsg2(errmsg, _("Create DB FileSet record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  } else {
+    fsr->created = true;
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
- * All sql_batch_* functions are used to do bulk batch insert in File/Filename/Path
- * tables.
+ * All sql_batch_* functions are used to do bulk batch insert in
+ * File/Filename/Path tables.
  *
  * To sum up :
  *  - bulk load a temp table
- *  - insert missing paths into path with another single query (lock Path table to avoid duplicates).
+ *  - insert missing paths into path with another single query (lock Path table
+ * to avoid duplicates).
  *  - then insert the join between the temp, filename and path tables into file.
  *
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::WriteBatchFileRecords(JobControlRecord *jcr)
+bool BareosDb::WriteBatchFileRecords(JobControlRecord* jcr)
 {
-   bool retval = false;
-   int JobStatus = jcr->JobStatus;
+  bool retval = false;
+  int JobStatus = jcr->JobStatus;
 
-   if (!jcr->batch_started) {         /* no files to backup ? */
-      Dmsg0(50,"db_create_file_record : no files\n");
-      return true;
-   }
+  if (!jcr->batch_started) { /* no files to backup ? */
+    Dmsg0(50, "db_create_file_record : no files\n");
+    return true;
+  }
 
-   if (JobCanceled(jcr)) {
-      goto bail_out;
-   }
+  if (JobCanceled(jcr)) { goto bail_out; }
 
-   Dmsg1(50,"db_create_file_record changes=%u\n", changes);
+  Dmsg1(50, "db_create_file_record changes=%u\n", changes);
 
-   jcr->JobStatus = JS_AttrInserting;
+  jcr->JobStatus = JS_AttrInserting;
 
-   Jmsg(jcr, M_INFO, 0, "Insert of attributes batch table with %u entries start\n", jcr->db_batch->changes);
+  Jmsg(jcr, M_INFO, 0,
+       "Insert of attributes batch table with %u entries start\n",
+       jcr->db_batch->changes);
 
-   if (!jcr->db_batch->SqlBatchEnd(jcr, NULL)) {
-      Jmsg1(jcr, M_FATAL, 0, "Batch end %s\n", errmsg);
-      goto bail_out;
-   }
-   if (JobCanceled(jcr)) {
-      goto bail_out;
-   }
+  if (!jcr->db_batch->SqlBatchEnd(jcr, NULL)) {
+    Jmsg1(jcr, M_FATAL, 0, "Batch end %s\n", errmsg);
+    goto bail_out;
+  }
+  if (JobCanceled(jcr)) { goto bail_out; }
 
-   /*
-    * We have to lock tables
-    */
-   if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_lock_path_query)) {
-      Jmsg1(jcr, M_FATAL, 0, "Lock Path table %s\n", errmsg);
-      goto bail_out;
-   }
+  /*
+   * We have to lock tables
+   */
+  if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_lock_path_query)) {
+    Jmsg1(jcr, M_FATAL, 0, "Lock Path table %s\n", errmsg);
+    goto bail_out;
+  }
 
-   if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_fill_path_query)) {
-      Jmsg1(jcr, M_FATAL, 0, "Fill Path table %s\n",errmsg);
-      jcr->db_batch->SqlQuery(SQL_QUERY_batch_unlock_tables_query);
-      goto bail_out;
-   }
+  if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_fill_path_query)) {
+    Jmsg1(jcr, M_FATAL, 0, "Fill Path table %s\n", errmsg);
+    jcr->db_batch->SqlQuery(SQL_QUERY_batch_unlock_tables_query);
+    goto bail_out;
+  }
 
-   if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_unlock_tables_query)) {
-      Jmsg1(jcr, M_FATAL, 0, "Unlock Path table %s\n", errmsg);
-      goto bail_out;
-   }
+  if (!jcr->db_batch->SqlQuery(SQL_QUERY_batch_unlock_tables_query)) {
+    Jmsg1(jcr, M_FATAL, 0, "Unlock Path table %s\n", errmsg);
+    goto bail_out;
+  }
 
-   if (!jcr->db_batch->SqlQuery(
-                     "INSERT INTO File (FileIndex, JobId, PathId, Name, LStat, MD5, DeltaSeq, Fhinfo, Fhnode) "
-                     "SELECT batch.FileIndex, batch.JobId, Path.PathId, "
-                     "batch.Name, batch.LStat, batch.MD5, batch.DeltaSeq, batch.Fhinfo, batch.Fhnode "
-                     "FROM batch "
-                     "JOIN Path ON (batch.Path = Path.Path) ")) {
-      Jmsg1(jcr, M_FATAL, 0, "Fill File table %s\n", errmsg);
-      goto bail_out;
-   }
+  if (!jcr->db_batch->SqlQuery(
+          "INSERT INTO File (FileIndex, JobId, PathId, Name, LStat, MD5, "
+          "DeltaSeq, Fhinfo, Fhnode) "
+          "SELECT batch.FileIndex, batch.JobId, Path.PathId, "
+          "batch.Name, batch.LStat, batch.MD5, batch.DeltaSeq, batch.Fhinfo, "
+          "batch.Fhnode "
+          "FROM batch "
+          "JOIN Path ON (batch.Path = Path.Path) ")) {
+    Jmsg1(jcr, M_FATAL, 0, "Fill File table %s\n", errmsg);
+    goto bail_out;
+  }
 
-   jcr->JobStatus = JobStatus;         /* reset entry status */
-   Jmsg(jcr, M_INFO, 0, "Insert of attributes batch table done\n");
-   retval = true;
+  jcr->JobStatus = JobStatus; /* reset entry status */
+  Jmsg(jcr, M_INFO, 0, "Insert of attributes batch table done\n");
+  retval = true;
 
 
 bail_out:
-   SqlQuery("DROP TABLE batch");
-   jcr->batch_started = false;
-   changes = 0;
+  SqlQuery("DROP TABLE batch");
+  jcr->batch_started = false;
+  changes = 0;
 
-   return retval;
+  return retval;
 }
 
 /**
@@ -899,35 +888,35 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateBatchFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreateBatchFileAttributesRecord(JobControlRecord* jcr,
+                                               AttributesDbRecord* ar)
 {
-   ASSERT(ar->FileType != FT_BASE);
+  ASSERT(ar->FileType != FT_BASE);
 
-   Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
-   Dmsg0(dbglevel, "put_file_into_catalog\n");
+  Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
+  Dmsg0(dbglevel, "put_file_into_catalog\n");
 
-   if (jcr->batch_started && jcr->db_batch->changes > BATCH_FLUSH) {
-      jcr->db_batch->WriteBatchFileRecords(jcr);
-   }
+  if (jcr->batch_started && jcr->db_batch->changes > BATCH_FLUSH) {
+    jcr->db_batch->WriteBatchFileRecords(jcr);
+  }
 
-   /*
-    * Open the dedicated connection
-    */
-   if (!jcr->batch_started) {
-      if (!OpenBatchConnection(jcr)) {
-         return false;     /* error already printed */
-      }
-      if (!jcr->db_batch->SqlBatchStart(jcr)) {
-         Mmsg1(errmsg, "Can't start batch mode: ERR=%s", jcr->db_batch->strerror());
-         Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-         return false;
-      }
-      jcr->batch_started = true;
-   }
+  /*
+   * Open the dedicated connection
+   */
+  if (!jcr->batch_started) {
+    if (!OpenBatchConnection(jcr)) { return false; /* error already printed */ }
+    if (!jcr->db_batch->SqlBatchStart(jcr)) {
+      Mmsg1(errmsg, "Can't start batch mode: ERR=%s",
+            jcr->db_batch->strerror());
+      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+      return false;
+    }
+    jcr->batch_started = true;
+  }
 
-   jcr->db_batch->SplitPathAndFile(jcr, ar->fname);
+  jcr->db_batch->SplitPathAndFile(jcr, ar->fname);
 
-   return jcr->db_batch->SqlBatchInsert(jcr, ar);
+  return jcr->db_batch->SqlBatchInsert(jcr, ar);
 }
 
 /**
@@ -942,33 +931,30 @@ bool BareosDb::CreateBatchFileAttributesRecord(JobControlRecord *jcr, Attributes
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
+                                          AttributesDbRecord* ar)
 {
-   bool retval = false;
+  bool retval = false;
 
-   DbLock(this);
-   Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
-   Dmsg0(dbglevel, "put_file_into_catalog\n");
+  DbLock(this);
+  Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
+  Dmsg0(dbglevel, "put_file_into_catalog\n");
 
-   SplitPathAndFile(jcr, ar->fname);
+  SplitPathAndFile(jcr, ar->fname);
 
-   if (!CreatePathRecord(jcr, ar)) {
-      goto bail_out;
-   }
-   Dmsg1(dbglevel, "CreatePathRecord: %s\n", esc_name);
+  if (!CreatePathRecord(jcr, ar)) { goto bail_out; }
+  Dmsg1(dbglevel, "CreatePathRecord: %s\n", esc_name);
 
-   /* Now create master File record */
-   if (!CreateFileRecord(jcr, ar)) {
-      goto bail_out;
-   }
-   Dmsg0(dbglevel, "CreateFileRecord OK\n");
+  /* Now create master File record */
+  if (!CreateFileRecord(jcr, ar)) { goto bail_out; }
+  Dmsg0(dbglevel, "CreateFileRecord OK\n");
 
-   Dmsg2(dbglevel, "CreateAttributes Path=%s File=%s\n", path, fname);
-   retval = true;
+  Dmsg2(dbglevel, "CreateAttributes Path=%s File=%s\n", path, fname);
+  retval = true;
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -977,39 +963,41 @@ bail_out:
  * Returns: false on failure
  *          true on success with fileid filled in
  */
-bool BareosDb::CreateFileRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreateFileRecord(JobControlRecord* jcr, AttributesDbRecord* ar)
 {
-   bool retval = false;
-   static const char *no_digest = "0";
-   const char *digest;
+  bool retval = false;
+  static const char* no_digest = "0";
+  const char* digest;
 
-   ASSERT(ar->JobId);
-   ASSERT(ar->PathId);
+  ASSERT(ar->JobId);
+  ASSERT(ar->PathId);
 
-   esc_name = CheckPoolMemorySize(esc_name, 2*fnl+2);
-   EscapeString(jcr, esc_name, fname, fnl);
+  esc_name = CheckPoolMemorySize(esc_name, 2 * fnl + 2);
+  EscapeString(jcr, esc_name, fname, fnl);
 
-   if (ar->Digest == NULL || ar->Digest[0] == 0) {
-      digest = no_digest;
-   } else {
-      digest = ar->Digest;
-   }
+  if (ar->Digest == NULL || ar->Digest[0] == 0) {
+    digest = no_digest;
+  } else {
+    digest = ar->Digest;
+  }
 
-   /* Must create it */
-   Mmsg(cmd,
-        "INSERT INTO File (FileIndex,JobId,PathId,Name,"
-        "LStat,MD5,DeltaSeq,Fhinfo,Fhnode) VALUES (%u,%u,%u,'%s','%s','%s',%u,%llu,%llu)",
-        ar->FileIndex, ar->JobId, ar->PathId, esc_name,
-        ar->attr, digest, ar->DeltaSeq, ar->Fhinfo, ar->Fhnode);
+  /* Must create it */
+  Mmsg(cmd,
+       "INSERT INTO File (FileIndex,JobId,PathId,Name,"
+       "LStat,MD5,DeltaSeq,Fhinfo,Fhnode) VALUES "
+       "(%u,%u,%u,'%s','%s','%s',%u,%llu,%llu)",
+       ar->FileIndex, ar->JobId, ar->PathId, esc_name, ar->attr, digest,
+       ar->DeltaSeq, ar->Fhinfo, ar->Fhnode);
 
-   ar->FileId = SqlInsertAutokeyRecord(cmd, NT_("File"));
-   if (ar->FileId == 0) {
-      Mmsg2(errmsg, _("Create db File record %s failed. ERR=%s"), cmd, sql_strerror());
-      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-   } else {
-      retval = true;
-   }
-   return retval;
+  ar->FileId = SqlInsertAutokeyRecord(cmd, NT_("File"));
+  if (ar->FileId == 0) {
+    Mmsg2(errmsg, _("Create db File record %s failed. ERR=%s"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
+  return retval;
 }
 
 
@@ -1018,39 +1006,41 @@ bool BareosDb::CreateFileRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreateAttributesRecord(JobControlRecord* jcr,
+                                      AttributesDbRecord* ar)
 {
-   bool retval;
+  bool retval;
 
-   errmsg[0] = 0;
-   /*
-    * Make sure we have an acceptable attributes record.
-    */
-   if (!(ar->Stream == STREAM_UNIX_ATTRIBUTES ||
-         ar->Stream == STREAM_UNIX_ATTRIBUTES_EX)) {
-      Mmsg1(errmsg, _("Attempt to put non-attributes into catalog. Stream=%d\n"), ar->Stream);
-      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-      return false;
-   }
+  errmsg[0] = 0;
+  /*
+   * Make sure we have an acceptable attributes record.
+   */
+  if (!(ar->Stream == STREAM_UNIX_ATTRIBUTES ||
+        ar->Stream == STREAM_UNIX_ATTRIBUTES_EX)) {
+    Mmsg1(errmsg, _("Attempt to put non-attributes into catalog. Stream=%d\n"),
+          ar->Stream);
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+    return false;
+  }
 
-   if (ar->FileType != FT_BASE) {
-      if (BatchInsertAvailable()) {
-         retval = CreateBatchFileAttributesRecord(jcr, ar);
-         /*
-          * Error message already printed
-          */
-      } else {
-         retval = CreateFileAttributesRecord(jcr, ar);
-      }
-   } else if (jcr->HasBase) {
-      retval = CreateBaseFileAttributesRecord(jcr, ar);
-   } else {
-      Mmsg0(errmsg, _("Cannot Copy/Migrate job using BaseJob.\n"));
-      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-      retval = true;               /* in copy/migration what do we do ? */
-   }
+  if (ar->FileType != FT_BASE) {
+    if (BatchInsertAvailable()) {
+      retval = CreateBatchFileAttributesRecord(jcr, ar);
+      /*
+       * Error message already printed
+       */
+    } else {
+      retval = CreateFileAttributesRecord(jcr, ar);
+    }
+  } else if (jcr->HasBase) {
+    retval = CreateBaseFileAttributesRecord(jcr, ar);
+  } else {
+    Mmsg0(errmsg, _("Cannot Copy/Migrate job using BaseJob.\n"));
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+    retval = true; /* in copy/migration what do we do ? */
+  }
 
-   return retval;
+  return retval;
 }
 
 /**
@@ -1058,42 +1048,42 @@ bool BareosDb::CreateAttributesRecord(JobControlRecord *jcr, AttributesDbRecord 
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord *jcr, AttributesDbRecord *ar)
+bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
+                                              AttributesDbRecord* ar)
 {
-   bool retval;
-   Dmsg1(dbglevel, "create_base_file Fname=%s\n", ar->fname);
-   Dmsg0(dbglevel, "put_base_file_into_catalog\n");
+  bool retval;
+  Dmsg1(dbglevel, "create_base_file Fname=%s\n", ar->fname);
+  Dmsg0(dbglevel, "put_base_file_into_catalog\n");
 
-   DbLock(this);
-   SplitPathAndFile(jcr, ar->fname);
+  DbLock(this);
+  SplitPathAndFile(jcr, ar->fname);
 
-   esc_name = CheckPoolMemorySize(esc_name, fnl * 2 + 1);
-   EscapeString(jcr, esc_name, fname, fnl);
+  esc_name = CheckPoolMemorySize(esc_name, fnl * 2 + 1);
+  EscapeString(jcr, esc_name, fname, fnl);
 
-   esc_path = CheckPoolMemorySize(esc_path, pnl * 2 + 1);
-   EscapeString(jcr, esc_path, path, pnl);
+  esc_path = CheckPoolMemorySize(esc_path, pnl * 2 + 1);
+  EscapeString(jcr, esc_path, path, pnl);
 
-   Mmsg(cmd,
-        "INSERT INTO basefile%lld (Path, Name) VALUES ('%s','%s')",
-        (uint64_t)jcr->JobId, esc_path, esc_name);
+  Mmsg(cmd, "INSERT INTO basefile%lld (Path, Name) VALUES ('%s','%s')",
+       (uint64_t)jcr->JobId, esc_path, esc_name);
 
-   retval = INSERT_DB(jcr, cmd);
-   DbUnlock(this);
+  retval = INSERT_DB(jcr, cmd);
+  DbUnlock(this);
 
-   return retval;
+  return retval;
 }
 
 /**
  * Cleanup the base file temporary tables
  */
-void BareosDb::CleanupBaseFile(JobControlRecord *jcr)
+void BareosDb::CleanupBaseFile(JobControlRecord* jcr)
 {
-   PoolMem buf(PM_MESSAGE);
-   Mmsg(buf, "DROP TABLE new_basefile%lld", (uint64_t) jcr->JobId);
-   SqlQuery(buf.c_str());
+  PoolMem buf(PM_MESSAGE);
+  Mmsg(buf, "DROP TABLE new_basefile%lld", (uint64_t)jcr->JobId);
+  SqlQuery(buf.c_str());
 
-   Mmsg(buf, "DROP TABLE basefile%lld", (uint64_t) jcr->JobId);
-   SqlQuery(buf.c_str());
+  Mmsg(buf, "DROP TABLE basefile%lld", (uint64_t)jcr->JobId);
+  SqlQuery(buf.c_str());
 }
 
 /**
@@ -1102,64 +1092,63 @@ void BareosDb::CleanupBaseFile(JobControlRecord *jcr)
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CommitBaseFileAttributesRecord(JobControlRecord *jcr)
+bool BareosDb::CommitBaseFileAttributesRecord(JobControlRecord* jcr)
 {
-   bool retval;
-   char ed1[50];
+  bool retval;
+  char ed1[50];
 
-   DbLock(this);
+  DbLock(this);
 
-   Mmsg(cmd,
-        "INSERT INTO BaseFiles (BaseJobId, JobId, FileId, FileIndex) "
-        "SELECT B.JobId AS BaseJobId, %s AS JobId, "
-        "B.FileId, B.FileIndex "
-        "FROM basefile%s AS A, new_basefile%s AS B "
-        "WHERE A.Path = B.Path "
-        "AND A.Name = B.Name "
-        "ORDER BY B.FileId",
-        edit_uint64(jcr->JobId, ed1), ed1, ed1);
-   retval = SqlQuery(cmd);
-   jcr->nb_base_files_used = SqlAffectedRows();
-   CleanupBaseFile(jcr);
+  Mmsg(cmd,
+       "INSERT INTO BaseFiles (BaseJobId, JobId, FileId, FileIndex) "
+       "SELECT B.JobId AS BaseJobId, %s AS JobId, "
+       "B.FileId, B.FileIndex "
+       "FROM basefile%s AS A, new_basefile%s AS B "
+       "WHERE A.Path = B.Path "
+       "AND A.Name = B.Name "
+       "ORDER BY B.FileId",
+       edit_uint64(jcr->JobId, ed1), ed1, ed1);
+  retval = SqlQuery(cmd);
+  jcr->nb_base_files_used = SqlAffectedRows();
+  CleanupBaseFile(jcr);
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
  * Find the last "accurate" backup state with Base jobs
  * 1) Get all files with jobid in list (F subquery)
- * 2) Take only the last version of each file (Temp subquery) => accurate list is ok
- * 3) Put the result in a temporary table for the end of job
+ * 2) Take only the last version of each file (Temp subquery) => accurate list
+ * is ok 3) Put the result in a temporary table for the end of job
  *
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateBaseFileList(JobControlRecord *jcr, char *jobids)
+bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, char* jobids)
 {
-   bool retval = false;
-   PoolMem buf(PM_MESSAGE);
+  bool retval = false;
+  PoolMem buf(PM_MESSAGE);
 
-   DbLock(this);
+  DbLock(this);
 
-   if (!*jobids) {
-      Mmsg(errmsg, _("ERR=JobIds are empty\n"));
-      goto bail_out;
-   }
+  if (!*jobids) {
+    Mmsg(errmsg, _("ERR=JobIds are empty\n"));
+    goto bail_out;
+  }
 
-   FillQuery(SQL_QUERY_create_temp_basefile, (uint64_t)jcr->JobId);
-   if (!SqlQuery(cmd)) {
-      goto bail_out;
-   }
+  FillQuery(SQL_QUERY_create_temp_basefile, (uint64_t)jcr->JobId);
+  if (!SqlQuery(cmd)) { goto bail_out; }
 
-   FillQuery(buf, SQL_QUERY_select_recent_version, jobids, jobids);
-   FillQuery(SQL_QUERY_create_temp_new_basefile, (uint64_t)jcr->JobId, buf.c_str());
+  FillQuery(buf, SQL_QUERY_select_recent_version, jobids, jobids);
+  FillQuery(SQL_QUERY_create_temp_new_basefile, (uint64_t)jcr->JobId,
+            buf.c_str());
 
-   retval = SqlQuery(cmd);
+  retval = SqlQuery(cmd);
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1167,46 +1156,48 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateRestoreObjectRecord(JobControlRecord *jcr, RestoreObjectDbRecord *ro)
+bool BareosDb::CreateRestoreObjectRecord(JobControlRecord* jcr,
+                                         RestoreObjectDbRecord* ro)
 {
-   bool retval = false;
-   int plug_name_len;
-   POOLMEM *esc_plug_name = GetPoolMemory(PM_MESSAGE);
+  bool retval = false;
+  int plug_name_len;
+  POOLMEM* esc_plug_name = GetPoolMemory(PM_MESSAGE);
 
-   DbLock(this);
+  DbLock(this);
 
-   Dmsg1(dbglevel, "Oname=%s\n", ro->object_name);
-   Dmsg0(dbglevel, "put_object_into_catalog\n");
+  Dmsg1(dbglevel, "Oname=%s\n", ro->object_name);
+  Dmsg0(dbglevel, "put_object_into_catalog\n");
 
-   fnl = strlen(ro->object_name);
-   esc_name = CheckPoolMemorySize(esc_name, fnl * 2 + 1);
-   EscapeString(jcr, esc_name, ro->object_name, fnl);
+  fnl = strlen(ro->object_name);
+  esc_name = CheckPoolMemorySize(esc_name, fnl * 2 + 1);
+  EscapeString(jcr, esc_name, ro->object_name, fnl);
 
-   EscapeObject(jcr, ro->object, ro->object_len);
+  EscapeObject(jcr, ro->object, ro->object_len);
 
-   plug_name_len = strlen(ro->plugin_name);
-   esc_plug_name = CheckPoolMemorySize(esc_plug_name, plug_name_len*2+1);
-   EscapeString(jcr, esc_plug_name, ro->plugin_name, plug_name_len);
+  plug_name_len = strlen(ro->plugin_name);
+  esc_plug_name = CheckPoolMemorySize(esc_plug_name, plug_name_len * 2 + 1);
+  EscapeString(jcr, esc_plug_name, ro->plugin_name, plug_name_len);
 
-   Mmsg(cmd,
-        "INSERT INTO RestoreObject (ObjectName,PluginName,RestoreObject,"
-        "ObjectLength,ObjectFullLength,ObjectIndex,ObjectType,"
-        "ObjectCompression,FileIndex,JobId) "
-        "VALUES ('%s','%s','%s',%d,%d,%d,%d,%d,%d,%u)",
-        esc_name, esc_plug_name, esc_obj,
-        ro->object_len, ro->object_full_len, ro->object_index,
-        ro->FileType, ro->object_compression, ro->FileIndex, ro->JobId);
+  Mmsg(cmd,
+       "INSERT INTO RestoreObject (ObjectName,PluginName,RestoreObject,"
+       "ObjectLength,ObjectFullLength,ObjectIndex,ObjectType,"
+       "ObjectCompression,FileIndex,JobId) "
+       "VALUES ('%s','%s','%s',%d,%d,%d,%d,%d,%d,%u)",
+       esc_name, esc_plug_name, esc_obj, ro->object_len, ro->object_full_len,
+       ro->object_index, ro->FileType, ro->object_compression, ro->FileIndex,
+       ro->JobId);
 
-   ro->RestoreObjectId = SqlInsertAutokeyRecord(cmd, NT_("RestoreObject"));
-   if (ro->RestoreObjectId == 0) {
-      Mmsg2(errmsg, _("Create db Object record %s failed. ERR=%s"), cmd, sql_strerror());
-      Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
-   } else {
-      retval = true;
-   }
-   DbUnlock(this);
-   FreePoolMemory(esc_plug_name);
-   return retval;
+  ro->RestoreObjectId = SqlInsertAutokeyRecord(cmd, NT_("RestoreObject"));
+  if (ro->RestoreObjectId == 0) {
+    Mmsg2(errmsg, _("Create db Object record %s failed. ERR=%s"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
+  DbUnlock(this);
+  FreePoolMemory(esc_plug_name);
+  return retval;
 }
 
 /**
@@ -1214,45 +1205,45 @@ bool BareosDb::CreateRestoreObjectRecord(JobControlRecord *jcr, RestoreObjectDbR
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateQuotaRecord(JobControlRecord *jcr, ClientDbRecord *cr)
+bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-   bool retval = false;
-   char ed1[50];
-   int num_rows;
+  bool retval = false;
+  char ed1[50];
+  int num_rows;
 
-   DbLock(this);
-   Mmsg(cmd,
-        "SELECT ClientId FROM Quota WHERE ClientId='%s'",
-        edit_uint64(cr->ClientId,ed1));
+  DbLock(this);
+  Mmsg(cmd, "SELECT ClientId FROM Quota WHERE ClientId='%s'",
+       edit_uint64(cr->ClientId, ed1));
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
-      }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO Quota (ClientId, GraceTime, QuotaLimit)"
-        " VALUES ('%s', '%s', %s)",
-        edit_uint64(cr->ClientId, ed1), "0", "0");
-
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB Quota record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO Quota (ClientId, GraceTime, QuotaLimit)"
+       " VALUES ('%s', '%s', %s)",
+       edit_uint64(cr->ClientId, ed1), "0", "0");
+
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB Quota record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1260,49 +1251,54 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateNdmpLevelMapping(JobControlRecord *jcr, JobDbRecord *jr, char *filesystem)
+bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
+                                      JobDbRecord* jr,
+                                      char* filesystem)
 {
-   bool retval = false;
-   char ed1[50], ed2[50];
-   int num_rows;
+  bool retval = false;
+  char ed1[50], ed2[50];
+  int num_rows;
 
-   DbLock(this);
+  DbLock(this);
 
-   esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
-   EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
+  esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
+  EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
 
-   Mmsg(cmd,
-         "SELECT ClientId FROM NDMPLevelMap WHERE "
-        "ClientId='%s' AND FileSetId='%s' AND FileSystem='%s'",
-        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2), esc_name);
+  Mmsg(cmd,
+       "SELECT ClientId FROM NDMPLevelMap WHERE "
+       "ClientId='%s' AND FileSetId='%s' AND FileSystem='%s'",
+       edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
+       esc_name);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
-      }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
       SqlFreeResult();
-   }
-
-   /*
-    * Must create it
-    */
-   Mmsg(cmd,
-        "INSERT INTO NDMPLevelMap (ClientId, FilesetId, FileSystem, DumpLevel)"
-        " VALUES ('%s', '%s', '%s', %s)",
-        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2), esc_name, "0");
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB NDMP Level Map record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
       retval = true;
-   }
+      goto bail_out;
+    }
+    SqlFreeResult();
+  }
+
+  /*
+   * Must create it
+   */
+  Mmsg(cmd,
+       "INSERT INTO NDMPLevelMap (ClientId, FilesetId, FileSystem, DumpLevel)"
+       " VALUES ('%s', '%s', '%s', %s)",
+       edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
+       esc_name, "0");
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB NDMP Level Map record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1310,29 +1306,36 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord *jcr, JobDbRecord *jr, char *name, char *value)
+bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
+                                           JobDbRecord* jr,
+                                           char* name,
+                                           char* value)
 {
-   bool retval = false;
-   char ed1[50], ed2[50];
-   char esc_envname[MAX_ESCAPE_NAME_LENGTH];
-   char esc_envvalue[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  char ed1[50], ed2[50];
+  char esc_envname[MAX_ESCAPE_NAME_LENGTH];
+  char esc_envvalue[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
+  DbLock(this);
 
-   EscapeString(jcr, esc_envname, name, strlen(name));
-   EscapeString(jcr, esc_envvalue, value, strlen(value));
-   Mmsg(cmd, "INSERT INTO NDMPJobEnvironment (JobId, FileIndex, EnvName, EnvValue)"
-                  " VALUES ('%s', '%s', '%s', '%s')",
-        edit_int64(jr->JobId, ed1), edit_uint64(jr->FileIndex, ed2), esc_envname, esc_envvalue);
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB NDMP Job Environment record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   } else {
-      retval = true;
-   }
+  EscapeString(jcr, esc_envname, name, strlen(name));
+  EscapeString(jcr, esc_envvalue, value, strlen(value));
+  Mmsg(cmd,
+       "INSERT INTO NDMPJobEnvironment (JobId, FileIndex, EnvName, EnvValue)"
+       " VALUES ('%s', '%s', '%s', '%s')",
+       edit_int64(jr->JobId, ed1), edit_uint64(jr->FileIndex, ed2), esc_envname,
+       esc_envvalue);
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg,
+          _("Create DB NDMP Job Environment record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  } else {
+    retval = true;
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1340,43 +1343,43 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord *jcr, JobDbRecord *j
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateJobStatistics(JobControlRecord *jcr, JobStatisticsDbRecord *jsr)
+bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
+                                   JobStatisticsDbRecord* jsr)
 {
-   time_t stime;
-   bool retval = false;
-   char dt[MAX_TIME_LENGTH];
-   char ed1[50], ed2[50], ed3[50], ed4[50];
+  time_t stime;
+  bool retval = false;
+  char dt[MAX_TIME_LENGTH];
+  char ed1[50], ed2[50], ed3[50], ed4[50];
 
-   DbLock(this);
+  DbLock(this);
 
-   stime = jsr->SampleTime;
-   ASSERT(stime != 0);
+  stime = jsr->SampleTime;
+  ASSERT(stime != 0);
 
-   bstrutime(dt, sizeof(dt), stime);
+  bstrutime(dt, sizeof(dt), stime);
 
-   /*
-    * Create job statistics record
-    */
-   Mmsg(cmd, "INSERT INTO JobStats (SampleTime, JobId, JobFiles, JobBytes, DeviceId)"
-                  " VALUES ('%s', %s, %s, %s, %s)",
-                  dt,
-                  edit_int64(jsr->JobId, ed1),
-                  edit_uint64(jsr->JobFiles, ed2),
-                  edit_uint64(jsr->JobBytes, ed3),
-                  edit_int64(jsr->DeviceId, ed4));
-   Dmsg1(200, "Create job stats: %s\n", cmd);
+  /*
+   * Create job statistics record
+   */
+  Mmsg(cmd,
+       "INSERT INTO JobStats (SampleTime, JobId, JobFiles, JobBytes, DeviceId)"
+       " VALUES ('%s', %s, %s, %s, %s)",
+       dt, edit_int64(jsr->JobId, ed1), edit_uint64(jsr->JobFiles, ed2),
+       edit_uint64(jsr->JobBytes, ed3), edit_int64(jsr->DeviceId, ed4));
+  Dmsg1(200, "Create job stats: %s\n", cmd);
 
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB JobStats record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   } else {
-      retval = true;
-   }
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB JobStats record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1384,55 +1387,51 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateDeviceStatistics(JobControlRecord *jcr, DeviceStatisticsDbRecord *dsr)
+bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
+                                      DeviceStatisticsDbRecord* dsr)
 {
-   time_t stime;
-   bool retval = false;
-   char dt[MAX_TIME_LENGTH];
-   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50];
-   char ed7[50], ed8[50], ed9[50], ed10[50], ed11[50], ed12[50];
+  time_t stime;
+  bool retval = false;
+  char dt[MAX_TIME_LENGTH];
+  char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50];
+  char ed7[50], ed8[50], ed9[50], ed10[50], ed11[50], ed12[50];
 
-   DbLock(this);
+  DbLock(this);
 
-   stime = dsr->SampleTime;
-   ASSERT(stime != 0);
+  stime = dsr->SampleTime;
+  ASSERT(stime != 0);
 
-   bstrutime(dt, sizeof(dt), stime);
+  bstrutime(dt, sizeof(dt), stime);
 
-   /*
-    * Create device statistics record
-    */
-   Mmsg(cmd,
-        "INSERT INTO DeviceStats (DeviceId, SampleTime, ReadTime, WriteTime,"
-        " ReadBytes, WriteBytes, SpoolSize, NumWaiting, NumWriters, MediaId,"
-        " VolCatBytes, VolCatFiles, VolCatBlocks)"
-        " VALUES (%s, '%s', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
-        edit_int64(dsr->DeviceId, ed1),
-        dt,
-        edit_uint64(dsr->ReadTime, ed2),
-        edit_uint64(dsr->WriteTime, ed3),
-        edit_uint64(dsr->ReadBytes, ed4),
-        edit_uint64(dsr->WriteBytes, ed5),
-        edit_uint64(dsr->SpoolSize, ed6),
-        edit_uint64(dsr->NumWaiting, ed7),
-        edit_uint64(dsr->NumWriters, ed8),
-        edit_int64(dsr->MediaId, ed9),
-        edit_uint64(dsr->VolCatBytes, ed10),
-        edit_uint64(dsr->VolCatFiles, ed11),
-        edit_uint64(dsr->VolCatBlocks, ed12));
-   Dmsg1(200, "Create device stats: %s\n", cmd);
+  /*
+   * Create device statistics record
+   */
+  Mmsg(cmd,
+       "INSERT INTO DeviceStats (DeviceId, SampleTime, ReadTime, WriteTime,"
+       " ReadBytes, WriteBytes, SpoolSize, NumWaiting, NumWriters, MediaId,"
+       " VolCatBytes, VolCatFiles, VolCatBlocks)"
+       " VALUES (%s, '%s', %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+       edit_int64(dsr->DeviceId, ed1), dt, edit_uint64(dsr->ReadTime, ed2),
+       edit_uint64(dsr->WriteTime, ed3), edit_uint64(dsr->ReadBytes, ed4),
+       edit_uint64(dsr->WriteBytes, ed5), edit_uint64(dsr->SpoolSize, ed6),
+       edit_uint64(dsr->NumWaiting, ed7), edit_uint64(dsr->NumWriters, ed8),
+       edit_int64(dsr->MediaId, ed9), edit_uint64(dsr->VolCatBytes, ed10),
+       edit_uint64(dsr->VolCatFiles, ed11),
+       edit_uint64(dsr->VolCatBlocks, ed12));
+  Dmsg1(200, "Create device stats: %s\n", cmd);
 
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB DeviceStats record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   } else {
-      retval = true;
-   }
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB DeviceStats record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1440,41 +1439,42 @@ bail_out:
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::CreateTapealertStatistics(JobControlRecord *jcr, TapealertStatsDbRecord *tsr)
+bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
+                                         TapealertStatsDbRecord* tsr)
 {
-   time_t stime;
-   bool retval = false;
-   char dt[MAX_TIME_LENGTH];
-   char ed1[50], ed2[50];
+  time_t stime;
+  bool retval = false;
+  char dt[MAX_TIME_LENGTH];
+  char ed1[50], ed2[50];
 
-   DbLock(this);
+  DbLock(this);
 
-   stime = tsr->SampleTime;
-   ASSERT(stime != 0);
+  stime = tsr->SampleTime;
+  ASSERT(stime != 0);
 
-   bstrutime(dt, sizeof(dt), stime);
+  bstrutime(dt, sizeof(dt), stime);
 
-   /*
-    * Create device statistics record
-    */
-   Mmsg(cmd,
-        "INSERT INTO TapeAlerts (DeviceId, SampleTime, AlertFlags)"
-        " VALUES (%s, '%s', %s)",
-        edit_int64(tsr->DeviceId, ed1),
-        dt,
-        edit_uint64(tsr->AlertFlags, ed2));
-   Dmsg1(200, "Create tapealert: %s\n", cmd);
+  /*
+   * Create device statistics record
+   */
+  Mmsg(cmd,
+       "INSERT INTO TapeAlerts (DeviceId, SampleTime, AlertFlags)"
+       " VALUES (%s, '%s', %s)",
+       edit_int64(tsr->DeviceId, ed1), dt, edit_uint64(tsr->AlertFlags, ed2));
+  Dmsg1(200, "Create tapealert: %s\n", cmd);
 
-   if (!INSERT_DB(jcr, cmd)) {
-      Mmsg2(errmsg, _("Create DB TapeAlerts record %s failed. ERR=%s\n"), cmd, sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   } else {
-      retval = true;
-   }
+  if (!INSERT_DB(jcr, cmd)) {
+    Mmsg2(errmsg, _("Create DB TapeAlerts record %s failed. ERR=%s\n"), cmd,
+          sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  } else {
+    retval = true;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
-#endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || HAVE_DBI */
+#endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
+          HAVE_DBI */

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -1316,6 +1316,8 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
   char esc_envname[MAX_ESCAPE_NAME_LENGTH];
   char esc_envvalue[MAX_ESCAPE_NAME_LENGTH];
 
+  Jmsg(jcr, M_INFO, 0, "NDMP Environment: %s=%s\n", name, value);
+
   DbLock(this);
 
   EscapeString(jcr, esc_envname, name, strlen(name));

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -56,20 +56,22 @@
  *  Returns: 0 on failure
  *           1 on success with the File record in FileDbRecord
  */
-bool BareosDb::GetFileAttributesRecord(JobControlRecord *jcr, char *filename, JobDbRecord *jr, FileDbRecord *fdbr)
+bool BareosDb::GetFileAttributesRecord(JobControlRecord* jcr,
+                                       char* filename,
+                                       JobDbRecord* jr,
+                                       FileDbRecord* fdbr)
 {
-   bool retval;
-   Dmsg1(100, "db_get_file_attributes_record filename=%s \n", filename);
+  bool retval;
+  Dmsg1(100, "db_get_file_attributes_record filename=%s \n", filename);
 
-   DbLock(this);
+  DbLock(this);
 
-   SplitPathAndFile(jcr, filename);
-   fdbr->PathId = GetPathRecord(jcr);
-   retval = GetFileRecord(jcr, jr, fdbr);
+  SplitPathAndFile(jcr, filename);
+  fdbr->PathId = GetPathRecord(jcr);
+  retval = GetFileRecord(jcr, jr, fdbr);
 
-   DbUnlock(this);
-   return retval;
-
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -95,75 +97,72 @@ bool BareosDb::GetFileAttributesRecord(JobControlRecord *jcr, char *filename, Jo
  *    of the version of the directory/file we actually want and do
  *    a more explicit SQL search.
  */
-bool BareosDb::GetFileRecord(JobControlRecord *jcr, JobDbRecord *jr, FileDbRecord *fdbr)
+bool BareosDb::GetFileRecord(JobControlRecord* jcr,
+                             JobDbRecord* jr,
+                             FileDbRecord* fdbr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[50], ed2[50], ed3[50];
-   int num_rows;
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[50], ed2[50], ed3[50];
+  int num_rows;
 
-   esc_name = CheckPoolMemorySize(esc_name, 2*fnl+2);
-   EscapeString(jcr, esc_name, fname, fnl);
+  esc_name = CheckPoolMemorySize(esc_name, 2 * fnl + 2);
+  EscapeString(jcr, esc_name, fname, fnl);
 
-   if (jcr->getJobLevel() == L_VERIFY_DISK_TO_CATALOG) {
-      Mmsg(cmd,
-"SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File,Job WHERE "
-"File.JobId=Job.JobId AND File.PathId=%s AND "
-"File.Name='%s' AND Job.Type='B' AND Job.JobStatus IN ('T','W') AND "
-"ClientId=%s ORDER BY StartTime DESC LIMIT 1",
-      edit_int64(fdbr->PathId, ed1),
-      esc_name,
-      edit_int64(jr->ClientId,ed3));
-   } else if (jcr->getJobLevel() == L_VERIFY_VOLUME_TO_CATALOG) {
-      Mmsg(cmd,
-           "SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File WHERE File.JobId=%s AND File.PathId=%s AND "
-           "File.Name='%s' AND File.FileIndex=%u",
-           edit_int64(fdbr->JobId, ed1),
-           edit_int64(fdbr->PathId, ed2),
-           esc_name,
-           jr->FileIndex);
-   } else {
-      Mmsg(cmd,
-"SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File WHERE File.JobId=%s AND File.PathId=%s AND "
-"File.Name='%s'",
-      edit_int64(fdbr->JobId, ed1),
-      edit_int64(fdbr->PathId, ed2),
-      esc_name);
-   }
-   Dmsg3(450, "Get_file_record JobId=%u Filename=%s PathId=%u\n",
-      fdbr->JobId, esc_name, fdbr->PathId);
+  if (jcr->getJobLevel() == L_VERIFY_DISK_TO_CATALOG) {
+    Mmsg(cmd,
+         "SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File,Job WHERE "
+         "File.JobId=Job.JobId AND File.PathId=%s AND "
+         "File.Name='%s' AND Job.Type='B' AND Job.JobStatus IN ('T','W') AND "
+         "ClientId=%s ORDER BY StartTime DESC LIMIT 1",
+         edit_int64(fdbr->PathId, ed1), esc_name,
+         edit_int64(jr->ClientId, ed3));
+  } else if (jcr->getJobLevel() == L_VERIFY_VOLUME_TO_CATALOG) {
+    Mmsg(cmd,
+         "SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File WHERE "
+         "File.JobId=%s AND File.PathId=%s AND "
+         "File.Name='%s' AND File.FileIndex=%u",
+         edit_int64(fdbr->JobId, ed1), edit_int64(fdbr->PathId, ed2), esc_name,
+         jr->FileIndex);
+  } else {
+    Mmsg(cmd,
+         "SELECT FileId, LStat, MD5, Fhinfo, Fhnode FROM File WHERE "
+         "File.JobId=%s AND File.PathId=%s AND "
+         "File.Name='%s'",
+         edit_int64(fdbr->JobId, ed1), edit_int64(fdbr->PathId, ed2), esc_name);
+  }
+  Dmsg3(450, "Get_file_record JobId=%u Filename=%s PathId=%u\n", fdbr->JobId,
+        esc_name, fdbr->PathId);
 
-   Dmsg1(100, "Query=%s\n", cmd);
+  Dmsg1(100, "Query=%s\n", cmd);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      Dmsg1(050, "GetFileRecord num_rows=%d\n", num_rows);
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("Error fetching row: %s\n"), sql_strerror());
-         } else {
-            fdbr->FileId = (FileId_t)str_to_int64(row[0]);
-            bstrncpy(fdbr->LStat, row[1], sizeof(fdbr->LStat));
-            bstrncpy(fdbr->Digest, row[2], sizeof(fdbr->Digest));
-            retval = true;
-            if (num_rows > 1) {
-               Mmsg3(errmsg, _("GetFileRecord want 1 got rows=%d PathId=%s Filename=%s\n"),
-                  num_rows,
-                  edit_int64(fdbr->PathId, ed1),
-                  esc_name);
-               Dmsg1(000, "=== Problem!  %s", errmsg);
-            }
-         }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    Dmsg1(050, "GetFileRecord num_rows=%d\n", num_rows);
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("Error fetching row: %s\n"), sql_strerror());
       } else {
-         Mmsg2(errmsg, _("File record for PathId=%s Filename=%s not found.\n"),
-            edit_int64(fdbr->PathId, ed1),
-            esc_name);
+        fdbr->FileId = (FileId_t)str_to_int64(row[0]);
+        bstrncpy(fdbr->LStat, row[1], sizeof(fdbr->LStat));
+        bstrncpy(fdbr->Digest, row[2], sizeof(fdbr->Digest));
+        retval = true;
+        if (num_rows > 1) {
+          Mmsg3(errmsg,
+                _("GetFileRecord want 1 got rows=%d PathId=%s Filename=%s\n"),
+                num_rows, edit_int64(fdbr->PathId, ed1), esc_name);
+          Dmsg1(000, "=== Problem!  %s", errmsg);
+        }
       }
-      SqlFreeResult();
-   } else {
-      Mmsg(errmsg, _("File record not found in Catalog.\n"));
-   }
-   return retval;
+    } else {
+      Mmsg2(errmsg, _("File record for PathId=%s Filename=%s not found.\n"),
+            edit_int64(fdbr->PathId, ed1), esc_name);
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("File record not found in Catalog.\n"));
+  }
+  return retval;
 }
 
 
@@ -174,62 +173,65 @@ bool BareosDb::GetFileRecord(JobControlRecord *jcr, JobDbRecord *jr, FileDbRecor
  *
  *   DO NOT use Jmsg in this routine (see notes for GetFileRecord)
  */
-int BareosDb::GetPathRecord(JobControlRecord *jcr)
+int BareosDb::GetPathRecord(JobControlRecord* jcr)
 {
-   SQL_ROW row;
-   DBId_t PathId = 0;
-   int num_rows;
+  SQL_ROW row;
+  DBId_t PathId = 0;
+  int num_rows;
 
-   esc_name = CheckPoolMemorySize(esc_name, 2 * pnl + 2);
-   EscapeString(jcr, esc_name, path, pnl);
+  esc_name = CheckPoolMemorySize(esc_name, 2 * pnl + 2);
+  EscapeString(jcr, esc_name, path, pnl);
 
-   if (cached_path_id != 0 && cached_path_len == pnl && bstrcmp(cached_path, path)) {
-      return cached_path_id;
-   }
+  if (cached_path_id != 0 && cached_path_len == pnl &&
+      bstrcmp(cached_path, path)) {
+    return cached_path_id;
+  }
 
-   Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
-   if (QUERY_DB(jcr, cmd)) {
-      char ed1[30];
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         Mmsg2(errmsg, _("More than one Path!: %s for path: %s\n"), edit_uint64(num_rows, ed1), path);
-         Jmsg(jcr, M_WARNING, 0, "%s", errmsg);
-      }
-      /* Even if there are multiple paths, take the first one */
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-         } else {
-            PathId = str_to_int64(row[0]);
-            if (PathId <= 0) {
-               Mmsg2(errmsg, _("Get DB path record %s found bad record: %s\n"), cmd, edit_int64(PathId, ed1));
-               PathId = 0;
-            } else {
-               /*
-                * Cache path
-                */
-               if (PathId != cached_path_id) {
-                  cached_path_id = PathId;
-                  cached_path_len = pnl;
-                  PmStrcpy(cached_path, path);
-               }
-            }
-         }
+  Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
+  if (QUERY_DB(jcr, cmd)) {
+    char ed1[30];
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      Mmsg2(errmsg, _("More than one Path!: %s for path: %s\n"),
+            edit_uint64(num_rows, ed1), path);
+      Jmsg(jcr, M_WARNING, 0, "%s", errmsg);
+    }
+    /* Even if there are multiple paths, take the first one */
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
       } else {
-         Mmsg1(errmsg, _("Path record: %s not found.\n"), path);
+        PathId = str_to_int64(row[0]);
+        if (PathId <= 0) {
+          Mmsg2(errmsg, _("Get DB path record %s found bad record: %s\n"), cmd,
+                edit_int64(PathId, ed1));
+          PathId = 0;
+        } else {
+          /*
+           * Cache path
+           */
+          if (PathId != cached_path_id) {
+            cached_path_id = PathId;
+            cached_path_len = pnl;
+            PmStrcpy(cached_path, path);
+          }
+        }
       }
-      SqlFreeResult();
-   } else {
-      Mmsg(errmsg, _("Path record: %s not found in Catalog.\n"), path);
-   }
-   return PathId;
+    } else {
+      Mmsg1(errmsg, _("Path record: %s not found.\n"), path);
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("Path record: %s not found in Catalog.\n"), path);
+  }
+  return PathId;
 }
 
-int BareosDb::GetPathRecord(JobControlRecord *jcr, const char *new_path)
+int BareosDb::GetPathRecord(JobControlRecord* jcr, const char* new_path)
 {
-   PmStrcpy(path, new_path);
-   pnl = strlen(path);
-   return GetPathRecord(jcr);
+  PmStrcpy(path, new_path);
+  pnl = strlen(path);
+  return GetPathRecord(jcr);
 }
 
 /**
@@ -237,75 +239,78 @@ int BareosDb::GetPathRecord(JobControlRecord *jcr, const char *new_path)
  * Returns: false on failure
  *          true  on success
  */
-bool BareosDb::GetJobRecord(JobControlRecord *jcr, JobDbRecord *jr)
+bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[50];
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[50];
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (jr->JobId == 0) {
-      EscapeString(jcr, esc, jr->Job, strlen(jr->Job));
-      Mmsg(cmd, "SELECT VolSessionId,VolSessionTime,"
-"PoolId,StartTime,EndTime,JobFiles,JobBytes,JobTDate,Job,JobStatus,"
-"Type,Level,ClientId,Name,PriorJobId,RealEndTime,JobId,FileSetId,"
-"SchedTime,RealEndTime,ReadBytes,HasBase,PurgedFiles "
-"FROM Job WHERE Job='%s'", esc);
-    } else {
-      Mmsg(cmd, "SELECT VolSessionId,VolSessionTime,"
-"PoolId,StartTime,EndTime,JobFiles,JobBytes,JobTDate,Job,JobStatus,"
-"Type,Level,ClientId,Name,PriorJobId,RealEndTime,JobId,FileSetId,"
-"SchedTime,RealEndTime,ReadBytes,HasBase,PurgedFiles "
-"FROM Job WHERE JobId=%s",
-          edit_int64(jr->JobId, ed1));
-    }
+  DbLock(this);
+  if (jr->JobId == 0) {
+    EscapeString(jcr, esc, jr->Job, strlen(jr->Job));
+    Mmsg(cmd,
+         "SELECT VolSessionId,VolSessionTime,"
+         "PoolId,StartTime,EndTime,JobFiles,JobBytes,JobTDate,Job,JobStatus,"
+         "Type,Level,ClientId,Name,PriorJobId,RealEndTime,JobId,FileSetId,"
+         "SchedTime,RealEndTime,ReadBytes,HasBase,PurgedFiles "
+         "FROM Job WHERE Job='%s'",
+         esc);
+  } else {
+    Mmsg(cmd,
+         "SELECT VolSessionId,VolSessionTime,"
+         "PoolId,StartTime,EndTime,JobFiles,JobBytes,JobTDate,Job,JobStatus,"
+         "Type,Level,ClientId,Name,PriorJobId,RealEndTime,JobId,FileSetId,"
+         "SchedTime,RealEndTime,ReadBytes,HasBase,PurgedFiles "
+         "FROM Job WHERE JobId=%s",
+         edit_int64(jr->JobId, ed1));
+  }
 
-   if (!QUERY_DB(jcr, cmd)) {
-      goto bail_out;
-   }
-   if ((row = SqlFetchRow()) == NULL) {
-      Mmsg1(errmsg, _("No Job found for JobId %s\n"), edit_int64(jr->JobId, ed1));
-      SqlFreeResult();
-      goto bail_out;
-   }
+  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if ((row = SqlFetchRow()) == NULL) {
+    Mmsg1(errmsg, _("No Job found for JobId %s\n"), edit_int64(jr->JobId, ed1));
+    SqlFreeResult();
+    goto bail_out;
+  }
 
-   jr->VolSessionId = str_to_uint64(row[0]);
-   jr->VolSessionTime = str_to_uint64(row[1]);
-   jr->PoolId = str_to_int64(row[2]);
-   bstrncpy(jr->cStartTime, (row[3] != NULL) ? row[3] : "", sizeof(jr->cStartTime));
-   bstrncpy(jr->cEndTime, (row[4] != NULL) ? row[4] : "", sizeof(jr->cEndTime));
-   jr->JobFiles = str_to_int64(row[5]);
-   jr->JobBytes = str_to_int64(row[6]);
-   jr->JobTDate = str_to_int64(row[7]);
-   bstrncpy(jr->Job, (row[8] != NULL) ? row[8] : "", sizeof(jr->Job));
-   jr->JobStatus = (row[9] != NULL) ? (int)*row[9] : JS_FatalError;
-   jr->JobType = (row[10] !=NULL) ? (int)*row[10] : JT_BACKUP;
-   jr->JobLevel = (row[11] !=NULL) ? (int)*row[11] : L_NONE;
-   jr->ClientId = str_to_uint64((row[12] != NULL) ? row[12] : (char *)"");
-   bstrncpy(jr->Name, (row[13] != NULL) ? row[13] : "", sizeof(jr->Name));
-   jr->PriorJobId = str_to_uint64((row[14] !=NULL) ? row[14] : (char *)"");
-   bstrncpy(jr->cRealEndTime, (row[15] != NULL) ? row[15] : "", sizeof(jr->cRealEndTime));
-   if (jr->JobId == 0) {
-      jr->JobId = str_to_int64(row[16]);
-   }
-   jr->FileSetId = str_to_int64(row[17]);
-   bstrncpy(jr->cSchedTime, (row[18] != NULL) ? row[18] : "", sizeof(jr->cSchedTime));
-   bstrncpy(jr->cRealEndTime, (row[19] != NULL) ? row[19] : "", sizeof(jr->cRealEndTime));
-   jr->ReadBytes = str_to_int64(row[20]);
-   jr->StartTime = StrToUtime(jr->cStartTime);
-   jr->SchedTime = StrToUtime(jr->cSchedTime);
-   jr->EndTime = StrToUtime(jr->cEndTime);
-   jr->RealEndTime = StrToUtime(jr->cRealEndTime);
-   jr->HasBase = str_to_int64(row[21]);
-   jr->PurgedFiles = str_to_int64(row[22]);
+  jr->VolSessionId = str_to_uint64(row[0]);
+  jr->VolSessionTime = str_to_uint64(row[1]);
+  jr->PoolId = str_to_int64(row[2]);
+  bstrncpy(jr->cStartTime, (row[3] != NULL) ? row[3] : "",
+           sizeof(jr->cStartTime));
+  bstrncpy(jr->cEndTime, (row[4] != NULL) ? row[4] : "", sizeof(jr->cEndTime));
+  jr->JobFiles = str_to_int64(row[5]);
+  jr->JobBytes = str_to_int64(row[6]);
+  jr->JobTDate = str_to_int64(row[7]);
+  bstrncpy(jr->Job, (row[8] != NULL) ? row[8] : "", sizeof(jr->Job));
+  jr->JobStatus = (row[9] != NULL) ? (int)*row[9] : JS_FatalError;
+  jr->JobType = (row[10] != NULL) ? (int)*row[10] : JT_BACKUP;
+  jr->JobLevel = (row[11] != NULL) ? (int)*row[11] : L_NONE;
+  jr->ClientId = str_to_uint64((row[12] != NULL) ? row[12] : (char*)"");
+  bstrncpy(jr->Name, (row[13] != NULL) ? row[13] : "", sizeof(jr->Name));
+  jr->PriorJobId = str_to_uint64((row[14] != NULL) ? row[14] : (char*)"");
+  bstrncpy(jr->cRealEndTime, (row[15] != NULL) ? row[15] : "",
+           sizeof(jr->cRealEndTime));
+  if (jr->JobId == 0) { jr->JobId = str_to_int64(row[16]); }
+  jr->FileSetId = str_to_int64(row[17]);
+  bstrncpy(jr->cSchedTime, (row[18] != NULL) ? row[18] : "",
+           sizeof(jr->cSchedTime));
+  bstrncpy(jr->cRealEndTime, (row[19] != NULL) ? row[19] : "",
+           sizeof(jr->cRealEndTime));
+  jr->ReadBytes = str_to_int64(row[20]);
+  jr->StartTime = StrToUtime(jr->cStartTime);
+  jr->SchedTime = StrToUtime(jr->cSchedTime);
+  jr->EndTime = StrToUtime(jr->cEndTime);
+  jr->RealEndTime = StrToUtime(jr->cRealEndTime);
+  jr->HasBase = str_to_int64(row[21]);
+  jr->PurgedFiles = str_to_int64(row[22]);
 
-   SqlFreeResult();
-   retval = true;
+  SqlFreeResult();
+  retval = true;
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -318,56 +323,58 @@ bail_out:
  *
  * Returns: number of volumes on success
  */
-int BareosDb::GetJobVolumeNames(JobControlRecord *jcr, JobId_t JobId, POOLMEM *&VolumeNames)
+int BareosDb::GetJobVolumeNames(JobControlRecord* jcr,
+                                JobId_t JobId,
+                                POOLMEM*& VolumeNames)
 {
-   SQL_ROW row;
-   char ed1[50];
-   int retval = 0;
-   int i;
-   int num_rows;
+  SQL_ROW row;
+  char ed1[50];
+  int retval = 0;
+  int i;
+  int num_rows;
 
-   DbLock(this);
+  DbLock(this);
 
-   /*
-    * Get one entry per VolumeName, but "sort" by VolIndex
-    */
-   Mmsg(cmd,
-        "SELECT VolumeName,MAX(VolIndex) FROM JobMedia,Media WHERE "
-        "JobMedia.JobId=%s AND JobMedia.MediaId=Media.MediaId "
-        "GROUP BY VolumeName "
-        "ORDER BY 2 ASC", edit_int64(JobId,ed1));
+  /*
+   * Get one entry per VolumeName, but "sort" by VolIndex
+   */
+  Mmsg(cmd,
+       "SELECT VolumeName,MAX(VolIndex) FROM JobMedia,Media WHERE "
+       "JobMedia.JobId=%s AND JobMedia.MediaId=Media.MediaId "
+       "GROUP BY VolumeName "
+       "ORDER BY 2 ASC",
+       edit_int64(JobId, ed1));
 
-   Dmsg1(130, "VolNam=%s\n", cmd);
-   VolumeNames[0] = '\0';
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      Dmsg1(130, "Num rows=%d\n", num_rows);
-      if (num_rows <= 0) {
-         Mmsg1(errmsg, _("No volumes found for JobId=%d\n"), JobId);
-         retval = 0;
-      } else {
-         retval = num_rows;
-         for (i = 0; i < retval; i++) {
-            if ((row = SqlFetchRow()) == NULL) {
-               Mmsg2(errmsg, _("Error fetching row %d: ERR=%s\n"), i, sql_strerror());
-               Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-               retval = 0;
-               break;
-            } else {
-               if (VolumeNames[0] != '\0') {
-                  PmStrcat(VolumeNames, "|");
-               }
-               PmStrcat(VolumeNames, row[0]);
-            }
-         }
+  Dmsg1(130, "VolNam=%s\n", cmd);
+  VolumeNames[0] = '\0';
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    Dmsg1(130, "Num rows=%d\n", num_rows);
+    if (num_rows <= 0) {
+      Mmsg1(errmsg, _("No volumes found for JobId=%d\n"), JobId);
+      retval = 0;
+    } else {
+      retval = num_rows;
+      for (i = 0; i < retval; i++) {
+        if ((row = SqlFetchRow()) == NULL) {
+          Mmsg2(errmsg, _("Error fetching row %d: ERR=%s\n"), i,
+                sql_strerror());
+          Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+          retval = 0;
+          break;
+        } else {
+          if (VolumeNames[0] != '\0') { PmStrcat(VolumeNames, "|"); }
+          PmStrcat(VolumeNames, row[0]);
+        }
       }
-      SqlFreeResult();
-   } else {
-      Mmsg(errmsg, _("No Volume for JobId %d found in Catalog.\n"), JobId);
-   }
-   DbUnlock(this);
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("No Volume for JobId %d found in Catalog.\n"), JobId);
+  }
+  DbUnlock(this);
 
-   return retval;
+  return retval;
 }
 
 /**
@@ -378,87 +385,89 @@ int BareosDb::GetJobVolumeNames(JobControlRecord *jcr, JobId_t JobId, POOLMEM *&
  *
  * Returns: number of volumes on success
  */
-int BareosDb::GetJobVolumeParameters(JobControlRecord *jcr, JobId_t JobId, VolumeParameters **VolParams)
+int BareosDb::GetJobVolumeParameters(JobControlRecord* jcr,
+                                     JobId_t JobId,
+                                     VolumeParameters** VolParams)
 {
-   SQL_ROW row;
-   char ed1[50];
-   int retval = 0;
-   int i;
-   VolumeParameters *Vols = NULL;
-   int num_rows;
+  SQL_ROW row;
+  char ed1[50];
+  int retval = 0;
+  int i;
+  VolumeParameters* Vols = NULL;
+  int num_rows;
 
-   DbLock(this);
-   Mmsg(cmd,
-"SELECT VolumeName,MediaType,FirstIndex,LastIndex,StartFile,"
-"JobMedia.EndFile,StartBlock,JobMedia.EndBlock,"
-"Slot,StorageId,InChanger,"
-"JobBytes"
-" FROM JobMedia,Media WHERE JobMedia.JobId=%s"
-" AND JobMedia.MediaId=Media.MediaId ORDER BY VolIndex,JobMediaId",
-        edit_int64(JobId, ed1));
+  DbLock(this);
+  Mmsg(cmd,
+       "SELECT VolumeName,MediaType,FirstIndex,LastIndex,StartFile,"
+       "JobMedia.EndFile,StartBlock,JobMedia.EndBlock,"
+       "Slot,StorageId,InChanger,"
+       "JobBytes"
+       " FROM JobMedia,Media WHERE JobMedia.JobId=%s"
+       " AND JobMedia.MediaId=Media.MediaId ORDER BY VolIndex,JobMediaId",
+       edit_int64(JobId, ed1));
 
-   Dmsg1(130, "VolNam=%s\n", cmd);
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      Dmsg1(200, "Num rows=%d\n", num_rows);
-      if (num_rows <= 0) {
-         Mmsg1(errmsg, _("No volumes found for JobId=%d\n"), JobId);
-         retval = 0;
-      } else {
-         retval = num_rows;
-         DBId_t *SId = NULL;
-         if (retval > 0) {
-            *VolParams = Vols = (VolumeParameters *)malloc(retval * sizeof(VolumeParameters));
-            SId = (DBId_t *)malloc(retval * sizeof(DBId_t));
-         }
-         for (i=0; i < retval; i++) {
-            if ((row = SqlFetchRow()) == NULL) {
-               Mmsg2(errmsg, _("Error fetching row %d: ERR=%s\n"), i, sql_strerror());
-               Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-               retval = 0;
-               break;
-            } else {
-               DBId_t StorageId;
-               uint32_t StartBlock, EndBlock, StartFile, EndFile;
-
-               bstrncpy(Vols[i].VolumeName, row[0], MAX_NAME_LENGTH);
-               bstrncpy(Vols[i].MediaType, row[1], MAX_NAME_LENGTH);
-               Vols[i].FirstIndex = str_to_uint64(row[2]);
-               Vols[i].LastIndex = str_to_uint64(row[3]);
-               StartFile = str_to_uint64(row[4]);
-               EndFile = str_to_uint64(row[5]);
-               StartBlock = str_to_uint64(row[6]);
-               EndBlock = str_to_uint64(row[7]);
-               Vols[i].Slot = str_to_uint64(row[8]);
-               StorageId = str_to_uint64(row[9]);
-               Vols[i].InChanger = str_to_uint64(row[10]);
-               Vols[i].JobBytes = str_to_uint64(row[11]);
-
-               Vols[i].StartAddr = (((uint64_t)StartFile)<<32) | StartBlock;
-               Vols[i].EndAddr =   (((uint64_t)EndFile)<<32) | EndBlock;
-               Vols[i].Storage[0] = 0;
-               SId[i] = StorageId;
-            }
-         }
-         for (i=0; i < retval; i++) {
-            if (SId[i] != 0) {
-               Mmsg(cmd, "SELECT Name from Storage WHERE StorageId=%s",
-                  edit_int64(SId[i], ed1));
-               if (QUERY_DB(jcr, cmd)) {
-                  if ((row = SqlFetchRow()) && row[0]) {
-                     bstrncpy(Vols[i].Storage, row[0], MAX_NAME_LENGTH);
-                  }
-               }
-            }
-         }
-         if (SId) {
-            free(SId);
-         }
+  Dmsg1(130, "VolNam=%s\n", cmd);
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    Dmsg1(200, "Num rows=%d\n", num_rows);
+    if (num_rows <= 0) {
+      Mmsg1(errmsg, _("No volumes found for JobId=%d\n"), JobId);
+      retval = 0;
+    } else {
+      retval = num_rows;
+      DBId_t* SId = NULL;
+      if (retval > 0) {
+        *VolParams = Vols =
+            (VolumeParameters*)malloc(retval * sizeof(VolumeParameters));
+        SId = (DBId_t*)malloc(retval * sizeof(DBId_t));
       }
-      SqlFreeResult();
-   }
-   DbUnlock(this);
-   return retval;
+      for (i = 0; i < retval; i++) {
+        if ((row = SqlFetchRow()) == NULL) {
+          Mmsg2(errmsg, _("Error fetching row %d: ERR=%s\n"), i,
+                sql_strerror());
+          Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+          retval = 0;
+          break;
+        } else {
+          DBId_t StorageId;
+          uint32_t StartBlock, EndBlock, StartFile, EndFile;
+
+          bstrncpy(Vols[i].VolumeName, row[0], MAX_NAME_LENGTH);
+          bstrncpy(Vols[i].MediaType, row[1], MAX_NAME_LENGTH);
+          Vols[i].FirstIndex = str_to_uint64(row[2]);
+          Vols[i].LastIndex = str_to_uint64(row[3]);
+          StartFile = str_to_uint64(row[4]);
+          EndFile = str_to_uint64(row[5]);
+          StartBlock = str_to_uint64(row[6]);
+          EndBlock = str_to_uint64(row[7]);
+          Vols[i].Slot = str_to_uint64(row[8]);
+          StorageId = str_to_uint64(row[9]);
+          Vols[i].InChanger = str_to_uint64(row[10]);
+          Vols[i].JobBytes = str_to_uint64(row[11]);
+
+          Vols[i].StartAddr = (((uint64_t)StartFile) << 32) | StartBlock;
+          Vols[i].EndAddr = (((uint64_t)EndFile) << 32) | EndBlock;
+          Vols[i].Storage[0] = 0;
+          SId[i] = StorageId;
+        }
+      }
+      for (i = 0; i < retval; i++) {
+        if (SId[i] != 0) {
+          Mmsg(cmd, "SELECT Name from Storage WHERE StorageId=%s",
+               edit_int64(SId[i], ed1));
+          if (QUERY_DB(jcr, cmd)) {
+            if ((row = SqlFetchRow()) && row[0]) {
+              bstrncpy(Vols[i].Storage, row[0], MAX_NAME_LENGTH);
+            }
+          }
+        }
+      }
+      if (SId) { free(SId); }
+    }
+    SqlFreeResult();
+  }
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -467,16 +476,16 @@ int BareosDb::GetJobVolumeParameters(JobControlRecord *jcr, JobId_t JobId, Volum
  * Returns: -1 on failure
  *          number on success
  */
-int BareosDb::GetNumPoolRecords(JobControlRecord *jcr)
+int BareosDb::GetNumPoolRecords(JobControlRecord* jcr)
 {
-   int retval = 0;
+  int retval = 0;
 
-   DbLock(this);
-   Mmsg(cmd, "SELECT count(*) from Pool");
-   retval = GetSqlRecordMax(jcr);
-   DbUnlock(this);
+  DbLock(this);
+  Mmsg(cmd, "SELECT count(*) from Pool");
+  retval = GetSqlRecordMax(jcr);
+  DbUnlock(this);
 
-   return retval;
+  return retval;
 }
 
 /**
@@ -486,35 +495,33 @@ int BareosDb::GetNumPoolRecords(JobControlRecord *jcr)
  * Returns 0: on failure
  *         1: on success
  */
-int BareosDb::GetPoolIds(JobControlRecord *jcr, int *num_ids, DBId_t **ids)
+int BareosDb::GetPoolIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids)
 {
-   SQL_ROW row;
-   int retval = 0;
-   int i = 0;
-   DBId_t *id;
+  SQL_ROW row;
+  int retval = 0;
+  int i = 0;
+  DBId_t* id;
 
-   DbLock(this);
-   *ids = NULL;
-   Mmsg(cmd, "SELECT PoolId FROM Pool");
-   if (QUERY_DB(jcr, cmd)) {
-      *num_ids = SqlNumRows();
-      if (*num_ids > 0) {
-         id = (DBId_t *)malloc(*num_ids * sizeof(DBId_t));
-         while ((row = SqlFetchRow()) != NULL) {
-            id[i++] = str_to_uint64(row[0]);
-         }
-         *ids = id;
-      }
-      SqlFreeResult();
-      retval = 1;
-   } else {
-      Mmsg(errmsg, _("Pool id select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      retval = 0;
-   }
+  DbLock(this);
+  *ids = NULL;
+  Mmsg(cmd, "SELECT PoolId FROM Pool");
+  if (QUERY_DB(jcr, cmd)) {
+    *num_ids = SqlNumRows();
+    if (*num_ids > 0) {
+      id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
+      while ((row = SqlFetchRow()) != NULL) { id[i++] = str_to_uint64(row[0]); }
+      *ids = id;
+    }
+    SqlFreeResult();
+    retval = 1;
+  } else {
+    Mmsg(errmsg, _("Pool id select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    retval = 0;
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -524,35 +531,33 @@ int BareosDb::GetPoolIds(JobControlRecord *jcr, int *num_ids, DBId_t **ids)
  *  Returns 0: on failure
  *          1: on success
  */
-int BareosDb::GetStorageIds(JobControlRecord *jcr, int *num_ids, DBId_t *ids[])
+int BareosDb::GetStorageIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
 {
-   SQL_ROW row;
-   int retval = 0;
-   int i = 0;
-   DBId_t *id;
+  SQL_ROW row;
+  int retval = 0;
+  int i = 0;
+  DBId_t* id;
 
-   DbLock(this);
-   *ids = NULL;
-   Mmsg(cmd, "SELECT StorageId FROM Storage");
-   if (QUERY_DB(jcr, cmd)) {
-      *num_ids = SqlNumRows();
-      if (*num_ids > 0) {
-         id = (DBId_t *)malloc(*num_ids * sizeof(DBId_t));
-         while ((row = SqlFetchRow()) != NULL) {
-            id[i++] = str_to_uint64(row[0]);
-         }
-         *ids = id;
-      }
-      SqlFreeResult();
-      retval = 1;
-   } else {
-      Mmsg(errmsg, _("Storage id select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      retval = 0;
-   }
+  DbLock(this);
+  *ids = NULL;
+  Mmsg(cmd, "SELECT StorageId FROM Storage");
+  if (QUERY_DB(jcr, cmd)) {
+    *num_ids = SqlNumRows();
+    if (*num_ids > 0) {
+      id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
+      while ((row = SqlFetchRow()) != NULL) { id[i++] = str_to_uint64(row[0]); }
+      *ids = id;
+    }
+    SqlFreeResult();
+    retval = 1;
+  } else {
+    Mmsg(errmsg, _("Storage id select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    retval = 0;
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -562,33 +567,31 @@ int BareosDb::GetStorageIds(JobControlRecord *jcr, int *num_ids, DBId_t *ids[])
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetClientIds(JobControlRecord *jcr, int *num_ids, DBId_t *ids[])
+bool BareosDb::GetClientIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
 {
-   bool retval = false;
-   SQL_ROW row;
-   int i = 0;
-   DBId_t *id;
+  bool retval = false;
+  SQL_ROW row;
+  int i = 0;
+  DBId_t* id;
 
-   DbLock(this);
-   *ids = NULL;
-   Mmsg(cmd, "SELECT ClientId FROM Client ORDER BY Name");
-   if (QUERY_DB(jcr, cmd)) {
-      *num_ids = SqlNumRows();
-      if (*num_ids > 0) {
-         id = (DBId_t *)malloc(*num_ids * sizeof(DBId_t));
-         while ((row = SqlFetchRow()) != NULL) {
-            id[i++] = str_to_uint64(row[0]);
-         }
-         *ids = id;
-      }
-      SqlFreeResult();
-      retval = true;
-   } else {
-      Mmsg(errmsg, _("Client id select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   }
-   DbUnlock(this);
-   return retval;
+  DbLock(this);
+  *ids = NULL;
+  Mmsg(cmd, "SELECT ClientId FROM Client ORDER BY Name");
+  if (QUERY_DB(jcr, cmd)) {
+    *num_ids = SqlNumRows();
+    if (*num_ids > 0) {
+      id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
+      while ((row = SqlFetchRow()) != NULL) { id[i++] = str_to_uint64(row[0]); }
+      *ids = id;
+    }
+    SqlFreeResult();
+    retval = true;
+  } else {
+    Mmsg(errmsg, _("Client id select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  }
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -599,195 +602,215 @@ bool BareosDb::GetClientIds(JobControlRecord *jcr, int *num_ids, DBId_t *ids[])
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::GetPoolRecord(JobControlRecord *jcr, PoolDbRecord *pdbr)
+bool BareosDb::GetPoolRecord(JobControlRecord* jcr, PoolDbRecord* pdbr)
 {
-   SQL_ROW row;
-   bool ok = false;
-   char ed1[50];
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  SQL_ROW row;
+  bool ok = false;
+  char ed1[50];
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (pdbr->PoolId != 0) {               /* find by id */
-      Mmsg(cmd,
-"SELECT PoolId,Name,NumVols,MaxVols,UseOnce,UseCatalog,AcceptAnyVolume,"
-"AutoPrune,Recycle,VolRetention,VolUseDuration,MaxVolJobs,MaxVolFiles,"
-"MaxVolBytes,PoolType,LabelType,LabelFormat,RecyclePoolId,ScratchPoolId,"
-"ActionOnPurge,MinBlocksize,MaxBlocksize FROM Pool WHERE Pool.PoolId=%s",
+  DbLock(this);
+  if (pdbr->PoolId != 0) { /* find by id */
+    Mmsg(
+        cmd,
+        "SELECT PoolId,Name,NumVols,MaxVols,UseOnce,UseCatalog,AcceptAnyVolume,"
+        "AutoPrune,Recycle,VolRetention,VolUseDuration,MaxVolJobs,MaxVolFiles,"
+        "MaxVolBytes,PoolType,LabelType,LabelFormat,RecyclePoolId,"
+        "ScratchPoolId,"
+        "ActionOnPurge,MinBlocksize,MaxBlocksize FROM Pool WHERE "
+        "Pool.PoolId=%s",
+        edit_int64(pdbr->PoolId, ed1));
+  } else { /* find by name */
+    EscapeString(jcr, esc, pdbr->Name, strlen(pdbr->Name));
+    Mmsg(
+        cmd,
+        "SELECT PoolId,Name,NumVols,MaxVols,UseOnce,UseCatalog,AcceptAnyVolume,"
+        "AutoPrune,Recycle,VolRetention,VolUseDuration,MaxVolJobs,MaxVolFiles,"
+        "MaxVolBytes,PoolType,LabelType,LabelFormat,RecyclePoolId,"
+        "ScratchPoolId,"
+        "ActionOnPurge,MinBlocksize,MaxBlocksize FROM Pool WHERE "
+        "Pool.Name='%s'",
+        esc);
+  }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      char ed1[30];
+      Mmsg1(errmsg, _("More than one Pool!: %s\n"), edit_uint64(num_rows, ed1));
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    } else if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+      } else {
+        pdbr->PoolId = str_to_int64(row[0]);
+        bstrncpy(pdbr->Name, (row[1] != NULL) ? row[1] : "",
+                 sizeof(pdbr->Name));
+        pdbr->NumVols = str_to_int64(row[2]);
+        pdbr->MaxVols = str_to_int64(row[3]);
+        pdbr->UseOnce = str_to_int64(row[4]);
+        pdbr->UseCatalog = str_to_int64(row[5]);
+        pdbr->AcceptAnyVolume = str_to_int64(row[6]);
+        pdbr->AutoPrune = str_to_int64(row[7]);
+        pdbr->Recycle = str_to_int64(row[8]);
+        pdbr->VolRetention = str_to_int64(row[9]);
+        pdbr->VolUseDuration = str_to_int64(row[10]);
+        pdbr->MaxVolJobs = str_to_int64(row[11]);
+        pdbr->MaxVolFiles = str_to_int64(row[12]);
+        pdbr->MaxVolBytes = str_to_uint64(row[13]);
+        bstrncpy(pdbr->PoolType, (row[14] != NULL) ? row[14] : "",
+                 sizeof(pdbr->PoolType));
+        pdbr->LabelType = str_to_int64(row[15]);
+        bstrncpy(pdbr->LabelFormat, (row[16] != NULL) ? row[16] : "",
+                 sizeof(pdbr->LabelFormat));
+        pdbr->RecyclePoolId = str_to_int64(row[17]);
+        pdbr->ScratchPoolId = str_to_int64(row[18]);
+        pdbr->ActionOnPurge = str_to_int32(row[19]);
+        pdbr->MinBlocksize = str_to_int32(row[20]);
+        pdbr->MaxBlocksize = str_to_int32(row[21]);
+        ok = true;
+      }
+    }
+    SqlFreeResult();
+  }
+
+  if (ok) {
+    uint32_t NumVols;
+
+    Mmsg(cmd, "SELECT count(*) from Media WHERE PoolId=%s",
          edit_int64(pdbr->PoolId, ed1));
-   } else {                           /* find by name */
-      EscapeString(jcr, esc, pdbr->Name, strlen(pdbr->Name));
-      Mmsg(cmd,
-"SELECT PoolId,Name,NumVols,MaxVols,UseOnce,UseCatalog,AcceptAnyVolume,"
-"AutoPrune,Recycle,VolRetention,VolUseDuration,MaxVolJobs,MaxVolFiles,"
-"MaxVolBytes,PoolType,LabelType,LabelFormat,RecyclePoolId,ScratchPoolId,"
-"ActionOnPurge,MinBlocksize,MaxBlocksize FROM Pool WHERE Pool.Name='%s'", esc);
-   }
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         char ed1[30];
-         Mmsg1(errmsg, _("More than one Pool!: %s\n"),
-            edit_uint64(num_rows, ed1));
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      } else if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-         } else {
-            pdbr->PoolId = str_to_int64(row[0]);
-            bstrncpy(pdbr->Name, (row[1] != NULL) ? row[1] : "", sizeof(pdbr->Name));
-            pdbr->NumVols = str_to_int64(row[2]);
-            pdbr->MaxVols = str_to_int64(row[3]);
-            pdbr->UseOnce = str_to_int64(row[4]);
-            pdbr->UseCatalog = str_to_int64(row[5]);
-            pdbr->AcceptAnyVolume = str_to_int64(row[6]);
-            pdbr->AutoPrune = str_to_int64(row[7]);
-            pdbr->Recycle = str_to_int64(row[8]);
-            pdbr->VolRetention = str_to_int64(row[9]);
-            pdbr->VolUseDuration = str_to_int64(row[10]);
-            pdbr->MaxVolJobs = str_to_int64(row[11]);
-            pdbr->MaxVolFiles = str_to_int64(row[12]);
-            pdbr->MaxVolBytes = str_to_uint64(row[13]);
-            bstrncpy(pdbr->PoolType, (row[14] != NULL) ? row[14] : "", sizeof(pdbr->PoolType));
-            pdbr->LabelType = str_to_int64(row[15]);
-            bstrncpy(pdbr->LabelFormat, (row[16] != NULL) ? row[16] : "", sizeof(pdbr->LabelFormat));
-            pdbr->RecyclePoolId = str_to_int64(row[17]);
-            pdbr->ScratchPoolId = str_to_int64(row[18]);
-            pdbr->ActionOnPurge = str_to_int32(row[19]);
-            pdbr->MinBlocksize = str_to_int32(row[20]);
-            pdbr->MaxBlocksize = str_to_int32(row[21]);
-            ok = true;
-         }
-      }
-      SqlFreeResult();
-   }
+    NumVols = GetSqlRecordMax(jcr);
+    Dmsg2(400, "Actual NumVols=%d Pool NumVols=%d\n", NumVols, pdbr->NumVols);
+    if (NumVols != pdbr->NumVols) {
+      pdbr->NumVols = NumVols;
+      ok = UpdatePoolRecord(jcr, pdbr);
+    }
+  } else {
+    Mmsg(errmsg, _("Pool record not found in Catalog.\n"));
+  }
 
-   if (ok) {
-      uint32_t NumVols;
-
-      Mmsg(cmd, "SELECT count(*) from Media WHERE PoolId=%s", edit_int64(pdbr->PoolId, ed1));
-      NumVols = GetSqlRecordMax(jcr);
-      Dmsg2(400, "Actual NumVols=%d Pool NumVols=%d\n", NumVols, pdbr->NumVols);
-      if (NumVols != pdbr->NumVols) {
-         pdbr->NumVols = NumVols;
-         ok = UpdatePoolRecord(jcr, pdbr);
-      }
-   } else {
-      Mmsg(errmsg, _("Pool record not found in Catalog.\n"));
-   }
-
-   DbUnlock(this);
-   return ok;
+  DbUnlock(this);
+  return ok;
 }
 
 /**
  * Get Storage Record
- * If the StorageId is non-zero, we get its record, otherwise, we search on the StorageName
+ * If the StorageId is non-zero, we get its record, otherwise, we search on the
+ * StorageName
  *
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::GetStorageRecord(JobControlRecord *jcr, StorageDbRecord *sdbr)
+bool BareosDb::GetStorageRecord(JobControlRecord* jcr, StorageDbRecord* sdbr)
 {
-   SQL_ROW row;
-   bool ok = false;
-   char ed1[50];
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  SQL_ROW row;
+  bool ok = false;
+  char ed1[50];
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (sdbr->StorageId != 0) {               /* find by id */
-      Mmsg(cmd,
-           "SELECT StorageId,Name,AutoChanger FROM Storage WHERE Storage.StorageId=%s",
-           edit_int64(sdbr->StorageId, ed1));
-   } else {                           /* find by name */
-      EscapeString(jcr, esc, sdbr->Name, strlen(sdbr->Name));
-      Mmsg(cmd,
-           "SELECT StorageId,Name,Autochanger FROM Storage WHERE Storage.Name='%s'", esc);
-   }
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         char ed1[30];
+  DbLock(this);
+  if (sdbr->StorageId != 0) { /* find by id */
+    Mmsg(cmd,
+         "SELECT StorageId,Name,AutoChanger FROM Storage WHERE "
+         "Storage.StorageId=%s",
+         edit_int64(sdbr->StorageId, ed1));
+  } else { /* find by name */
+    EscapeString(jcr, esc, sdbr->Name, strlen(sdbr->Name));
+    Mmsg(cmd,
+         "SELECT StorageId,Name,Autochanger FROM Storage WHERE "
+         "Storage.Name='%s'",
+         esc);
+  }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      char ed1[30];
 
-         Mmsg1(errmsg, _("More than one Storage!: %s\n"), edit_uint64(num_rows, ed1));
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      } else if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-         } else {
-            sdbr->StorageId = str_to_int64(row[0]);
-            bstrncpy(sdbr->Name, (row[1] != NULL) ? row[1] : "", sizeof(sdbr->Name));
-            sdbr->AutoChanger = str_to_int64(row[2]);
-            ok = true;
-         }
+      Mmsg1(errmsg, _("More than one Storage!: %s\n"),
+            edit_uint64(num_rows, ed1));
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    } else if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+      } else {
+        sdbr->StorageId = str_to_int64(row[0]);
+        bstrncpy(sdbr->Name, (row[1] != NULL) ? row[1] : "",
+                 sizeof(sdbr->Name));
+        sdbr->AutoChanger = str_to_int64(row[2]);
+        ok = true;
       }
-      SqlFreeResult();
-   }
+    }
+    SqlFreeResult();
+  }
 
-   DbUnlock(this);
-   return ok;
+  DbUnlock(this);
+  return ok;
 }
 
 /**
  * Get Client Record
- * If the ClientId is non-zero, we get its record, otherwise, we search on the Client Name
+ * If the ClientId is non-zero, we get its record, otherwise, we search on the
+ * Client Name
  *
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::GetClientRecord(JobControlRecord *jcr, ClientDbRecord *cdbr)
+bool BareosDb::GetClientRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[50];
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[50];
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (cdbr->ClientId != 0) {               /* find by id */
-      Mmsg(cmd,
-           "SELECT ClientId,Name,Uname,AutoPrune,FileRetention,JobRetention "
-           "FROM Client WHERE Client.ClientId=%s",
-           edit_int64(cdbr->ClientId, ed1));
-   } else {                           /* find by name */
-      EscapeString(jcr, esc, cdbr->Name, strlen(cdbr->Name));
-      Mmsg(cmd,
-           "SELECT ClientId,Name,Uname,AutoPrune,FileRetention,JobRetention "
-           "FROM Client WHERE Client.Name='%s'", esc);
-   }
+  DbLock(this);
+  if (cdbr->ClientId != 0) { /* find by id */
+    Mmsg(cmd,
+         "SELECT ClientId,Name,Uname,AutoPrune,FileRetention,JobRetention "
+         "FROM Client WHERE Client.ClientId=%s",
+         edit_int64(cdbr->ClientId, ed1));
+  } else { /* find by name */
+    EscapeString(jcr, esc, cdbr->Name, strlen(cdbr->Name));
+    Mmsg(cmd,
+         "SELECT ClientId,Name,Uname,AutoPrune,FileRetention,JobRetention "
+         "FROM Client WHERE Client.Name='%s'",
+         esc);
+  }
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Client!: %s\n"),
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Client!: %s\n"),
             edit_uint64(num_rows, ed1));
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      } else if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-         } else {
-            cdbr->ClientId = str_to_int64(row[0]);
-            bstrncpy(cdbr->Name, (row[1] != NULL) ? row[1] : "", sizeof(cdbr->Name));
-            bstrncpy(cdbr->Uname, (row[2] != NULL) ? row[2] : "", sizeof(cdbr->Uname));
-            cdbr->AutoPrune = str_to_int64(row[3]);
-            cdbr->FileRetention = str_to_int64(row[4]);
-            cdbr->JobRetention = str_to_int64(row[5]);
-            retval = true;
-         }
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    } else if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
       } else {
-         Mmsg(errmsg, _("Client record not found in Catalog.\n"));
+        cdbr->ClientId = str_to_int64(row[0]);
+        bstrncpy(cdbr->Name, (row[1] != NULL) ? row[1] : "",
+                 sizeof(cdbr->Name));
+        bstrncpy(cdbr->Uname, (row[2] != NULL) ? row[2] : "",
+                 sizeof(cdbr->Uname));
+        cdbr->AutoPrune = str_to_int64(row[3]);
+        cdbr->FileRetention = str_to_int64(row[4]);
+        cdbr->JobRetention = str_to_int64(row[5]);
+        retval = true;
       }
-      SqlFreeResult();
-   } else {
+    } else {
       Mmsg(errmsg, _("Client record not found in Catalog.\n"));
-   }
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("Client record not found in Catalog.\n"));
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -796,54 +819,54 @@ bool BareosDb::GetClientRecord(JobControlRecord *jcr, ClientDbRecord *cdbr)
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::GetCounterRecord(JobControlRecord *jcr, CounterDbRecord *cr)
+bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
+  DbLock(this);
+  EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
-   FillQuery(SQL_QUERY_select_counter_values, esc);
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
+  FillQuery(SQL_QUERY_select_counter_values, esc);
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
 
-      /*
-       * If more than one, report error, but return first row
-       */
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Counter!: %d\n"), num_rows);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    /*
+     * If more than one, report error, but return first row
+     */
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Counter!: %d\n"), num_rows);
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    }
+    if (num_rows >= 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching Counter row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
       }
-      if (num_rows >= 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching Counter row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         }
-         cr->MinValue = str_to_int64(row[0]);
-         cr->MaxValue = str_to_int64(row[1]);
-         cr->CurrentValue = str_to_int64(row[2]);
-         if (row[3]) {
-            bstrncpy(cr->WrapCounter, row[3], sizeof(cr->WrapCounter));
-         } else {
-            cr->WrapCounter[0] = 0;
-         }
-         SqlFreeResult();
-         retval = true;
-         goto bail_out;
+      cr->MinValue = str_to_int64(row[0]);
+      cr->MaxValue = str_to_int64(row[1]);
+      cr->CurrentValue = str_to_int64(row[2]);
+      if (row[3]) {
+        bstrncpy(cr->WrapCounter, row[3], sizeof(cr->WrapCounter));
+      } else {
+        cr->WrapCounter[0] = 0;
       }
       SqlFreeResult();
-   } else {
-      Mmsg(errmsg, _("Counter record: %s not found in Catalog.\n"), cr->Counter);
-   }
+      retval = true;
+      goto bail_out;
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("Counter record: %s not found in Catalog.\n"), cr->Counter);
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -854,50 +877,53 @@ bail_out:
  * Returns: 0 on failure
  *          id on success
  */
-int BareosDb::GetFilesetRecord(JobControlRecord *jcr, FileSetDbRecord *fsr)
+int BareosDb::GetFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
 {
-   SQL_ROW row;
-   int retval = 0;
-   char ed1[50];
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  SQL_ROW row;
+  int retval = 0;
+  char ed1[50];
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (fsr->FileSetId != 0) {               /* find by id */
-      Mmsg(cmd,
-           "SELECT FileSetId,FileSet,MD5,CreateTime FROM FileSet "
-           "WHERE FileSetId=%s",
-           edit_int64(fsr->FileSetId, ed1));
-   } else {                           /* find by name */
-      EscapeString(jcr, esc, fsr->FileSet, strlen(fsr->FileSet));
-      Mmsg(cmd,
-           "SELECT FileSetId,FileSet,MD5,CreateTime FROM FileSet "
-           "WHERE FileSet='%s' ORDER BY CreateTime DESC LIMIT 1", esc);
-   }
+  DbLock(this);
+  if (fsr->FileSetId != 0) { /* find by id */
+    Mmsg(cmd,
+         "SELECT FileSetId,FileSet,MD5,CreateTime FROM FileSet "
+         "WHERE FileSetId=%s",
+         edit_int64(fsr->FileSetId, ed1));
+  } else { /* find by name */
+    EscapeString(jcr, esc, fsr->FileSet, strlen(fsr->FileSet));
+    Mmsg(cmd,
+         "SELECT FileSetId,FileSet,MD5,CreateTime FROM FileSet "
+         "WHERE FileSet='%s' ORDER BY CreateTime DESC LIMIT 1",
+         esc);
+  }
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         char ed1[30];
-         Mmsg1(errmsg, _("Error got %s FileSets but expected only one!\n"),
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      char ed1[30];
+      Mmsg1(errmsg, _("Error got %s FileSets but expected only one!\n"),
             edit_uint64(num_rows, ed1));
-         SqlDataSeek(num_rows - 1);
-      }
-      if ((row = SqlFetchRow()) == NULL) {
-         Mmsg1(errmsg, _("FileSet record \"%s\" not found.\n"), fsr->FileSet);
-      } else {
-         fsr->FileSetId = str_to_int64(row[0]);
-         bstrncpy(fsr->FileSet, (row[1] != NULL) ? row[1] : "", sizeof(fsr->FileSet));
-         bstrncpy(fsr->MD5, (row[2] != NULL) ? row[2] : "", sizeof(fsr->MD5));
-         bstrncpy(fsr->cCreateTime, (row[3] != NULL) ? row[3] : "", sizeof(fsr->cCreateTime));
-         retval = fsr->FileSetId;
-      }
-      SqlFreeResult();
-   } else {
-      Mmsg(errmsg, _("FileSet record not found in Catalog.\n"));
-   }
-   DbUnlock(this);
-   return retval;
+      SqlDataSeek(num_rows - 1);
+    }
+    if ((row = SqlFetchRow()) == NULL) {
+      Mmsg1(errmsg, _("FileSet record \"%s\" not found.\n"), fsr->FileSet);
+    } else {
+      fsr->FileSetId = str_to_int64(row[0]);
+      bstrncpy(fsr->FileSet, (row[1] != NULL) ? row[1] : "",
+               sizeof(fsr->FileSet));
+      bstrncpy(fsr->MD5, (row[2] != NULL) ? row[2] : "", sizeof(fsr->MD5));
+      bstrncpy(fsr->cCreateTime, (row[3] != NULL) ? row[3] : "",
+               sizeof(fsr->cCreateTime));
+      retval = fsr->FileSetId;
+    }
+    SqlFreeResult();
+  } else {
+    Mmsg(errmsg, _("FileSet record not found in Catalog.\n"));
+  }
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -906,147 +932,157 @@ int BareosDb::GetFilesetRecord(JobControlRecord *jcr, FileSetDbRecord *fsr)
  * Returns: -1 on failure
  *          number on success
  */
-int BareosDb::GetNumMediaRecords(JobControlRecord *jcr)
+int BareosDb::GetNumMediaRecords(JobControlRecord* jcr)
 {
-   int retval = 0;
+  int retval = 0;
 
-   DbLock(this);
-   Mmsg(cmd, "SELECT count(*) from Media");
-   retval = GetSqlRecordMax(jcr);
-   DbUnlock(this);
-   return retval;
+  DbLock(this);
+  Mmsg(cmd, "SELECT count(*) from Media");
+  retval = GetSqlRecordMax(jcr);
+  DbUnlock(this);
+  return retval;
 }
 
-bool BareosDb::PrepareMediaSqlQuery(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem &volumes)
+bool BareosDb::PrepareMediaSqlQuery(JobControlRecord* jcr,
+                                    MediaDbRecord* mr,
+                                    PoolMem& volumes)
 {
-   bool ok = true;
-   char ed1[50];
-   char esc[MAX_NAME_LENGTH * 2 + 1];
-   PoolMem buf(PM_MESSAGE);
+  bool ok = true;
+  char ed1[50];
+  char esc[MAX_NAME_LENGTH * 2 + 1];
+  PoolMem buf(PM_MESSAGE);
 
-   Mmsg(cmd, "SELECT DISTINCT MediaId FROM Media WHERE Recycle=%d AND Enabled=%d ", mr->Recycle, mr->Enabled);
+  Mmsg(cmd,
+       "SELECT DISTINCT MediaId FROM Media WHERE Recycle=%d AND Enabled=%d ",
+       mr->Recycle, mr->Enabled);
 
-   if (*mr->MediaType) {
-      EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
-      Mmsg(buf, "AND MediaType='%s' ", esc);
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (*mr->MediaType) {
+    EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
+    Mmsg(buf, "AND MediaType='%s' ", esc);
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   if (mr->StorageId) {
-      Mmsg(buf, "AND StorageId=%s ", edit_uint64(mr->StorageId, ed1));
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (mr->StorageId) {
+    Mmsg(buf, "AND StorageId=%s ", edit_uint64(mr->StorageId, ed1));
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   if (mr->PoolId) {
-      Mmsg(buf, "AND PoolId=%s ", edit_uint64(mr->PoolId, ed1));
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (mr->PoolId) {
+    Mmsg(buf, "AND PoolId=%s ", edit_uint64(mr->PoolId, ed1));
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   if (mr->VolBytes) {
-      Mmsg(buf, "AND VolBytes > %s ", edit_uint64(mr->VolBytes, ed1));
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (mr->VolBytes) {
+    Mmsg(buf, "AND VolBytes > %s ", edit_uint64(mr->VolBytes, ed1));
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   if (*mr->VolStatus) {
-      EscapeString(jcr, esc, mr->VolStatus, strlen(mr->VolStatus));
-      Mmsg(buf, "AND VolStatus = '%s' ", esc);
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (*mr->VolStatus) {
+    EscapeString(jcr, esc, mr->VolStatus, strlen(mr->VolStatus));
+    Mmsg(buf, "AND VolStatus = '%s' ", esc);
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   if (volumes.strlen() > 0) {
-      /* extra list of volumes given */
-      Mmsg(buf, "AND VolumeName IN (%s) ", volumes.c_str());
-      PmStrcat(cmd, buf.c_str());
-   } else if (*mr->VolumeName) {
-      /* single volume given in media record */
-      EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
-      Mmsg(buf, "AND VolumeName = '%s' ", esc);
-      PmStrcat(cmd, buf.c_str());
-   }
+  if (volumes.strlen() > 0) {
+    /* extra list of volumes given */
+    Mmsg(buf, "AND VolumeName IN (%s) ", volumes.c_str());
+    PmStrcat(cmd, buf.c_str());
+  } else if (*mr->VolumeName) {
+    /* single volume given in media record */
+    EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
+    Mmsg(buf, "AND VolumeName = '%s' ", esc);
+    PmStrcat(cmd, buf.c_str());
+  }
 
-   Dmsg1(100, "query=%s\n", cmd);
+  Dmsg1(100, "query=%s\n", cmd);
 
-   return ok;
+  return ok;
 }
 
 /**
- * This function creates a sql query string at cmd to return a list of all the Media records for
- * the current Pool, the correct Media Type, Recyle, Enabled, StorageId, VolBytes and
- * volumes or VolumeName if specified. Comma separated list of volumes takes precedence
- * over VolumeName. The caller must free ids if non-NULL.
+ * This function creates a sql query string at cmd to return a list of all the
+ * Media records for the current Pool, the correct Media Type, Recyle, Enabled,
+ * StorageId, VolBytes and volumes or VolumeName if specified. Comma separated
+ * list of volumes takes precedence over VolumeName. The caller must free ids if
+ * non-NULL.
  */
-bool BareosDb::GetMediaIds(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem &volumes, int *num_ids, DBId_t *ids[])
+bool BareosDb::GetMediaIds(JobControlRecord* jcr,
+                           MediaDbRecord* mr,
+                           PoolMem& volumes,
+                           int* num_ids,
+                           DBId_t* ids[])
 {
-   bool ok = false;
-   SQL_ROW row;
-   int i = 0;
-   DBId_t *id;
+  bool ok = false;
+  SQL_ROW row;
+  int i = 0;
+  DBId_t* id;
 
-   DbLock(this);
-   *ids = NULL;
+  DbLock(this);
+  *ids = NULL;
 
-   if (!PrepareMediaSqlQuery(jcr, mr, volumes)) {
-      Mmsg(errmsg, _("Media id select failed: invalid parameter"));
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   }
+  if (!PrepareMediaSqlQuery(jcr, mr, volumes)) {
+    Mmsg(errmsg, _("Media id select failed: invalid parameter"));
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  }
 
-   if (!QUERY_DB(jcr, cmd)) {
-      Mmsg(errmsg, _("Media id select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      goto bail_out;
-   }
+  if (!QUERY_DB(jcr, cmd)) {
+    Mmsg(errmsg, _("Media id select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    goto bail_out;
+  }
 
-   *num_ids = SqlNumRows();
-   if (*num_ids > 0) {
-      id = (DBId_t *)malloc(*num_ids * sizeof(DBId_t));
-      while ((row = SqlFetchRow()) != NULL) {
-         id[i++] = str_to_uint64(row[0]);
-      }
-      *ids = id;
-   }
-   SqlFreeResult();
-   ok = true;
+  *num_ids = SqlNumRows();
+  if (*num_ids > 0) {
+    id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
+    while ((row = SqlFetchRow()) != NULL) { id[i++] = str_to_uint64(row[0]); }
+    *ids = id;
+  }
+  SqlFreeResult();
+  ok = true;
 bail_out:
-   DbUnlock(this);
-   return ok;
+  DbUnlock(this);
+  return ok;
 }
 
 
 /**
- * This function returns a list of all the DBIds that are returned for the query.
+ * This function returns a list of all the DBIds that are returned for the
+ * query.
  *
  * Returns false: on failure
  *         true:  on success
  */
-bool BareosDb::GetQueryDbids(JobControlRecord *jcr, PoolMem &query, dbid_list &ids)
+bool BareosDb::GetQueryDbids(JobControlRecord* jcr,
+                             PoolMem& query,
+                             dbid_list& ids)
 {
-   SQL_ROW row;
-   int i = 0;
-   bool ok = false;
+  SQL_ROW row;
+  int i = 0;
+  bool ok = false;
 
-   DbLock(this);
-   ids.num_ids = 0;
-   if (QUERY_DB(jcr, query.c_str())) {
-      ids.num_ids = SqlNumRows();
-      if (ids.num_ids > 0) {
-         if (ids.max_ids < ids.num_ids) {
-            free(ids.DBId);
-            ids.DBId = (DBId_t *)malloc(ids.num_ids * sizeof(DBId_t));
-         }
-         while ((row = SqlFetchRow()) != NULL) {
-            ids.DBId[i++] = str_to_uint64(row[0]);
-         }
+  DbLock(this);
+  ids.num_ids = 0;
+  if (QUERY_DB(jcr, query.c_str())) {
+    ids.num_ids = SqlNumRows();
+    if (ids.num_ids > 0) {
+      if (ids.max_ids < ids.num_ids) {
+        free(ids.DBId);
+        ids.DBId = (DBId_t*)malloc(ids.num_ids * sizeof(DBId_t));
       }
-      SqlFreeResult();
-      ok = true;
-   } else {
-      Mmsg(errmsg, _("query dbids failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      ok = false;
-   }
-   DbUnlock(this);
-   return ok;
+      while ((row = SqlFetchRow()) != NULL) {
+        ids.DBId[i++] = str_to_uint64(row[0]);
+      }
+    }
+    SqlFreeResult();
+    ok = true;
+  } else {
+    Mmsg(errmsg, _("query dbids failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    ok = false;
+  }
+  DbUnlock(this);
+  return ok;
 }
 
 
@@ -1056,23 +1092,24 @@ bool BareosDb::GetQueryDbids(JobControlRecord *jcr, PoolMem &query, dbid_list &i
  * Returns: false: on failure
  *          true:  on success
  */
-bool BareosDb::GetMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr)
+bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 {
-   bool retval = false;
-   SQL_ROW row;
-   char ed1[50];
-   int num_rows;
-   char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  SQL_ROW row;
+  char ed1[50];
+  int num_rows;
+  char esc[MAX_ESCAPE_NAME_LENGTH];
 
-   DbLock(this);
-   if (mr->MediaId == 0 && mr->VolumeName[0] == 0) {
-      Mmsg(cmd, "SELECT count(*) from Media");
-      mr->MediaId = GetSqlRecordMax(jcr);
-      retval = true;
-      goto bail_out;
-   }
-   if (mr->MediaId != 0) {               /* find by id */
-      Mmsg(cmd, "SELECT MediaId,VolumeName,VolJobs,VolFiles,VolBlocks,"
+  DbLock(this);
+  if (mr->MediaId == 0 && mr->VolumeName[0] == 0) {
+    Mmsg(cmd, "SELECT count(*) from Media");
+    mr->MediaId = GetSqlRecordMax(jcr);
+    retval = true;
+    goto bail_out;
+  }
+  if (mr->MediaId != 0) { /* find by id */
+    Mmsg(cmd,
+         "SELECT MediaId,VolumeName,VolJobs,VolFiles,VolBlocks,"
          "VolBytes,VolMounts,VolErrors,VolWrites,MaxVolBytes,VolCapacityBytes,"
          "MediaType,VolStatus,PoolId,VolRetention,VolUseDuration,MaxVolJobs,"
          "MaxVolFiles,Recycle,Slot,FirstWritten,LastWritten,InChanger,"
@@ -1082,9 +1119,10 @@ bool BareosDb::GetMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr)
          "ActionOnPurge,EncryptionKey,MinBlocksize,MaxBlocksize "
          "FROM Media WHERE MediaId=%s",
          edit_int64(mr->MediaId, ed1));
-   } else {                           /* find by name */
-      EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
-      Mmsg(cmd, "SELECT MediaId,VolumeName,VolJobs,VolFiles,VolBlocks,"
+  } else { /* find by name */
+    EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
+    Mmsg(cmd,
+         "SELECT MediaId,VolumeName,VolJobs,VolFiles,VolBlocks,"
          "VolBytes,VolMounts,VolErrors,VolWrites,MaxVolBytes,VolCapacityBytes,"
          "MediaType,VolStatus,PoolId,VolRetention,VolUseDuration,MaxVolJobs,"
          "MaxVolFiles,Recycle,Slot,FirstWritten,LastWritten,InChanger,"
@@ -1092,102 +1130,109 @@ bool BareosDb::GetMediaRecord(JobControlRecord *jcr, MediaDbRecord *mr)
          "Enabled,LocationId,RecycleCount,InitialWrite,"
          "ScratchPoolId,RecyclePoolId,VolReadTime,VolWriteTime,"
          "ActionOnPurge,EncryptionKey,MinBlocksize,MaxBlocksize "
-         "FROM Media WHERE VolumeName='%s'", esc);
-   }
+         "FROM Media WHERE VolumeName='%s'",
+         esc);
+  }
 
-   if (QUERY_DB(jcr, cmd)) {
-      char ed1[50];
-      num_rows = SqlNumRows();
-      if (num_rows > 1) {
-         Mmsg1(errmsg, _("More than one Volume!: %s\n"),
+  if (QUERY_DB(jcr, cmd)) {
+    char ed1[50];
+    num_rows = SqlNumRows();
+    if (num_rows > 1) {
+      Mmsg1(errmsg, _("More than one Volume!: %s\n"),
             edit_uint64(num_rows, ed1));
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-      } else if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-         } else {
-            /* return values */
-            mr->MediaId = str_to_int64(row[0]);
-            bstrncpy(mr->VolumeName, (row[1] != NULL) ? row[1] : "", sizeof(mr->VolumeName));
-            mr->VolJobs = str_to_int64(row[2]);
-            mr->VolFiles = str_to_int64(row[3]);
-            mr->VolBlocks = str_to_int64(row[4]);
-            mr->VolBytes = str_to_uint64(row[5]);
-            mr->VolMounts = str_to_int64(row[6]);
-            mr->VolErrors = str_to_int64(row[7]);
-            mr->VolWrites = str_to_int64(row[8]);
-            mr->MaxVolBytes = str_to_uint64(row[9]);
-            mr->VolCapacityBytes = str_to_uint64(row[10]);
-            bstrncpy(mr->MediaType, (row[11] != NULL) ? row[11] : "", sizeof(mr->MediaType));
-            bstrncpy(mr->VolStatus, (row[12] != NULL) ? row[12] : "", sizeof(mr->VolStatus));
-            mr->PoolId = str_to_int64(row[13]);
-            mr->VolRetention = str_to_uint64(row[14]);
-            mr->VolUseDuration = str_to_uint64(row[15]);
-            mr->MaxVolJobs = str_to_int64(row[16]);
-            mr->MaxVolFiles = str_to_int64(row[17]);
-            mr->Recycle = str_to_int64(row[18]);
-            mr->Slot = str_to_int64(row[19]);
-            bstrncpy(mr->cFirstWritten, (row[20] != NULL) ? row[20] : "", sizeof(mr->cFirstWritten));
-            mr->FirstWritten = (time_t)StrToUtime(mr->cFirstWritten);
-            bstrncpy(mr->cLastWritten, (row[21] != NULL) ? row[21] : "", sizeof(mr->cLastWritten));
-            mr->LastWritten = (time_t)StrToUtime(mr->cLastWritten);
-            mr->InChanger = str_to_uint64(row[22]);
-            mr->EndFile = str_to_uint64(row[23]);
-            mr->EndBlock = str_to_uint64(row[24]);
-            mr->LabelType = str_to_int64(row[25]);
-            bstrncpy(mr->cLabelDate, (row[26] != NULL) ? row[26] : "", sizeof(mr->cLabelDate));
-            mr->LabelDate = (time_t)StrToUtime(mr->cLabelDate);
-            mr->StorageId = str_to_int64(row[27]);
-            mr->Enabled = str_to_int64(row[28]);
-            mr->LocationId = str_to_int64(row[29]);
-            mr->RecycleCount = str_to_int64(row[30]);
-            bstrncpy(mr->cInitialWrite, (row[31] != NULL) ? row[31] : "", sizeof(mr->cInitialWrite));
-            mr->InitialWrite = (time_t)StrToUtime(mr->cInitialWrite);
-            mr->ScratchPoolId = str_to_int64(row[32]);
-            mr->RecyclePoolId = str_to_int64(row[33]);
-            mr->VolReadTime = str_to_int64(row[34]);
-            mr->VolWriteTime = str_to_int64(row[35]);
-            mr->ActionOnPurge = str_to_int32(row[36]);
-            bstrncpy(mr->EncrKey, (row[37] != NULL) ? row[37] : "", sizeof(mr->EncrKey));
-            mr->MinBlocksize = str_to_int32(row[38]);
-            mr->MaxBlocksize = str_to_int32(row[39]);
-            retval = true;
-         }
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    } else if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
       } else {
-         if (mr->MediaId != 0) {
-            Mmsg1(errmsg, _("Media record MediaId=%s not found.\n"),
-               edit_int64(mr->MediaId, ed1));
-         } else {
-            Mmsg1(errmsg, _("Media record for Volume \"%s\" not found.\n"),
-                  mr->VolumeName);
-         }
+        /* return values */
+        mr->MediaId = str_to_int64(row[0]);
+        bstrncpy(mr->VolumeName, (row[1] != NULL) ? row[1] : "",
+                 sizeof(mr->VolumeName));
+        mr->VolJobs = str_to_int64(row[2]);
+        mr->VolFiles = str_to_int64(row[3]);
+        mr->VolBlocks = str_to_int64(row[4]);
+        mr->VolBytes = str_to_uint64(row[5]);
+        mr->VolMounts = str_to_int64(row[6]);
+        mr->VolErrors = str_to_int64(row[7]);
+        mr->VolWrites = str_to_int64(row[8]);
+        mr->MaxVolBytes = str_to_uint64(row[9]);
+        mr->VolCapacityBytes = str_to_uint64(row[10]);
+        bstrncpy(mr->MediaType, (row[11] != NULL) ? row[11] : "",
+                 sizeof(mr->MediaType));
+        bstrncpy(mr->VolStatus, (row[12] != NULL) ? row[12] : "",
+                 sizeof(mr->VolStatus));
+        mr->PoolId = str_to_int64(row[13]);
+        mr->VolRetention = str_to_uint64(row[14]);
+        mr->VolUseDuration = str_to_uint64(row[15]);
+        mr->MaxVolJobs = str_to_int64(row[16]);
+        mr->MaxVolFiles = str_to_int64(row[17]);
+        mr->Recycle = str_to_int64(row[18]);
+        mr->Slot = str_to_int64(row[19]);
+        bstrncpy(mr->cFirstWritten, (row[20] != NULL) ? row[20] : "",
+                 sizeof(mr->cFirstWritten));
+        mr->FirstWritten = (time_t)StrToUtime(mr->cFirstWritten);
+        bstrncpy(mr->cLastWritten, (row[21] != NULL) ? row[21] : "",
+                 sizeof(mr->cLastWritten));
+        mr->LastWritten = (time_t)StrToUtime(mr->cLastWritten);
+        mr->InChanger = str_to_uint64(row[22]);
+        mr->EndFile = str_to_uint64(row[23]);
+        mr->EndBlock = str_to_uint64(row[24]);
+        mr->LabelType = str_to_int64(row[25]);
+        bstrncpy(mr->cLabelDate, (row[26] != NULL) ? row[26] : "",
+                 sizeof(mr->cLabelDate));
+        mr->LabelDate = (time_t)StrToUtime(mr->cLabelDate);
+        mr->StorageId = str_to_int64(row[27]);
+        mr->Enabled = str_to_int64(row[28]);
+        mr->LocationId = str_to_int64(row[29]);
+        mr->RecycleCount = str_to_int64(row[30]);
+        bstrncpy(mr->cInitialWrite, (row[31] != NULL) ? row[31] : "",
+                 sizeof(mr->cInitialWrite));
+        mr->InitialWrite = (time_t)StrToUtime(mr->cInitialWrite);
+        mr->ScratchPoolId = str_to_int64(row[32]);
+        mr->RecyclePoolId = str_to_int64(row[33]);
+        mr->VolReadTime = str_to_int64(row[34]);
+        mr->VolWriteTime = str_to_int64(row[35]);
+        mr->ActionOnPurge = str_to_int32(row[36]);
+        bstrncpy(mr->EncrKey, (row[37] != NULL) ? row[37] : "",
+                 sizeof(mr->EncrKey));
+        mr->MinBlocksize = str_to_int32(row[38]);
+        mr->MaxBlocksize = str_to_int32(row[39]);
+        retval = true;
       }
-      SqlFreeResult();
-   } else {
+    } else {
       if (mr->MediaId != 0) {
-         Mmsg(errmsg, _("Media record for MediaId=%u not found in Catalog.\n"),
-            mr->MediaId);
+        Mmsg1(errmsg, _("Media record MediaId=%s not found.\n"),
+              edit_int64(mr->MediaId, ed1));
       } else {
-         Mmsg(errmsg, _("Media record for Vol=%s not found in Catalog.\n"),
-            mr->VolumeName);
+        Mmsg1(errmsg, _("Media record for Volume \"%s\" not found.\n"),
+              mr->VolumeName);
       }
-   }
+    }
+    SqlFreeResult();
+  } else {
+    if (mr->MediaId != 0) {
+      Mmsg(errmsg, _("Media record for MediaId=%u not found in Catalog.\n"),
+           mr->MediaId);
+    } else {
+      Mmsg(errmsg, _("Media record for Vol=%s not found in Catalog.\n"),
+           mr->VolumeName);
+    }
+  }
 
 bail_out:
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
  * Remove all MD5 from a query (can save lot of memory with many files)
  */
-static void strip_md5(char *q)
+static void strip_md5(char* q)
 {
-   char *p = q;
-   while ((p = strstr(p, ", MD5"))) {
-      memset(p, ' ', 5 * sizeof(char));
-   }
+  char* p = q;
+  while ((p = strstr(p, ", MD5"))) { memset(p, ' ', 5 * sizeof(char)); }
 }
 
 /**
@@ -1197,65 +1242,74 @@ static void strip_md5(char *q)
  *    Get all files in BaseFiles with jobid in list
  * 2) Take only the last version of each file (Temp subquery) => accurate list
  *    is ok
- * 3) Join the result to file table to get fileindex, jobid and lstat information
+ * 3) Join the result to file table to get fileindex, jobid and lstat
+ * information
  *
  * TODO: See if we can do the SORT only if needed (as an argument)
  */
-bool BareosDb::GetFileList(JobControlRecord *jcr, char *jobids, bool use_md5, bool use_delta,
-                         DB_RESULT_HANDLER *ResultHandler, void *ctx)
+bool BareosDb::GetFileList(JobControlRecord* jcr,
+                           char* jobids,
+                           bool use_md5,
+                           bool use_delta,
+                           DB_RESULT_HANDLER* ResultHandler,
+                           void* ctx)
 {
-   PoolMem query(PM_MESSAGE);
-   PoolMem query2(PM_MESSAGE);
+  PoolMem query(PM_MESSAGE);
+  PoolMem query2(PM_MESSAGE);
 
-   if (!*jobids) {
-      DbLock(this);
-      Mmsg(errmsg, _("ERR=JobIds are empty\n"));
-      DbUnlock(this);
-      return false;
-   }
+  if (!*jobids) {
+    DbLock(this);
+    Mmsg(errmsg, _("ERR=JobIds are empty\n"));
+    DbUnlock(this);
+    return false;
+  }
 
-   if (use_delta) {
-      FillQuery(query2, SQL_QUERY_select_recent_version_with_basejob_and_delta, jobids, jobids, jobids, jobids);
-   } else {
-      FillQuery(query2, SQL_QUERY_select_recent_version_with_basejob, jobids, jobids, jobids, jobids);
-   }
+  if (use_delta) {
+    FillQuery(query2, SQL_QUERY_select_recent_version_with_basejob_and_delta,
+              jobids, jobids, jobids, jobids);
+  } else {
+    FillQuery(query2, SQL_QUERY_select_recent_version_with_basejob, jobids,
+              jobids, jobids, jobids);
+  }
 
-   /*
-    * BootStrapRecord code is optimized for JobId sorted, with Delta, we need to get
-    * them ordered by date. JobTDate and JobId can be mixed if using Copy
-    * or Migration
-    */
-   Mmsg(query,
-"SELECT Path.Path, T1.Name, T1.FileIndex, T1.JobId, LStat, DeltaSeq, MD5, Fhinfo, Fhnode "
- "FROM ( %s ) AS T1 "
- "JOIN Path ON (Path.PathId = T1.PathId) "
-"WHERE FileIndex > 0 "
-"ORDER BY T1.JobTDate, FileIndex ASC",/* Return sorted by JobTDate */
-                                      /* FileIndex for restore code */
-        query2.c_str());
+  /*
+   * BootStrapRecord code is optimized for JobId sorted, with Delta, we need to
+   * get them ordered by date. JobTDate and JobId can be mixed if using Copy or
+   * Migration
+   */
+  Mmsg(query,
+       "SELECT Path.Path, T1.Name, T1.FileIndex, T1.JobId, LStat, DeltaSeq, "
+       "MD5, Fhinfo, Fhnode "
+       "FROM ( %s ) AS T1 "
+       "JOIN Path ON (Path.PathId = T1.PathId) "
+       "WHERE FileIndex > 0 "
+       "ORDER BY T1.JobTDate, FileIndex ASC", /* Return sorted by JobTDate */
+                                              /* FileIndex for restore code */
+       query2.c_str());
 
-   if (!use_md5) {
-      strip_md5(query.c_str());
-   }
+  if (!use_md5) { strip_md5(query.c_str()); }
 
-   Dmsg1(100, "q=%s\n", query.c_str());
+  Dmsg1(100, "q=%s\n", query.c_str());
 
-   return BigSqlQuery(query.c_str(), ResultHandler, ctx);
+  return BigSqlQuery(query.c_str(), ResultHandler, ctx);
 }
 
 /**
  * This procedure gets the base jobid list used by jobids,
  */
-bool BareosDb::GetUsedBaseJobids(JobControlRecord *jcr, POOLMEM *jobids, db_list_ctx *result)
+bool BareosDb::GetUsedBaseJobids(JobControlRecord* jcr,
+                                 POOLMEM* jobids,
+                                 db_list_ctx* result)
 {
-   PoolMem query(PM_MESSAGE);
+  PoolMem query(PM_MESSAGE);
 
-   Mmsg(query,
- "SELECT DISTINCT BaseJobId "
- "  FROM Job JOIN BaseFiles USING (JobId) "
- " WHERE Job.HasBase = 1 "
- "   AND Job.JobId IN (%s) ", jobids);
-   return SqlQueryWithHandler(query.c_str(), DbListHandler, result);
+  Mmsg(query,
+       "SELECT DISTINCT BaseJobId "
+       "  FROM Job JOIN BaseFiles USING (JobId) "
+       " WHERE Job.HasBase = 1 "
+       "   AND Job.JobId IN (%s) ",
+       jobids);
+  return SqlQueryWithHandler(query.c_str(), DbListHandler, result);
 }
 
 /**
@@ -1272,177 +1326,179 @@ bool BareosDb::GetUsedBaseJobids(JobControlRecord *jcr, POOLMEM *jobids, db_list
  *
  * TODO: look and merge from ua_restore.c
  */
-bool BareosDb::AccurateGetJobids(JobControlRecord *jcr, JobDbRecord *jr, db_list_ctx *jobids)
+bool BareosDb::AccurateGetJobids(JobControlRecord* jcr,
+                                 JobDbRecord* jr,
+                                 db_list_ctx* jobids)
 {
-   bool retval = false;
-   char clientid[50], jobid[50], filesetid[50];
-   char date[MAX_TIME_LENGTH];
-   PoolMem query(PM_MESSAGE);
+  bool retval = false;
+  char clientid[50], jobid[50], filesetid[50];
+  char date[MAX_TIME_LENGTH];
+  PoolMem query(PM_MESSAGE);
 
-   /* Take the current time as upper limit if nothing else specified */
-   utime_t StartTime = (jr->StartTime) ? jr->StartTime : time(NULL);
+  /* Take the current time as upper limit if nothing else specified */
+  utime_t StartTime = (jr->StartTime) ? jr->StartTime : time(NULL);
 
-   bstrutime(date, sizeof(date),  StartTime + 1);
-   jobids->reset();
+  bstrutime(date, sizeof(date), StartTime + 1);
+  jobids->reset();
 
-   /*
-    * First, find the last good Full backup for this job/client/fileset
-    */
-   FillQuery(query, SQL_QUERY_create_temp_accurate_jobids, edit_uint64(jcr->JobId, jobid),
-              edit_uint64(jr->ClientId, clientid), date, edit_uint64(jr->FileSetId, filesetid));
+  /*
+   * First, find the last good Full backup for this job/client/fileset
+   */
+  FillQuery(query, SQL_QUERY_create_temp_accurate_jobids,
+            edit_uint64(jcr->JobId, jobid), edit_uint64(jr->ClientId, clientid),
+            date, edit_uint64(jr->FileSetId, filesetid));
 
-   if (!SqlQuery(query.c_str())) {
-      goto bail_out;
-   }
+  if (!SqlQuery(query.c_str())) { goto bail_out; }
 
-   if (jr->JobLevel == L_INCREMENTAL || jr->JobLevel == L_VIRTUAL_FULL) {
-      /*
-       * Now, find the last differential backup after the last full
-       */
-      Mmsg(query,
-"INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, PurgedFiles) "
- "SELECT JobId, StartTime, EndTime, JobTDate, PurgedFiles "
-   "FROM Job JOIN FileSet USING (FileSetId) "
-  "WHERE ClientId = %s "
-    "AND JobFiles > 0 "
-    "AND Level='D' AND JobStatus IN ('T','W') AND Type='B' "
-    "AND StartTime > (SELECT EndTime FROM btemp3%s ORDER BY EndTime DESC LIMIT 1) "
-    "AND StartTime < '%s' "
-    "AND FileSet.FileSet= (SELECT FileSet FROM FileSet WHERE FileSetId = %s) "
-  "ORDER BY Job.JobTDate DESC LIMIT 1 ",
-           jobid,
-           clientid,
-           jobid,
-           date,
-           filesetid);
+  if (jr->JobLevel == L_INCREMENTAL || jr->JobLevel == L_VIRTUAL_FULL) {
+    /*
+     * Now, find the last differential backup after the last full
+     */
+    Mmsg(query,
+         "INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, "
+         "PurgedFiles) "
+         "SELECT JobId, StartTime, EndTime, JobTDate, PurgedFiles "
+         "FROM Job JOIN FileSet USING (FileSetId) "
+         "WHERE ClientId = %s "
+         "AND JobFiles > 0 "
+         "AND Level='D' AND JobStatus IN ('T','W') AND Type='B' "
+         "AND StartTime > (SELECT EndTime FROM btemp3%s ORDER BY EndTime DESC "
+         "LIMIT 1) "
+         "AND StartTime < '%s' "
+         "AND FileSet.FileSet= (SELECT FileSet FROM FileSet WHERE FileSetId = "
+         "%s) "
+         "ORDER BY Job.JobTDate DESC LIMIT 1 ",
+         jobid, clientid, jobid, date, filesetid);
 
-      if (!SqlQuery(query.c_str())) {
-         goto bail_out;
-      }
+    if (!SqlQuery(query.c_str())) { goto bail_out; }
 
-      /*
-       * We just have to take all incremental after the last Full/Diff
-       *
-       * If we are doing always incremental, we need to limit the search to
-       * only include incrementals that are older than (now - AlwaysIncrementalInterval)
-       * and leave AlwaysIncrementalNumber incrementals
-       */
-      Mmsg(query,
-"INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, PurgedFiles) "
- "SELECT JobId, StartTime, EndTime, JobTDate, PurgedFiles "
-   "FROM Job JOIN FileSet USING (FileSetId) "
-  "WHERE ClientId = %s "
-    "AND JobFiles > 0 "
-    "AND Level='I' AND JobStatus IN ('T','W') AND Type='B' "
-    "AND StartTime > (SELECT EndTime FROM btemp3%s ORDER BY EndTime DESC LIMIT 1) "
-    "AND StartTime < '%s' "
-    "AND FileSet.FileSet= (SELECT FileSet FROM FileSet WHERE FileSetId = %s) "
-  "ORDER BY Job.JobTDate DESC ",
-           jobid,
-           clientid,
-           jobid,
-           date,
-           filesetid);
-      if (!SqlQuery(query.c_str())) {
-         goto bail_out;
-      }
-   }
+    /*
+     * We just have to take all incremental after the last Full/Diff
+     *
+     * If we are doing always incremental, we need to limit the search to
+     * only include incrementals that are older than (now -
+     * AlwaysIncrementalInterval) and leave AlwaysIncrementalNumber incrementals
+     */
+    Mmsg(query,
+         "INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, "
+         "PurgedFiles) "
+         "SELECT JobId, StartTime, EndTime, JobTDate, PurgedFiles "
+         "FROM Job JOIN FileSet USING (FileSetId) "
+         "WHERE ClientId = %s "
+         "AND JobFiles > 0 "
+         "AND Level='I' AND JobStatus IN ('T','W') AND Type='B' "
+         "AND StartTime > (SELECT EndTime FROM btemp3%s ORDER BY EndTime DESC "
+         "LIMIT 1) "
+         "AND StartTime < '%s' "
+         "AND FileSet.FileSet= (SELECT FileSet FROM FileSet WHERE FileSetId = "
+         "%s) "
+         "ORDER BY Job.JobTDate DESC ",
+         jobid, clientid, jobid, date, filesetid);
+    if (!SqlQuery(query.c_str())) { goto bail_out; }
+  }
 
-   /*
-    * Build a jobid list ie: 1,2,3,4
-    */
-   if (jr->limit) {
-      Mmsg(query, "SELECT JobId FROM btemp3%s ORDER by JobTDate LIMIT %d", jobid, jr->limit);
-   } else {
-      Mmsg(query, "SELECT JobId FROM btemp3%s ORDER by JobTDate", jobid);
-   }
-   SqlQueryWithHandler(query.c_str(), DbListHandler, jobids);
-   Dmsg1(1, "db_accurate_get_jobids=%s\n", jobids->list);
-   retval = true;
+  /*
+   * Build a jobid list ie: 1,2,3,4
+   */
+  if (jr->limit) {
+    Mmsg(query, "SELECT JobId FROM btemp3%s ORDER by JobTDate LIMIT %d", jobid,
+         jr->limit);
+  } else {
+    Mmsg(query, "SELECT JobId FROM btemp3%s ORDER by JobTDate", jobid);
+  }
+  SqlQueryWithHandler(query.c_str(), DbListHandler, jobids);
+  Dmsg1(1, "db_accurate_get_jobids=%s\n", jobids->list);
+  retval = true;
 
 bail_out:
-   Mmsg(query, "DROP TABLE btemp3%s", jobid);
-   SqlQuery(query.c_str());
-   return retval;
+  Mmsg(query, "DROP TABLE btemp3%s", jobid);
+  SqlQuery(query.c_str());
+  return retval;
 }
 
-bool BareosDb::GetBaseFileList(JobControlRecord *jcr, bool use_md5, DB_RESULT_HANDLER *ResultHandler, void *ctx)
+bool BareosDb::GetBaseFileList(JobControlRecord* jcr,
+                               bool use_md5,
+                               DB_RESULT_HANDLER* ResultHandler,
+                               void* ctx)
 {
-   PoolMem query(PM_MESSAGE);
+  PoolMem query(PM_MESSAGE);
 
-   Mmsg(query,
- "SELECT Path, Name, FileIndex, JobId, LStat, 0 As DeltaSeq, MD5, Fhinfo, Fhnode "
-   "FROM new_basefile%lld ORDER BY JobId, FileIndex ASC",
-        (uint64_t) jcr->JobId);
+  Mmsg(query,
+       "SELECT Path, Name, FileIndex, JobId, LStat, 0 As DeltaSeq, MD5, "
+       "Fhinfo, Fhnode "
+       "FROM new_basefile%lld ORDER BY JobId, FileIndex ASC",
+       (uint64_t)jcr->JobId);
 
-   if (!use_md5) {
-      strip_md5(query.c_str());
-   }
-   return BigSqlQuery(query.c_str(), ResultHandler, ctx);
+  if (!use_md5) { strip_md5(query.c_str()); }
+  return BigSqlQuery(query.c_str(), ResultHandler, ctx);
 }
 
-bool BareosDb::GetBaseJobid(JobControlRecord *jcr, JobDbRecord *jr, JobId_t *jobid)
+bool BareosDb::GetBaseJobid(JobControlRecord* jcr,
+                            JobDbRecord* jr,
+                            JobId_t* jobid)
 {
-   PoolMem query(PM_MESSAGE);
-   utime_t StartTime;
-   db_int64_ctx lctx;
-   char date[MAX_TIME_LENGTH];
-   char esc[MAX_ESCAPE_NAME_LENGTH];
-   bool retval = false;
-// char clientid[50], filesetid[50];
+  PoolMem query(PM_MESSAGE);
+  utime_t StartTime;
+  db_int64_ctx lctx;
+  char date[MAX_TIME_LENGTH];
+  char esc[MAX_ESCAPE_NAME_LENGTH];
+  bool retval = false;
+  // char clientid[50], filesetid[50];
 
-   *jobid = 0;
-   lctx.count = 0;
-   lctx.value = 0;
+  *jobid = 0;
+  lctx.count = 0;
+  lctx.value = 0;
 
-   StartTime = (jr->StartTime) ? jr->StartTime : time(NULL);
-   bstrutime(date, sizeof(date),  StartTime + 1);
-   EscapeString(jcr, esc, jr->Name, strlen(jr->Name));
+  StartTime = (jr->StartTime) ? jr->StartTime : time(NULL);
+  bstrutime(date, sizeof(date), StartTime + 1);
+  EscapeString(jcr, esc, jr->Name, strlen(jr->Name));
 
-   /* we can take also client name, fileset, etc... */
+  /* we can take also client name, fileset, etc... */
 
-   Mmsg(query,
- "SELECT JobId, Job, StartTime, EndTime, JobTDate, PurgedFiles "
-   "FROM Job "
-// "JOIN FileSet USING (FileSetId) JOIN Client USING (ClientId) "
-  "WHERE Job.Name = '%s' "
-    "AND Level='B' AND JobStatus IN ('T','W') AND Type='B' "
-//    "AND FileSet.FileSet= '%s' "
-//    "AND Client.Name = '%s' "
-    "AND StartTime<'%s' "
-  "ORDER BY Job.JobTDate DESC LIMIT 1",
-        esc,
-//      edit_uint64(jr->ClientId, clientid),
-//      edit_uint64(jr->FileSetId, filesetid));
-        date);
+  Mmsg(query,
+       "SELECT JobId, Job, StartTime, EndTime, JobTDate, PurgedFiles "
+       "FROM Job "
+       // "JOIN FileSet USING (FileSetId) JOIN Client USING (ClientId) "
+       "WHERE Job.Name = '%s' "
+       "AND Level='B' AND JobStatus IN ('T','W') AND Type='B' "
+       //    "AND FileSet.FileSet= '%s' "
+       //    "AND Client.Name = '%s' "
+       "AND StartTime<'%s' "
+       "ORDER BY Job.JobTDate DESC LIMIT 1",
+       esc,
+       //      edit_uint64(jr->ClientId, clientid),
+       //      edit_uint64(jr->FileSetId, filesetid));
+       date);
 
-   Dmsg1(10, "GetBaseJobid q=%s\n", query.c_str());
-   if (!SqlQueryWithHandler(query.c_str(), db_int64_handler, &lctx)) {
-      goto bail_out;
-   }
-   *jobid = (JobId_t) lctx.value;
+  Dmsg1(10, "GetBaseJobid q=%s\n", query.c_str());
+  if (!SqlQueryWithHandler(query.c_str(), db_int64_handler, &lctx)) {
+    goto bail_out;
+  }
+  *jobid = (JobId_t)lctx.value;
 
-   Dmsg1(10, "GetBaseJobid=%lld\n", *jobid);
-   retval = true;
+  Dmsg1(10, "GetBaseJobid=%lld\n", *jobid);
+  retval = true;
 
 bail_out:
-   return retval;
+  return retval;
 }
 
 /**
  * Get JobIds associated with a volume
  */
-bool BareosDb::GetVolumeJobids(JobControlRecord *jcr, MediaDbRecord *mr, db_list_ctx *lst)
+bool BareosDb::GetVolumeJobids(JobControlRecord* jcr,
+                               MediaDbRecord* mr,
+                               db_list_ctx* lst)
 {
-   char ed1[50];
-   bool retval;
+  char ed1[50];
+  bool retval;
 
-   DbLock(this);
-   Mmsg(cmd, "SELECT DISTINCT JobId FROM JobMedia WHERE MediaId=%s",
-        edit_int64(mr->MediaId, ed1));
-   retval = SqlQueryWithHandler(cmd, DbListHandler, lst);
-   DbUnlock(this);
-   return retval;
+  DbLock(this);
+  Mmsg(cmd, "SELECT DISTINCT JobId FROM JobMedia WHERE MediaId=%s",
+       edit_int64(mr->MediaId, ed1));
+  retval = SqlQueryWithHandler(cmd, DbListHandler, lst);
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1451,50 +1507,53 @@ bool BareosDb::GetVolumeJobids(JobControlRecord *jcr, MediaDbRecord *mr, db_list
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::get_quota_jobbytes(JobControlRecord *jcr, JobDbRecord *jr, utime_t JobRetention)
+bool BareosDb::get_quota_jobbytes(JobControlRecord* jcr,
+                                  JobDbRecord* jr,
+                                  utime_t JobRetention)
 {
-   SQL_ROW row;
-   int num_rows;
-   char dt[MAX_TIME_LENGTH];
-   char ed1[50], ed2[50];
-   bool retval = false;
-   time_t now, schedtime;
+  SQL_ROW row;
+  int num_rows;
+  char dt[MAX_TIME_LENGTH];
+  char ed1[50], ed2[50];
+  bool retval = false;
+  time_t now, schedtime;
 
-   /*
-    * Determine the first schedtime we are interested in.
-    */
-   now = time(NULL);
-   schedtime = now - JobRetention;
+  /*
+   * Determine the first schedtime we are interested in.
+   */
+  now = time(NULL);
+  schedtime = now - JobRetention;
 
-   /*
-    * Bugfix, theres a small timing bug in the scheduler.
-    * Add 5 seconds to the schedtime to ensure the
-    * last job from the job retention gets excluded.
-    */
-   schedtime += 5;
+  /*
+   * Bugfix, theres a small timing bug in the scheduler.
+   * Add 5 seconds to the schedtime to ensure the
+   * last job from the job retention gets excluded.
+   */
+  schedtime += 5;
 
-   bstrutime(dt, sizeof(dt), schedtime);
+  bstrutime(dt, sizeof(dt), schedtime);
 
-   DbLock(this);
+  DbLock(this);
 
-   FillQuery(SQL_QUERY_get_quota_jobbytes, edit_uint64(jr->ClientId, ed1), edit_uint64(jr->JobId, ed2), dt);
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-          row = SqlFetchRow();
-          jr->JobSumTotalBytes = str_to_uint64(row[0]);
-      } else if (num_rows < 1) {
-          jr->JobSumTotalBytes = 0;
-      }
-      SqlFreeResult();
-      retval = true;
-   } else {
-      Mmsg(errmsg, _("JobBytes sum select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   }
+  FillQuery(SQL_QUERY_get_quota_jobbytes, edit_uint64(jr->ClientId, ed1),
+            edit_uint64(jr->JobId, ed2), dt);
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
+      row = SqlFetchRow();
+      jr->JobSumTotalBytes = str_to_uint64(row[0]);
+    } else if (num_rows < 1) {
+      jr->JobSumTotalBytes = 0;
+    }
+    SqlFreeResult();
+    retval = true;
+  } else {
+    Mmsg(errmsg, _("JobBytes sum select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1503,50 +1562,53 @@ bool BareosDb::get_quota_jobbytes(JobControlRecord *jcr, JobDbRecord *jr, utime_
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord *jcr, JobDbRecord *jr, utime_t JobRetention)
+bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord* jcr,
+                                           JobDbRecord* jr,
+                                           utime_t JobRetention)
 {
-   SQL_ROW row;
-   char ed1[50], ed2[50];
-   int num_rows;
-   char dt[MAX_TIME_LENGTH];
-   bool retval = false;
-   time_t now, schedtime;
+  SQL_ROW row;
+  char ed1[50], ed2[50];
+  int num_rows;
+  char dt[MAX_TIME_LENGTH];
+  bool retval = false;
+  time_t now, schedtime;
 
-   /*
-    * Determine the first schedtime we are interested in.
-    */
-   now = time(NULL);
-   schedtime = now - JobRetention;
+  /*
+   * Determine the first schedtime we are interested in.
+   */
+  now = time(NULL);
+  schedtime = now - JobRetention;
 
-   /*
-    * Bugfix, theres a small timing bug in the scheduler.
-    * Add 5 seconds to the schedtime to ensure the
-    * last job from the job retention gets excluded.
-    */
-   schedtime += 5;
+  /*
+   * Bugfix, theres a small timing bug in the scheduler.
+   * Add 5 seconds to the schedtime to ensure the
+   * last job from the job retention gets excluded.
+   */
+  schedtime += 5;
 
-   bstrutime(dt, sizeof(dt), schedtime);
+  bstrutime(dt, sizeof(dt), schedtime);
 
-   DbLock(this);
+  DbLock(this);
 
-   FillQuery(SQL_QUERY_get_quota_jobbytes_nofailed, edit_uint64(jr->ClientId, ed1), edit_uint64(jr->JobId, ed2), dt);
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-          row = SqlFetchRow();
-          jr->JobSumTotalBytes = str_to_uint64(row[0]);
-      } else if (num_rows < 1) {
-          jr->JobSumTotalBytes = 0;
-      }
-      SqlFreeResult();
-      retval = true;
-   } else {
-      Mmsg(errmsg, _("JobBytes sum select failed: ERR=%s\n"), sql_strerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-   }
+  FillQuery(SQL_QUERY_get_quota_jobbytes_nofailed,
+            edit_uint64(jr->ClientId, ed1), edit_uint64(jr->JobId, ed2), dt);
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
+      row = SqlFetchRow();
+      jr->JobSumTotalBytes = str_to_uint64(row[0]);
+    } else if (num_rows < 1) {
+      jr->JobSumTotalBytes = 0;
+    }
+    SqlFreeResult();
+    retval = true;
+  } else {
+    Mmsg(errmsg, _("JobBytes sum select failed: ERR=%s\n"), sql_strerror());
+    Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1554,42 +1616,42 @@ bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord *jcr, JobDbRecord *j
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetQuotaRecord(JobControlRecord *jcr, ClientDbRecord *cdbr)
+bool BareosDb::GetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
 {
-   SQL_ROW row;
-   char ed1[50];
-   int num_rows;
-   bool retval = false;
+  SQL_ROW row;
+  char ed1[50];
+  int num_rows;
+  bool retval = false;
 
-   DbLock(this);
-   Mmsg(cmd,
-  "SELECT GraceTime, QuotaLimit "
-    "FROM Quota "
-   "WHERE ClientId = %s",
-        edit_int64(cdbr->ClientId, ed1));
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-         } else {
-            cdbr->GraceTime = str_to_uint64(row[0]);
-            cdbr->QuotaLimit = str_to_int64(row[1]);
-            SqlFreeResult();
-            retval = true;
-         }
+  DbLock(this);
+  Mmsg(cmd,
+       "SELECT GraceTime, QuotaLimit "
+       "FROM Quota "
+       "WHERE ClientId = %s",
+       edit_int64(cdbr->ClientId, ed1));
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
       } else {
-         Mmsg(errmsg, _("Quota record not found in Catalog.\n"));
-         SqlFreeResult();
+        cdbr->GraceTime = str_to_uint64(row[0]);
+        cdbr->QuotaLimit = str_to_int64(row[1]);
+        SqlFreeResult();
+        retval = true;
       }
-   } else {
+    } else {
       Mmsg(errmsg, _("Quota record not found in Catalog.\n"));
-   }
+      SqlFreeResult();
+    }
+  } else {
+    Mmsg(errmsg, _("Quota record not found in Catalog.\n"));
+  }
 
-   DbUnlock(this);
-   return retval;
+  DbUnlock(this);
+  return retval;
 }
 
 /**
@@ -1598,49 +1660,53 @@ bool BareosDb::GetQuotaRecord(JobControlRecord *jcr, ClientDbRecord *cdbr)
  * Returns dumplevel on success
  *         0: on failure
  */
-int BareosDb::GetNdmpLevelMapping(JobControlRecord *jcr, JobDbRecord *jr, char *filesystem)
+int BareosDb::GetNdmpLevelMapping(JobControlRecord* jcr,
+                                  JobDbRecord* jr,
+                                  char* filesystem)
 {
-   SQL_ROW row;
-   char ed1[50], ed2[50];
-   int num_rows;
-   int dumplevel = 0;
+  SQL_ROW row;
+  char ed1[50], ed2[50];
+  int num_rows;
+  int dumplevel = 0;
 
-   DbLock(this);
+  DbLock(this);
 
-   esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
-   EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
+  esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
+  EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
 
-   Mmsg(cmd, "SELECT DumpLevel FROM NDMPLevelMap WHERE "
-                  "ClientId='%s' AND FileSetId='%s' AND FileSystem='%s'",
-        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2), esc_name);
+  Mmsg(cmd,
+       "SELECT DumpLevel FROM NDMPLevelMap WHERE "
+       "ClientId='%s' AND FileSetId='%s' AND FileSystem='%s'",
+       edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
+       esc_name);
 
-   if (QUERY_DB(jcr, cmd)) {
-      num_rows = SqlNumRows();
-      if (num_rows == 1) {
-         if ((row = SqlFetchRow()) == NULL) {
-            Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
-            Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-            SqlFreeResult();
-            goto bail_out;
-         } else {
-            dumplevel = str_to_uint64(row[0]);
-            dumplevel++;                    /* select next dumplevel */
-            SqlFreeResult();
-            goto bail_out;
-         }
+  if (QUERY_DB(jcr, cmd)) {
+    num_rows = SqlNumRows();
+    if (num_rows == 1) {
+      if ((row = SqlFetchRow()) == NULL) {
+        Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
+        Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+        SqlFreeResult();
+        goto bail_out;
       } else {
-         Mmsg(errmsg, _("NDMP Dump Level record not found in Catalog.\n"));
-         SqlFreeResult();
-         goto bail_out;
+        dumplevel = str_to_uint64(row[0]);
+        dumplevel++; /* select next dumplevel */
+        SqlFreeResult();
+        goto bail_out;
       }
-   } else {
+    } else {
       Mmsg(errmsg, _("NDMP Dump Level record not found in Catalog.\n"));
+      SqlFreeResult();
       goto bail_out;
-   }
+    }
+  } else {
+    Mmsg(errmsg, _("NDMP Dump Level record not found in Catalog.\n"));
+    goto bail_out;
+  }
 
 bail_out:
-   DbUnlock(this);
-   return dumplevel;
+  DbUnlock(this);
+  return dumplevel;
 }
 
 
@@ -1650,23 +1716,27 @@ bail_out:
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(JobControlRecord *jcr, JobId_t JobId, DB_RESULT_HANDLER *ResultHandler, void *ctx)
+bool BareosDb::GetNdmpEnvironmentString(JobControlRecord* jcr,
+                                        JobId_t JobId,
+                                        DB_RESULT_HANDLER* ResultHandler,
+                                        void* ctx)
 {
-   PoolMem query(PM_FNAME);
-   char ed1[50];
-   db_int64_ctx lctx;
-   bool retval = false;
+  PoolMem query(PM_FNAME);
+  char ed1[50];
+  db_int64_ctx lctx;
+  bool retval = false;
 
-   /*
-    * Lookup all environment settings belonging to this JobId.
-    */
-   Mmsg(query, "SELECT EnvName, EnvValue FROM NDMPJobEnvironment "
-               "WHERE JobId='%s' ",
-               edit_uint64(JobId, ed1));
+  /*
+   * Lookup all environment settings belonging to this JobId.
+   */
+  Mmsg(query,
+       "SELECT EnvName, EnvValue FROM NDMPJobEnvironment "
+       "WHERE JobId='%s' ",
+       edit_uint64(JobId, ed1));
 
-   retval = SqlQueryWithHandler(query.c_str(), ResultHandler, ctx);
+  retval = SqlQueryWithHandler(query.c_str(), ResultHandler, ctx);
 
-   return retval;
+  return retval;
 }
 
 
@@ -1676,67 +1746,75 @@ bool BareosDb::GetNdmpEnvironmentString(JobControlRecord *jcr, JobId_t JobId, DB
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(JobControlRecord *jcr, JobDbRecord *jr, DB_RESULT_HANDLER *ResultHandler, void *ctx)
+bool BareosDb::GetNdmpEnvironmentString(JobControlRecord* jcr,
+                                        JobDbRecord* jr,
+                                        DB_RESULT_HANDLER* ResultHandler,
+                                        void* ctx)
 {
-   PoolMem query(PM_MESSAGE);
-   char ed1[50], ed2[50];
-   db_int64_ctx lctx;
-   JobId_t JobId;
-   bool retval = false;
+  PoolMem query(PM_MESSAGE);
+  char ed1[50], ed2[50];
+  db_int64_ctx lctx;
+  JobId_t JobId;
+  bool retval = false;
 
-   lctx.count = 0;
-   lctx.value = 0;
+  lctx.count = 0;
+  lctx.value = 0;
 
-   /*
-    * Lookup the JobId
-    */
-   Mmsg(query, "SELECT JobId FROM Job "
-               "WHERE VolSessionId = '%s' "
-               "AND VolSessionTime = '%s'",
-               edit_uint64(jr->VolSessionId, ed1),
-               edit_uint64(jr->VolSessionTime, ed2));
-   if (!SqlQueryWithHandler(query.c_str(), db_int64_handler, &lctx)) {
-      goto bail_out;
-   }
+  /*
+   * Lookup the JobId
+   */
+  Mmsg(query,
+       "SELECT JobId FROM Job "
+       "WHERE VolSessionId = '%s' "
+       "AND VolSessionTime = '%s'",
+       edit_uint64(jr->VolSessionId, ed1),
+       edit_uint64(jr->VolSessionTime, ed2));
+  if (!SqlQueryWithHandler(query.c_str(), db_int64_handler, &lctx)) {
+    goto bail_out;
+  }
 
-   JobId = (JobId_t) lctx.value;
+  JobId = (JobId_t)lctx.value;
 
-   /*
-    * Lookup all environment settings belonging to this JobId and FileIndex.
-    */
-   Mmsg(query, "SELECT EnvName, EnvValue FROM NDMPJobEnvironment "
-               "WHERE JobId='%s' "
-               "AND FileIndex='%s'",
-               edit_uint64(JobId, ed1),
-               edit_uint64(jr->FileIndex, ed2));
+  /*
+   * Lookup all environment settings belonging to this JobId and FileIndex.
+   */
+  Mmsg(query,
+       "SELECT EnvName, EnvValue FROM NDMPJobEnvironment "
+       "WHERE JobId='%s' "
+       "AND FileIndex='%s'",
+       edit_uint64(JobId, ed1), edit_uint64(jr->FileIndex, ed2));
 
-   retval = SqlQueryWithHandler(query.c_str(), ResultHandler, ctx);
+  retval = SqlQueryWithHandler(query.c_str(), ResultHandler, ctx);
 
 bail_out:
-   return retval;
+  return retval;
 }
 
 /**
- * This function creates a sql query string at cmd to return a list of all the Media records for
- * the current Pool, the correct Media Type, Recyle, Enabled, StorageId, VolBytes and
- * volumes or VolumeName if specified. Comma separated list of volumes takes precedence
- * over VolumeName. The caller must free ids if non-NULL.
+ * This function creates a sql query string at cmd to return a list of all the
+ * Media records for the current Pool, the correct Media Type, Recyle, Enabled,
+ * StorageId, VolBytes and volumes or VolumeName if specified. Comma separated
+ * list of volumes takes precedence over VolumeName. The caller must free ids if
+ * non-NULL.
  */
-bool BareosDb::PrepareMediaSqlQuery(JobControlRecord *jcr, MediaDbRecord *mr, PoolMem *querystring, PoolMem &volumes)
+bool BareosDb::PrepareMediaSqlQuery(JobControlRecord* jcr,
+                                    MediaDbRecord* mr,
+                                    PoolMem* querystring,
+                                    PoolMem& volumes)
 {
-   bool ok = true;
-   char ed1[50];
-   char esc[MAX_NAME_LENGTH * 2 + 1];
-   PoolMem buf(PM_MESSAGE);
+  bool ok = true;
+  char ed1[50];
+  char esc[MAX_NAME_LENGTH * 2 + 1];
+  PoolMem buf(PM_MESSAGE);
 
-   /*
-    * columns we care of.
-    * Reduced, to be better displayable.
-    * Important:
-    * column 2: pool.name, column 3: storage.name,
-    * as this is used for ACL handling (counting starts at 0).
-    */
-   const char *columns =
+  /*
+   * columns we care of.
+   * Reduced, to be better displayable.
+   * Important:
+   * column 2: pool.name, column 3: storage.name,
+   * as this is used for ACL handling (counting starts at 0).
+   */
+  const char* columns =
       "Media.MediaId,"
       "Media.VolumeName,"
       "Pool.Name AS Pool,"
@@ -1753,80 +1831,81 @@ bool BareosDb::PrepareMediaSqlQuery(JobControlRecord *jcr, MediaDbRecord *mr, Po
       /* "Media.VolRetention," */
       "Media.Comment";
 
-   Mmsg(querystring,
-        "SELECT DISTINCT %s FROM Media "
-        "LEFT JOIN Pool USING(PoolId) "
-        "LEFT JOIN Storage USING(StorageId) "
-        "WHERE Media.Recycle=%d AND Media.Enabled=%d ",
-        columns, mr->Recycle, mr->Enabled);
+  Mmsg(querystring,
+       "SELECT DISTINCT %s FROM Media "
+       "LEFT JOIN Pool USING(PoolId) "
+       "LEFT JOIN Storage USING(StorageId) "
+       "WHERE Media.Recycle=%d AND Media.Enabled=%d ",
+       columns, mr->Recycle, mr->Enabled);
 
-   if (*mr->MediaType) {
-      EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
-      Mmsg(buf, "AND Media.MediaType='%s' ", esc);
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (*mr->MediaType) {
+    EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
+    Mmsg(buf, "AND Media.MediaType='%s' ", esc);
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   if (mr->StorageId) {
-      Mmsg(buf, "AND Media.StorageId=%s ", edit_uint64(mr->StorageId, ed1));
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (mr->StorageId) {
+    Mmsg(buf, "AND Media.StorageId=%s ", edit_uint64(mr->StorageId, ed1));
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   if (mr->PoolId) {
-      Mmsg(buf, "AND Media.PoolId=%s ", edit_uint64(mr->PoolId, ed1));
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (mr->PoolId) {
+    Mmsg(buf, "AND Media.PoolId=%s ", edit_uint64(mr->PoolId, ed1));
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   if (mr->VolBytes) {
-      Mmsg(buf, "AND Media.VolBytes > %s ", edit_uint64(mr->VolBytes, ed1));
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (mr->VolBytes) {
+    Mmsg(buf, "AND Media.VolBytes > %s ", edit_uint64(mr->VolBytes, ed1));
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   if (*mr->VolStatus) {
-      EscapeString(jcr, esc, mr->VolStatus, strlen(mr->VolStatus));
-      Mmsg(buf, "AND Media.VolStatus = '%s' ", esc);
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (*mr->VolStatus) {
+    EscapeString(jcr, esc, mr->VolStatus, strlen(mr->VolStatus));
+    Mmsg(buf, "AND Media.VolStatus = '%s' ", esc);
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   if (volumes.strlen() > 0) {
-      /* extra list of volumes given */
-      Mmsg(buf, "AND Media.VolumeName IN (%s) ", volumes.c_str());
-      PmStrcat(querystring, buf.c_str());
-   } else if (*mr->VolumeName) {
-      /* single volume given in media record */
-      EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
-      Mmsg(buf, "AND Media.VolumeName = '%s' ", esc);
-      PmStrcat(querystring, buf.c_str());
-   }
+  if (volumes.strlen() > 0) {
+    /* extra list of volumes given */
+    Mmsg(buf, "AND Media.VolumeName IN (%s) ", volumes.c_str());
+    PmStrcat(querystring, buf.c_str());
+  } else if (*mr->VolumeName) {
+    /* single volume given in media record */
+    EscapeString(jcr, esc, mr->VolumeName, strlen(mr->VolumeName));
+    Mmsg(buf, "AND Media.VolumeName = '%s' ", esc);
+    PmStrcat(querystring, buf.c_str());
+  }
 
-   Dmsg1(100, "query=%s\n", querystring);
+  Dmsg1(100, "query=%s\n", querystring);
 
-   return ok;
+  return ok;
 }
 
 /**
  * verify that all media use the same storage.
  */
-bool BareosDb::VerifyMediaIdsFromSingleStorage(JobControlRecord *jcr, dbid_list &mediaIds)
+bool BareosDb::VerifyMediaIdsFromSingleStorage(JobControlRecord* jcr,
+                                               dbid_list& mediaIds)
 {
-   MediaDbRecord mr;
-   DBId_t storageId = 0;
+  MediaDbRecord mr;
+  DBId_t storageId = 0;
 
-   for (int i = 0; i < mediaIds.size(); i++) {
-      memset(&mr, 0, sizeof(mr));
-      mr.MediaId = mediaIds.get(i);
-      if (!GetMediaRecord(jcr, &mr)) {
-         Mmsg1(errmsg, _("Failed to find MediaId=%lld\n"), (uint64_t)mr.MediaId);
-         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-         return false;
-      } else if (i == 0) {
-         storageId = mr.StorageId;
-      } else if (storageId != mr.StorageId) {
-         return false;
-      }
-   }
-   return true;
+  for (int i = 0; i < mediaIds.size(); i++) {
+    memset(&mr, 0, sizeof(mr));
+    mr.MediaId = mediaIds.get(i);
+    if (!GetMediaRecord(jcr, &mr)) {
+      Mmsg1(errmsg, _("Failed to find MediaId=%lld\n"), (uint64_t)mr.MediaId);
+      Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+      return false;
+    } else if (i == 0) {
+      storageId = mr.StorageId;
+    } else if (storageId != mr.StorageId) {
+      return false;
+    }
+  }
+  return true;
 }
 
 
-
-#endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || HAVE_DBI */
+#endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
+          HAVE_DBI */

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1711,17 +1711,17 @@ bail_out:
 }
 
 /**
- * CountingHandler() with a count_context* can be used to count the number of
+ * CountingHandler() with a CountContext* can be used to count the number of
  * times that SqlQueryWithHandler() calls the handler.
  * This is not neccesarily the number of rows, because the ResultHandler can
  * stop processing of further rows by returning non-zero.
  */
-struct count_context {
+struct CountContext {
   DB_RESULT_HANDLER* handler;
   void* ctx;
   int count;
 
-  count_context(DB_RESULT_HANDLER* t_handler, void* t_ctx)
+  CountContext(DB_RESULT_HANDLER* t_handler, void* t_ctx)
       : handler(t_handler), ctx(t_ctx), count(0)
   {
   }
@@ -1729,7 +1729,7 @@ struct count_context {
 
 static int CountingHandler(void* counting_ctx, int num_fields, char** rows)
 {
-  auto* c = static_cast<struct count_context*>(counting_ctx);
+  auto* c = static_cast<struct CountContext*>(counting_ctx);
   c->count++;
   return c->handler(c->ctx, num_fields, rows);
 }
@@ -1743,7 +1743,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
-  auto myctx = std::unique_ptr<count_context>(new count_context(ResultHandler, ctx));
+  auto myctx = std::unique_ptr<CountContext>(new CountContext(ResultHandler, ctx));
   bool status =
       SqlQueryWithHandler(query.c_str(), CountingHandler, myctx.get());
   Dmsg1(150, "Got %d NDMP environment records\n", myctx->count);

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1757,7 +1757,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
+bool BareosDb::GetNdmpEnvironmentString(JobId_t JobId,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
@@ -1774,8 +1774,8 @@ bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
  * Returns false: on failure
  *         true: on success
  */
-bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
-                                        const int32_t FileIndex,
+bool BareosDb::GetNdmpEnvironmentString(JobId_t JobId,
+                                        int32_t FileIndex,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
@@ -1795,7 +1795,7 @@ bool BareosDb::GetNdmpEnvironmentString(const JobId_t JobId,
  *         true: on success
  */
 bool BareosDb::GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
-                                        const int32_t FileIndex,
+                                        int32_t FileIndex,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -40,7 +40,6 @@
 #include "sql.h"
 #include "lib/edit.h"
 #include "lib/volume_session_info.h"
-#include "include/make_unique.h"
 
 /* -----------------------------------------------------------------------
  *
@@ -1744,10 +1743,10 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
                                         DB_RESULT_HANDLER* ResultHandler,
                                         void* ctx)
 {
-  auto myctx = std::make_unique<count_context>(ResultHandler, ctx);
+  auto myctx = std::unique_ptr<count_context>(new count_context(ResultHandler, ctx));
   bool status =
       SqlQueryWithHandler(query.c_str(), CountingHandler, myctx.get());
-  Dmsg3(150, "Got %d NDMP environment records\n", myctx->count);
+  Dmsg1(150, "Got %d NDMP environment records\n", myctx->count);
   return status && myctx->count > 0;  // no rows means no environment was found
 }
 

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1730,7 +1730,7 @@ struct count_context {
 
 static int CountingHandler(void* counting_ctx, int num_fields, char** rows)
 {
-  auto* c = (struct count_context*)counting_ctx;
+  auto* c = static_cast<struct count_context*>(counting_ctx);
   c->count++;
   return c->handler(c->ctx, num_fields, rows);
 }
@@ -1747,7 +1747,7 @@ bool BareosDb::GetNdmpEnvironmentString(const std::string& query,
   auto myctx = std::make_unique<count_context>(ResultHandler, ctx);
   bool status =
       SqlQueryWithHandler(query.c_str(), CountingHandler, myctx.get());
-  Dmsg3(150, "Got %d NDMP environment records", myctx->count);
+  Dmsg3(150, "Got %d NDMP environment records\n", myctx->count);
   return status && myctx->count > 0;  // no rows means no environment was found
 }
 
@@ -1811,9 +1811,10 @@ bool BareosDb::GetNdmpEnvironmentString(const VolumeSessionInfo& vsi,
                                       ctx);
     }
   }
-  Dmsg3(100,
-        "Got %d JobIds for VolSessionTime=%lld VolSessionId=%lld instead of 1",
-        lctx.count, vsi.time, vsi.id);
+  Dmsg3(
+      100,
+      "Got %d JobIds for VolSessionTime=%lld VolSessionId=%lld instead of 1\n",
+      lctx.count, vsi.time, vsi.id);
   return false;
 }
 

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -212,6 +212,8 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
      * the database when its either expired or when an old NDMP backup is
      * restored where the whole environment was not saved.
      */
+    Jmsg(jcr, M_WARNING, 0,
+         _("Could not load NDMP environment. Using fallback.\n"));
 
     if (!nbf_options || nbf_options->uses_file_history) {
       /*

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -56,355 +56,350 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Forward referenced functions */
 
-static char OKbootstrap[] =
-   "3000 OK bootstrap\n";
+static char OKbootstrap[] = "3000 OK bootstrap\n";
 
 /**
  * Walk the tree of selected files for restore and lookup the
  * correct fileid. Return the actual full pathname of the file
  * corresponding to the given fileid.
  */
-static inline char *lookup_fileindex(JobControlRecord *jcr, int32_t FileIndex)
+static inline char* lookup_fileindex(JobControlRecord* jcr, int32_t FileIndex)
 {
-   TREE_NODE *node, *parent;
-   PoolMem restore_pathname, tmp;
+  TREE_NODE *node, *parent;
+  PoolMem restore_pathname, tmp;
 
-   node = FirstTreeNode(jcr->restore_tree_root);
-   while (node) {
+  node = FirstTreeNode(jcr->restore_tree_root);
+  while (node) {
+    /*
+     * See if this is the wanted FileIndex.
+     */
+    if (node->FileIndex == FileIndex) {
+      PmStrcpy(restore_pathname, node->fname);
+
       /*
-       * See if this is the wanted FileIndex.
+       * Walk up the parent until we hit the head of the list.
        */
-      if (node->FileIndex == FileIndex) {
-         PmStrcpy(restore_pathname, node->fname);
-
-         /*
-          * Walk up the parent until we hit the head of the list.
-          */
-         for (parent = node->parent; parent; parent = parent->parent) {
-            PmStrcpy(tmp, restore_pathname.c_str());
-            Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
-         }
-
-         if (bstrncmp(restore_pathname.c_str(), "/@NDMP/", 7)) {
-            return bstrdup(restore_pathname.c_str());
-         }
+      for (parent = node->parent; parent; parent = parent->parent) {
+        PmStrcpy(tmp, restore_pathname.c_str());
+        Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
       }
 
-      node = NextTreeNode(node);
-   }
+      if (bstrncmp(restore_pathname.c_str(), "/@NDMP/", 7)) {
+        return bstrdup(restore_pathname.c_str());
+      }
+    }
 
-   return NULL;
+    node = NextTreeNode(node);
+  }
+
+  return NULL;
 }
 
 /**
  * See in the tree with selected files what files were selected to be restored.
  */
-static inline int set_files_to_restore(JobControlRecord *jcr, struct ndm_job_param *job, int32_t FileIndex,
-                                       const char *restore_prefix, const char *ndmp_filesystem)
+static inline int set_files_to_restore(JobControlRecord* jcr,
+                                       struct ndm_job_param* job,
+                                       int32_t FileIndex,
+                                       const char* restore_prefix,
+                                       const char* ndmp_filesystem)
 {
-   int len;
-   int cnt = 0;
-   TREE_NODE *node, *parent;
-   PoolMem restore_pathname, tmp;
+  int len;
+  int cnt = 0;
+  TREE_NODE *node, *parent;
+  PoolMem restore_pathname, tmp;
 
-   node = FirstTreeNode(jcr->restore_tree_root);
-   while (node) {
+  node = FirstTreeNode(jcr->restore_tree_root);
+  while (node) {
+    /*
+     * See if this is the wanted FileIndex and the user asked to extract it.
+     */
+    if (node->FileIndex == FileIndex && node->extract) {
+      PmStrcpy(restore_pathname, node->fname);
+
       /*
-       * See if this is the wanted FileIndex and the user asked to extract it.
+       * Walk up the parent until we hit the head of the list.
        */
-      if (node->FileIndex == FileIndex && node->extract) {
-         PmStrcpy(restore_pathname, node->fname);
-
-         /*
-          * Walk up the parent until we hit the head of the list.
-          */
-         for (parent = node->parent; parent; parent = parent->parent) {
-            PmStrcpy(tmp, restore_pathname.c_str());
-            Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
-         }
-
-         /*
-          * We only want to restore the non pseudo NDMP names e.g. not the full backup stream name.
-          */
-         if (!bstrncmp(restore_pathname.c_str(), "/@NDMP/", 7)) {
-            /*
-             * See if we need to strip the prefix from the filename.
-             */
-            len = strlen(ndmp_filesystem);
-            if (bstrncmp(restore_pathname.c_str(), ndmp_filesystem, len)) {
-               AddToNamelist(job,  restore_pathname.c_str() + len, restore_prefix,
-                               (char *)"", (char *)"",
-                               NDMP_INVALID_U_QUAD, NDMP_INVALID_U_QUAD);
-            } else {
-               AddToNamelist(job,  restore_pathname.c_str(), restore_prefix,
-                               (char *)"", (char *)"",
-                               NDMP_INVALID_U_QUAD, NDMP_INVALID_U_QUAD);
-            }
-            cnt++;
-         }
+      for (parent = node->parent; parent; parent = parent->parent) {
+        PmStrcpy(tmp, restore_pathname.c_str());
+        Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
       }
 
-      node = NextTreeNode(node);
-   }
+      /*
+       * We only want to restore the non pseudo NDMP names e.g. not the full
+       * backup stream name.
+       */
+      if (!bstrncmp(restore_pathname.c_str(), "/@NDMP/", 7)) {
+        /*
+         * See if we need to strip the prefix from the filename.
+         */
+        len = strlen(ndmp_filesystem);
+        if (bstrncmp(restore_pathname.c_str(), ndmp_filesystem, len)) {
+          AddToNamelist(job, restore_pathname.c_str() + len, restore_prefix,
+                        (char*)"", (char*)"", NDMP_INVALID_U_QUAD,
+                        NDMP_INVALID_U_QUAD);
+        } else {
+          AddToNamelist(job, restore_pathname.c_str(), restore_prefix,
+                        (char*)"", (char*)"", NDMP_INVALID_U_QUAD,
+                        NDMP_INVALID_U_QUAD);
+        }
+        cnt++;
+      }
+    }
 
-   return cnt;
+    node = NextTreeNode(node);
+  }
+
+  return cnt;
 }
 
 /**
- * Fill the NDMP restore environment table with the data for the data agent to act on.
+ * Fill the NDMP restore environment table with the data for the data agent to
+ * act on.
  */
-static inline bool fill_restore_environment(JobControlRecord *jcr,
+static inline bool fill_restore_environment(JobControlRecord* jcr,
                                             int32_t current_fi,
-                                            struct ndm_job_param *job)
+                                            struct ndm_job_param* job)
 {
-   int i;
-   char *bp;
-   ndmp9_pval pv;
-   FilesetResource *fileset;
-   char *restore_pathname,
-        *ndmp_filesystem,
-        *restore_prefix,
-        *level;
-   PoolMem tape_device;
-   PoolMem destination_path;
-   ndmp_backup_format_option *nbf_options;
+  int i;
+  char* bp;
+  ndmp9_pval pv;
+  FilesetResource* fileset;
+  char *restore_pathname, *ndmp_filesystem, *restore_prefix, *level;
+  PoolMem tape_device;
+  PoolMem destination_path;
+  ndmp_backup_format_option* nbf_options;
 
-   /*
-    * See if we know this backup format and get it options.
-    */
-   nbf_options = ndmp_lookup_backup_format_options(job->bu_type);
+  /*
+   * See if we know this backup format and get it options.
+   */
+  nbf_options = ndmp_lookup_backup_format_options(job->bu_type);
 
-   /*
-    * Lookup the current fileindex and map it to an actual pathname.
-    */
-   restore_pathname = lookup_fileindex(jcr, current_fi);
-   if (!restore_pathname) {
-      return false;
-   } else {
+  /*
+   * Lookup the current fileindex and map it to an actual pathname.
+   */
+  restore_pathname = lookup_fileindex(jcr, current_fi);
+  if (!restore_pathname) {
+    return false;
+  } else {
+    /*
+     * Skip over the /@NDMP prefix.
+     */
+    ndmp_filesystem = restore_pathname + 6;
+  }
+
+  /*
+   * See if there is a level embedded in the pathname.
+   */
+  bp = strrchr(ndmp_filesystem, '%');
+  if (bp) {
+    *bp++ = '\0';
+    level = bp;
+  } else {
+    level = NULL;
+  }
+
+  /*
+   * Lookup the environment stack saved during the backup so we can restore it.
+   */
+  if (!jcr->db->GetNdmpEnvironmentString(jcr, &jcr->jr, NdmpEnvHandler,
+                                         &job->env_tab)) {
+    /*
+     * Fallback code try to build a environment stack that is good enough to
+     * restore this NDMP backup. This is used when the data is not available in
+     * the database when its either expired or when an old NDMP backup is
+     * restored where the whole environment was not saved.
+     */
+
+    if (!nbf_options || nbf_options->uses_file_history) {
       /*
-       * Skip over the /@NDMP prefix.
+       * We asked during the NDMP backup to receive file history info.
        */
-      ndmp_filesystem = restore_pathname + 6;
-   }
-
-   /*
-    * See if there is a level embedded in the pathname.
-    */
-   bp = strrchr(ndmp_filesystem, '%');
-   if (bp) {
-      *bp++ = '\0';
-      level = bp;
-   } else {
-      level = NULL;
-   }
-
-   /*
-    * Lookup the environment stack saved during the backup so we can restore it.
-    */
-   if (!jcr->db->GetNdmpEnvironmentString(jcr, &jcr->jr, NdmpEnvHandler, &job->env_tab)) {
-      /*
-       * Fallback code try to build a environment stack that is good enough to
-       * restore this NDMP backup. This is used when the data is not available in
-       * the database when its either expired or when an old NDMP backup is restored
-       * where the whole environment was not saved.
-       */
-
-      if (!nbf_options || nbf_options->uses_file_history) {
-         /*
-          * We asked during the NDMP backup to receive file history info.
-          */
-         pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
-         pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
-         ndma_store_env_list(&job->env_tab, &pv);
-      }
-
-      /*
-       * Tell the data agent what type of restore stream to expect.
-       */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
-      pv.value = job->bu_type;
+      pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
+      pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
       ndma_store_env_list(&job->env_tab, &pv);
+    }
 
-      /*
-       * Tell the data agent that this is a NDMP backup which uses a level indicator.
-       */
-      if (level) {
-         pv.name = ndmp_env_keywords[NDMP_ENV_KW_LEVEL];
-         pv.value = level;
-         ndma_store_env_list(&job->env_tab, &pv);
-      }
+    /*
+     * Tell the data agent what type of restore stream to expect.
+     */
+    pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
+    pv.value = job->bu_type;
+    ndma_store_env_list(&job->env_tab, &pv);
 
-      /*
-       * Tell the data engine what was backuped.
-       */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
-      pv.value = ndmp_filesystem;
+    /*
+     * Tell the data agent that this is a NDMP backup which uses a level
+     * indicator.
+     */
+    if (level) {
+      pv.name = ndmp_env_keywords[NDMP_ENV_KW_LEVEL];
+      pv.value = level;
       ndma_store_env_list(&job->env_tab, &pv);
-   }
+    }
 
-   /*
-    * Lookup any meta tags that need to be added.
-    */
-   fileset = jcr->res.fileset;
-   for (i = 0; i < fileset->num_includes; i++) {
-      int j;
-      char *item;
-      IncludeExcludeItem *ie = fileset->include_items[i];
+    /*
+     * Tell the data engine what was backuped.
+     */
+    pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
+    pv.value = ndmp_filesystem;
+    ndma_store_env_list(&job->env_tab, &pv);
+  }
+
+  /*
+   * Lookup any meta tags that need to be added.
+   */
+  fileset = jcr->res.fileset;
+  for (i = 0; i < fileset->num_includes; i++) {
+    int j;
+    char* item;
+    IncludeExcludeItem* ie = fileset->include_items[i];
+
+    /*
+     * Loop over each file = entry of the fileset.
+     */
+    for (j = 0; j < ie->name_list.size(); j++) {
+      item = (char*)ie->name_list.get(j);
 
       /*
-       * Loop over each file = entry of the fileset.
+       * See if the original path matches.
        */
-      for (j = 0; j < ie->name_list.size(); j++) {
-         item = (char *)ie->name_list.get(j);
+      if (Bstrcasecmp(item, ndmp_filesystem)) {
+        int k, l;
+        FileOptions* fo;
 
-         /*
-          * See if the original path matches.
-          */
-         if (Bstrcasecmp(item, ndmp_filesystem)) {
-            int k, l;
-            FileOptions *fo;
+        for (k = 0; k < ie->num_opts; k++) {
+          fo = ie->opts_list[i];
 
-            for (k = 0; k < ie->num_opts; k++) {
-               fo = ie->opts_list[i];
-
-               /*
-                * Parse all specific META tags for this option block.
-                */
-               for (l = 0; l < fo->meta.size(); l++) {
-                  NdmpParseMetaTag(&job->env_tab, (char *)fo->meta.get(l));
-               }
-            }
-         }
+          /*
+           * Parse all specific META tags for this option block.
+           */
+          for (l = 0; l < fo->meta.size(); l++) {
+            NdmpParseMetaTag(&job->env_tab, (char*)fo->meta.get(l));
+          }
+        }
       }
-   }
+    }
+  }
 
-   /*
-    * See where to restore the data.
-    */
-   restore_prefix = NULL;
-   if (jcr->where) {
-      restore_prefix = jcr->where;
-   } else {
-      restore_prefix = jcr->res.job->RestoreWhere;
-   }
+  /*
+   * See where to restore the data.
+   */
+  restore_prefix = NULL;
+  if (jcr->where) {
+    restore_prefix = jcr->where;
+  } else {
+    restore_prefix = jcr->res.job->RestoreWhere;
+  }
 
-   if (!restore_prefix) {
-      return false;
-   }
+  if (!restore_prefix) { return false; }
 
-   /*
-    * Tell the data engine where to restore.
-    */
-   if (nbf_options && nbf_options->restore_prefix_relative) {
-      switch (*restore_prefix) {
+  /*
+   * Tell the data engine where to restore.
+   */
+  if (nbf_options && nbf_options->restore_prefix_relative) {
+    switch (*restore_prefix) {
       case '^':
-         /*
-          * Use the restore_prefix as an absolute restore prefix.
-          * We skip the leading ^ that is the trigger for absolute restores.
-          */
-         PmStrcpy(destination_path, restore_prefix + 1);
-         break;
+        /*
+         * Use the restore_prefix as an absolute restore prefix.
+         * We skip the leading ^ that is the trigger for absolute restores.
+         */
+        PmStrcpy(destination_path, restore_prefix + 1);
+        break;
       default:
-         /*
-          * Use the restore_prefix as an relative restore prefix.
-          */
-         if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
-            PmStrcpy(destination_path, ndmp_filesystem);
-         } else {
-            PmStrcpy(destination_path, ndmp_filesystem);
-            PmStrcat(destination_path, restore_prefix);
-         }
-      }
-   } else {
-      if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
-         /*
-          * Use the original pathname as restore prefix.
-          */
-         PmStrcpy(destination_path, ndmp_filesystem);
-      } else {
-         /*
-          * Use the restore_prefix as an absolute restore prefix.
-          */
-         PmStrcpy(destination_path, restore_prefix);
-      }
-   }
+        /*
+         * Use the restore_prefix as an relative restore prefix.
+         */
+        if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
+          PmStrcpy(destination_path, ndmp_filesystem);
+        } else {
+          PmStrcpy(destination_path, ndmp_filesystem);
+          PmStrcat(destination_path, restore_prefix);
+        }
+    }
+  } else {
+    if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
+      /*
+       * Use the original pathname as restore prefix.
+       */
+      PmStrcpy(destination_path, ndmp_filesystem);
+    } else {
+      /*
+       * Use the restore_prefix as an absolute restore prefix.
+       */
+      PmStrcpy(destination_path, restore_prefix);
+    }
+  }
 
-   pv.name = ndmp_env_keywords[NDMP_ENV_KW_PREFIX];
-   pv.value = ndmp_filesystem;
-   ndma_store_env_list(&job->env_tab, &pv);
+  pv.name = ndmp_env_keywords[NDMP_ENV_KW_PREFIX];
+  pv.value = ndmp_filesystem;
+  ndma_store_env_list(&job->env_tab, &pv);
 
-   if (!nbf_options || nbf_options->needs_namelist) {
-      if (set_files_to_restore(jcr, job, current_fi,
-                               destination_path.c_str(), ndmp_filesystem) == 0) {
-         /*
-          * There is no specific filename selected so restore everything.
-          */
-         AddToNamelist(job, (char *)"", destination_path.c_str(),
-                         (char *)"", (char *)"",
-                         NDMP_INVALID_U_QUAD, NDMP_INVALID_U_QUAD);
-      }
-   }
+  if (!nbf_options || nbf_options->needs_namelist) {
+    if (set_files_to_restore(jcr, job, current_fi, destination_path.c_str(),
+                             ndmp_filesystem) == 0) {
+      /*
+       * There is no specific filename selected so restore everything.
+       */
+      AddToNamelist(job, (char*)"", destination_path.c_str(), (char*)"",
+                    (char*)"", NDMP_INVALID_U_QUAD, NDMP_INVALID_U_QUAD);
+    }
+  }
 
-   /*
-    * If we have a paired storage definition we put the storage daemon
-    * auth key and the filesystem into the tape device name of the
-    * NDMP session. This way the storage daemon can link the NDMP
-    * data and the normal save session together.
-    */
-   if (jcr->store_bsock) {
-      Mmsg(tape_device, "%s@%s", jcr->sd_auth_key, restore_pathname + 6);
-      job->tape_device = bstrdup(tape_device.c_str());
-   }
+  /*
+   * If we have a paired storage definition we put the storage daemon
+   * auth key and the filesystem into the tape device name of the
+   * NDMP session. This way the storage daemon can link the NDMP
+   * data and the normal save session together.
+   */
+  if (jcr->store_bsock) {
+    Mmsg(tape_device, "%s@%s", jcr->sd_auth_key, restore_pathname + 6);
+    job->tape_device = bstrdup(tape_device.c_str());
+  }
 
-   free(restore_pathname);
-   return true;
+  free(restore_pathname);
+  return true;
 }
 
 /**
  * Setup a NDMP restore session.
  */
-bool DoNdmpRestoreInit(JobControlRecord *jcr)
+bool DoNdmpRestoreInit(JobControlRecord* jcr)
 {
-   FreeWstorage(jcr);                /* we don't write */
+  FreeWstorage(jcr); /* we don't write */
 
-   if (!jcr->restore_tree_root) {
-      Jmsg(jcr, M_FATAL, 0, _("Cannot NDMP restore without a file selection.\n"));
-      return false;
-   }
+  if (!jcr->restore_tree_root) {
+    Jmsg(jcr, M_FATAL, 0, _("Cannot NDMP restore without a file selection.\n"));
+    return false;
+  }
 
-   return true;
+  return true;
 }
 
-static inline int NdmpWaitForJobTermination(JobControlRecord *jcr)
+static inline int NdmpWaitForJobTermination(JobControlRecord* jcr)
 {
-   jcr->setJobStatus(JS_Running);
+  jcr->setJobStatus(JS_Running);
 
-   /*
-    * Force cancel in SD if failing, but not for Incomplete jobs
-    * so that we let the SD despool.
-    */
-   Dmsg4(100, "cancel=%d FDJS=%d JS=%d SDJS=%d\n",
-         jcr->IsCanceled(), jcr->FDJobStatus,
-         jcr->JobStatus, jcr->SDJobStatus);
-   if (jcr->IsCanceled() || (!jcr->res.job->RescheduleIncompleteJobs)) {
-      Dmsg3(100, "FDJS=%d JS=%d SDJS=%d\n",
-            jcr->FDJobStatus, jcr->JobStatus, jcr->SDJobStatus);
-      CancelStorageDaemonJob(jcr);
-   }
+  /*
+   * Force cancel in SD if failing, but not for Incomplete jobs
+   * so that we let the SD despool.
+   */
+  Dmsg4(100, "cancel=%d FDJS=%d JS=%d SDJS=%d\n", jcr->IsCanceled(),
+        jcr->FDJobStatus, jcr->JobStatus, jcr->SDJobStatus);
+  if (jcr->IsCanceled() || (!jcr->res.job->RescheduleIncompleteJobs)) {
+    Dmsg3(100, "FDJS=%d JS=%d SDJS=%d\n", jcr->FDJobStatus, jcr->JobStatus,
+          jcr->SDJobStatus);
+    CancelStorageDaemonJob(jcr);
+  }
 
-   /*
-    * Note, the SD stores in jcr->JobFiles/ReadBytes/JobBytes/JobErrors
-    */
-   WaitForStorageDaemonTermination(jcr);
+  /*
+   * Note, the SD stores in jcr->JobFiles/ReadBytes/JobBytes/JobErrors
+   */
+  WaitForStorageDaemonTermination(jcr);
 
-   jcr->FDJobStatus = JS_Terminated;
-   if (jcr->JobStatus != JS_Terminated) {
-      return jcr->JobStatus;
-   }
-   if (jcr->FDJobStatus != JS_Terminated) {
-      return jcr->FDJobStatus;
-   }
-   return jcr->SDJobStatus;
+  jcr->FDJobStatus = JS_Terminated;
+  if (jcr->JobStatus != JS_Terminated) { return jcr->JobStatus; }
+  if (jcr->FDJobStatus != JS_Terminated) { return jcr->FDJobStatus; }
+  return jcr->SDJobStatus;
 }
 
 /**
@@ -417,445 +412,435 @@ static inline int NdmpWaitForJobTermination(JobControlRecord *jcr)
  * restore.  E.g. your Full is stored on tape, and Incrementals
  * on disk.
  */
-static inline bool DoNdmpRestoreBootstrap(JobControlRecord *jcr)
+static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
 {
-   int cnt;
-   BareosSocket *sd;
-   storagedaemon::BootStrapRecord *bsr;
-   NIS *nis = NULL;
-   int32_t current_fi;
-   bootstrap_info info;
-   storagedaemon::BsrFileIndex *fileindex;
-   struct ndm_session ndmp_sess;
-   struct ndm_job_param ndmp_job;
-   bool session_initialized = false;
-   bool retval = false;
-   int NdmpLoglevel;
+  int cnt;
+  BareosSocket* sd;
+  storagedaemon::BootStrapRecord* bsr;
+  NIS* nis = NULL;
+  int32_t current_fi;
+  bootstrap_info info;
+  storagedaemon::BsrFileIndex* fileindex;
+  struct ndm_session ndmp_sess;
+  struct ndm_job_param ndmp_job;
+  bool session_initialized = false;
+  bool retval = false;
+  int NdmpLoglevel;
 
-   if (jcr->res.client->ndmp_loglevel > me->ndmp_loglevel) {
-      NdmpLoglevel = jcr->res.client->ndmp_loglevel;
-   } else {
-      NdmpLoglevel = me->ndmp_loglevel;
-   }
+  if (jcr->res.client->ndmp_loglevel > me->ndmp_loglevel) {
+    NdmpLoglevel = jcr->res.client->ndmp_loglevel;
+  } else {
+    NdmpLoglevel = me->ndmp_loglevel;
+  }
 
-   /*
-    * We first parse the BootStrapRecord ourself so we know what to restore.
-    */
-   jcr->bsr = libbareos::parse_bsr(jcr, jcr->RestoreBootstrap);
-   if (!jcr->bsr) {
-      Jmsg(jcr, M_FATAL, 0, _("Error parsing bootstrap file.\n"));
-      goto bail_out;
-   }
+  /*
+   * We first parse the BootStrapRecord ourself so we know what to restore.
+   */
+  jcr->bsr = libbareos::parse_bsr(jcr, jcr->RestoreBootstrap);
+  if (!jcr->bsr) {
+    Jmsg(jcr, M_FATAL, 0, _("Error parsing bootstrap file.\n"));
+    goto bail_out;
+  }
 
-   /*
-    * Setup all paired read storage.
-    */
-   SetPairedStorage(jcr);
-   if (!jcr->res.paired_read_write_storage) {
-      Jmsg(jcr, M_FATAL, 0,
-           _("Read storage %s doesn't point to storage definition with paired storage option.\n"),
-           jcr->res.read_storage->name());
-      goto bail_out;
-   }
+  /*
+   * Setup all paired read storage.
+   */
+  SetPairedStorage(jcr);
+  if (!jcr->res.paired_read_write_storage) {
+    Jmsg(jcr, M_FATAL, 0,
+         _("Read storage %s doesn't point to storage definition with paired "
+           "storage option.\n"),
+         jcr->res.read_storage->name());
+    goto bail_out;
+  }
 
-   /*
-    * Open the bootstrap file
-    */
-   if (!OpenBootstrapFile(jcr, info)) {
-      goto bail_out;
-   }
+  /*
+   * Open the bootstrap file
+   */
+  if (!OpenBootstrapFile(jcr, info)) { goto bail_out; }
 
-   nis = (NIS *)malloc(sizeof(NIS));
-   memset(nis, 0, sizeof(NIS));
+  nis = (NIS*)malloc(sizeof(NIS));
+  memset(nis, 0, sizeof(NIS));
 
-   /*
-    * Read the bootstrap file
-    */
-   bsr = jcr->bsr;
-   while (!feof(info.bs)) {
-      if (!SelectNextRstore(jcr, info)) {
-         goto cleanup;
+  /*
+   * Read the bootstrap file
+   */
+  bsr = jcr->bsr;
+  while (!feof(info.bs)) {
+    if (!SelectNextRstore(jcr, info)) { goto cleanup; }
+
+    /*
+     * Initialize the NDMP restore job. We build the generic job once per
+     * storage daemon and reuse the job definition for each separate sub-restore
+     * we perform as part of the whole job. We only free the env_table between
+     * every sub-restore.
+     */
+    if (!NdmpBuildClientJob(jcr, jcr->res.client,
+                            jcr->res.paired_read_write_storage,
+                            NDM_JOB_OP_EXTRACT, &ndmp_job)) {
+      goto cleanup;
+    }
+
+    /*
+     * Open a message channel connection to the Storage
+     * daemon. This is to let him know that our client
+     * will be contacting him for a backup session.
+     *
+     */
+    Dmsg0(10, "Open connection to storage daemon\n");
+    jcr->setJobStatus(JS_WaitSD);
+
+    /*
+     * Start conversation with Storage daemon
+     */
+    if (!ConnectToStorageDaemon(jcr, 10, me->SDConnectTimeout, true)) {
+      goto cleanup;
+    }
+    sd = jcr->store_bsock;
+
+    /*
+     * Now start a job with the Storage daemon
+     */
+    if (!StartStorageDaemonJob(jcr, jcr->res.read_storage_list, NULL)) {
+      goto cleanup;
+    }
+
+    jcr->setJobStatus(JS_Running);
+
+    /*
+     * Send the bootstrap file -- what Volumes/files to restore
+     */
+    if (!SendBootstrapFile(jcr, sd, info) ||
+        !response(jcr, sd, OKbootstrap, "Bootstrap", DISPLAY_ERROR)) {
+      goto cleanup;
+    }
+
+    if (!sd->fsend("run")) { goto cleanup; }
+
+    /*
+     * Now start a Storage daemon message thread
+     */
+    if (!StartStorageDaemonMessageThread(jcr)) { goto cleanup; }
+    Dmsg0(50, "Storage daemon connection OK\n");
+
+    /*
+     * We need to run a NDMP restore for
+     * each File Index of each Session Id
+     *
+     * So we go over each BootStrapRecord
+     *   * look for the Session IDs that we find.
+     *      * look for the FileIndexes of that Session ID
+     *
+     * and run a restore for each SessionID - FileIndex tuple
+     */
+
+    char dt[MAX_TIME_LENGTH];
+    bool first_run = true;
+    bool next_sessid = true;
+    bool next_fi = true;
+    int first_fi = jcr->bsr->FileIndex->findex;
+    int last_fi = jcr->bsr->FileIndex->findex2;
+    uint32_t current_sessionid = jcr->bsr->sessid->sessid;
+    uint32_t current_sessiontime = jcr->bsr->sesstime->sesstime;
+    cnt = 0;
+
+    for (bsr = jcr->bsr; bsr; bsr = bsr->next) {
+      if (current_sessionid != bsr->sessid->sessid) {
+        current_sessionid = bsr->sessid->sessid;
+        current_sessiontime = bsr->sesstime->sesstime;
+        first_run = true;
+        next_sessid = true;
+      }
+      /*
+       * check for the first and last fileindex  we have in the current
+       * BootStrapRecord
+       */
+      for (fileindex = bsr->FileIndex; fileindex; fileindex = fileindex->next) {
+        if (first_run) {
+          first_fi = fileindex->findex;
+          last_fi = fileindex->findex2;
+          first_run = false;
+        } else {
+          first_fi = MIN(first_fi, fileindex->findex);
+          if (last_fi != fileindex->findex2) {
+            next_fi = true;
+            last_fi = fileindex->findex2;
+          }
+        }
+        Dmsg4(20, "sessionid:sesstime : first_fi/last_fi : %d:%d %d/%d \n",
+              current_sessionid, current_sessiontime, first_fi, last_fi);
       }
 
-      /*
-       * Initialize the NDMP restore job. We build the generic job once per storage daemon
-       * and reuse the job definition for each separate sub-restore we perform as
-       * part of the whole job. We only free the env_table between every sub-restore.
-       */
-      if (!NdmpBuildClientJob(jcr, jcr->res.client, jcr->res.paired_read_write_storage, NDM_JOB_OP_EXTRACT, &ndmp_job)) {
-         goto cleanup;
+      if (next_sessid | next_fi) {
+        if (next_sessid) { next_sessid = false; }
+        if (next_fi) { next_fi = false; }
+
+        current_fi = last_fi;
+
+        Jmsg(
+            jcr, M_INFO, 0,
+            _("Run restore for sesstime %s (%d), sessionid %d, fileindex %d\n"),
+            bstrftime(dt, sizeof(dt), current_sessiontime, NULL),
+            current_sessiontime, current_sessionid, current_fi);
+
+
+        /*
+         * See if this is the first Restore NDMP stream or not. For NDMP we can
+         * have multiple Backup runs as part of the same Job. When we are
+         * restoring data from a Native Storage Daemon we let it know to expect
+         * a next restore session. It will generate a new authorization key so
+         * we wait for the nextrun_ready conditional variable to be raised by
+         * the msg_thread.
+         */
+        if (jcr->store_bsock && cnt > 0) {
+          jcr->store_bsock->fsend("nextrun");
+          P(mutex);
+          pthread_cond_wait(&jcr->nextrun_ready, &mutex);
+          V(mutex);
+        }
+
+        /*
+         * Perform the actual NDMP job.
+         * Initialize a new NDMP session
+         */
+        memset(&ndmp_sess, 0, sizeof(ndmp_sess));
+        ndmp_sess.conn_snooping = (me->ndmp_snooping) ? 1 : 0;
+        ndmp_sess.control_agent_enabled = 1;
+
+        ndmp_sess.param =
+            (struct ndm_session_param*)malloc(sizeof(struct ndm_session_param));
+        memset(ndmp_sess.param, 0, sizeof(struct ndm_session_param));
+        ndmp_sess.param->log.deliver = NdmpLoghandler;
+        ndmp_sess.param->log_level =
+            NativeToNdmpLoglevel(NdmpLoglevel, debug_level, nis);
+        nis->jcr = jcr;
+        ndmp_sess.param->log.ctx = nis;
+        ndmp_sess.param->log_tag = bstrdup("DIR-NDMP");
+
+        /*
+         * Initialize the session structure.
+         */
+        if (ndma_session_initialize(&ndmp_sess)) { goto cleanup_ndmp; }
+        session_initialized = true;
+
+        /*
+         * Copy the actual job to perform.
+         */
+        jcr->jr.FileIndex = current_fi;
+
+        memcpy(&ndmp_sess.control_acb->job, &ndmp_job,
+               sizeof(struct ndm_job_param));
+        if (!fill_restore_environment(jcr, current_fi,
+                                      &ndmp_sess.control_acb->job)) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
+          goto cleanup_ndmp;
+        }
+
+        ndma_job_auto_adjust(&ndmp_sess.control_acb->job);
+        if (!NdmpValidateJob(jcr, &ndmp_sess.control_acb->job)) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in NdmpValidateJob\n"));
+          goto cleanup_ndmp;
+        }
+
+        /*
+         * Commission the session for a run.
+         */
+        if (ndma_session_commission(&ndmp_sess)) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in ndma_session_commission\n"));
+          goto cleanup_ndmp;
+        }
+
+        /*
+         * Setup the DMA.
+         */
+        if (ndmca_connect_control_agent(&ndmp_sess)) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_connect_control_agent\n"));
+          goto cleanup_ndmp;
+        }
+
+        ndmp_sess.conn_open = 1;
+        ndmp_sess.conn_authorized = 1;
+
+        /*
+         * Let the DMA perform its magic.
+         */
+        if (ndmca_control_agent(&ndmp_sess) != 0) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_control_agent\n"));
+          goto cleanup_ndmp;
+        }
+
+        /*
+         * See if there were any errors during the restore.
+         */
+        if (!ExtractPostRestoreStats(jcr, &ndmp_sess)) {
+          Jmsg(jcr, M_ERROR, 0, _("ERROR in ExtractPostRestoreStats\n"));
+          goto cleanup_ndmp;
+        }
+
+        /*
+         * Reset the NDMP session states.
+         */
+        ndma_session_decommission(&ndmp_sess);
+
+        /*
+         * Cleanup the job after it has run.
+         */
+        ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
+        ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
+        ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
+
+        /*
+         * Release any tape device name allocated.
+         */
+        if (ndmp_sess.control_acb->job.tape_device) {
+          free(ndmp_sess.control_acb->job.tape_device);
+          ndmp_sess.control_acb->job.tape_device = NULL;
+        }
+
+        /*
+         * Destroy the session.
+         */
+        ndma_session_destroy(&ndmp_sess);
+
+        /*
+         * Free the param block.
+         */
+        free(ndmp_sess.param->log_tag);
+        free(ndmp_sess.param);
+        ndmp_sess.param = NULL;
+
+        /*
+         * Reset the initialized state so we don't try to cleanup again.
+         */
+        session_initialized = false;
+
+        /*
+         * Keep track that we finished this part of the restore.
+         */
+        cnt++;
       }
-
-      /*
-       * Open a message channel connection to the Storage
-       * daemon. This is to let him know that our client
-       * will be contacting him for a backup session.
-       *
-       */
-      Dmsg0(10, "Open connection to storage daemon\n");
-      jcr->setJobStatus(JS_WaitSD);
-
-      /*
-       * Start conversation with Storage daemon
-       */
-      if (!ConnectToStorageDaemon(jcr, 10, me->SDConnectTimeout, true)) {
-         goto cleanup;
-      }
-      sd = jcr->store_bsock;
-
-      /*
-       * Now start a job with the Storage daemon
-       */
-      if (!StartStorageDaemonJob(jcr, jcr->res.read_storage_list, NULL)) {
-         goto cleanup;
-      }
-
-      jcr->setJobStatus(JS_Running);
-
-      /*
-       * Send the bootstrap file -- what Volumes/files to restore
-       */
-      if (!SendBootstrapFile(jcr, sd, info) ||
-            !response(jcr, sd, OKbootstrap, "Bootstrap", DISPLAY_ERROR)) {
-         goto cleanup;
-      }
-
-      if (!sd->fsend("run")) {
-         goto cleanup;
-      }
-
-      /*
-       * Now start a Storage daemon message thread
-       */
-      if (!StartStorageDaemonMessageThread(jcr)) {
-         goto cleanup;
-      }
-      Dmsg0(50, "Storage daemon connection OK\n");
-
-      /*
-       * We need to run a NDMP restore for
-       * each File Index of each Session Id
-       *
-       * So we go over each BootStrapRecord
-       *   * look for the Session IDs that we find.
-       *      * look for the FileIndexes of that Session ID
-       *
-       * and run a restore for each SessionID - FileIndex tuple
-       */
-
-      char dt[MAX_TIME_LENGTH];
-      bool first_run = true;
-      bool next_sessid = true;
-      bool next_fi = true;
-      int first_fi = jcr->bsr->FileIndex->findex;
-      int last_fi  = jcr->bsr->FileIndex->findex2;
-      uint32_t current_sessionid = jcr->bsr->sessid->sessid;
-      uint32_t current_sessiontime =  jcr->bsr->sesstime->sesstime;
-      cnt = 0;
-
-      for (bsr = jcr->bsr; bsr; bsr = bsr->next) {
-
-         if (current_sessionid != bsr->sessid->sessid) {
-            current_sessionid = bsr->sessid->sessid;
-            current_sessiontime = bsr->sesstime->sesstime;
-            first_run = true;
-            next_sessid = true;
-         }
-         /*
-          * check for the first and last fileindex  we have in the current BootStrapRecord
-          */
-         for (fileindex = bsr->FileIndex; fileindex; fileindex = fileindex->next) {
-
-            if (first_run)  {
-               first_fi = fileindex->findex;
-               last_fi = fileindex->findex2;
-               first_run = false;
-            } else {
-               first_fi = MIN(first_fi, fileindex->findex);
-               if (last_fi != fileindex->findex2) {
-                  next_fi = true;
-                  last_fi = fileindex->findex2;
-               }
-            }
-            Dmsg4(20 ,"sessionid:sesstime : first_fi/last_fi : %d:%d %d/%d \n",
-                  current_sessionid, current_sessiontime, first_fi, last_fi);
-         }
-
-         if (next_sessid | next_fi) {
-            if (next_sessid) {
-               next_sessid = false;
-            }
-            if (next_fi) {
-               next_fi = false;
-            }
-
-            current_fi = last_fi;
-
-            Jmsg(jcr, M_INFO, 0, _("Run restore for sesstime %s (%d), sessionid %d, fileindex %d\n"),
-                  bstrftime(dt, sizeof(dt), current_sessiontime, NULL),
-                  current_sessiontime, current_sessionid, current_fi);
+    }
 
 
-            /*
-             * See if this is the first Restore NDMP stream or not. For NDMP we can have multiple Backup
-             * runs as part of the same Job. When we are restoring data from a Native Storage Daemon
-             * we let it know to expect a next restore session. It will generate a new authorization
-             * key so we wait for the nextrun_ready conditional variable to be raised by the msg_thread.
-             */
-            if (jcr->store_bsock && cnt > 0) {
-               jcr->store_bsock->fsend("nextrun");
-               P(mutex);
-               pthread_cond_wait(&jcr->nextrun_ready, &mutex);
-               V(mutex);
-            }
+    /*
+     * Tell the storage daemon we are done.
+     */
+    jcr->store_bsock->fsend("finish");
+    WaitForStorageDaemonTermination(jcr);
+  }
 
-            /*
-             * Perform the actual NDMP job.
-             * Initialize a new NDMP session
-             */
-            memset(&ndmp_sess, 0, sizeof(ndmp_sess));
-            ndmp_sess.conn_snooping = (me->ndmp_snooping) ? 1 : 0;
-            ndmp_sess.control_agent_enabled = 1;
-
-            ndmp_sess.param = (struct ndm_session_param *)malloc(sizeof(struct ndm_session_param));
-            memset(ndmp_sess.param, 0, sizeof(struct ndm_session_param));
-            ndmp_sess.param->log.deliver = NdmpLoghandler;
-            ndmp_sess.param->log_level = NativeToNdmpLoglevel(NdmpLoglevel, debug_level, nis);
-            nis->jcr = jcr;
-            ndmp_sess.param->log.ctx = nis;
-            ndmp_sess.param->log_tag = bstrdup("DIR-NDMP");
-
-            /*
-             * Initialize the session structure.
-             */
-            if (ndma_session_initialize(&ndmp_sess)) {
-               goto cleanup_ndmp;
-            }
-            session_initialized = true;
-
-            /*
-             * Copy the actual job to perform.
-             */
-            jcr->jr.FileIndex = current_fi;
-
-            memcpy(&ndmp_sess.control_acb->job, &ndmp_job, sizeof(struct ndm_job_param));
-            if (!fill_restore_environment(jcr,
-                     current_fi,
-                     &ndmp_sess.control_acb->job)) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
-               goto cleanup_ndmp;
-            }
-
-            ndma_job_auto_adjust(&ndmp_sess.control_acb->job);
-            if (!NdmpValidateJob(jcr, &ndmp_sess.control_acb->job)) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in NdmpValidateJob\n"));
-               goto cleanup_ndmp;
-            }
-
-            /*
-             * Commission the session for a run.
-             */
-            if (ndma_session_commission(&ndmp_sess)) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in ndma_session_commission\n"));
-               goto cleanup_ndmp;
-            }
-
-            /*
-             * Setup the DMA.
-             */
-            if (ndmca_connect_control_agent(&ndmp_sess)) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_connect_control_agent\n"));
-               goto cleanup_ndmp;
-            }
-
-            ndmp_sess.conn_open = 1;
-            ndmp_sess.conn_authorized = 1;
-
-            /*
-             * Let the DMA perform its magic.
-             */
-            if (ndmca_control_agent(&ndmp_sess) != 0) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_control_agent\n"));
-               goto cleanup_ndmp;
-            }
-
-            /*
-             * See if there were any errors during the restore.
-             */
-            if (!ExtractPostRestoreStats(jcr, &ndmp_sess)) {
-               Jmsg(jcr, M_ERROR, 0, _("ERROR in ExtractPostRestoreStats\n"));
-               goto cleanup_ndmp;
-            }
-
-            /*
-             * Reset the NDMP session states.
-             */
-            ndma_session_decommission(&ndmp_sess);
-
-            /*
-             * Cleanup the job after it has run.
-             */
-            ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
-            ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
-            ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
-
-            /*
-             * Release any tape device name allocated.
-             */
-            if (ndmp_sess.control_acb->job.tape_device) {
-               free(ndmp_sess.control_acb->job.tape_device);
-               ndmp_sess.control_acb->job.tape_device = NULL;
-            }
-
-            /*
-             * Destroy the session.
-             */
-            ndma_session_destroy(&ndmp_sess);
-
-            /*
-             * Free the param block.
-             */
-            free(ndmp_sess.param->log_tag);
-            free(ndmp_sess.param);
-            ndmp_sess.param = NULL;
-
-            /*
-             * Reset the initialized state so we don't try to cleanup again.
-             */
-            session_initialized = false;
-
-            /*
-             * Keep track that we finished this part of the restore.
-             */
-            cnt++;
-         }
-      }
-
-
-      /*
-       * Tell the storage daemon we are done.
-       */
-      jcr->store_bsock->fsend("finish");
-      WaitForStorageDaemonTermination(jcr);
-   }
-
-   /*
-    * Jump to the generic cleanup done for every Job.
-    */
-   retval = true;
-   goto cleanup;
+  /*
+   * Jump to the generic cleanup done for every Job.
+   */
+  retval = true;
+  goto cleanup;
 
 cleanup_ndmp:
-   /*
-    * Only need to cleanup when things are initialized.
-    */
-   if (session_initialized) {
-      ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
-      ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
-      ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
+  /*
+   * Only need to cleanup when things are initialized.
+   */
+  if (session_initialized) {
+    ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
+    ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
+    ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
 
-      if (ndmp_sess.control_acb->job.tape_device) {
-         free(ndmp_sess.control_acb->job.tape_device);
-      }
+    if (ndmp_sess.control_acb->job.tape_device) {
+      free(ndmp_sess.control_acb->job.tape_device);
+    }
 
-      /*
-       * Destroy the session.
-       */
-      ndma_session_destroy(&ndmp_sess);
-   }
+    /*
+     * Destroy the session.
+     */
+    ndma_session_destroy(&ndmp_sess);
+  }
 
-   if (ndmp_sess.param) {
-      free(ndmp_sess.param->log_tag);
-      free(ndmp_sess.param);
-   }
+  if (ndmp_sess.param) {
+    free(ndmp_sess.param->log_tag);
+    free(ndmp_sess.param);
+  }
 
 cleanup:
-   if (nis) {
-      free(nis);
-   }
-   FreePairedStorage(jcr);
-   CloseBootstrapFile(info);
+  if (nis) { free(nis); }
+  FreePairedStorage(jcr);
+  CloseBootstrapFile(info);
 
 bail_out:
-   FreeTree(jcr->restore_tree_root);
-   jcr->restore_tree_root = NULL;
-   return retval;
+  FreeTree(jcr->restore_tree_root);
+  jcr->restore_tree_root = NULL;
+  return retval;
 }
 
 
 /**
  * Run a NDMP restore session.
  */
-bool DoNdmpRestore(JobControlRecord *jcr)
+bool DoNdmpRestore(JobControlRecord* jcr)
 {
-   JobDbRecord rjr;                       /* restore job record */
-   int status;
+  JobDbRecord rjr; /* restore job record */
+  int status;
 
-   memset(&rjr, 0, sizeof(rjr));
-   jcr->jr.JobLevel = L_FULL;         /* Full restore */
-   if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->jr)) {
-      Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
-      goto bail_out;
-   }
-   Dmsg0(20, "Updated job start record\n");
+  memset(&rjr, 0, sizeof(rjr));
+  jcr->jr.JobLevel = L_FULL; /* Full restore */
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->jr)) {
+    Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
+    goto bail_out;
+  }
+  Dmsg0(20, "Updated job start record\n");
 
-   Dmsg1(20, "RestoreJobId=%d\n", jcr->res.job->RestoreJobId);
+  Dmsg1(20, "RestoreJobId=%d\n", jcr->res.job->RestoreJobId);
 
-   /*
-    * Validate the Job to have a NDMP client.
-    */
-   if (!NdmpValidateClient(jcr)) {
-      return false;
-   }
+  /*
+   * Validate the Job to have a NDMP client.
+   */
+  if (!NdmpValidateClient(jcr)) { return false; }
 
-   if (!jcr->RestoreBootstrap) {
-      Jmsg(jcr, M_FATAL, 0, _("Cannot restore without a bootstrap file.\n"
+  if (!jcr->RestoreBootstrap) {
+    Jmsg(jcr, M_FATAL, 0,
+         _("Cannot restore without a bootstrap file.\n"
            "You probably ran a restore job directly. All restore jobs must\n"
            "be run using the restore command.\n"));
-      goto bail_out;
-   }
+    goto bail_out;
+  }
 
-   /*
-    * Print Job Start message
-    */
-   Jmsg(jcr, M_INFO, 0, _("Start Restore Job %s\n"), jcr->Job);
+  /*
+   * Print Job Start message
+   */
+  Jmsg(jcr, M_INFO, 0, _("Start Restore Job %s\n"), jcr->Job);
 
-   /*
-    * Read the bootstrap file and do the restore
-    */
-   if (!DoNdmpRestoreBootstrap(jcr)) {
-      goto bail_out;
-   }
+  /*
+   * Read the bootstrap file and do the restore
+   */
+  if (!DoNdmpRestoreBootstrap(jcr)) { goto bail_out; }
 
-   /*
-    * Wait for Job Termination
-    */
-   status = NdmpWaitForJobTermination(jcr);
-   NdmpRestoreCleanup(jcr, status);
-   return true;
+  /*
+   * Wait for Job Termination
+   */
+  status = NdmpWaitForJobTermination(jcr);
+  NdmpRestoreCleanup(jcr, status);
+  return true;
 
 bail_out:
-   return false;
+  return false;
 }
 
 #else /* HAVE_NDMP */
 
-bool DoNdmpRestoreInit(JobControlRecord *jcr)
+bool DoNdmpRestoreInit(JobControlRecord* jcr)
 {
-   Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
-   return false;
+  Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
+  return false;
 }
 
-bool DoNdmpRestore(JobControlRecord *jcr)
+bool DoNdmpRestore(JobControlRecord* jcr)
 {
-   Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
-   return false;
+  Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
+  return false;
 }
 
-bool DoNdmpRestoreNdmpNative(JobControlRecord *jcr)
+bool DoNdmpRestoreNdmpNative(JobControlRecord* jcr)
 {
-   Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
-   return false;
+  Jmsg(jcr, M_FATAL, 0, _("NDMP protocol not supported\n"));
+  return false;
 }
 
 #endif /* HAVE_NDMP */

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -36,6 +36,7 @@
 #include "dird/storage.h"
 
 #include "lib/parse_bsr.h"
+#include "lib/volume_session_info.h"
 
 #if HAVE_NDMP
 #include "dird/ndmp_dma_generic.h"
@@ -159,6 +160,7 @@ static inline int set_files_to_restore(JobControlRecord* jcr,
  */
 static inline bool fill_restore_environment(JobControlRecord* jcr,
                                             int32_t current_fi,
+                                            VolumeSessionInfo current_session,
                                             struct ndm_job_param* job)
 {
   int i;
@@ -202,8 +204,8 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
   /*
    * Lookup the environment stack saved during the backup so we can restore it.
    */
-  if (!jcr->db->GetNdmpEnvironmentString(jcr, &jcr->jr, NdmpEnvHandler,
-                                         &job->env_tab)) {
+  if (!jcr->db->GetNdmpEnvironmentString(current_session, current_fi,
+                                         NdmpEnvHandler, &job->env_tab)) {
     /*
      * Fallback code try to build a environment stack that is good enough to
      * restore this NDMP backup. This is used when the data is not available in
@@ -540,14 +542,13 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
     bool next_fi = true;
     int first_fi = jcr->bsr->FileIndex->findex;
     int last_fi = jcr->bsr->FileIndex->findex2;
-    uint32_t current_sessionid = jcr->bsr->sessid->sessid;
-    uint32_t current_sessiontime = jcr->bsr->sesstime->sesstime;
+    VolumeSessionInfo current_session{jcr->bsr->sessid->sessid,
+                                      jcr->bsr->sesstime->sesstime};
     cnt = 0;
 
     for (bsr = jcr->bsr; bsr; bsr = bsr->next) {
-      if (current_sessionid != bsr->sessid->sessid) {
-        current_sessionid = bsr->sessid->sessid;
-        current_sessiontime = bsr->sesstime->sesstime;
+      if (current_session.id != bsr->sessid->sessid) {
+        current_session = {bsr->sessid->sessid, bsr->sesstime->sesstime};
         first_run = true;
         next_sessid = true;
       }
@@ -568,7 +569,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
           }
         }
         Dmsg4(20, "sessionid:sesstime : first_fi/last_fi : %d:%d %d/%d \n",
-              current_sessionid, current_sessiontime, first_fi, last_fi);
+              current_session.id, current_session.time, first_fi, last_fi);
       }
 
       if (next_sessid | next_fi) {
@@ -580,8 +581,8 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
         Jmsg(
             jcr, M_INFO, 0,
             _("Run restore for sesstime %s (%d), sessionid %d, fileindex %d\n"),
-            bstrftime(dt, sizeof(dt), current_sessiontime, NULL),
-            current_sessiontime, current_sessionid, current_fi);
+            bstrftime(dt, sizeof(dt), current_session.time, NULL),
+            current_session.time, current_session.id, current_fi);
 
 
         /*
@@ -630,7 +631,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
 
         memcpy(&ndmp_sess.control_acb->job, &ndmp_job,
                sizeof(struct ndm_job_param));
-        if (!fill_restore_environment(jcr, current_fi,
+        if (!fill_restore_environment(jcr, current_fi, current_session,
                                       &ndmp_sess.control_acb->job)) {
           Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
           goto cleanup_ndmp;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -98,6 +98,9 @@ static inline bool fill_restore_environment_ndmp_native(
      * the database when its either expired or when an old NDMP backup is
      * restored where the whole environment was not saved.
      */
+    Jmsg(jcr, M_WARNING, 0,
+         _("Could not load NDMP environment. Using fallback.\n"));
+
 
     if (!nbf_options || nbf_options->uses_file_history) {
       /*
@@ -117,6 +120,7 @@ static inline bool fill_restore_environment_ndmp_native(
 
     /*
      * Tell the data engine what was backuped.
+     * As we have no idea without an environment, just set to a nullstring.
      */
     pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
     pv.value = ndmp_filesystem;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -73,7 +73,7 @@ static inline bool fill_restore_environment_ndmp_native(
    * We use the first jobid to get the environment string
    */
 
-  JobId_t JobId = (JobId_t)str_to_int32(jcr->JobIds);
+  JobId_t JobId{str_to_uint32(jcr->JobIds)};
   if (JobId <= 0) {
     Jmsg(jcr, M_FATAL, 0, "Impossible JobId: %d", JobId);
     return false;

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -55,12 +55,9 @@ static inline bool fill_restore_environment_ndmp_native(
     struct ndm_job_param* job)
 {
   ndmp9_pval pv;
-  char *ndmp_filesystem, *restore_prefix;
   PoolMem tape_device;
   PoolMem destination_path;
   ndmp_backup_format_option* nbf_options;
-
-  ndmp_filesystem = NULL;
 
   /*
    * See if we know this backup format and get it options.
@@ -79,59 +76,33 @@ static inline bool fill_restore_environment_ndmp_native(
     return false;
   }
 
-  if (jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler, &job->env_tab)) {
-    /*
-     * extract ndmp_filesystem from environment
-     */
-    for (struct ndm_env_entry* entry = job->env_tab.head; entry;
-         entry = entry->next) {
-      if (bstrcmp(entry->pval.name,
-                  ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
-        ndmp_filesystem = entry->pval.value;
-        break;
-      }
-    }
-  } else {
-    /*
-     * Fallback code try to build a environment stack that is good enough to
-     * restore this NDMP backup. This is used when the data is not available in
-     * the database when its either expired or when an old NDMP backup is
-     * restored where the whole environment was not saved.
-     */
-    Jmsg(jcr, M_WARNING, 0,
-         _("Could not load NDMP environment. Using fallback.\n"));
-
-
-    if (!nbf_options || nbf_options->uses_file_history) {
-      /*
-       * We asked during the NDMP backup to receive file history info.
-       */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
-      pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
-      ndma_store_env_list(&job->env_tab, &pv);
-    }
-
-    /*
-     * Tell the data agent what type of restore stream to expect.
-     */
-    pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
-    pv.value = job->bu_type;
-    ndma_store_env_list(&job->env_tab, &pv);
-
-    /*
-     * Tell the data engine what was backuped.
-     * As we have no idea without an environment, just set to a nullstring.
-     */
-    pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
-    pv.value = ndmp_filesystem;
-    ndma_store_env_list(&job->env_tab, &pv);
+  if (!jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler,
+                                         &job->env_tab)) {
+    Jmsg(jcr, M_FATAL, 0,
+         _("Could not load NDMP environment. Cannot continue without one.\n"));
+    return false;
   }
 
+  /* try to extract ndmp_filesystem from environment */
+  char *ndmp_filesystem = nullptr;
+  for (struct ndm_env_entry* entry = job->env_tab.head; entry;
+       entry = entry->next) {
+    if (bstrcmp(entry->pval.name, ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
+      ndmp_filesystem = entry->pval.value;
+      break;
+    }
+  }
+
+  if (!ndmp_filesystem) {
+    Jmsg(jcr, M_FATAL, 0, _("No %s in NDMP environment. Cannot continue.\n"),
+         ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM]);
+    return false;
+  }
 
   /*
    * See where to restore the data.
    */
-  restore_prefix = NULL;
+  char* restore_prefix = nullptr;
   if (jcr->where) {
     restore_prefix = jcr->where;
   } else {

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -46,465 +46,471 @@
 namespace directordaemon {
 
 /*
- * Fill the NDMP restore environment table with the data for the data agent to act on.
+ * Fill the NDMP restore environment table with the data for the data agent to
+ * act on.
  */
-static inline bool fill_restore_environment_ndmp_native(JobControlRecord *jcr,
-                                            int32_t current_fi,
-                                            struct ndm_job_param *job)
+static inline bool fill_restore_environment_ndmp_native(
+    JobControlRecord* jcr,
+    int32_t current_fi,
+    struct ndm_job_param* job)
 {
-   ndmp9_pval pv;
-   char *ndmp_filesystem,
-        *restore_prefix;
-   PoolMem tape_device;
-   PoolMem destination_path;
-   ndmp_backup_format_option *nbf_options;
+  ndmp9_pval pv;
+  char *ndmp_filesystem, *restore_prefix;
+  PoolMem tape_device;
+  PoolMem destination_path;
+  ndmp_backup_format_option* nbf_options;
 
-   ndmp_filesystem = NULL;
+  ndmp_filesystem = NULL;
 
-   /*
-    * See if we know this backup format and get it options.
-    */
-   nbf_options = ndmp_lookup_backup_format_options(job->bu_type);
+  /*
+   * See if we know this backup format and get it options.
+   */
+  nbf_options = ndmp_lookup_backup_format_options(job->bu_type);
 
 
-   /*
-    * Selected JobIds are stored in jcr->JobIds, comma separated
-    * We use the first jobid to get the environment string
-    */
+  /*
+   * Selected JobIds are stored in jcr->JobIds, comma separated
+   * We use the first jobid to get the environment string
+   */
 
-   JobId_t JobId = str_to_int32(jcr->JobIds);
-   // TODO: Check if JobId is Zero as this indicates error
+  JobId_t JobId = str_to_int32(jcr->JobIds);
+  // TODO: Check if JobId is Zero as this indicates error
 
-   if (jcr->db->GetNdmpEnvironmentString(jcr, JobId,
-                           NdmpEnvHandler, &job->env_tab)) {
-      /*
-       * extract ndmp_filesystem from environment
-       */
-      for (struct ndm_env_entry *entry = job->env_tab.head; entry; entry = entry->next) {
-         if (bstrcmp(entry->pval.name,ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
-            ndmp_filesystem = entry->pval.value;
-            break;
-         }
+  if (jcr->db->GetNdmpEnvironmentString(jcr, JobId, NdmpEnvHandler,
+                                        &job->env_tab)) {
+    /*
+     * extract ndmp_filesystem from environment
+     */
+    for (struct ndm_env_entry* entry = job->env_tab.head; entry;
+         entry = entry->next) {
+      if (bstrcmp(entry->pval.name,
+                  ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM])) {
+        ndmp_filesystem = entry->pval.value;
+        break;
       }
-   } else {
-      /*
-       * Fallback code try to build a environment stack that is good enough to
-       * restore this NDMP backup. This is used when the data is not available in
-       * the database when its either expired or when an old NDMP backup is restored
-       * where the whole environment was not saved.
-       */
+    }
+  } else {
+    /*
+     * Fallback code try to build a environment stack that is good enough to
+     * restore this NDMP backup. This is used when the data is not available in
+     * the database when its either expired or when an old NDMP backup is
+     * restored where the whole environment was not saved.
+     */
 
-      if (!nbf_options || nbf_options->uses_file_history) {
-         /*
-          * We asked during the NDMP backup to receive file history info.
-          */
-         pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
-         pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
-         ndma_store_env_list(&job->env_tab, &pv);
-      }
-
+    if (!nbf_options || nbf_options->uses_file_history) {
       /*
-       * Tell the data agent what type of restore stream to expect.
+       * We asked during the NDMP backup to receive file history info.
        */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
-      pv.value = job->bu_type;
+      pv.name = ndmp_env_keywords[NDMP_ENV_KW_HIST];
+      pv.value = ndmp_env_values[NDMP_ENV_VALUE_YES];
       ndma_store_env_list(&job->env_tab, &pv);
+    }
 
-      /*
-       * Tell the data engine what was backuped.
-       */
-      pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
-      pv.value = ndmp_filesystem;
-      ndma_store_env_list(&job->env_tab, &pv);
-   }
+    /*
+     * Tell the data agent what type of restore stream to expect.
+     */
+    pv.name = ndmp_env_keywords[NDMP_ENV_KW_TYPE];
+    pv.value = job->bu_type;
+    ndma_store_env_list(&job->env_tab, &pv);
+
+    /*
+     * Tell the data engine what was backuped.
+     */
+    pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
+    pv.value = ndmp_filesystem;
+    ndma_store_env_list(&job->env_tab, &pv);
+  }
 
 
-   /*
-    * See where to restore the data.
-    */
-   restore_prefix = NULL;
-   if (jcr->where) {
-      restore_prefix = jcr->where;
-   } else {
-      restore_prefix = jcr->res.job->RestoreWhere;
-   }
+  /*
+   * See where to restore the data.
+   */
+  restore_prefix = NULL;
+  if (jcr->where) {
+    restore_prefix = jcr->where;
+  } else {
+    restore_prefix = jcr->res.job->RestoreWhere;
+  }
 
-   if (!restore_prefix) {
-      return false;
-   }
+  if (!restore_prefix) { return false; }
 
-   /*
-    * Tell the data engine where to restore.
-    */
-   if (nbf_options && nbf_options->restore_prefix_relative) {
-      switch (*restore_prefix) {
+  /*
+   * Tell the data engine where to restore.
+   */
+  if (nbf_options && nbf_options->restore_prefix_relative) {
+    switch (*restore_prefix) {
       case '^':
-         /*
-          * Use the restore_prefix as an absolute restore prefix.
-          * We skip the leading ^ that is the trigger for absolute restores.
-          */
-         PmStrcpy(destination_path, restore_prefix + 1);
-         break;
+        /*
+         * Use the restore_prefix as an absolute restore prefix.
+         * We skip the leading ^ that is the trigger for absolute restores.
+         */
+        PmStrcpy(destination_path, restore_prefix + 1);
+        break;
       default:
-         /*
-          * Use the restore_prefix as an relative restore prefix.
-          */
-         if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
-            PmStrcpy(destination_path, ndmp_filesystem);
-         } else {
-            PmStrcpy(destination_path, ndmp_filesystem);
-            PmStrcat(destination_path, restore_prefix);
-         }
-      }
-   } else {
-      if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
-         /*
-          * Use the original pathname as restore prefix.
-          */
-         PmStrcpy(destination_path, ndmp_filesystem);
-      } else {
-         /*
-          * Use the restore_prefix as an absolute restore prefix.
-          */
-         PmStrcpy(destination_path, restore_prefix);
-      }
-   }
+        /*
+         * Use the restore_prefix as an relative restore prefix.
+         */
+        if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
+          PmStrcpy(destination_path, ndmp_filesystem);
+        } else {
+          PmStrcpy(destination_path, ndmp_filesystem);
+          PmStrcat(destination_path, restore_prefix);
+        }
+    }
+  } else {
+    if (strlen(restore_prefix) == 1 && *restore_prefix == '/') {
+      /*
+       * Use the original pathname as restore prefix.
+       */
+      PmStrcpy(destination_path, ndmp_filesystem);
+    } else {
+      /*
+       * Use the restore_prefix as an absolute restore prefix.
+       */
+      PmStrcpy(destination_path, restore_prefix);
+    }
+  }
 
-   pv.name = ndmp_env_keywords[NDMP_ENV_KW_PREFIX];
-   pv.value = ndmp_filesystem;
-   ndma_store_env_list(&job->env_tab, &pv);
+  pv.name = ndmp_env_keywords[NDMP_ENV_KW_PREFIX];
+  pv.value = ndmp_filesystem;
+  ndma_store_env_list(&job->env_tab, &pv);
 
-   if (ndmp_filesystem &&
-         SetFilesToRestoreNdmpNative(jcr, job, current_fi,
-            destination_path.c_str(), ndmp_filesystem) == 0) {
-            Jmsg(jcr, M_INFO, 0, _("No files selected for restore\n"));
-      return false;
-   }
-   return true;
+  if (ndmp_filesystem && SetFilesToRestoreNdmpNative(jcr, job, current_fi,
+                                                     destination_path.c_str(),
+                                                     ndmp_filesystem) == 0) {
+    Jmsg(jcr, M_INFO, 0, _("No files selected for restore\n"));
+    return false;
+  }
+  return true;
 }
 
 /*
  * See in the tree with selected files what files were selected to be restored.
  */
-int SetFilesToRestoreNdmpNative(JobControlRecord *jcr, struct ndm_job_param *job, int32_t FileIndex,
-                                       const char *restore_prefix, const char *ndmp_filesystem)
+int SetFilesToRestoreNdmpNative(JobControlRecord* jcr,
+                                struct ndm_job_param* job,
+                                int32_t FileIndex,
+                                const char* restore_prefix,
+                                const char* ndmp_filesystem)
 {
-   int len;
-   int cnt = 0;
-   TREE_NODE *node, *parent;
-   PoolMem restore_pathname, tmp;
+  int len;
+  int cnt = 0;
+  TREE_NODE *node, *parent;
+  PoolMem restore_pathname, tmp;
 
-   node = FirstTreeNode(jcr->restore_tree_root);
-   while (node) {
+  node = FirstTreeNode(jcr->restore_tree_root);
+  while (node) {
+    /*
+     * node->extract_dir  means that only the directory should be selected for
+     * extraction itself, the subdirs and subfiles are not automaticaly marked
+     * for extraction ( i.e. set node->extract)
+     *
+     * We can use this to select a directory for DDAR.
+     *
+     * If "DIRECT = Y" AND "RECURSIVE = Y" are set, directories in the namelist
+     * will be recursively extracted.
+     *
+     * Restoring a whole directory using this mechanism is much more efficient
+     * than creating an namelist entry for every single file and directory below
+     * the selected one.
+     */
+    if (node->extract_dir || node->extract) {
+      PmStrcpy(restore_pathname, node->fname);
       /*
-       * node->extract_dir  means that only the directory should be selected for extraction
-       * itself, the subdirs and subfiles are not automaticaly marked for extraction ( i.e. set node->extract)
-       *
-       * We can use this to select a directory for DDAR.
-       *
-       * If "DIRECT = Y" AND "RECURSIVE = Y" are set, directories in the namelist will be
-       * recursively extracted.
-       *
-       * Restoring a whole directory using this mechanism is much more efficient than creating
-       * an namelist entry for every single file and directory below the selected one.
+       * Walk up the parent until we hit the head of the list.
        */
-      if (node->extract_dir || node->extract) {
-         PmStrcpy(restore_pathname, node->fname);
-         /*
-          * Walk up the parent until we hit the head of the list.
-          */
-         for (parent = node->parent; parent; parent = parent->parent) {
-            PmStrcpy(tmp, restore_pathname.c_str());
-            Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
-         }
-         /*
-          * only add nodes that have valid DAR info i.e. fhinfo is not NDMP9_INVALID_U_QUAD
-          */
-         if (node->fhinfo != NDMP9_INVALID_U_QUAD) {
-            /*
-             * See if we need to strip the prefix from the filename.
-             */
-            len = 0;
-            if (ndmp_filesystem &&
-                  bstrncmp(restore_pathname.c_str(), ndmp_filesystem, strlen(ndmp_filesystem))) {
-               len = strlen(ndmp_filesystem);
-            }
-
-            Jmsg(jcr, M_INFO, 0, _("Namelist add: node:%llu, info:%llu, name:\"%s\" \n"),
-                  node->fhnode, node->fhinfo, restore_pathname.c_str());
-
-            AddToNamelist(job,  restore_pathname.c_str() + len, restore_prefix,
-                  (char *)"", (char *)"", node->fhnode, node->fhinfo);
-
-            cnt++;
-
-         } else {
-            Jmsg(jcr, M_INFO, 0, _("not added node \"%s\" to namelist because "
-                                        "of missing fhinfo: node:%llu info:%llu\n"),
-                  restore_pathname.c_str(), node->fhnode, node->fhinfo );
-         }
-
+      for (parent = node->parent; parent; parent = parent->parent) {
+        PmStrcpy(tmp, restore_pathname.c_str());
+        Mmsg(restore_pathname, "%s/%s", parent->fname, tmp.c_str());
       }
-      node = NextTreeNode(node);
-   }
-   return cnt;
+      /*
+       * only add nodes that have valid DAR info i.e. fhinfo is not
+       * NDMP9_INVALID_U_QUAD
+       */
+      if (node->fhinfo != NDMP9_INVALID_U_QUAD) {
+        /*
+         * See if we need to strip the prefix from the filename.
+         */
+        len = 0;
+        if (ndmp_filesystem &&
+            bstrncmp(restore_pathname.c_str(), ndmp_filesystem,
+                     strlen(ndmp_filesystem))) {
+          len = strlen(ndmp_filesystem);
+        }
+
+        Jmsg(jcr, M_INFO, 0,
+             _("Namelist add: node:%llu, info:%llu, name:\"%s\" \n"),
+             node->fhnode, node->fhinfo, restore_pathname.c_str());
+
+        AddToNamelist(job, restore_pathname.c_str() + len, restore_prefix,
+                      (char*)"", (char*)"", node->fhnode, node->fhinfo);
+
+        cnt++;
+
+      } else {
+        Jmsg(jcr, M_INFO, 0,
+             _("not added node \"%s\" to namelist because "
+               "of missing fhinfo: node:%llu info:%llu\n"),
+             restore_pathname.c_str(), node->fhnode, node->fhinfo);
+      }
+    }
+    node = NextTreeNode(node);
+  }
+  return cnt;
 }
 
 /**
  * Execute native NDMP restore.
  */
-static bool DoNdmpNativeRestore(JobControlRecord *jcr)
+static bool DoNdmpNativeRestore(JobControlRecord* jcr)
 {
-   NIS *nis = NULL;
-   int32_t current_fi = 0;
-   struct ndm_session ndmp_sess;
-   struct ndm_job_param ndmp_job;
-   bool session_initialized = false;
-   bool retval = false;
-   int NdmpLoglevel;
-   char mediabuf[100];
-   slot_number_t ndmp_slot;
-   StorageResource *store = NULL;
+  NIS* nis = NULL;
+  int32_t current_fi = 0;
+  struct ndm_session ndmp_sess;
+  struct ndm_job_param ndmp_job;
+  bool session_initialized = false;
+  bool retval = false;
+  int NdmpLoglevel;
+  char mediabuf[100];
+  slot_number_t ndmp_slot;
+  StorageResource* store = NULL;
 
-   store = jcr->res.read_storage;
+  store = jcr->res.read_storage;
 
-   memset(&ndmp_sess, 0, sizeof(ndmp_sess));
+  memset(&ndmp_sess, 0, sizeof(ndmp_sess));
 
-   nis = (NIS *)malloc(sizeof(NIS));
-   memset(nis, 0, sizeof(NIS));
+  nis = (NIS*)malloc(sizeof(NIS));
+  memset(nis, 0, sizeof(NIS));
 
-   NdmpLoglevel = std::max(jcr->res.client->ndmp_loglevel, me->ndmp_loglevel);
+  NdmpLoglevel = std::max(jcr->res.client->ndmp_loglevel, me->ndmp_loglevel);
 
-   if (!NdmpBuildClientAndStorageJob(jcr, store, jcr->res.client,
-            true, /* init_tape */
-            true, /* init_robot */
-            NDM_JOB_OP_EXTRACT, &ndmp_job)) {
-      goto cleanup;
-   }
-
-
-   if ( !ndmp_native_setup_robot_and_tape_for_native_backup_job(jcr, store, ndmp_job)) {
-      Jmsg(jcr, M_ERROR, 0, _("ndmp_native_setup_robot_and_tape_for_native_backup_job failed\n"));
-      goto cleanup;
-   }
+  if (!NdmpBuildClientAndStorageJob(jcr, store, jcr->res.client,
+                                    true, /* init_tape */
+                                    true, /* init_robot */
+                                    NDM_JOB_OP_EXTRACT, &ndmp_job)) {
+    goto cleanup;
+  }
 
 
-
-   /*
-    * Get media from database and put into ndmmmedia table
-    */
-
-   GetNdmmediaInfoFromDatabase(&ndmp_job.media_tab, jcr);
-
-   for (ndmmedia *media = ndmp_job.media_tab.head; media; media = media->next) {
-      ndmmedia_to_str(media, mediabuf);
-      Jmsg(jcr, M_INFO, 0, _("Media: %s\n"), mediabuf);
-   }
-
-   for (ndmmedia *media = ndmp_job.media_tab.head; media; media = media->next) {
-      Jmsg(jcr, M_INFO, 0, _("Logical slot for volume %s is %d\n"), media->label, media->slot_addr);
-      ndmp_slot = GetElementAddressByBareosSlotNumber(&store->rss->storage_mapping, slot_type_storage, media->slot_addr);
-      media->slot_addr = ndmp_slot;
-      Jmsg(jcr, M_INFO, 0, _("Physical(NDMP) slot for volume %s is %d\n"), media->label, media->slot_addr);
-      Jmsg(jcr, M_INFO, 0, _("Media Index of volume %s is %d\n"), media->label, media->index);
-   }
+  if (!ndmp_native_setup_robot_and_tape_for_native_backup_job(jcr, store,
+                                                              ndmp_job)) {
+    Jmsg(jcr, M_ERROR, 0,
+         _("ndmp_native_setup_robot_and_tape_for_native_backup_job failed\n"));
+    goto cleanup;
+  }
 
 
-   if (!NdmpValidateJob(jcr, &ndmp_job)) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmp_validate_job\n"));
-      goto cleanup_ndmp;
-   }
+  /*
+   * Get media from database and put into ndmmmedia table
+   */
 
-   /*
-    * session initialize
-    */
-   ndmp_sess.param = (struct ndm_session_param *)malloc(sizeof(struct ndm_session_param));
-   memset(ndmp_sess.param, 0, sizeof(struct ndm_session_param));
-   ndmp_sess.param->log.deliver = NdmpLoghandler;
-   ndmp_sess.param->log_level = NativeToNdmpLoglevel(NdmpLoglevel, debug_level, nis);
-   nis->jcr = jcr;
-   ndmp_sess.param->log.ctx = nis;
-   ndmp_sess.param->log_tag = bstrdup("DIR-NDMP");
+  GetNdmmediaInfoFromDatabase(&ndmp_job.media_tab, jcr);
 
-   ndmp_sess.conn_snooping = (me->ndmp_snooping) ? 1 : 0;
-   ndmp_sess.control_agent_enabled = 1;
+  for (ndmmedia* media = ndmp_job.media_tab.head; media; media = media->next) {
+    ndmmedia_to_str(media, mediabuf);
+    Jmsg(jcr, M_INFO, 0, _("Media: %s\n"), mediabuf);
+  }
 
-   ndmp_sess.dump_media_info = 1; // for debugging
-
-   jcr->setJobStatus(JS_Running);
-
-   /*
-    * Initialize the session structure.
-    */
-   if (ndma_session_initialize(&ndmp_sess)) {
-      goto cleanup_ndmp;
-   }
-   session_initialized = true;
-
-   ndmca_media_calculate_offsets(&ndmp_sess);
-
-   /*
-    * copy our prepared ndmp_job into the session
-    */
-   memcpy(&ndmp_sess.control_acb->job, &ndmp_job, sizeof(struct ndm_job_param));
+  for (ndmmedia* media = ndmp_job.media_tab.head; media; media = media->next) {
+    Jmsg(jcr, M_INFO, 0, _("Logical slot for volume %s is %d\n"), media->label,
+         media->slot_addr);
+    ndmp_slot = GetElementAddressByBareosSlotNumber(
+        &store->rss->storage_mapping, slot_type_storage, media->slot_addr);
+    media->slot_addr = ndmp_slot;
+    Jmsg(jcr, M_INFO, 0, _("Physical(NDMP) slot for volume %s is %d\n"),
+         media->label, media->slot_addr);
+    Jmsg(jcr, M_INFO, 0, _("Media Index of volume %s is %d\n"), media->label,
+         media->index);
+  }
 
 
+  if (!NdmpValidateJob(jcr, &ndmp_job)) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmp_validate_job\n"));
+    goto cleanup_ndmp;
+  }
 
-   if (!fill_restore_environment_ndmp_native(jcr,
-            current_fi,
-            &ndmp_sess.control_acb->job)) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
-      goto cleanup_ndmp;
-   }
+  /*
+   * session initialize
+   */
+  ndmp_sess.param =
+      (struct ndm_session_param*)malloc(sizeof(struct ndm_session_param));
+  memset(ndmp_sess.param, 0, sizeof(struct ndm_session_param));
+  ndmp_sess.param->log.deliver = NdmpLoghandler;
+  ndmp_sess.param->log_level =
+      NativeToNdmpLoglevel(NdmpLoglevel, debug_level, nis);
+  nis->jcr = jcr;
+  ndmp_sess.param->log.ctx = nis;
+  ndmp_sess.param->log_tag = bstrdup("DIR-NDMP");
 
-   /*
-    * Commission the session for a run.
-    */
-   if (ndma_session_commission(&ndmp_sess)) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in ndma_session_commission\n"));
-      goto cleanup_ndmp;
-   }
+  ndmp_sess.conn_snooping = (me->ndmp_snooping) ? 1 : 0;
+  ndmp_sess.control_agent_enabled = 1;
 
-   /*
-    * Setup the DMA.
-    */
-   if (ndmca_connect_control_agent(&ndmp_sess)) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_connect_control_agent\n"));
-      goto cleanup_ndmp;
-   }
+  ndmp_sess.dump_media_info = 1;  // for debugging
 
-   ndmp_sess.conn_open = 1;
-   ndmp_sess.conn_authorized = 1;
+  jcr->setJobStatus(JS_Running);
 
-   /*
-    * Let the DMA perform its magic.
-    */
-   if (ndmca_control_agent(&ndmp_sess) != 0) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_control_agent\n"));
-      goto cleanup_ndmp;
-   }
+  /*
+   * Initialize the session structure.
+   */
+  if (ndma_session_initialize(&ndmp_sess)) { goto cleanup_ndmp; }
+  session_initialized = true;
 
-   if (!unreserve_ndmp_tapedevice_for_job(store, jcr)) {
-      Jmsg(jcr, M_ERROR, 0, "could not free ndmp tape device %s from job %d",
-            ndmp_job.tape_device, jcr->JobId);
-   }
+  ndmca_media_calculate_offsets(&ndmp_sess);
 
-   /*
-    * See if there were any errors during the restore.
-    */
-   if (!ExtractPostRestoreStats(jcr, &ndmp_sess)) {
-      Jmsg(jcr, M_ERROR, 0, _("ERROR in ExtractPostRestoreStats\n"));
-      goto cleanup_ndmp;
-   }
+  /*
+   * copy our prepared ndmp_job into the session
+   */
+  memcpy(&ndmp_sess.control_acb->job, &ndmp_job, sizeof(struct ndm_job_param));
 
-   /*
-    * Reset the NDMP session states.
-    */
-   ndma_session_decommission(&ndmp_sess);
 
-   /*
-    * Cleanup the job after it has run.
-    */
-   ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
-   ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
-   ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
+  if (!fill_restore_environment_ndmp_native(jcr, current_fi,
+                                            &ndmp_sess.control_acb->job)) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in fill_restore_environment\n"));
+    goto cleanup_ndmp;
+  }
 
-   /*
-    * Destroy the session.
-    */
-   ndma_session_destroy(&ndmp_sess);
+  /*
+   * Commission the session for a run.
+   */
+  if (ndma_session_commission(&ndmp_sess)) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in ndma_session_commission\n"));
+    goto cleanup_ndmp;
+  }
 
-   /*
-    * Free the param block.
-    */
-   free(ndmp_sess.param->log_tag);
-   free(ndmp_sess.param);
-   ndmp_sess.param = NULL;
+  /*
+   * Setup the DMA.
+   */
+  if (ndmca_connect_control_agent(&ndmp_sess)) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_connect_control_agent\n"));
+    goto cleanup_ndmp;
+  }
 
-   /*
-    * Reset the initialized state so we don't try to cleanup again.
-    */
-   session_initialized = false;
+  ndmp_sess.conn_open = 1;
+  ndmp_sess.conn_authorized = 1;
 
-   /*
-    * Jump to the generic cleanup done for every Job.
-    */
-   retval = true;
-   goto cleanup;
+  /*
+   * Let the DMA perform its magic.
+   */
+  if (ndmca_control_agent(&ndmp_sess) != 0) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in ndmca_control_agent\n"));
+    goto cleanup_ndmp;
+  }
+
+  if (!unreserve_ndmp_tapedevice_for_job(store, jcr)) {
+    Jmsg(jcr, M_ERROR, 0, "could not free ndmp tape device %s from job %d",
+         ndmp_job.tape_device, jcr->JobId);
+  }
+
+  /*
+   * See if there were any errors during the restore.
+   */
+  if (!ExtractPostRestoreStats(jcr, &ndmp_sess)) {
+    Jmsg(jcr, M_ERROR, 0, _("ERROR in ExtractPostRestoreStats\n"));
+    goto cleanup_ndmp;
+  }
+
+  /*
+   * Reset the NDMP session states.
+   */
+  ndma_session_decommission(&ndmp_sess);
+
+  /*
+   * Cleanup the job after it has run.
+   */
+  ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
+  ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
+  ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
+
+  /*
+   * Destroy the session.
+   */
+  ndma_session_destroy(&ndmp_sess);
+
+  /*
+   * Free the param block.
+   */
+  free(ndmp_sess.param->log_tag);
+  free(ndmp_sess.param);
+  ndmp_sess.param = NULL;
+
+  /*
+   * Reset the initialized state so we don't try to cleanup again.
+   */
+  session_initialized = false;
+
+  /*
+   * Jump to the generic cleanup done for every Job.
+   */
+  retval = true;
+  goto cleanup;
 
 cleanup_ndmp:
-   if (!unreserve_ndmp_tapedevice_for_job(store, jcr)) {
-      Jmsg(jcr, M_ERROR, 0, "could not free ndmp tape device %s from job %d",
-            ndmp_job.tape_device, jcr->JobId);
-   }
-   /*
-    * Only need to cleanup when things are initialized.
-    */
-   if (session_initialized) {
-      ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
-      ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
-      ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
+  if (!unreserve_ndmp_tapedevice_for_job(store, jcr)) {
+    Jmsg(jcr, M_ERROR, 0, "could not free ndmp tape device %s from job %d",
+         ndmp_job.tape_device, jcr->JobId);
+  }
+  /*
+   * Only need to cleanup when things are initialized.
+   */
+  if (session_initialized) {
+    ndma_destroy_env_list(&ndmp_sess.control_acb->job.env_tab);
+    ndma_destroy_env_list(&ndmp_sess.control_acb->job.result_env_tab);
+    ndma_destroy_nlist(&ndmp_sess.control_acb->job.nlist_tab);
 
-      /*
-       * Destroy the session.
-       */
-      ndma_session_destroy(&ndmp_sess);
-   }
+    /*
+     * Destroy the session.
+     */
+    ndma_session_destroy(&ndmp_sess);
+  }
 
-   if (ndmp_sess.param) {
-      if (ndmp_sess.param->log_tag) {
-         free(ndmp_sess.param->log_tag);
-      }
-      free(ndmp_sess.param);
-   }
+  if (ndmp_sess.param) {
+    if (ndmp_sess.param->log_tag) { free(ndmp_sess.param->log_tag); }
+    free(ndmp_sess.param);
+  }
 cleanup:
-   free(nis);
+  free(nis);
 
-   FreeTree(jcr->restore_tree_root);
-   jcr->restore_tree_root = NULL;
-   return retval;
+  FreeTree(jcr->restore_tree_root);
+  jcr->restore_tree_root = NULL;
+  return retval;
 }
 
 /*
  * Run a NDMP restore session.
  */
-bool DoNdmpRestoreNdmpNative(JobControlRecord *jcr)
+bool DoNdmpRestoreNdmpNative(JobControlRecord* jcr)
 {
-   JobDbRecord rjr;                       /* restore job record */
-   int status;
+  JobDbRecord rjr; /* restore job record */
+  int status;
 
-   memset(&rjr, 0, sizeof(rjr));
-   jcr->jr.JobLevel = L_FULL;         /* Full restore */
-   if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->jr)) {
-      Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
-      goto bail_out;
-   }
-   Dmsg0(20, "Updated job start record\n");
+  memset(&rjr, 0, sizeof(rjr));
+  jcr->jr.JobLevel = L_FULL; /* Full restore */
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->jr)) {
+    Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
+    goto bail_out;
+  }
+  Dmsg0(20, "Updated job start record\n");
 
-   Dmsg1(20, "RestoreJobId=%d\n", jcr->res.job->RestoreJobId);
+  Dmsg1(20, "RestoreJobId=%d\n", jcr->res.job->RestoreJobId);
 
-   /*
-    * Validate the Job to have a NDMP client.
-    */
-   if (!NdmpValidateClient(jcr)) {
-      return false;
-   }
+  /*
+   * Validate the Job to have a NDMP client.
+   */
+  if (!NdmpValidateClient(jcr)) { return false; }
 
-   /*
-    * Print Job Start message
-    */
-   Jmsg(jcr, M_INFO, 0, _("Start Restore Job %s\n"), jcr->Job);
+  /*
+   * Print Job Start message
+   */
+  Jmsg(jcr, M_INFO, 0, _("Start Restore Job %s\n"), jcr->Job);
 
-   if (!DoNdmpNativeRestore(jcr)) {
-      goto bail_out;
-   }
+  if (!DoNdmpNativeRestore(jcr)) { goto bail_out; }
 
-   status = JS_Terminated;
-   NdmpRestoreCleanup(jcr, status);
-   return true;
+  status = JS_Terminated;
+  NdmpRestoreCleanup(jcr, status);
+  return true;
 
 bail_out:
-   return false;
+  return false;
 }
 
 } /* namespace directordaemon */

--- a/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_NATIVE.cc
@@ -73,11 +73,13 @@ static inline bool fill_restore_environment_ndmp_native(
    * We use the first jobid to get the environment string
    */
 
-  JobId_t JobId = str_to_int32(jcr->JobIds);
-  // TODO: Check if JobId is Zero as this indicates error
+  JobId_t JobId = (JobId_t)str_to_int32(jcr->JobIds);
+  if (JobId <= 0) {
+    Jmsg(jcr, M_FATAL, 0, "Impossible JobId: %d", JobId);
+    return false;
+  }
 
-  if (jcr->db->GetNdmpEnvironmentString(jcr, JobId, NdmpEnvHandler,
-                                        &job->env_tab)) {
+  if (jcr->db->GetNdmpEnvironmentString(JobId, NdmpEnvHandler, &job->env_tab)) {
     /*
      * extract ndmp_filesystem from environment
      */

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -21,25 +21,25 @@
 #ifndef BAREOS_LIB_EDIT_H_
 #define BAREOS_LIB_EDIT_H_
 
-uint64_t str_to_uint64(const char *str);
-int64_t str_to_int64(const char *str);
-#define str_to_int16(str)((int16_t)str_to_int64(str))
-#define str_to_int32(str)((int32_t)str_to_int64(str))
-char *edit_uint64_with_commas(uint64_t val, char *buf);
-char *edit_uint64_with_suffix(uint64_t val, char *buf);
-char *add_commas(char *val, char *buf);
-char *edit_uint64(uint64_t val, char *buf);
-char *edit_int64(int64_t val, char *buf);
-char *edit_int64_with_commas(int64_t val, char *buf);
-bool DurationToUtime(char *str, utime_t *value);
-bool size_to_uint64(char *str, uint64_t *value);
-bool speed_to_uint64(char *str, uint64_t *value);
-char *edit_utime(utime_t val, char *buf, int buf_len);
-char *edit_pthread(pthread_t val, char *buf, int buf_len);
-bool Is_a_number(const char *num);
-bool Is_a_number_list(const char *n);
-bool IsAnInteger(const char *n);
-bool IsNameValid(const char *name, POOLMEM *&msg);
-bool IsNameValid(const char *name);
+uint64_t str_to_uint64(const char* str);
+int64_t str_to_int64(const char* str);
+#define str_to_int16(str) ((int16_t)str_to_int64(str))
+#define str_to_int32(str) ((int32_t)str_to_int64(str))
+char* edit_uint64_with_commas(uint64_t val, char* buf);
+char* edit_uint64_with_suffix(uint64_t val, char* buf);
+char* add_commas(char* val, char* buf);
+char* edit_uint64(uint64_t val, char* buf);
+char* edit_int64(int64_t val, char* buf);
+char* edit_int64_with_commas(int64_t val, char* buf);
+bool DurationToUtime(char* str, utime_t* value);
+bool size_to_uint64(char* str, uint64_t* value);
+bool speed_to_uint64(char* str, uint64_t* value);
+char* edit_utime(utime_t val, char* buf, int buf_len);
+char* edit_pthread(pthread_t val, char* buf, int buf_len);
+bool Is_a_number(const char* num);
+bool Is_a_number_list(const char* n);
+bool IsAnInteger(const char* n);
+bool IsNameValid(const char* name, POOLMEM*& msg);
+bool IsNameValid(const char* name);
 
-#endif // BAREOS_LIB_EDIT_H_
+#endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -22,6 +22,8 @@
 #define BAREOS_LIB_EDIT_H_
 
 uint64_t str_to_uint64(const char* str);
+#define str_to_uint16(str) ((uint16_t)str_to_uint64(str))
+#define str_to_uint32(str) ((uint32_t)str_to_uint64(str))
 int64_t str_to_int64(const char* str);
 #define str_to_int16(str) ((int16_t)str_to_int64(str))
 #define str_to_int32(str) ((int32_t)str_to_int64(str))

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -1,0 +1,35 @@
+/*
+ * BAREOS® - Backup Archiving REcovery Open Sourced
+ *
+ * Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+ *
+ * This program is Free Software; you can redistribute it and/or modify
+ * it under the terms of version three of the GNU Affero General Public License
+ * as published by the Free Software Foundation and included in the file
+ * LICENSE.
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+ * details. You should have received a copy of the GNU Affero General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ *
+ */
+
+/*
+ * provides a struct to wrap a pair of VolumeSessionId and VolumeSessionTime
+ */
+
+#ifndef BAREOS_LIB_VOLUME_SESSION_INFO_H_
+#define BAREOS_LIB_VOLUME_SESSION_INFO_H_ 1
+
+struct VolumeSessionInfo {
+  uint32_t id;
+  uint32_t time;
+
+  /* explicit constructor disables default construction */
+  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
+};
+
+#endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -29,10 +29,7 @@ struct VolumeSessionInfo {
   uint32_t time;
 
   /* explicit constructor disables default construction */
-  VolumeSessionInfo(const uint32_t t_id, const uint32_t t_time)
-      : id(t_id), time(t_time)
-  {
-  }
+  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
 };
 
 #endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/lib/volume_session_info.h
+++ b/core/src/lib/volume_session_info.h
@@ -29,7 +29,10 @@ struct VolumeSessionInfo {
   uint32_t time;
 
   /* explicit constructor disables default construction */
-  VolumeSessionInfo(uint32_t t_id, uint32_t t_time) : id(t_id), time(t_time) {}
+  VolumeSessionInfo(const uint32_t t_id, const uint32_t t_time)
+      : id(t_id), time(t_time)
+  {
+  }
 };
 
 #endif /**  BAREOS_LIB_VOLUME_SESSION_INFO_H_ */

--- a/core/src/ndmp/ndmos.h
+++ b/core/src/ndmp/ndmos.h
@@ -328,9 +328,6 @@
 #define NDMOS_OPTION_ROBOT_SIMULATOR	1
 #define NDMOS_OPTION_GAP_SIMULATOR	1
 
-/* Convert IP to human readable string instead of HEX String */
-/* #define NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP 1 */
-
 /*
  * Constants
  */

--- a/core/src/ndmp/ndmp4_pp.c
+++ b/core/src/ndmp/ndmp4_pp.c
@@ -80,17 +80,13 @@ ndmp4_pp_addr (char *buf, ndmp4_addr *ma)
       for (i = 0; i < ma->ndmp4_addr_u.tcp_addr.tcp_addr_len; i++) {
          tcp = &ma->ndmp4_addr_u.tcp_addr.tcp_addr_val[i];
 
-#ifndef NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP
-         sprintf (NDMOS_API_STREND(buf), " #%d(%lx,%d",
-			i, tcp->ip_addr, tcp->port);
-#else
          char ip_addr[100];
          ip_in_host_order = ntohl(tcp->ip_addr);
          sprintf (NDMOS_API_STREND(buf), "%d(%s:%u",
                i,
                inet_ntop (AF_INET, &ip_in_host_order, ip_addr, sizeof(ip_addr)),
                tcp->port);
-#endif /* NDMOS_OPTION_PRETTYPRINT_HUMAN_READABLE_IP */
+
          for (j = 0; j < tcp->addr_env.addr_env_len; j++) {
             sprintf (NDMOS_API_STREND(buf), ",%s=%s",
                   tcp->addr_env.addr_env_val[j].name,


### PR DESCRIPTION
This is the bareos-18.2 variant of PR#160

Fixes #1056: NDMP restore on 16.2.5 and above does not fill NDMP environment correctly

Previously one overload of the function GetNdmpEnvironmentString() wanted a JobDbRecord* and expected jr->VolSessionId and jr->VolSessionTime to contain the values for the volume from which the
restore happens. These had to be filled manually before calling GetNdmlEnvironmentString() which had not been done since 16.2.5 resulting in #1056.

This patch now redesigns the API for all overloads of GetNdmpEnviromentString() to make it harder
to misuse.

We also add a new struct VolumeSessionInfo to wrap a pair of VolumeSessionId and VolumeSessionTime. These two numbers are only meaningful together, so they now have their own container.