### PR TITLE
vss crossbuild: Eliminated an incompatible type conversion and a compiler error 

### DIFF
--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -1579,7 +1579,7 @@ static void CloseVssBackupSession(JobControlRecord* jcr)
       /*
        * Inform user about writer states
        */
-      for (int i = 0; i < (int)jcr->pVSSClient->GetWriterCount(); i++) {
+      for (size_t i = 0; i < jcr->pVSSClient->GetWriterCount(); i++) {
         int msg_type = M_INFO;
         if (jcr->pVSSClient->GetWriterState(i) < 1) {
           msg_type = M_WARNING;

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -2106,7 +2106,7 @@ static bool BackupCmd(JobControlRecord* jcr)
           /*
            * Inform user about writer states
            */
-          for (int i = 0; i < (int)jcr->pVSSClient->GetWriterCount(); i++) {
+          for (size_t i = 0; i < jcr->pVSSClient->GetWriterCount(); i++) {
             if (jcr->pVSSClient->GetWriterState(i) < 1) {
               Jmsg(jcr, M_INFO, 0, _("VSS Writer (PrepareForBackup): %s\n"),
                    jcr->pVSSClient->GetWriterInfo(i));
@@ -2510,7 +2510,7 @@ static bool RestoreCmd(JobControlRecord* jcr)
       /*
        * Inform user about writer states
        */
-      for (int i = 0; i < (int)jcr->pVSSClient->GetWriterCount(); i++) {
+      for (size_t i = 0; i < jcr->pVSSClient->GetWriterCount(); i++) {
         int msg_type = M_INFO;
 
         if (jcr->pVSSClient->GetWriterState(i) < 1) {


### PR DESCRIPTION
- in class VSSClient for GetWriterState replaced alists by a std::vector
- in lex_add(..) added nullpointer guard for filename to savely use strdup