### PR TITLE
webui: topnavbar follow up fix to commit 637095dee

### DIFF
--- a/webui/module/Application/view/layout/layout.phtml.in
+++ b/webui/module/Application/view/layout/layout.phtml.in
@@ -69,7 +69,7 @@ include 'version.php';
 <body>
 
 <style>
-@media (max-width: 1330px) {
+@media (max-width: 1480px) {
     .navbar-header {
         float: none;
     }


### PR DESCRIPTION
Unfortunately, some languages have pretty long words, so we need to adjust the previous
introduced media query a bit.

The collapse happens at 1480px now to avoid the top navigation bar overflowing issue
in any language currently available for the webui.