### PR TITLE
webui: Fix overflowing top navigation bar content

### DIFF
--- a/webui/module/Application/view/layout/layout.phtml.in
+++ b/webui/module/Application/view/layout/layout.phtml.in
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos-webui for the canonical source repository
- * @copyright Copyright (c) 2013-2016 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  * @author    Frank Bergkemper
  *
@@ -67,6 +67,46 @@ include 'version.php';
 </head>
 
 <body>
+
+<style>
+@media (max-width: 1330px) {
+    .navbar-header {
+        float: none;
+    }
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse {
+        border-top: 1px solid transparent;
+        box-shadow: inset 0 1px 0 rgba(255,255,255,0.1);
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-nav {
+        float: none!important;
+        margin: 7.5px -15px;
+    }
+    .navbar-nav>li {
+        float: none;
+    }
+    .navbar-nav>li>a {
+        padding-top: 10px;
+        padding-bottom: 10px;
+    }
+    .navbar-text {
+        float: none;
+        margin: 15px 0;
+    }
+    /* since 3.1.0 */
+    .navbar-collapse.collapse.in {
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+}
+</style>
 
 <div class="spinner" id="spinner"></div>
 


### PR DESCRIPTION
Since Bootstrap doesn't know how much space the content in a navbar needs,
it can cause issues with content wrapping into a second row.

To resolve this, we can:

1. Reduce the amount or width of navbar items.
2. Hide certain navbar items at certain screen sizes using responsive utility classes.
3. Change the point at which the navbar switches between collapsed and horizontal mode.

As we don't want to fiddle with SAAS to customize the Bootstrap @grid-float-breakpoint
variable, we simply add our own media query.

By default the collapse occurs before 768px. This patch overrides the default behaviour
with a custom media query, so the collapse happens earlier at 1330px to avoid the top
navigation bar overflowing issue.