### PR TITLE
Fix #1030: bscan does not work for migration and copy jobs

### DIFF
--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -794,8 +794,6 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
               Pmsg1(0, _("Could not update job record. ERR=%s\n"),
                     db->strerror());
             }
-            mjcr->read_dcr = NULL;
-            FreeJcr(mjcr);
           }
         }
         mr.VolFiles = rec->File;

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -146,13 +146,16 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
 
         UnserSessionLabel(label, rec);
 
-        /*
-         * set job info from first SOS label
-         */
+        if (jcr->is_JobType(JT_MIGRATE) || jcr->is_JobType(JT_COPY)) {
+          bstrncpy(jcr->Job, label->Job, sizeof(jcr->Job));
+          PmStrcpy(jcr->job_name, label->JobName);
+          PmStrcpy(jcr->client_name, label->ClientName);
+          PmStrcpy(jcr->fileset_name, label->FileSetName);
+          PmStrcpy(jcr->fileset_md5, label->FileSetMD5);
+        }
         jcr->setJobType(label->JobType);
         jcr->setJobLevel(label->JobLevel);
         Dmsg1(200, "joblevel from SOS_LABEL is now %c\n", label->JobLevel);
-        bstrncpy(jcr->Job, label->Job, sizeof(jcr->Job));
 
         if (label->VerNum >= 11) {
           jcr->sched_time = BtimeToUnix(label->write_btime);
@@ -176,15 +179,11 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
         }
       } else {
         Dmsg0(200, "Found additional SOS_LABEL, ignoring! \n");
-        retval = true;
-        goto bail_out;
       }
-
-    } else {
-      /* Other label than SOS -> skip */
-      retval = true;
-      goto bail_out;
     }
+    /* Other label than SOS -> skip */
+    retval = true;
+    goto bail_out;
   }
 
   /*

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -163,6 +163,11 @@ set(SYSTEM_TESTS
   backup-bareos-test
   backup-bareos-passive-test
   multiplied-device-test
+  virtualfull
+  virtualfull-bscan
+  backup-bscan
+  copy-bscan
+  copy-remote-bscan
 )
 
 set(BASEPORT 42001)
@@ -191,6 +196,7 @@ foreach(TEST_NAME ${SYSTEM_TESTS})
   math(EXPR dir_port "${BASEPORT} + 0")
   math(EXPR  fd_port "${BASEPORT} + 1")
   math(EXPR  sd_port "${BASEPORT} + 2")
+  math(EXPR sd2_port "${BASEPORT} + 3")
 
 
   # set(DEFAULT_DB_TYPE )

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -5,6 +5,7 @@ db_password="@db_password@"
 
 PROJECT_BINARY_DIR=@PROJECT_BINARY_DIR@
 bin=${PROJECT_BINARY_DIR}/bin
+sbin=${PROJECT_BINARY_DIR}/sbin
 
 current_test_directory=${PROJECT_BINARY_DIR}/tests/@TEST_NAME@
 
@@ -19,6 +20,7 @@ tmp=${current_test_directory}/tmp
 
 
 dumps=${current_test_directory}/dumps
+backenddir=@backenddir@
 plugindir=${PROJECT_BINARY_DIR}/plugins
 plugindirtmp=${PROJECT_BINARY_DIR}/pluginstmp
 rscripts=${PROJECT_BINARY_DIR}/scripts
@@ -39,6 +41,7 @@ export BAREOS_WORKING_DIR=${working}
 export BASEPORT=@BASEPORT@
 export BAREOS_DIRECTOR_PORT=@dir_port@
 export BAREOS_STORAGE_PORT=@sd_port@
+export BAREOS_STORAGE2_PORT=@sd2_port@
 export BAREOS_FD_PORT=@fd_port@
 export PIDDIR=@piddir@
 

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -7,25 +7,25 @@
 copy_configs()
 {
     COMPONENTS="bareos-dir bareos-sd bareos-fd bconsole tray-monitor"
-    CONFIGDIRS="BASE ${TestName} $@"
+    CONFIGDIRS="BASE ${TestName} $*"
     FOUND=""
 
     for component in $COMPONENTS; do
         # try to find a config file, store the most specific.
         FOUND=""
         for directory in $CONFIGDIRS; do
-            if [ -f ${rconfigs}/${directory}/${component}.conf ]; then
-                FOUND=${rconfigs}/${directory}/${component}.conf
+            if [ -f "${rconfigs}/${directory}/${component}.conf" ]; then
+                FOUND="${rconfigs}/${directory}/${component}.conf"
             fi
         done
         if [ "$FOUND" ]; then
-            /bin/cp ${FOUND} ${conf}
+            /bin/cp "${FOUND}" "${conf}"
         else
             # copy all config files from subdirectories,
             # start with the most generic.
             for directory in $CONFIGDIRS; do
-                if [ -d ${rconfigs}/${directory}/${component}.d ]; then
-                    /bin/cp -r ${rconfigs}/${directory}/${component}.d ${conf}
+                if [ -d "${rconfigs}/${directory}/${component}.d" ]; then
+                    /bin/cp -r "${rconfigs}/${directory}/${component}.d" "${conf}"
                 fi
             done
         fi
@@ -33,8 +33,8 @@ copy_configs()
 
     # copy certificates
     for directory in $CONFIGDIRS; do
-        if [ -d ${rconfigs}/${directory}/tls/ ]; then
-            /bin/cp -r ${rconfigs}/${directory}/tls ${conf}
+        if [ -d "${rconfigs}/${directory}/tls/" ]; then
+            /bin/cp -r "${rconfigs}/${directory}/tls" "${conf}"
         fi
     done
 }
@@ -54,7 +54,7 @@ enable_plugin()
       exit 1
    fi
 
-   if ! cp $plugindir/${PLUGIN}.* $plugindirtmp/; then
+   if ! cp $plugindir/${PLUGIN}.* "$plugindirtmp/"; then
       set_error "enable_plugin: failed to enable ${PLUGIN} plugin."
       RC=1
       exit 1
@@ -88,7 +88,7 @@ disable_plugin()
 
 check_encoding()
 {
-   ${bin}/bareos-dir -d50 -t 2>&1 | grep 'Wanted SQL_ASCII, got UTF8' >/dev/null
+   "${bin}/bareos-dir" -d50 -t 2>&1 | grep 'Wanted SQL_ASCII, got UTF8' >/dev/null
    if [ $? = 0 ]; then
        echo "Found database encoding problem, please modify the database encoding (SQL_ASCII)"
        exit 1
@@ -98,9 +98,9 @@ check_encoding()
 cleanup()
 {
     if has_tape_drive; then
-        ${rscripts}/cleanup-tape
+        "${rscripts}/cleanup-tape"
     else
-        ${rscripts}/cleanup
+        "${rscripts}/cleanup"
     fi
 }
 
@@ -124,12 +124,12 @@ setup_data()
         return 1
     fi
 
-    mkdir -p ${tmp}/data
-    (cd ${tmp}/data && tar xzf ${cwd}/$SRC)
+    mkdir -p "${tmp}/data"
+    (cd "${tmp}/data" && tar xzf "${cwd}/$SRC")
     RC=$?
 
    # if [ ! -e ${tmp}/file-list ]; then
-       echo "${tmp}/data" >${tmp}/file-list
+       echo "${tmp}/data" >"${tmp}/file-list"
    # fi
 
     return $RC
@@ -148,17 +148,17 @@ start_test()
    check_encoding
    # Turn off email
    outf="${tmp}/sed_tmp"
-   echo "s%  mail =%# mail = %g" >${outf}
-   echo "s%  operator =%# operator =%g" >>${outf}
-   if [ -f ${conf}/bareos-dir.conf ]; then
-      cp ${conf}/bareos-dir.conf ${tmp}/1
-      sed -f ${outf} ${tmp}/1 > ${conf}/bareos-dir.conf
+   echo "s%  mail =%# mail = %g" >"${outf}"
+   echo "s%  operator =%# operator =%g" >>"${outf}"
+   if [ -f "${conf}/bareos-dir.conf" ]; then
+      cp "${conf}/bareos-dir.conf" "${tmp}/1"
+      sed -f "${outf}" "${tmp}/1" > "${conf}/bareos-dir.conf"
    fi
-   STARTDATE=`date +%R:%S`
+   STARTDATE="$(date +%R:%S)"
    echo " "
    echo " "
    echo "=== $TestName: starting at $STARTDATE ==="
-   echo "=== $TestName: starting at $STARTDATE ===" >> ${working}/log
+   echo "=== $TestName: starting at $STARTDATE ===" >> "${working}/log"
    echo "="
    echo "="
    export TestName
@@ -170,20 +170,19 @@ start_test()
    rstat=0
    dstat=0
    # marker for cleanup()
-   echo "$STARTDATE" > ${working}/CLEANUPMARKER
+   echo "$STARTDATE" > "${working}/CLEANUPMARKER"
 }
 
 require_root()
 {
-MUID=`/usr/bin/id | awk -F= '{print $2}' | awk -F\( '{print $1}'`
-if [ $MUID != 0 ] ; then
-   echo " "
-   echo "You must be root to run this test."
-   echo "  ===== !!!! $TestName not run at `date +%R:%S` ==="
-   echo "  ===== !!!! $TestName not run at `date +%R:%S` !!!! ===== " >>test.out
-   echo " "
-   exit 1
-fi
+  if [ "$(id -u)" != 0 ] ; then
+    echo " "
+    echo "You must be root to run this test."
+    echo "  ===== !!!! $TestName not run at $(date +%R:%S) ==="
+    echo "  ===== !!!! $TestName not run at $(date +%R:%S) !!!! ===== " >>test.out
+    echo " "
+    exit 1
+  fi
 }
 
 has_tape_drive()
@@ -202,7 +201,7 @@ fi
 
 require_second_drive()
 {
-if test x${TAPE_DRIVE1} = x/dev/null ; then
+if [ "${TAPE_DRIVE1}" = "/dev/null" ]; then
    echo "This test $TestName has a Job $JobName which needs a second drive, but has none."
    exit 1
 fi
@@ -210,7 +209,7 @@ fi
 
 require_autochanger()
 {
-if test x${AUTOCHANGER} = x/dev/null ; then
+if [ "${AUTOCHANGER}" = "/dev/null" ]; then
    echo "This test $TestName needs an autochanger, but has none."
    exit 1
 fi
@@ -218,19 +217,18 @@ fi
 
 require_linux()
 {
-os=`uname`
-if [ $os != 'Linux' ]; then
-   echo "This test $TestName runs only on Linux"
-   exit 1
-fi
+  if [ "$(uname)" != 'Linux' ]; then
+    echo "This test $TestName runs only on Linux"
+    exit 1
+  fi
 }
 
 skip_if_no_autochanger()
 {
-if test x${AUTOCHANGER} = x/dev/null ; then
-   echo "$TestName test skipped. No autochanger."
-   exit 1
-fi
+  if [ "${AUTOCHANGER}" = "/dev/null" ]; then
+    echo "$TestName test skipped. No autochanger."
+    exit 1
+  fi
 }
 
 is_debug()
@@ -243,9 +241,9 @@ set_debug()
 {
    debug=$1
    if is_debug; then
-     out="tee"
+     out=tee
    else
-     out="output"
+     out=output
    fi
 }
 
@@ -253,7 +251,7 @@ print_debug()
 {
    echo "$*" | grep -q ERROR > /dev/null
    if test $? -eq 0; then
-     echo "$*" >> $tmp/err.log
+     echo "$*" >> "$tmp/err.log"
    fi
    if is_debug; then
      echo "$*" >&2
@@ -265,11 +263,11 @@ write_stdin_to_file()
   FILE="$1"
 
   # empty file
-  >${FILE}
+  >"${FILE}"
 
   # read stdin and write to file
   while read input; do
-    printf '%s\n' "$input" >>${FILE}
+    printf '%s\n' "$input" >>"${FILE}"
   done
 }
 
@@ -282,22 +280,22 @@ log_stdin()
     # print if debug is set
     print_debug "$input"
     # write to log file
-    printf '%s\n' "$input" >>${FILE}
+    printf '%s\n' "$input" >>"${FILE}"
   done
 }
 
 set_error()
 {
     estat=9
-    echo "ERROR: $@" >> $tmp/err.log
-    echo "ERROR: $@"
+    echo "ERROR: $*" >> "$tmp/err.log"
+    echo "ERROR: $*"
 }
 
 check_files_written()
 {
     LOG=$1
     NB=$2
-    FILES=`awk '/FD Files Written:/ { last=$4 } END { print last }' $LOG`
+    FILES="$(awk '/FD Files Written:/ { last=$4 } END { print last }' "$LOG")"
 
     if [ "$NB" != "$FILES" ]; then
         print_debug "ERROR: Expect $NB files, get $FILES"
@@ -313,8 +311,8 @@ check_linked_against()
    #
    # See if library is linked against libfastlz
    #
-   cnt=`ldd ${BIN} 2>/dev/null | grep -c ${LIB}`
-   if test ${cnt} -lt 1; then
+   cnt="$(ldd "${BIN}" 2>/dev/null | grep -c "${LIB}")"
+   if [ "${cnt}" -lt 1 ]; then
       print_debug "ERROR: ${BIN} not linked against ${LIB}."
       return 1
    fi
@@ -330,7 +328,7 @@ bls_files_verbose()
    #local JOBID=${3}
    #local FILENAME=${4}
 
-   ${bin}/bls -V "${VOLUME}" -c ${conf} -v "${STORAGE}"
+   "${bin}/bls" -V "${VOLUME}" -c "${conf}" -v "${STORAGE}"
    return $?
 }
 
@@ -367,62 +365,77 @@ get_mig_info()
     # Prev Backup JobId
     JOBID=$1
     LOG=$2
-    RET=`awk -F: "BEGIN { jobid=$JOBID } "'/Prev Backup JobId/ { cjid=$2 } /New Backup JobId/  { if (cjid == jobid) { print $2 } }' $LOG`
+    RET="$(awk -F: "BEGIN { jobid=$JOBID } "'/Prev Backup JobId/ { cjid=$2 } /New Backup JobId/  { if (cjid == jobid) { print $2 } }' "$LOG")"
 }
 
 get_duration()
 {
    LOG=$1
-   RET=`awk 'BEGIN {t["secs"]=1;t["sec"]=1;t["min"]=60;t["mins"]=60}; /Elapsed time:/ { last=$3*t[$4] } END { print last }' $LOG`
+   RET="$(awk 'BEGIN {t["secs"]=1;t["sec"]=1;t["min"]=60;t["mins"]=60}; /Elapsed time:/ { last=$3*t[$4] } END { print last }' "$LOG")"
 }
 
-check_duration()
+check_duration_gt()
 {
-   LOG=$1
-   TIME=$2
-   OP=${3-gt}
+   LOG="$1"
+   TIME="$2"
 
-   get_duration $LOG
-   if [ "$RET" -$OP "$TIME" ]; then
-       print_debug "Expect $OP than $TIME sec, get $RET"
+   get_duration "$LOG"
+   if [ "$RET" -gt "$TIME" ]; then
+       print_debug "Expect greater than $TIME sec, get $RET"
        bstat=2
    fi
 }
 
-run_bareos()
+check_duration_lt()
+{
+   LOG="$1"
+   TIME="$2"
+
+   get_duration "$LOG"
+   if [ "$RET" -lt "$TIME" ]; then
+       print_debug "Expect less than $TIME sec, get $RET"
+       bstat=2
+   fi
+}
+
+start_bareos()
 {
    debug_wait
    zstat=0
    estat=0
    if test "$debug" -eq 1 ; then
-     ${scripts}/bareos-ctl-dir start -m -d 100
-     ${scripts}/bareos-ctl-sd start -m -d 100
-     ${scripts}/bareos-ctl-fd start -m $1 -d 100
+     "${scripts}/bareos-ctl-dir" start -m -d 100
+     "${scripts}/bareos-ctl-sd" start -m -d 100
+     "${scripts}/bareos-ctl-fd" start -m "$1" -d 100
    else
-     ${scripts}/bareos start >/dev/null 2>&1
+     "${scripts}/bareos" start >/dev/null 2>&1
    fi
 
    # check daemons
-   DAEMON_STATUS_OUT=`${scripts}/bareos status`
+   DAEMON_STATUS_OUT="$("${scripts}/bareos" status)"
    DAEMON_STATUS=$?
    print_debug "$DAEMON_STATUS_OUT"
 
    if [ $DAEMON_STATUS -ne 0 ]; then
       exit 1
    fi
+}
 
+run_bareos()
+{
+   start_bareos "$@"
    run_bconsole
    return $?
 }
 
 run_bconsole()
 {
-   bconsole_file=${1:-${tmp}/bconcmds}
-   if [ -f $bconsole_file ]; then
+   bconsole_file="${1:-${tmp}/bconcmds}"
+   if [ -f "$bconsole_file" ]; then
       if test "$debug" -eq 1 ; then
-        cat $bconsole_file | ${bin}/bconsole -c ${conf}
+        "${bin}/bconsole" -c "${conf}" < "$bconsole_file"
       else
-        cat $bconsole_file | ${bin}/bconsole -c ${conf} 2>&1 >/dev/null
+        "${bin}/bconsole" -c "${conf}" < "$bconsole_file" 2>&1 >/dev/null
       fi
    fi
    return $?
@@ -431,47 +444,32 @@ run_bconsole()
 run_btape()
 {
    if test "$debug" -eq 1 ; then
-     cat ${tmp}/bconcmds | ${bin}/btape -c ${conf} tape | tee ${tmp}/log1.out
+     "${bin}/btape" -c "${conf}" tape < "${tmp}/bconcmds" | tee "${tmp}/log1.out"
    else
-     cat ${tmp}/bconcmds | ${bin}/btape -c ${conf} tape >${tmp}/log1.out 2>&1
+     "${bin}/btape" -c "${conf}" tape < "${tmp}/bconcmds" >"${tmp}/log1.out" 2>&1
    fi
 }
 
 run_bscan()
 {
    if test "$debug" -eq 1 ; then
-      ${bin}/bscan -c ${conf} $* | tee ${tmp}/log.out
+      "${sbin}/bscan" -B "$DBTYPE" -a "$backenddir" -c "${conf}" "$@" </dev/null | tee "${tmp}/bscan.out"
    else
-      ${bin}/bscan -c ${conf} $* 2>&1 >/dev/null
+      "${sbin}/bscan" -B "$DBTYPE" -a "$backenddir" -c "${conf}" "$@" </dev/null 2>&1 >"${tmp}/bscan.out"
    fi
 }
 
-bscan_libdbi()
+run_bscan_db()
 {
-   # examples for LIBDBI settings:
-   # LIBDBI="dbdriver = "dbi:postgresql"; dbaddress = 127.0.0.1; dbport = 5432"
-   # LIBDBI="dbdriver = "dbi:sqlite"; dbaddress = 127.0.0.1; dbport = 0"
-
-   B=`echo $LIBDBI | sed 's/;//' | sed 's/;//g'`
-   B_D=`echo $B | awk '{print $3}'`
-   B_t=`echo $B | awk '{print $6}'`
-   B_p=`echo $B | awk '{print $9}'`
-
-   BSCANLIBDBI="${LIBDBI:+1}"
-
-   if test "$BSCANLIBDBI" = "1" ; then
-      BSCANLIBDBI="-D $B_D -h $B_t -t $B_p"
-   else
-      BSCANLIBDBI=" "
-   fi
+  run_bscan -n "$db_name" -u "$db_user" -P "$db_password" "$@"
 }
 
 stop_bareos()
 {
    if test "$debug" -eq 1 ; then
-      ${scripts}/bareos stop
+      "${scripts}/bareos" stop
    else
-      ${scripts}/bareos stop 2>&1 >/dev/null
+      "${scripts}/bareos" stop 2>&1 >/dev/null
    fi
 }
 
@@ -496,9 +494,9 @@ change_files()
       return 1
    fi
 
-   for i in `seq 1 9`; do
-      mkdir -p ${DIR}/test$i
-      echo "testdata" >> ${DIR}/test$i/test$i.txt
+   for i in $(seq 1 9); do
+      mkdir -p "${DIR}/test$i"
+      echo "testdata" >> "${DIR}/test$i/test$i.txt"
    done
 
    return 0
@@ -509,7 +507,7 @@ get_file_size()
    FILE="$1"
    SIZE=-1
    if [ -e "$FILE" ]; then
-      SIZE=`du "$FILE" | cut -f 1`
+     SIZE="$(du "$FILE" | cut -f 1)"
    fi
    print_debug "$FILE: $SIZE bytes"
    echo "$SIZE"
@@ -517,7 +515,7 @@ get_file_size()
 
 check_for_zombie_jobs()
 {
-   ${rscripts}/check_for_zombie_jobs $*
+   "${rscripts}/check_for_zombie_jobs" "$@"
 }
 
 change_jobname()
@@ -529,36 +527,36 @@ change_jobname()
       oldname=$1
       newname=$2
    fi
-   rm -f $tmp/1 $tmp/2
-   mv ${conf}/bareos-dir.conf $tmp/1
-   echo "s%${oldname}%${newname}%g" >$tmp/2
-   sed -f $tmp/2 $tmp/1 >$conf/bareos-dir.conf
+   rm -f "$tmp/1" "$tmp/2"
+   mv "${conf}/bareos-dir.conf" "$tmp/1"
+   echo "s%${oldname}%${newname}%g" >"$tmp/2"
+   sed -f "$tmp/2" "$tmp/1" >"$conf/bareos-dir.conf"
 #  echo "Job ${oldname} changed to ${newname}"
 }
 
 check_two_logs()
 {
-   grep "^  Termination: *Backup OK" ${tmp}/log1.out 2>&1 >/dev/null
+   grep "^  Termination: *Backup OK" "${tmp}/log1.out" 2>&1 >/dev/null
    bstat=${bstat:-$?}
-   grep "^  Termination: .*Backup Error" ${tmp}/log1.out 2>&1 >/dev/null
+   grep "^  Termination: .*Backup Error" "${tmp}/log1.out" 2>&1 >/dev/null
    if test $? -eq 0; then
       bstat=2
    fi
-   grep "^  Termination: *Restore OK" ${tmp}/log2.out 2>&1 >/dev/null
+   grep "^  Termination: *Restore OK" "${tmp}/log2.out" 2>&1 >/dev/null
    rstat=${rstat:-$?}
-   grep "^  Termination: .*Restore Error" ${tmp}/log2.out 2>&1 >/dev/null
+   grep "^  Termination: .*Restore Error" "${tmp}/log2.out" 2>&1 >/dev/null
    if test $? -eq 0; then
       rstat=2
    fi
-   grep "^  Termination: *Restore OK -- warning file count mismatch" ${tmp}/log2.out 2>&1 >/dev/null
+   grep "^  Termination: *Restore OK -- warning file count mismatch" "${tmp}/log2.out" 2>&1 >/dev/null
    if test $? -eq 0; then
       rstat=3
    fi
-   grep "^  Termination: .*Verify Differences" ${tmp}/log2.out 2>&1 >/dev/null
+   grep "^  Termination: .*Verify Differences" "${tmp}/log2.out" 2>&1 >/dev/null
    if test $? -eq 0; then
       rstat=4
    fi
-   grep "Encoding error for database" ${tmp}/log1.out > /dev/null
+   grep "Encoding error for database" "${tmp}/log1.out" > /dev/null
    if test $? -eq 0; then
       print_debug "Found database encoding error"
       bstat=2
@@ -569,7 +567,7 @@ check_log()
 {
    LOG=$1
    if [ -z "$LOG" ]; then
-      LOG=${tmp}/log1.out
+      LOG="${tmp}/log1.out"
    fi
 
    if ! [ -e "$LOG" ]; then
@@ -583,7 +581,7 @@ check_log()
          -e "Encoding error for database" \
          -e "^Could not find Client" \
          -e "ERR=" \
-         $LOG
+         "$LOG"
    then
       bstat=1
    fi
@@ -592,7 +590,7 @@ check_log()
          -e "^  Termination: .*Restore Error" \
          -e "^  Termination: *Restore OK -- warning " \
          -e "^  Termination: .*Verify Differences" \
-         $LOG
+         "$LOG"
    then
       rstat=1
    fi
@@ -612,19 +610,19 @@ check_restore_diff()
    #   * ${src}
    dest=${1:-${BackupDirectory:-$src}}
 
-   $rscripts/diff.pl -s ${dest} -d ${tmp}/bareos-restores/${dest}
+   "$rscripts/diff.pl" -s "${dest}" -d "${tmp}/bareos-restores/${dest}"
    result=$?
-   OUT=`diff -ur ${dest} ${tmp}/bareos-restores/${dest}`
-   result=`expr "$result" + $?`
+   OUT="$(diff -ur "${dest}" "${tmp}/bareos-restores/${dest}")"
+   result="$(expr "$result" + $?)"
    if is_debug; then
        printf "%s\n" "$OUT"
    fi
 
-   if [ $result -ne 0 -a ${dstat:-0} -eq 0 ]; then
-      dstat=$result
+   if [ "$result" -ne 0 -a "${dstat:-0}" -eq 0 ]; then
+      dstat="$result"
    fi
 
-   return $result
+   return "$result"
 }
 
 check_restore_only_files_diff()
@@ -635,13 +633,13 @@ check_restore_only_files_diff()
    #
    differences=0
    for i in "$@"; do
-      if ! diff -ur "$i" "${tmp}/bareos-restores/$i"; then
-         differences=`expr $differences + 1`
-         dstat=1
-      fi
+     if ! diff -ur "$i" "${tmp}/bareos-restores/$i"; then
+       differences="$(expr $differences + 1)"
+       dstat=1
+     fi
    done
 
-   test $differences -eq 0
+   test "$differences" -eq 0
    return $?
 }
 
@@ -656,13 +654,13 @@ check_restore_files_diff()
    #
 
    # get list of all restored files
-   RESTORED_FILES=`find ${tmp}/bareos-restores -type f | sed "s%^${tmp}/bareos-restores%%"`
+   RESTORED_FILES="$(find "${tmp}/bareos-restores" -type f | sed "s%^${tmp}/bareos-restores%%")"
    # remove all files given as parameter from the list
    for i in "$@"; do
-      RESTORED_FILES=`printf "%s" "$RESTORED_FILES" | grep -v "$i"`
+     RESTORED_FILES="$(printf "%s" "$RESTORED_FILES" | grep -v "$i")"
    done
    if [ "$RESTORED_FILES" ]; then
-       print_debug "given files: $@"
+       print_debug "given files: $*"
        print_debug "additional restored files: $RESTORED_FILES"
        set_error "More files then given as parameter have been restored."
        return 1
@@ -674,10 +672,10 @@ check_restore_files_diff()
 check_restore_bin_diff()
 {
    if test "$debug" -eq 1 ; then
-      $rscripts/diff.pl -s ${bin} -d ${tmp}/bareos-restores${bin}
-      diff -ur ${bin} ${tmp}/bareos-restores${bin}
+      "$rscripts/diff.pl" -s "${bin}" -d "${tmp}/bareos-restores${bin}"
+      diff -ur "${bin}" "${tmp}/bareos-restores${bin}"
    else
-      diff -ur ${bin} ${tmp}/bareos-restores${bin} 2>&1 >/dev/null
+      diff -ur "${bin}" "${tmp}/bareos-restores${bin}" 2>&1 >/dev/null
    fi
    dstat=$?
 }
@@ -686,10 +684,10 @@ check_restore_bin_diff()
 check_restore_tmp_build_diff()
 {
    if test "$debug" -eq 1 ; then
-      $rscripts/diff.pl -s ${tmpsrc} -d ${tmp}/bareos-restores${tmpsrc}
-      diff -ur ${tmpsrc} ${tmp}/bareos-restores${tmpsrc}
+      "$rscripts/diff.pl" -s "${tmpsrc}" -d "${tmp}/bareos-restores${tmpsrc}"
+      diff -ur "${tmpsrc}" "${tmp}/bareos-restores${tmpsrc}"
    else
-      diff -ur ${tmpsrc} ${tmp}/bareos-restores${tmpsrc} 2>&1 >/dev/null
+      diff -ur "${tmpsrc}" "${tmp}/bareos-restores${tmpsrc}" 2>&1 >/dev/null
    fi
    dstat=$?
 }
@@ -706,16 +704,16 @@ end_test()
    # Remove exit trap (set in start_test)
    trap '' EXIT
 
-   if [ x$notracedump != xyes ]; then
+   if [ "$notracedump" != "yes" ]; then
       cat ${working}/bareos.*.traceback 2>/dev/null
-      cp -f  ${working}/bareos.*.traceback ${dumps} 2>/dev/null
+      cp -f  ${working}/bareos.*.traceback "${dumps}" 2>/dev/null
       cat ${working}/*.bactrace 2>/dev/null
-      cp -f ${working}/*.bactrace ${dumps} 2>/dev/null
+      cp -f ${working}/*.bactrace "${dumps}" 2>/dev/null
    fi
-   if [ -f $tmp/err.log ]; then
-      cat $tmp/err.log
+   if [ -f "$tmp/err.log" ]; then
+      cat "$tmp/err.log"
    fi
-   ENDDATE=`date +%R:%S`
+   ENDDATE="$(date +%R:%S)"
    if [ $estat != 0 ] ; then
       echo " "
       echo "  !!!!! $TestName failed!!! $ENDDATE !!!!! "
@@ -765,29 +763,29 @@ end_test()
 
 copy_tape_confs()
 {
-   ${rscripts}/cleanup-tape
-   ${rscripts}/copy-tape-confs
+   "${rscripts}/cleanup-tape"
+   "${rscripts}/copy-tape-confs"
 }
 
 copy_test_confs()
 {
-   ${rscripts}/cleanup
-   ${rscripts}/copy-test-confs
+   "${rscripts}/cleanup"
+   "${rscripts}/copy-test-confs"
 }
 
 disable_plugins()
 {
    for i in ${conf}/bareos-fd.conf; do
-      sed 's/Plugin/#Plugin/' $i > $tmp/1
-      cp -f $tmp/1 $i
+      sed 's/Plugin/#Plugin/' "$i" > "$tmp/1"
+      cp -f "$tmp/1" "$i"
    done
 }
 
 update_win32()
 {
-   if [ -d $cwd/build/src/win32/release32   \
-     -a -d $cwd/build/src/win32/release64 ] \
-   || [ -d $cwd/release32 -a -d $cwd/release64 ]
+   if [ -d "$cwd/build/src/win32/release32"   \
+     -a -d "$cwd/build/src/win32/release64" ] \
+   || [ -d "$cwd/release32" -a -d "$cwd/release64" ]
    then
        echo -ne "Try to upgrade the FileDaemon:\t"
        wget -qO - "$WIN32_ADDR:8091/install"
@@ -796,7 +794,7 @@ update_win32()
 
 debug_wait()
 {
-  if test "x${REGRESS_WAIT}" = "x1"; then
+  if test "${REGRESS_WAIT}" = "1"; then
      echo "Start Bareos under debugger and enter anything when ready ..."
      read a
   fi
@@ -804,32 +802,32 @@ debug_wait()
 
 init_drive()
 {
-  mt -f $1 rewind
-  mt -f $1 weof
+  mt -f "$1" rewind
+  mt -f "$1" weof
 }
 
 rewind_drive()
 {
-  mt -f $1 rewind
+  mt -f "$1" rewind
 }
 
 load_slot1()
 {
 # Get a tape from slot1
-slot=`${scripts}/$MTX ${AUTOCHANGER} loaded 0 ${TAPE_DRIVE} $DRIVE1`
+slot="$("${scripts}/$MTX" "${AUTOCHANGER}" loaded 0 "${TAPE_DRIVE}" "$DRIVE1")"
 case $slot in
  0)
-    ${scripts}/$MTX ${AUTOCHANGER} load $SLOT1 ${TAPE_DRIVE} $DRIVE1
-    slot=$SLOT1
+    "${scripts}/$MTX" "${AUTOCHANGER}" load "$SLOT1" "${TAPE_DRIVE}" "$DRIVE1"
+    slot="$SLOT1"
     ;;
- $SLOT1)
-    slot=$SLOT1
+ "$SLOT1")
+    slot="$SLOT1"
     ;;
  *)
-    rewind_drive ${TAPE_DRIVE}
-    ${scripts}/$MTX ${AUTOCHANGER} unload $slot  ${TAPE_DRIVE} $DRIVE1
-    ${scripts}/$MTX ${AUTOCHANGER} load   $SLOT1 ${TAPE_DRIVE} $DRIVE1
-    slot=$SLOT1
+    rewind_drive "${TAPE_DRIVE}"
+    "${scripts}/$MTX" "${AUTOCHANGER}" unload "$slot"  "${TAPE_DRIVE}" "$DRIVE1"
+    "${scripts}/$MTX" "${AUTOCHANGER}" load   "$SLOT1" "${TAPE_DRIVE}" "$DRIVE1"
+    slot="$SLOT1"
     ;;
 esac
 }
@@ -840,20 +838,20 @@ esac
 #
 load_other_slot()
 {
-rewind_drive ${TAPE_DRIVE}
+rewind_drive "${TAPE_DRIVE}"
 case $1 in
  0)
-    ${scripts}/${AUTOCHANGER_SCRIPT} ${AUTOCHANGER} load $SLOT1 ${TAPE_DRIVE} $DRIVE1
+    "${scripts}/${AUTOCHANGER_SCRIPT}" "${AUTOCHANGER}" load "$SLOT1" "${TAPE_DRIVE}" "$DRIVE1"
     slot=1
     ;;
  $SLOT1)
-    ${scripts}/${AUTOCHANGER_SCRIPT} ${AUTOCHANGER} unload $1 ${TAPE_DRIVE} $DRIVE1
-    ${scripts}/${AUTOCHANGER_SCRIPT} ${AUTOCHANGER} load $SLOT2 ${TAPE_DRIVE} $DRIVE1
+    "${scripts}/${AUTOCHANGER_SCRIPT}" "${AUTOCHANGER}" unload "$1" "${TAPE_DRIVE}" "$DRIVE1"
+    "${scripts}/${AUTOCHANGER_SCRIPT}" "${AUTOCHANGER}" load "$SLOT2" "${TAPE_DRIVE}" "$DRIVE1"
     slot=2
     ;;
  $SLOT2)
-    ${scripts}/${AUTOCHANGER_SCRIPT} ${AUTOCHANGER} unload $1 ${TAPE_DRIVE} $DRIVE1
-    ${scripts}/${AUTOCHANGER_SCRIPT} ${AUTOCHANGER} load $SLOT1 ${TAPE_DRIVE} $DRIVE1
+    "${scripts}/${AUTOCHANGER_SCRIPT}" "${AUTOCHANGER}" unload "$1" "${TAPE_DRIVE}" "$DRIVE1"
+    "${scripts}/${AUTOCHANGER_SCRIPT}" "${AUTOCHANGER}" load "$SLOT1" "${TAPE_DRIVE}" "$DRIVE1"
     slot=1
     ;;
  *)
@@ -871,27 +869,27 @@ else
 fi
 
 # Save current directory
-cwd=`pwd`
+cwd="$(pwd)"
 
 # Source the configuration variables
-. ${cwd}/environment
+. "${cwd}/environment"
 
-db_name=${db_name:-"regress"}
-db_user=${db_user:-"regress"}
-db_password=${db_password:-""}
-working=${working:-"$cwd/working"}
-dumps=${dumps:-"$cwd/dumps"}
-bin=${bin:-"$cwd/bin"}
-tmp=${tmp:-"$cwd/tmp"}
+db_name="${db_name:-"regress"}"
+db_user="${db_user:-"regress"}"
+db_password="${db_password:-""}"
+working="${working:-"$cwd/working"}"
+dumps="${dumps:-"$cwd/dumps"}"
+bin="${bin:-"$cwd/bin"}"
+tmp="${tmp:-"$cwd/tmp"}"
 
 # Bareos scripts
-scripts=${scripts:-"$cwd/bin"}
+scripts="${scripts:-"$cwd/bin"}"
 
 # Bareos Plugin Directory
-plugindir=${plugindir:-"$cwd/bin/plugins"}
+plugindir="${plugindir:-"$cwd/bin/plugins"}"
 # some tests (BASE) load only the plugins copied to plugindirtmp,
 # to avoid that all plugins get loaded.
-plugindirtmp=${plugindirtmp:-"$working/plugins"}
+plugindirtmp="${plugindirtmp:-"$working/plugins"}"
 
 # Bareos conf files
 conf=${conf:-"$cwd/bin"}
@@ -928,9 +926,9 @@ export tmp
 export tmpsrc
 export working
 
-export dirport=$BASEPORT
-export fdport=$(($BASEPORT + 1))
-export sdport=$(($BASEPORT + 2))
+export dirport="$BASEPORT"
+export fdport="$((BASEPORT + 1))"
+export sdport="$((BASEPORT + 2))"
 export BAREOS_DIR_PORT=$dirport
 export BAREOS_FD_PORT=$fdport
 export BAREOS_SD_PORT=$sdport
@@ -940,12 +938,12 @@ export PERL5LIB="$cwd"
 bperl="perl -Mscripts::functions"
 export bperl
 
-mkdir -p ${working}
-mkdir -p ${tmp}
-mkdir -p ${plugindirtmp}
-touch ${tmp}/dir.out ${tmp}/fd.out ${tmp}/sd.out
+mkdir -p "${working}"
+mkdir -p "${tmp}"
+mkdir -p "${plugindirtmp}"
+touch "${tmp}/dir.out" "${tmp}/fd.out" "${tmp}/sd.out"
 
-CLIENT=${HOST}-fd
+CLIENT="${HOST}-fd"
 
 AUTOCHANGER_SCRIPT=${AUTOCHANGER_SCRIPT:-mtx-changer}
 LD_LIBRARY_PATH=$bin:$LD_LIBRARY_PATH

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "/var/lib/bareos/bareos.sql" # database dump
+    File = "/usr/local/etc/bareos"                   # configuration
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude /var/lib/bareos/storage
+  # on your bareos server
+  Exclude {
+    File = /var/lib/bareos
+    File = /var/lib/bareos/storage
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude @archivedir@
+  # on your bareos server
+  Exclude {
+    File = @working_dir@
+    File = @archivedir@
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "/usr/local/sbin"
+    File=</file-list
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "Windows All Drives"
+  Enable VSS = yes
+  Include {
+    Options {
+      Signature = MD5
+      Drive Type = fixed
+      IgnoreCase = yes
+      WildFile = "[A-Z]:/pagefile.sys"
+      WildDir = "[A-Z]:/RECYCLER"
+      WildDir = "[A-Z]:/$RECYCLE.BIN"
+      WildDir = "[A-Z]:/System Volume Information"
+      Exclude = yes
+    }
+    File = /
+  }
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,21 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+  Schedule = "WeeklyCycleAfterBackup"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = "LinuxAll"
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,16 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"                     # selftest fileset                            (#13)
+  Schedule = "WeeklyCycle"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool         (#05)
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool (#08)
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool  (#11)
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,9 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r"
+  mail = @job_email@ = all, !skipped, !audit # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,11 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  operatorcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
+  operator = @job_email@ = mount                                 # (#03)
+  mail = @job_email@ = all, !skipped, !saved, !audit             # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
@@ -1,0 +1,6 @@
+Schedule {
+  Name = "WeeklyCycle"
+#  Run = Full 1st sat at 21:00                   # (#04)
+#  Run = Differential 2nd-5th sat at 21:00       # (#07)
+#  Run = Incremental mon-fri at 21:00            # (#10)
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
@@ -1,0 +1,5 @@
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Description = "This schedule does the catalog. It starts after the WeeklyCycle."
+#  Run = Full mon-fri at 21:10
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/backup-bscan/testrunner
+++ b/systemtests/tests/backup-bscan/testrunner
@@ -1,0 +1,113 @@
+#!/bin/sh
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backuped.
+# Data will be placed at "${tmp}/data/".
+setup_data
+
+start_test
+
+start_bareos
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+purge volume=TestVolume001 yes
+delete volume=TestVolume001 yes
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds"
+
+run_bscan_db -vv -s -V TestVolume001 FileStorage
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bscan exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+original_job_id=1
+new_job_id=2
+
+if ! grep -q "Created new JobId=${new_job_id} record for original JobId=${original_job_id}" "$tmp/bscan.out"; then
+  echo 'Job numbers of scanned job are not correct'
+  stop_bareos
+  exit 1
+fi
+
+num_sos=$(grep -c '^Begin Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_sos" -ne 1 ]; then
+  echo "Found $num_sos start of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+num_eos=$(grep -c '^End Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_eos" -ne 1 ]; then
+  echo "Found $eum_sos end of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+
+total_jobid_records=$(grep -cE '^JobId +: ' "$tmp/bscan.out")
+my_jobid_records=$(grep -cE "^JobId +: ${original_job_id}" "$tmp/bscan.out")
+
+if [ "$my_jobid_records" -ne 2 ]; then
+  echo "Got $my_jobid_records mentions of my jobid, expected 2"
+  stop_bareos
+  exit 1
+fi
+if [ "$my_jobid_records" -ne "$total_jobid_records" ]; then
+  echo "Volume containes excess session records:"
+  echo "Got $total_jobid_records in total, only $my_jobid_records mention my original jobid"
+  stop_bareos
+  exit 1
+fi
+
+cat <<END_OF_DATA >"$tmp/bconcmds2"
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds2"
+check_for_zombie_jobs storage=File
+
+stop_bareos
+
+check_two_logs
+check_restore_diff "${BackupDirectory}"
+end_test

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "/var/lib/bareos/bareos.sql" # database dump
+    File = "/usr/local/etc/bareos"                   # configuration
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude /var/lib/bareos/storage
+  # on your bareos server
+  Exclude {
+    File = /var/lib/bareos
+    File = /var/lib/bareos/storage
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude @archivedir@
+  # on your bareos server
+  Exclude {
+    File = @working_dir@
+    File = @archivedir@
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "/usr/local/sbin"
+    File=</file-list
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "Windows All Drives"
+  Enable VSS = yes
+  Include {
+    Options {
+      Signature = MD5
+      Drive Type = fixed
+      IgnoreCase = yes
+      WildFile = "[A-Z]:/pagefile.sys"
+      WildDir = "[A-Z]:/RECYCLER"
+      WildDir = "[A-Z]:/$RECYCLE.BIN"
+      WildDir = "[A-Z]:/System Volume Information"
+      Exclude = yes
+    }
+    File = /
+  }
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,21 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+  Schedule = "WeeklyCycleAfterBackup"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = "LinuxAll"
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/copy.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/job/copy.conf
@@ -1,0 +1,9 @@
+Job {
+  Name = "copy"
+  Type = Copy
+  Pool = Full
+  Selection Type = Volume
+  Selection Pattern = "."
+  Client = "bareos-fd"
+  Messages = Standard
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,16 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"                     # selftest fileset                            (#13)
+  Schedule = "WeeklyCycle"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool         (#05)
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool (#08)
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool  (#11)
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,9 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r"
+  mail = @job_email@ = all, !skipped, !audit # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,11 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  operatorcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
+  operator = @job_email@ = mount                                 # (#03)
+  mail = @job_email@ = all, !skipped, !saved, !audit             # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Next Pool = FullCopy
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/FullCopy.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/FullCopy.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = FullCopy
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Storage = "File2"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
@@ -1,0 +1,6 @@
+Schedule {
+  Name = "WeeklyCycle"
+#  Run = Full 1st sat at 21:00                   # (#04)
+#  Run = Differential 2nd-5th sat at 21:00       # (#07)
+#  Run = Incremental mon-fri at 21:00            # (#10)
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
@@ -1,0 +1,5 @@
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Description = "This schedule does the catalog. It starts after the WeeklyCycle."
+#  Run = Full mon-fri at 21:10
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,17 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}
+
+Storage {
+  Name = File2
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage2
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,22 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/copy-bscan/testrunner
+++ b/systemtests/tests/copy-bscan/testrunner
@@ -1,0 +1,133 @@
+#!/bin/sh
+# run a backup
+# copy it
+# purge/delete original volume
+# bscan
+# restore
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backuped.
+# Data will be placed at "${tmp}/data/".
+setup_data
+
+start_test
+
+start_bareos
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+update volume=TestVolume001 volstatus=Used
+messages
+@#
+@# do a copy
+@#
+@$out $tmp/log1.out
+label volume=TestCopyVolume001 storage=File2 pool=FullCopy
+run copy yes
+status director
+status client
+status storage=File
+wait
+messages
+purge volume=TestVolume001 yes
+delete volume=TestVolume001 yes
+purge volume=TestCopyVolume001 yes
+delete volume=TestCopyVolume001 yes
+delete job jobid=3 yes
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds"
+
+run_bscan_db -vv -d100 -s -V TestCopyVolume001 FileStorage
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bscan exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+# we set this to the *wrong* number that is currently written to the SOS
+original_job_id=3
+new_job_id=5
+
+if ! grep -q "Created new JobId=${new_job_id} record for original JobId=${original_job_id}" "$tmp/bscan.out"; then
+  echo 'Job numbers of scanned job are not correct'
+  stop_bareos
+  exit 1
+fi
+
+num_sos=$(grep -c '^Begin Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_sos" -ne 1 ]; then
+  echo "Found $num_sos start of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+num_eos=$(grep -c '^End Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_eos" -ne 1 ]; then
+  echo "Found $eum_sos end of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+
+total_jobid_records=$(grep -cE '^JobId +: ' "$tmp/bscan.out")
+my_jobid_records=$(grep -cE "^JobId +: ${original_job_id}" "$tmp/bscan.out")
+
+if [ "$my_jobid_records" -ne 2 ]; then
+  echo "Got $my_jobid_records mentions of my jobid, expected 2"
+  stop_bareos
+  exit 1
+fi
+if [ "$my_jobid_records" -ne "$total_jobid_records" ]; then
+  echo "Volume containes excess session records:"
+  echo "Got $total_jobid_records in total, only $my_jobid_records mention my original jobid"
+  stop_bareos
+  exit 1
+fi
+
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds2"
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+                                                                                
+run_bconsole "$tmp/bconcmds2"
+
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+check_restore_diff "${BackupDirectory}"
+end_test

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,22 @@
+Device {
+  Name = RemoteFileStorage
+  Media Type = File
+  Archive Device = @archivedir@-remote
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+Device {
+  Name = RemoteFileStorage2
+  Media Type = File
+  Archive Device = @archivedir@2-remote
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd-remote
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd2_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "/var/lib/bareos/bareos.sql" # database dump
+    File = "/usr/local/etc/bareos"                   # configuration
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude /var/lib/bareos/storage
+  # on your bareos server
+  Exclude {
+    File = /var/lib/bareos
+    File = /var/lib/bareos/storage
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude @archivedir@
+  # on your bareos server
+  Exclude {
+    File = @working_dir@
+    File = @archivedir@
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "/usr/local/sbin"
+    File=</file-list
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "Windows All Drives"
+  Enable VSS = yes
+  Include {
+    Options {
+      Signature = MD5
+      Drive Type = fixed
+      IgnoreCase = yes
+      WildFile = "[A-Z]:/pagefile.sys"
+      WildDir = "[A-Z]:/RECYCLER"
+      WildDir = "[A-Z]:/$RECYCLE.BIN"
+      WildDir = "[A-Z]:/System Volume Information"
+      Exclude = yes
+    }
+    File = /
+  }
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,21 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+  Schedule = "WeeklyCycleAfterBackup"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = "LinuxAll"
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/copy.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/job/copy.conf
@@ -1,0 +1,9 @@
+Job {
+  Name = "copy"
+  Type = Copy
+  Pool = Full
+  Selection Type = Volume
+  Selection Pattern = "."
+  Client = "bareos-fd"
+  Messages = Standard
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,16 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"                     # selftest fileset                            (#13)
+  Schedule = "WeeklyCycle"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool         (#05)
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool (#08)
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool  (#11)
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,9 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r"
+  mail = @job_email@ = all, !skipped, !audit # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,11 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  operatorcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
+  operator = @job_email@ = mount                                 # (#03)
+  mail = @job_email@ = all, !skipped, !saved, !audit             # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,9 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Next Pool = FullCopy
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/FullCopy.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/FullCopy.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = FullCopy
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Storage = "RemoteFile"
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,9 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
@@ -1,0 +1,6 @@
+Schedule {
+  Name = "WeeklyCycle"
+#  Run = Full 1st sat at 21:00                   # (#04)
+#  Run = Differential 2nd-5th sat at 21:00       # (#07)
+#  Run = Incremental mon-fri at 21:00            # (#10)
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
@@ -1,0 +1,5 @@
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Description = "This schedule does the catalog. It starts after the WeeklyCycle."
+#  Run = Full mon-fri at 21:10
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,17 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}
+
+Storage {
+  Name = File2
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage2
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/storage/RemoteFile.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/storage/RemoteFile.conf.in
@@ -1,0 +1,17 @@
+Storage {
+  Name = RemoteFile
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = RemoteFileStorage
+  Media Type = File
+  SD Port = @sd2_port@
+}
+
+Storage {
+  Name = RemoteFile2
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = RemoteFileStorage2
+  Media Type = File
+  SD Port = @sd2_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,22 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/copy-remote-bscan/testrunner
+++ b/systemtests/tests/copy-remote-bscan/testrunner
@@ -1,0 +1,149 @@
+#!/bin/sh
+# run a backup
+# copy it
+# purge/delete original volume
+# bscan
+# restore
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+mkdir -p "${archivedir}-remote"
+find "${archivedir}-remote" -mindepth 1 -delete
+
+bareos_ctl_sd2() {
+  BAREOS_CONFIG_DIR="${BAREOS_CONFIG_DIR}-remote" BAREOS_SD_PORT=${BAREOS_STORAGE2_PORT} "${scripts}/bareos-ctl-sd" "$@"
+}
+
+my_stop_bareos() {
+  stop_bareos
+  bareos_ctl_sd2 stop
+}
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backuped.
+# Data will be placed at "${tmp}/data/".
+setup_data
+
+start_test
+
+start_bareos
+bareos_ctl_sd2 start
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+update volume=TestVolume001 volstatus=Used
+messages
+@#
+@# do a copy
+@#
+@$out $tmp/log1.out
+label volume=TestCopyVolume001 storage=RemoteFile pool=FullCopy
+run copy yes
+status director
+status client
+status storage=File
+wait
+messages
+purge volume=TestVolume001 yes
+delete volume=TestVolume001 yes
+purge volume=TestCopyVolume001 yes
+delete volume=TestCopyVolume001 yes
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds"
+
+oldconf="${conf}"
+conf="${conf}-remote"
+run_bscan_db -vv -d100 -s -V TestCopyVolume001 RemoteFileStorage
+ret=$?
+conf="${oldconf}"
+
+if [ $ret -ne 0 ]; then
+  echo "bscan exit code: $ret"
+  my_stop_bareos
+  exit $ret
+fi
+
+# we set this to the *wrong* number that is currently written to the SOS
+original_job_id=4
+new_job_id=5
+
+if ! grep -q "Created new JobId=${new_job_id} record for original JobId=${original_job_id}" "$tmp/bscan.out"; then
+  echo 'Job numbers of scanned job are not correct'
+  my_stop_bareos
+  exit 1
+fi
+
+num_sos=$(grep -c '^Begin Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_sos" -ne 1 ]; then
+  echo "Found $num_sos start of session records instead of 1"
+  my_stop_bareos
+  exit 1
+fi
+num_eos=$(grep -c '^End Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_eos" -ne 1 ]; then
+  echo "Found $eum_sos end of session records instead of 1"
+  my_stop_bareos
+  exit 1
+fi
+
+total_jobid_records=$(grep -cE '^JobId +: ' "$tmp/bscan.out")
+my_jobid_records=$(grep -cE "^JobId +: ${original_job_id}" "$tmp/bscan.out")
+
+if [ "$my_jobid_records" -ne 2 ]; then
+  echo "Got $my_jobid_records mentions of my jobid, expected 2"
+  my_stop_bareos
+  exit 1
+fi
+if [ "$my_jobid_records" -ne "$total_jobid_records" ]; then
+  echo "Volume containes excess session records:"
+  echo "Got $total_jobid_records in total, only $my_jobid_records mention my original jobid"
+  my_stop_bareos
+  exit 1
+fi
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds2"
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+                                                                                
+run_bconsole "$tmp/bconcmds2"
+
+check_for_zombie_jobs storage=File
+
+my_stop_bareos
+
+check_two_logs
+check_restore_diff "${BackupDirectory}"
+end_test

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "/var/lib/bareos/bareos.sql" # database dump
+    File = "/usr/local/etc/bareos"                   # configuration
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude /var/lib/bareos/storage
+  # on your bareos server
+  Exclude {
+    File = /var/lib/bareos
+    File = /var/lib/bareos/storage
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude @archivedir@
+  # on your bareos server
+  Exclude {
+    File = @working_dir@
+    File = @archivedir@
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "/usr/local/sbin"
+    File=</file-list
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "Windows All Drives"
+  Enable VSS = yes
+  Include {
+    Options {
+      Signature = MD5
+      Drive Type = fixed
+      IgnoreCase = yes
+      WildFile = "[A-Z]:/pagefile.sys"
+      WildDir = "[A-Z]:/RECYCLER"
+      WildDir = "[A-Z]:/$RECYCLE.BIN"
+      WildDir = "[A-Z]:/System Volume Information"
+      Exclude = yes
+    }
+    File = /
+  }
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,21 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+  Schedule = "WeeklyCycleAfterBackup"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = "LinuxAll"
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,6 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  Accurate = yes
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,16 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"                     # selftest fileset                            (#13)
+  Schedule = "WeeklyCycle"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool         (#05)
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool (#08)
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool  (#11)
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,9 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r"
+  mail = @job_email@ = all, !skipped, !audit # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,11 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  operatorcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
+  operator = @job_email@ = mount                                 # (#03)
+  mail = @job_email@ = all, !skipped, !saved, !audit             # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Next Pool = VirtualFull
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+  Next Pool = VirtualFull
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/VirtualFull.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/pool/VirtualFull.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = VirtualFull
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Storage = "File2"
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
@@ -1,0 +1,6 @@
+Schedule {
+  Name = "WeeklyCycle"
+#  Run = Full 1st sat at 21:00                   # (#04)
+#  Run = Differential 2nd-5th sat at 21:00       # (#07)
+#  Run = Incremental mon-fri at 21:00            # (#10)
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
@@ -1,0 +1,5 @@
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Description = "This schedule does the catalog. It starts after the WeeklyCycle."
+#  Run = Full mon-fri at 21:10
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,17 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}
+
+Storage {
+  Name = File2
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage2
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,22 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/virtualfull-bscan/testrunner
+++ b/systemtests/tests/virtualfull-bscan/testrunner
@@ -1,0 +1,134 @@
+#!/bin/sh
+# run a backup
+# run a incr backup
+# run a virtual full
+# purge all volumes
+# bscan virtual full
+# restore
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backuped.
+# Data will be placed at "${tmp}/data/".
+setup_data
+
+start_test
+
+start_bareos
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+label volume=TestVolume002 storage=File pool=Incremental
+label volume=TestVolume003 storage=File pool=VirtualFull
+run job=$JobName level=Full yes
+wait
+messages
+list jobs
+@exec "sh -c 'touch ${tmp}/data/*.c'"
+run job=$JobName level=Incremental yes
+wait
+messages
+list jobs
+run job=$JobName level=VirtualFull yes
+wait
+messages
+list jobs
+@# make sure we really restore the virtualfull
+purge volume=TestVolume001 yes
+delete volume=TestVolume001 yes
+purge volume=TestVolume002 yes
+delete volume=TestVolume002 yes
+purge volume=TestVolume003 yes
+delete volume=TestVolume003 yes
+status director
+status client
+status storage=File
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds"
+
+run_bscan_db -vv -d100 -s -V TestVolume003 FileStorage
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bscan exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+original_job_id=3
+new_job_id=4
+
+if ! grep -q "Created new JobId=${new_job_id} record for original JobId=${original_job_id}" "$tmp/bscan.out"; then
+  echo 'Job numbers of scanned job are not correct'
+  stop_bareos
+  exit 1
+fi
+
+num_sos=$(grep -c '^Begin Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_sos" -ne 1 ]; then
+  echo "Found $num_sos start of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+num_eos=$(grep -c '^End Job Session Record:$' "$tmp/bscan.out")
+if [ "$num_eos" -ne 1 ]; then
+  echo "Found $eum_sos end of session records instead of 1"
+  stop_bareos
+  exit 1
+fi
+
+total_jobid_records=$(grep -cE '^JobId +: ' "$tmp/bscan.out")
+my_jobid_records=$(grep -cE "^JobId +: ${original_job_id}" "$tmp/bscan.out")
+
+if [ "$my_jobid_records" -ne 2 ]; then
+  echo "Got $my_jobid_records mentions of my jobid, expected 2"
+  stop_bareos
+  exit 1
+fi
+if [ "$my_jobid_records" -ne "$total_jobid_records" ]; then
+  echo "Volume containes excess session records:"
+  echo "Got $total_jobid_records in total, only $my_jobid_records mention my original jobid"
+  stop_bareos
+  exit 1
+fi
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds2"
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+                                                                                
+run_bconsole "$tmp/bconcmds2"
+
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+check_restore_diff "${BackupDirectory}"
+end_test

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Catalog.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Catalog.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "/var/lib/bareos/bareos.sql" # database dump
+    File = "/usr/local/etc/bareos"                   # configuration
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude /var/lib/bareos/storage
+  # on your bareos server
+  Exclude {
+    File = /var/lib/bareos
+    File = /var/lib/bareos/storage
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -1,0 +1,31 @@
+FileSet {
+  Name = "LinuxAll"
+  Description = "Backup all regular filesystems, determined by filesystem type."
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+      One FS = No     # change into other filessytems
+      FS Type = btrfs
+      FS Type = ext2  # filesystems of given types will be backed up
+      FS Type = ext3  # others will be ignored
+      FS Type = ext4
+      FS Type = reiserfs
+      FS Type = jfs
+      FS Type = xfs
+      FS Type = zfs
+    }
+    File = /
+  }
+  # Things that usually have to be excluded
+  # You have to exclude @archivedir@
+  # on your bareos server
+  Exclude {
+    File = @working_dir@
+    File = @archivedir@
+    File = /proc
+    File = /tmp
+    File = /var/tmp
+    File = /.journal
+    File = /.fsck
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/SelfTest.conf
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "/usr/local/sbin"
+    File=</file-list
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/fileset/Windows All Drives.conf
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "Windows All Drives"
+  Enable VSS = yes
+  Include {
+    Options {
+      Signature = MD5
+      Drive Type = fixed
+      IgnoreCase = yes
+      WildFile = "[A-Z]:/pagefile.sys"
+      WildDir = "[A-Z]:/RECYCLER"
+      WildDir = "[A-Z]:/$RECYCLE.BIN"
+      WildDir = "[A-Z]:/System Volume Information"
+      Exclude = yes
+    }
+    File = /
+  }
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,21 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+  Schedule = "WeeklyCycleAfterBackup"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = "LinuxAll"
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,6 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  Accurate = yes
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,16 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"                     # selftest fileset                            (#13)
+  Schedule = "WeeklyCycle"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool         (#05)
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool (#08)
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool  (#11)
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,9 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos daemon message\" %r"
+  mail = @job_email@ = all, !skipped, !audit # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,11 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  operatorcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: Intervention needed for %j\" %r"
+  mailcommand = "@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \<%r\>\" -s \"Bareos: %t %e of %c %l\" %r"
+  operator = @job_email@ = mount                                 # (#03)
+  mail = @job_email@ = all, !skipped, !saved, !audit             # (#02)
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Next Pool = VirtualFull
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+  Next Pool = VirtualFull
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/VirtualFull.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/pool/VirtualFull.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = VirtualFull
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Storage = "File2"
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/schedule/WeeklyCycle.conf
@@ -1,0 +1,6 @@
+Schedule {
+  Name = "WeeklyCycle"
+#  Run = Full 1st sat at 21:00                   # (#04)
+#  Run = Differential 2nd-5th sat at 21:00       # (#07)
+#  Run = Incremental mon-fri at 21:00            # (#10)
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/schedule/WeeklyCycleAfterBackup.conf
@@ -1,0 +1,5 @@
+Schedule {
+  Name = "WeeklyCycleAfterBackup"
+  Description = "This schedule does the catalog. It starts after the WeeklyCycle."
+#  Run = Full mon-fri at 21:10
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,17 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}
+
+Storage {
+  Name = File2
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage2
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,22 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/virtualfull/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/virtualfull/testrunner
+++ b/systemtests/tests/virtualfull/testrunner
@@ -1,0 +1,83 @@
+#!/bin/sh
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backuped.
+# Data will be placed at "${tmp}/data/".
+setup_data
+
+start_test
+
+start_bareos
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+label volume=TestVolume002 storage=File pool=Incremental
+label volume=TestVolume003 storage=File pool=VirtualFull
+run job=$JobName level=Full yes
+wait
+messages
+list jobs
+@exec "sh -c 'touch ${tmp}/data/*.c'"
+run job=$JobName level=Incremental yes
+wait
+messages
+list jobs
+run job=$JobName level=VirtualFull yes
+wait
+messages
+list jobs
+@# make sure we really restore the virtualfull
+purge volume=TestVolume001
+delete volume=TestVolume001
+purge volume=TestVolume002
+delete volume=TestVolume002
+status director
+status client
+status storage=File
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds"
+
+cat <<END_OF_DATA >"$tmp/bconcmds2"
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+                                                                                
+run_bconsole "$tmp/bconcmds2"
+
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+check_restore_diff "${BackupDirectory}"
+end_test


### PR DESCRIPTION
Previous versions of Bareos wrote multiple SOS records to the destination volume when doing a local copy, migrate or virtualfull. This lead to multiple issues that are described in #1030.

This patch allows bscan to read such a broken volume. It also makes sure that newly written volumes don't contain multiple SOS records per job.