### PR TITLE
Backport URL changes for documentation

### DIFF
--- a/core/platforms/univention/AppCenter/README
+++ b/core/platforms/univention/AppCenter/README
@@ -22,7 +22,7 @@ In addition to that, you should set the login credentials for the Bareos WebUI w
 </p>
 
 <p>
-For more details, see the <a href="http://doc.bareos.org/master/html/bareos-manual-main-reference.html#sec:UniventionCorporateServer" target="_blank">Bareos documentation</a>.
+For more details, see the <a href="https://docs.bareos.org/Appendix/OperatingSystems.html#univention-corporate-server" target="_blank">Bareos documentation</a>.
 </p>
 
 <p>

--- a/core/platforms/univention/AppCenter/README_DE
+++ b/core/platforms/univention/AppCenter/README_DE
@@ -22,7 +22,7 @@ Zusätzlich sollten Sie die Anmelden-Informationen für das Bareos WebUI mit den
 </p>
 
 <p>
-Für genauere Informationen lesen sie bitte die entsprechenden Abschnitte der <a href="http://doc.bareos.org/master/html/bareos-manual-main-reference.html#sec:UniventionCorporateServer" target="_blank">Bareos Dokumentation</a>.
+Für genauere Informationen lesen sie bitte die entsprechenden Abschnitte der <a href="https://docs.bareos.org/Appendix/OperatingSystems.html#univention-corporate-server" target="_blank">Bareos Dokumentation</a>.
 </p>
 
 <p>

--- a/vmware/README.md
+++ b/vmware/README.md
@@ -11,7 +11,7 @@ and the [VMware Virtual Disk Development Kit (VDDK)](https://developercenter.vmw
 
 ### INSTALLATION
 
-Please see [Bareos VMware Plugin Documentation](http://doc.bareos.org/master/html/bareos-manual-main-reference.html#VMwarePlugin).
+Please see [Bareos VMware Plugin Documentation](https://docs.bareos.org/TasksAndConcepts/Plugins.html#vmware-plugin).
 
 ### FAQ
 


### PR DESCRIPTION
Backport doc.bareos.org/docs.bareos.org url changes from master to 18.2