### PR TITLE
FreeBSD: fix lmdb build on FreeBSD 12

### DIFF
--- a/core/src/lmdb/CMakeLists.txt
+++ b/core/src/lmdb/CMakeLists.txt
@@ -17,6 +17,9 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
+IF(HAVE_FREEBSD_OS)
+  add_definitions(-D_WANT_SEMUN=1)
+ENDIF()
 
 add_library(bareoslmdb SHARED mdb.c midl.c)
 


### PR DESCRIPTION
Defining -D_WANT_SEMUN=1 enables the definition of "union semun"
in sys/sem.h on FreeBSD 12.

This fixes the following compile error:

  /src/lmdb/mdb.c:4832:14: error: variable has incomplete type 'union semun'
        union semun semu;
                    ^
  /core/src/lmdb/mdb.c:4832:8: note: forward declaration of 'union semun'
        union semun semu;
              ^
1 error generated.