### PR TITLE
docs: remove references to doc.bareos.org (18.2)

### DIFF
--- a/docs/manuals/source/DeveloperGuide/messages.rst
+++ b/docs/manuals/source/DeveloperGuide/messages.rst
@@ -117,9 +117,7 @@ debug from user’s output.
     Jmsg1(jcr, M_ERROR, 0, "%s exists but is not a directory.\n", path);
     Jmsg0(NULL, M_ERROR_TERM, 0, "Failed to find config filename.\n");
 
-The `Message
-Ressource <http://doc.bareos.org/master/html/bareos-manual-main-reference.html#MessagesChapter>`__
-configuration defines how and to what destinations will be sent.
+The `Message Ressource <../Configuration/Messages.html>`__ configuration defines how and to what destinations will be sent.
 
 Special Cases
 ^^^^^^^^^^^^^

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1464,7 +1464,7 @@ Special dot (.) Commands
 
 :index:`\ <single: Console; Command; . commands>`\ 
 
-There is a list of commands that are prefixed with a period (.). These commands are intended to be used either by batch programs or graphical user interface front-ends. They are not normally used by interactive users. For details, see `Bareos Developer Guide (dot-commands) <http://doc.bareos.org/master/html/bareos-developer-guide.html#dot-commands>`_.
+There is a list of commands that are prefixed with a period (.). These commands are intended to be used either by batch programs or graphical user interface front-ends. They are not normally used by interactive users. For details, see `Bareos Developer Guide (dot-commands) <../DeveloperGuide/api.html#dot-commands>`_.
 
 .. _atcommands:
 

--- a/docs/manuals/source/index.rst
+++ b/docs/manuals/source/index.rst
@@ -3,12 +3,6 @@ Bareos Main Reference and Documentation
 
 for Bareos version |version| release |release|, created |today|
 
-Welcome to the new Bareos documentation. The documentation is being
-converted to the format that you are currently reading.
-As the conversion is automated, and there are still some things that are not
-perfectly converted, we still have the `old documentation <http://doc.bareos.org>`_ available.
-
-
 The Information regarding the newest release in the :ref:`bareos-current-releasenotes`.
 
 


### PR DESCRIPTION
This patch removes hard-coded links to doc.bareos.org.
It also removes the paragraph marking the RST documentation
a work-in-progress.