### PR TITLE
Replace RestoreBootstrapRecordFileIndex implementation

### DIFF
--- a/core/src/dird/bsr.cc
+++ b/core/src/dird/bsr.cc
@@ -38,34 +38,68 @@
 #include "lib/berrno.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
+#include "include/make_unique.h"
+
+#include <algorithm>
 
 namespace directordaemon {
 
 #define UA_CMD_SIZE 1000
 
-/* Forward referenced functions */
-
-/**
- * Create new FileIndex entry for BootStrapRecord
- */
-RestoreBootstrapRecordFileIndex* new_findex()
+RestoreBootstrapRecord::RestoreBootstrapRecord(JobId_t t_JobId)
 {
-  RestoreBootstrapRecordFileIndex* fi =
-      (RestoreBootstrapRecordFileIndex*)malloc(
-          sizeof(RestoreBootstrapRecordFileIndex));
-  memset(fi, 0, sizeof(RestoreBootstrapRecordFileIndex));
-  return fi;
+  JobId = t_JobId;
+  fi = std::make_unique<RestoreBootstrapRecordFileIndex>();
 }
 
-/**
- * Free all BootStrapRecord FileIndex entries
- */
-static inline void FreeFindex(RestoreBootstrapRecordFileIndex* fi)
+RestoreBootstrapRecord::~RestoreBootstrapRecord()
 {
-  RestoreBootstrapRecordFileIndex* next;
-  for (; fi; fi = next) {
-    next = fi->next;
-    free(fi);
+  if (VolParams) { free(VolParams); }
+  if (fileregex) { free(fileregex); }
+}
+
+void RestoreBootstrapRecordFileIndex::add(int32_t findex)
+{
+  if (findex == 0) { return; /* probably a dummy directory */ }
+  fileIds_.push_back(findex);
+  sorted_ = false;
+}
+
+void RestoreBootstrapRecordFileIndex::addAll() { allFiles_ = true; }
+void RestoreBootstrapRecordFileIndex::sort()
+{
+  if (sorted_) return;
+
+  if (!std::is_sorted(fileIds_.begin(), fileIds_.end())) {
+    std::sort(fileIds_.begin(), fileIds_.end());
+  }
+  sorted_ = true;
+}
+
+std::vector<std::pair<int32_t, int32_t>>
+RestoreBootstrapRecordFileIndex::getRanges()
+{
+  if (allFiles_) {
+    return std::vector<std::pair<int32_t, int32_t>>{
+        std::make_pair(1, INT32_MAX)};
+  } else {
+    sort();
+
+    auto ranges = std::vector<std::pair<int32_t, int32_t>>{};
+    auto begin = int32_t{0};
+    auto end = int32_t{0};
+
+    for (auto fileId : fileIds_) {
+      if (begin == 0) { begin = end = fileId; }
+      if (fileId > end + 1) {
+        ranges.push_back(std::make_pair(begin, end));
+        begin = end = fileId;
+      } else {
+        end = fileId;
+      }
+    }
+    ranges.push_back(std::make_pair(begin, end));
+    return ranges;
   }
 }
 
@@ -123,26 +157,26 @@ uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
                       int32_t LastIndex,
                       PoolMem* buffer)
 {
-  int32_t findex, findex2;
   uint32_t count = 0;
 
-  while (fi) {
-    if ((fi->findex >= FirstIndex && fi->findex <= LastIndex) ||
-        (fi->findex2 >= FirstIndex && fi->findex2 <= LastIndex) ||
-        (fi->findex < FirstIndex && fi->findex2 > LastIndex)) {
-      findex = fi->findex < FirstIndex ? FirstIndex : fi->findex;
-      findex2 = fi->findex2 > LastIndex ? LastIndex : fi->findex2;
-      if (findex == findex2) {
-        PrintBsrItem(buffer, "FileIndex=%d\n", findex);
+  for (auto& range : fi->getRanges()) {
+    auto first = std::get<0>(range);
+    auto last = std::get<1>(range);
+    if ((first >= FirstIndex && first <= LastIndex) ||
+        (last >= FirstIndex && last <= LastIndex) ||
+        (first < FirstIndex && last > LastIndex)) {
+      first = std::max(first, FirstIndex);
+      last = std::min(last, LastIndex);
+
+      if (first == last) {
+        PrintBsrItem(buffer, "FileIndex=%d\n", first);
         count++;
       } else {
-        PrintBsrItem(buffer, "FileIndex=%d-%d\n", findex, findex2);
-        count += findex2 - findex + 1;
+        PrintBsrItem(buffer, "FileIndex=%d-%d\n", first, last);
+        count += last - first + 1;
       }
     }
-    fi = fi->next;
   }
-
   return count;
 }
 
@@ -154,52 +188,19 @@ static inline bool is_volume_selected(RestoreBootstrapRecordFileIndex* fi,
                                       int32_t FirstIndex,
                                       int32_t LastIndex)
 {
-  while (fi) {
-    if ((fi->findex >= FirstIndex && fi->findex <= LastIndex) ||
-        (fi->findex2 >= FirstIndex && fi->findex2 <= LastIndex) ||
-        (fi->findex < FirstIndex && fi->findex2 > LastIndex)) {
+  auto ranges = fi->getRanges();
+  for (auto range : ranges) {
+    auto first = std::get<0>(range);
+    auto last = std::get<1>(range);
+    if ((first >= FirstIndex && first <= LastIndex) ||
+        (last >= FirstIndex && last <= LastIndex) ||
+        (first < FirstIndex && last > LastIndex)) {
       return true;
     }
-    fi = fi->next;
   }
   return false;
 }
 
-/**
- * Create a new bootstrap record
- */
-RestoreBootstrapRecord* new_bsr()
-{
-  RestoreBootstrapRecord* bsr =
-      (RestoreBootstrapRecord*)malloc(sizeof(RestoreBootstrapRecord));
-
-  memset(bsr, 0, sizeof(RestoreBootstrapRecord));
-  return bsr;
-}
-
-namespace directordaemon {
-
-/**
- * Free the entire BootStrapRecord
- */
-void FreeBsr(RestoreBootstrapRecord* bsr)
-{
-  RestoreBootstrapRecord* next;
-
-  while (bsr) {
-    FreeFindex(bsr->fi);
-
-    if (bsr->VolParams) { free(bsr->VolParams); }
-
-    if (bsr->fileregex) { free(bsr->fileregex); }
-
-    next = bsr->next;
-    free(bsr);
-    bsr = next;
-  }
-}
-
-}  // namespace directordaemon
 
 /**
  * Complete the BootStrapRecord by filling in the VolumeName and
@@ -207,7 +208,7 @@ void FreeBsr(RestoreBootstrapRecord* bsr)
  */
 bool CompleteBsr(UaContext* ua, RestoreBootstrapRecord* bsr)
 {
-  for (; bsr; bsr = bsr->next) {
+  for (; bsr; bsr = bsr->next.get()) {
     JobDbRecord jr;
     jr.JobId = bsr->JobId;
     if (!ua->db->GetJobRecord(ua->jcr, &jr)) {
@@ -313,7 +314,7 @@ static void DisplayVolInfo(UaContext* ua, RestoreContext& rx, JobId_t JobId)
   PoolMem volmsg(PM_MESSAGE);
   char Device[MAX_NAME_LENGTH];
 
-  for (bsr = rx.bsr; bsr; bsr = bsr->next) {
+  for (bsr = rx.bsr.get(); bsr; bsr = bsr->next.get()) {
     if (JobId && JobId != bsr->JobId) { continue; }
 
     for (i = 0; i < bsr->VolCount; i++) {
@@ -406,7 +407,7 @@ static uint32_t write_bsr_item(RestoreBootstrapRecord* bsr,
    * VolCount is the number of JobMedia records.
    */
   for (i = 0; i < bsr->VolCount; i++) {
-    if (!is_volume_selected(bsr->fi, bsr->VolParams[i].FirstIndex,
+    if (!is_volume_selected(bsr->fi.get(), bsr->VolParams[i].FirstIndex,
                             bsr->VolParams[i].LastIndex)) {
       bsr->VolParams[i].VolumeName[0] = 0; /* zap VolumeName */
       continue;
@@ -438,10 +439,8 @@ static uint32_t write_bsr_item(RestoreBootstrapRecord* bsr,
     PrintBsrItem(buffer, "VolAddr=%s-%s\n",
                  edit_uint64(bsr->VolParams[i].StartAddr, ed1),
                  edit_uint64(bsr->VolParams[i].EndAddr, ed2));
-    //    Dmsg2(100, "bsr VolParam FI=%u LI=%u\n",
-    //          bsr->VolParams[i].FirstIndex, bsr->VolParams[i].LastIndex);
 
-    count = write_findex(bsr->fi, bsr->VolParams[i].FirstIndex,
+    count = write_findex(bsr->fi.get(), bsr->VolParams[i].FirstIndex,
                          bsr->VolParams[i].LastIndex, buffer);
     if (count) { PrintBsrItem(buffer, "Count=%u\n", count); }
 
@@ -479,14 +478,14 @@ uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, PoolMem* buffer)
   RestoreBootstrapRecord* bsr;
 
   if (*rx.JobIds == 0) {
-    for (bsr = rx.bsr; bsr; bsr = bsr->next) {
+    for (bsr = rx.bsr.get(); bsr; bsr = bsr->next.get()) {
       total_count += write_bsr_item(bsr, ua, rx, buffer, first, LastIndex);
     }
     return total_count;
   }
 
   for (p = rx.JobIds; GetNextJobidFromList(&p, &JobId) > 0;) {
-    for (bsr = rx.bsr; bsr; bsr = bsr->next) {
+    for (bsr = rx.bsr.get(); bsr; bsr = bsr->next.get()) {
       if (JobId == bsr->JobId) {
         total_count += write_bsr_item(bsr, ua, rx, buffer, first, LastIndex);
       }
@@ -508,32 +507,22 @@ void PrintBsr(UaContext* ua, RestoreContext& rx)
  * Add a FileIndex to the list of BootStrap records.
  * Here we are only dealing with JobId's and the FileIndexes
  * associated with those JobIds.
- *
- * We expect that JobId, FileIndex are sorted ascending.
  */
 void AddFindex(RestoreBootstrapRecord* bsr, uint32_t JobId, int32_t findex)
 {
   RestoreBootstrapRecord* nbsr;
-  RestoreBootstrapRecordFileIndex *fi, *lfi;
 
   if (findex == 0) { return; /* probably a dummy directory */ }
 
-  if (bsr->fi == NULL) { /* if no FI add one */
-    /*
-     * This is the first FileIndex item in the chain
-     */
-    bsr->fi = new_findex();
+  if (bsr->fi->empty()) { /* if no FI yet, jobid is not yet set */
     bsr->JobId = JobId;
-    bsr->fi->findex = findex;
-    bsr->fi->findex2 = findex;
-    return;
   }
 
   /*
    * Walk down list of bsrs until we find the JobId
    */
   if (bsr->JobId != JobId) {
-    for (nbsr = bsr->next; nbsr; nbsr = nbsr->next) {
+    for (nbsr = bsr->next.get(); nbsr; nbsr = nbsr->next.get()) {
       if (nbsr->JobId == JobId) {
         bsr = nbsr;
         break;
@@ -544,91 +533,13 @@ void AddFindex(RestoreBootstrapRecord* bsr, uint32_t JobId, int32_t findex)
       /*
        * Add new JobId at end of chain
        */
-      for (nbsr = bsr; nbsr->next; nbsr = nbsr->next) {}
-      nbsr->next = new_bsr();
-      nbsr->next->JobId = JobId;
-      nbsr->next->fi = new_findex();
-      nbsr->next->fi->findex = findex;
-      nbsr->next->fi->findex2 = findex;
-      return;
+      for (nbsr = bsr; nbsr->next.get(); nbsr = nbsr->next.get()) {}
+      nbsr->next = std::make_unique<RestoreBootstrapRecord>(JobId);
+      bsr = nbsr->next.get();
     }
   }
 
-  /*
-   * At this point, bsr points to bsr containing this JobId,
-   *  and we are sure that there is at least one fi record.
-   */
-  lfi = fi = bsr->fi;
-
-  /*
-   * Check if this findex is a duplicate.
-   */
-  if (findex >= fi->findex && findex <= fi->findex2) { return; }
-
-  /*
-   * Check if this findex is smaller than first item
-   */
-  if (findex < fi->findex) {
-    if ((findex + 1) == fi->findex) {
-      fi->findex = findex; /* extend down */
-      return;
-    }
-    fi = new_findex(); /* yes, insert before first item */
-    fi->findex = findex;
-    fi->findex2 = findex;
-    fi->next = lfi;
-    bsr->fi = fi;
-    return;
-  }
-
-  /*
-   * Walk down fi chain and find where to insert insert new FileIndex
-   */
-  while (fi) {
-    /*
-     * Check if this findex is a duplicate.
-     */
-    if (findex >= fi->findex && findex <= fi->findex2) { return; }
-
-    if (findex == (fi->findex2 + 1)) { /* extend up */
-      RestoreBootstrapRecordFileIndex* nfi;
-      fi->findex2 = findex;
-
-      /*
-       * If the following record contains one higher, merge its
-       * file index by extending it up.
-       */
-      if (fi->next && ((findex + 1) == fi->next->findex)) {
-        nfi = fi->next;
-        fi->findex2 = nfi->findex2;
-        fi->next = nfi->next;
-        free(nfi);
-      }
-      return;
-    }
-
-    if (findex < fi->findex) { /* add before */
-      if ((findex + 1) == fi->findex) {
-        fi->findex = findex;
-        return;
-      }
-      break;
-    }
-
-    lfi = fi;
-    fi = fi->next;
-  }
-
-  /*
-   * Add to last place found
-   */
-  fi = new_findex();
-  fi->findex = findex;
-  fi->findex2 = findex;
-  fi->next = lfi->next;
-  lfi->next = fi;
-
-  return;
+  bsr->fi->add(findex);
 }
 
 /**
@@ -639,24 +550,16 @@ void AddFindex(RestoreBootstrapRecord* bsr, uint32_t JobId, int32_t findex)
 void AddFindexAll(RestoreBootstrapRecord* bsr, uint32_t JobId)
 {
   RestoreBootstrapRecord* nbsr;
-  RestoreBootstrapRecordFileIndex* fi;
 
-  if (bsr->fi == NULL) { /* if no FI add one */
-    /*
-     * This is the first FileIndex item in the chain
-     */
-    bsr->fi = new_findex();
+  if (bsr->fi->empty()) { /* if no FI add one */
     bsr->JobId = JobId;
-    bsr->fi->findex = 1;
-    bsr->fi->findex2 = INT32_MAX;
-    return;
   }
 
   /*
    * Walk down list of bsrs until we find the JobId
    */
   if (bsr->JobId != JobId) {
-    for (nbsr = bsr->next; nbsr; nbsr = nbsr->next) {
+    for (nbsr = bsr->next.get(); nbsr; nbsr = nbsr->next.get()) {
       if (nbsr->JobId == JobId) {
         bsr = nbsr;
         break;
@@ -667,31 +570,19 @@ void AddFindexAll(RestoreBootstrapRecord* bsr, uint32_t JobId)
       /*
        * Add new JobId at end of chain
        */
-      for (nbsr = bsr; nbsr->next; nbsr = nbsr->next) {}
+      for (nbsr = bsr; nbsr->next.get(); nbsr = nbsr->next.get()) {}
 
-      nbsr->next = new_bsr();
-      nbsr->next->JobId = JobId;
+      nbsr->next = std::make_unique<RestoreBootstrapRecord>(JobId);
 
       /*
        * If we use regexp to restore, set it for each jobid
        */
       if (bsr->fileregex) { nbsr->next->fileregex = strdup(bsr->fileregex); }
-
-      nbsr->next->fi = new_findex();
-      nbsr->next->fi->findex = 1;
-      nbsr->next->fi->findex2 = INT32_MAX;
-      return;
+      bsr = nbsr->next.get();
     }
   }
 
-  /*
-   * At this point, bsr points to bsr containing this JobId,
-   * and we are sure that there is at least one fi record.
-   */
-  fi = bsr->fi;
-  fi->findex = 1;
-  fi->findex2 = INT32_MAX;
-  return;
+  bsr->fi->addAll();
 }
 
 /**

--- a/core/src/dird/bsr.cc
+++ b/core/src/dird/bsr.cc
@@ -157,7 +157,8 @@ uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
                       int32_t LastIndex,
                       PoolMem* buffer)
 {
-  uint32_t count = 0;
+  auto count = uint32_t{0};
+  auto bsrItems = std::string{};
 
   for (auto& range : fi->getRanges()) {
     auto first = std::get<0>(range);
@@ -169,14 +170,16 @@ uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
       last = std::min(last, LastIndex);
 
       if (first == last) {
-        PrintBsrItem(buffer, "FileIndex=%d\n", first);
+        bsrItems += "FileIndex=" + std::to_string(first) + "\n";
         count++;
       } else {
-        PrintBsrItem(buffer, "FileIndex=%d-%d\n", first, last);
+        bsrItems += "FileIndex=" + std::to_string(first) + "-" +
+                    std::to_string(last) + "\n";
         count += last - first + 1;
       }
     }
   }
+  buffer->strcat(bsrItems.c_str());
   return count;
 }
 

--- a/core/src/dird/bsr.cc
+++ b/core/src/dird/bsr.cc
@@ -121,7 +121,7 @@ static bool GetStorageDevice(char* device, char* storage)
 /**
  * Print a BootStrapRecord entry into a memory buffer.
  */
-static void PrintBsrItem(PoolMem* pool_buf, const char* fmt, ...)
+static void PrintBsrItem(std::string& buffer, const char* fmt, ...)
 {
   va_list arg_ptr;
   int len, maxlen;
@@ -139,7 +139,7 @@ static void PrintBsrItem(PoolMem* pool_buf, const char* fmt, ...)
     break;
   }
 
-  pool_buf->strcat(item.c_str());
+  buffer += item.c_str();
 }
 
 /**
@@ -155,7 +155,7 @@ static void PrintBsrItem(PoolMem* pool_buf, const char* fmt, ...)
 uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
                       int32_t FirstIndex,
                       int32_t LastIndex,
-                      PoolMem* buffer)
+                      std::string& buffer)
 {
   auto count = uint32_t{0};
   auto bsrItems = std::string{};
@@ -179,7 +179,7 @@ uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
       }
     }
   }
-  buffer->strcat(bsrItems.c_str());
+  buffer += bsrItems.c_str();
   return count;
 }
 
@@ -268,7 +268,7 @@ uint32_t WriteBsrFile(UaContext* ua, RestoreContext& rx)
   bool err;
   uint32_t count = 0;
   PoolMem fname(PM_MESSAGE);
-  PoolMem buffer(PM_MESSAGE);
+  std::string buffer;
 
   MakeUniqueRestoreFilename(ua, fname);
   fd = fopen(fname.c_str(), "w+b");
@@ -282,7 +282,7 @@ uint32_t WriteBsrFile(UaContext* ua, RestoreContext& rx)
   /*
    * Write them to a buffer.
    */
-  count = WriteBsr(ua, rx, &buffer);
+  count = WriteBsr(ua, rx, buffer);
 
   /*
    * Write the buffer to file
@@ -395,7 +395,7 @@ void DisplayBsrInfo(UaContext* ua, RestoreContext& rx)
 static uint32_t write_bsr_item(RestoreBootstrapRecord* bsr,
                                UaContext* ua,
                                RestoreContext& rx,
-                               PoolMem* buffer,
+                               std::string& buffer,
                                bool& first,
                                uint32_t& LastIndex)
 {
@@ -471,7 +471,7 @@ static uint32_t write_bsr_item(RestoreBootstrapRecord* bsr,
  * The bsrs must be written out in the order the JobIds
  * are found in the jobid list.
  */
-uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, PoolMem* buffer)
+uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, std::string& buffer)
 {
   bool first = true;
   uint32_t LastIndex = 0;
@@ -500,9 +500,9 @@ uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, PoolMem* buffer)
 
 void PrintBsr(UaContext* ua, RestoreContext& rx)
 {
-  PoolMem buffer(PM_MESSAGE);
+  std::string buffer;
 
-  WriteBsr(ua, rx, &buffer);
+  WriteBsr(ua, rx, buffer);
   fprintf(stdout, "%s", buffer.c_str());
 }
 

--- a/core/src/dird/bsr.h
+++ b/core/src/dird/bsr.h
@@ -98,7 +98,7 @@ struct bootstrap_info {
 bool CompleteBsr(UaContext* ua, RestoreBootstrapRecord* bsr);
 uint32_t WriteBsrFile(UaContext* ua, RestoreContext& rx);
 void DisplayBsrInfo(UaContext* ua, RestoreContext& rx);
-uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, PoolMem* buffer);
+uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, std::string& buffer);
 void AddFindex(RestoreBootstrapRecord* bsr, uint32_t JobId, int32_t findex);
 void AddFindexAll(RestoreBootstrapRecord* bsr, uint32_t JobId);
 RestoreBootstrapRecordFileIndex* new_findex();
@@ -112,7 +112,7 @@ void CloseBootstrapFile(bootstrap_info& info);
 uint32_t write_findex(RestoreBootstrapRecordFileIndex* fi,
                       int32_t FirstIndex,
                       int32_t LastIndex,
-                      PoolMem* buffer);
+                      std::string& buffer);
 
 } /* namespace directordaemon */
 #endif  // BAREOS_DIRD_BSR_H_

--- a/core/src/dird/bsr.h
+++ b/core/src/dird/bsr.h
@@ -47,13 +47,13 @@ class RestoreBootstrapRecordFileIndex {
   std::vector<int32_t> fileIds_;
   bool allFiles_ = false;
   bool sorted_ = false;
-  void sort();
+  void Sort();
 
  public:
-  void add(int32_t findex);
-  void addAll();
-  std::vector<std::pair<int32_t, int32_t>> getRanges();
-  bool empty() const { return !allFiles_ && fileIds_.empty(); }
+  void Add(int32_t findex);
+  void AddAll();
+  std::vector<std::pair<int32_t, int32_t>> GetRanges();
+  bool Empty() const { return !allFiles_ && fileIds_.empty(); }
 };
 
 /**
@@ -61,7 +61,7 @@ class RestoreBootstrapRecordFileIndex {
  *  The restore bsr is a chain of BootStrapRecord records (linked by next).
  *  Each BootStrapRecord represents a single JobId, and within it, it
  *    contains a linked list of file indexes for that JobId.
- *    The CompleteBsr() routine, will then add all the volumes
+ *    The AddVolumeInformationToBsr() routine, will then add all the volumes
  *    on which the Job is stored to the BootStrapRecord.
  */
 struct RestoreBootstrapRecord {
@@ -75,8 +75,8 @@ struct RestoreBootstrapRecord {
       fi;                    /**< File indexes this JobId */
   char* fileregex = nullptr; /**< Only restore files matching regex */
 
-  RestoreBootstrapRecord() : RestoreBootstrapRecord(0) {}
-  RestoreBootstrapRecord(JobId_t JobId);
+  RestoreBootstrapRecord();
+  RestoreBootstrapRecord(JobId_t t_JobId);
   virtual ~RestoreBootstrapRecord();
   RestoreBootstrapRecord(const RestoreBootstrapRecord&) = delete;
   RestoreBootstrapRecord& operator=(const RestoreBootstrapRecord&) = delete;
@@ -95,7 +95,7 @@ struct bootstrap_info {
   char storage[MAX_NAME_LENGTH + 1];
 };
 
-bool CompleteBsr(UaContext* ua, RestoreBootstrapRecord* bsr);
+bool AddVolumeInformationToBsr(UaContext* ua, RestoreBootstrapRecord* bsr);
 uint32_t WriteBsrFile(UaContext* ua, RestoreContext& rx);
 void DisplayBsrInfo(UaContext* ua, RestoreContext& rx);
 uint32_t WriteBsr(UaContext* ua, RestoreContext& rx, std::string& buffer);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1851,20 +1851,22 @@ int CreateRestoreBootstrapFile(JobControlRecord* jcr)
     files = -1;
     goto bail_out;
   }
-  rx.bsr->fi->addAll();
+  for (auto fi = 1; fi <= jcr->previous_jr.JobFiles; fi++) {
+    rx.bsr->fi->add(fi);
+  }
   jcr->ExpectedFiles = WriteBsrFile(ua, rx);
   if (jcr->ExpectedFiles == 0) {
     files = 0;
     goto bail_out;
   }
   FreeUaContext(ua);
-  rx.bsr.reset(nullptr); 
+  rx.bsr.reset(nullptr);
   jcr->needs_sd = true;
   return jcr->ExpectedFiles;
 
 bail_out:
   FreeUaContext(ua);
-  rx.bsr.reset(nullptr); 
+  rx.bsr.reset(nullptr);
   return files;
 }
 

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1847,12 +1847,12 @@ int CreateRestoreBootstrapFile(JobControlRecord* jcr)
   rx.JobIds = (char*)"";
   rx.bsr->JobId = jcr->previous_jr.JobId;
   ua = new_ua_context(jcr);
-  if (!CompleteBsr(ua, rx.bsr.get())) {
+  if (!AddVolumeInformationToBsr(ua, rx.bsr.get())) {
     files = -1;
     goto bail_out;
   }
-  for (auto fi = 1; fi <= jcr->previous_jr.JobFiles; fi++) {
-    rx.bsr->fi->add(fi);
+  for (uint32_t fi = 1; fi <= jcr->previous_jr.JobFiles; fi++) {
+    rx.bsr->fi->Add(fi);
   }
   jcr->ExpectedFiles = WriteBsrFile(ua, rx);
   if (jcr->ExpectedFiles == 0) {

--- a/core/src/dird/ua.h
+++ b/core/src/dird/ua.h
@@ -215,7 +215,7 @@ struct RestoreContext {
   char* RegexWhere = nullptr;
   char* replace = nullptr;
   char* plugin_options = nullptr;
-  RestoreBootstrapRecord* bsr = nullptr;
+  std::unique_ptr<RestoreBootstrapRecord> bsr;
   POOLMEM* fname = nullptr; /**< Filename only */
   POOLMEM* path = nullptr;  /**< Path only */
   POOLMEM* query = nullptr;

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -45,6 +45,7 @@
 #include "lib/edit.h"
 #include "lib/berrno.h"
 #include "lib/parse_conf.h"
+#include "include/make_unique.h"
 
 namespace directordaemon {
 
@@ -109,7 +110,7 @@ bool RestoreCmd(UaContext* ua, const char* cmd)
   rx.JobIds[0] = 0;
   rx.BaseJobIds = GetPoolMemory(PM_FNAME);
   rx.query = GetPoolMemory(PM_FNAME);
-  rx.bsr = new_bsr();
+  rx.bsr = std::make_unique<RestoreBootstrapRecord>();
 
   i = FindArgWithValue(ua, "comment");
   if (i >= 0) {
@@ -225,7 +226,7 @@ bool RestoreCmd(UaContext* ua, const char* cmd)
     if (rx.bsr->JobId) {
       char ed1[50];
       if (!CompleteBsr(ua,
-                       rx.bsr)) { /* find Vol, SessId, SessTime from JobIds */
+                       rx.bsr.get())) { /* find Vol, SessId, SessTime from JobIds */
         ua->ErrorMsg(_(
             "Unable to construct a valid BootStrapRecord. Cannot continue.\n"));
         goto bail_out;
@@ -360,8 +361,7 @@ static void GetAndDisplayBasejobs(UaContext* ua, RestoreContext* rx)
 
 static void free_rx(RestoreContext* rx)
 {
-  directordaemon::FreeBsr(rx->bsr);
-  rx->bsr = NULL;
+  rx->bsr.reset(nullptr);
 
   if (rx->ClientName) {
     free(rx->ClientName);
@@ -1089,7 +1089,7 @@ static void AddDeltaListFindex(RestoreContext* rx, struct delta_list* lst)
 {
   if (lst == NULL) { return; }
   if (lst->next) { AddDeltaListFindex(rx, lst->next); }
-  AddFindex(rx->bsr, lst->JobId, lst->FileIndex);
+  AddFindex(rx->bsr.get(), lst->JobId, lst->FileIndex);
 }
 
 static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
@@ -1181,7 +1181,7 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
       last_JobId = 0;
       for (p = rx->JobIds; GetNextJobidFromList(&p, &JobId) > 0;) {
         if (JobId == last_JobId) { continue; /* eliminate duplicate JobIds */ }
-        AddFindexAll(rx->bsr, JobId);
+        AddFindexAll(rx->bsr.get(), JobId);
       }
     }
   } else {
@@ -1215,7 +1215,7 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
                 node->type, node->FileIndex);
           /* TODO: optimize bsr insertion when jobid are non sorted */
           AddDeltaListFindex(rx, node->delta_list);
-          AddFindex(rx->bsr, node->JobId, node->FileIndex);
+          AddFindex(rx->bsr.get(), node->JobId, node->FileIndex);
           if (node->extract && node->type != TN_NEWDIR) {
             rx->selected_files++; /* count only saved files */
           }
@@ -1482,7 +1482,7 @@ static int JobidFileindexHandler(void* ctx, int num_fields, char** row)
 
   Dmsg2(200, "JobId=%s FileIndex=%s\n", row[0], row[1]);
   rx->JobId = str_to_int64(row[0]);
-  AddFindex(rx->bsr, rx->JobId, str_to_int64(row[1]));
+  AddFindex(rx->bsr.get(), rx->JobId, str_to_int64(row[1]));
   rx->found = true;
   rx->selected_files++;
 

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -225,8 +225,7 @@ bool RestoreCmd(UaContext* ua, const char* cmd)
   } else {
     if (rx.bsr->JobId) {
       char ed1[50];
-      if (!CompleteBsr(ua,
-                       rx.bsr.get())) { /* find Vol, SessId, SessTime from JobIds */
+      if (!AddVolumeInformationToBsr(ua, rx.bsr.get())) {
         ua->ErrorMsg(_(
             "Unable to construct a valid BootStrapRecord. Cannot continue.\n"));
         goto bail_out;

--- a/core/src/dird/vbackup.cc
+++ b/core/src/dird/vbackup.cc
@@ -523,7 +523,7 @@ static bool CreateBootstrapFile(JobControlRecord* jcr, char* jobids)
     Jmsg(jcr, M_ERROR, 0, "%s", jcr->db_batch->strerror());
   }
 
-  CompleteBsr(ua, rx.bsr.get());
+  AddVolumeInformationToBsr(ua, rx.bsr.get());
   jcr->ExpectedFiles = WriteBsrFile(ua, rx);
   if (debug_level >= 10) {
     Dmsg1(000, "Found %d files to consolidate.\n", jcr->ExpectedFiles);

--- a/core/src/tests/test_fileindex_list.cc
+++ b/core/src/tests/test_fileindex_list.cc
@@ -18,7 +18,6 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
-
 #include "gtest/gtest.h"
 #include "include/bareos.h"
 
@@ -52,33 +51,15 @@ TEST(fileindex_list, add_filendexes)
   RestoreBootstrapRecord bsr;
   AddFindex(&bsr, kJobId_1, 1);
   ASSERT_NE(bsr.fi, nullptr);
-  EXPECT_EQ(bsr.fi->findex, 1);
-  EXPECT_EQ(bsr.fi->findex2, 1);
   EXPECT_EQ(bsr.JobId, kJobId_1);
+  EXPECT_EQ(bsr.fi->getRanges().size(), 1);
 
-  AddFindex(&bsr, kJobId_2, 2);
+  AddFindex(&bsr, kJobId_2, 1);
+  AddFindex(&bsr, kJobId_2, 3);
   ASSERT_NE(bsr.next, nullptr);
   EXPECT_EQ(bsr.next->JobId, kJobId_2);
   ASSERT_NE(bsr.next->fi, nullptr);
-  EXPECT_EQ(bsr.next->fi->findex, 2);
-  EXPECT_EQ(bsr.next->fi->findex2, 2);
-
-  AddFindex(&bsr, kJobId_1, 3);
-  EXPECT_EQ(bsr.JobId, kJobId_1);
-  ASSERT_NE(bsr.fi, nullptr);
-  ASSERT_NE(bsr.fi->next, nullptr);
-  EXPECT_EQ(bsr.fi->next->findex, 3);
-  EXPECT_EQ(bsr.fi->next->findex2, 3);
-
-  AddFindex(&bsr, kJobId_2, 4);
-  ASSERT_NE(bsr.next, nullptr);
-  EXPECT_EQ(bsr.next->JobId, kJobId_2);
-  ASSERT_NE(bsr.next->fi, nullptr);
-  EXPECT_EQ(bsr.next->fi->findex, 2);
-  EXPECT_EQ(bsr.next->fi->findex2, 2);
-  ASSERT_NE(bsr.next->fi->next, nullptr);
-  EXPECT_EQ(bsr.next->fi->next->findex, 4);
-  EXPECT_EQ(bsr.next->fi->next->findex2, 4);
+  EXPECT_EQ(bsr.next->fi->getRanges().size(), 2);
 }
 
 template <typename F>
@@ -138,7 +119,7 @@ static std::string ToBsrStringBareos(const itBegin& t_begin, const itEnd& t_end)
   auto maxId = *std::max_element(t_begin, t_end);
   auto buffer = PoolMem{PM_MESSAGE};
   TimedLambda("write_findex total",
-              [&]() { write_findex(bsr.fi, 1, maxId, &buffer); });
+              [&]() { write_findex(bsr.fi.get(), 1, maxId, &buffer); });
   return std::string{buffer.c_str()};
 }
 
@@ -146,7 +127,6 @@ static std::string ToBsrStringBareos(const std::vector<int>& t_fileIds)
 {
   return ToBsrStringBareos(t_fileIds.begin(), t_fileIds.end());
 }
-
 
 TEST(fileindex_list, continous_list)
 {

--- a/core/src/tests/test_fileindex_list.cc
+++ b/core/src/tests/test_fileindex_list.cc
@@ -117,9 +117,9 @@ static std::string ToBsrStringBareos(const itBegin& t_begin, const itEnd& t_end)
                   [&](int fid) { AddFindex(&bsr, kJobId_1, fid); });
   });
   auto maxId = *std::max_element(t_begin, t_end);
-  auto buffer = PoolMem{PM_MESSAGE};
+  auto buffer = std::string{};
   TimedLambda("write_findex total",
-              [&]() { write_findex(bsr.fi.get(), 1, maxId, &buffer); });
+              [&]() { write_findex(bsr.fi.get(), 1, maxId, buffer); });
   return std::string{buffer.c_str()};
 }
 

--- a/core/src/tests/test_fileindex_list.cc
+++ b/core/src/tests/test_fileindex_list.cc
@@ -52,14 +52,14 @@ TEST(fileindex_list, add_filendexes)
   AddFindex(&bsr, kJobId_1, 1);
   ASSERT_NE(bsr.fi, nullptr);
   EXPECT_EQ(bsr.JobId, kJobId_1);
-  EXPECT_EQ(bsr.fi->getRanges().size(), 1);
+  EXPECT_EQ(bsr.fi->GetRanges().size(), 1);
 
   AddFindex(&bsr, kJobId_2, 1);
   AddFindex(&bsr, kJobId_2, 3);
   ASSERT_NE(bsr.next, nullptr);
   EXPECT_EQ(bsr.next->JobId, kJobId_2);
   ASSERT_NE(bsr.next->fi, nullptr);
-  EXPECT_EQ(bsr.next->fi->getRanges().size(), 2);
+  EXPECT_EQ(bsr.next->fi->GetRanges().size(), 2);
 }
 
 template <typename F>


### PR DESCRIPTION
- replace RestoreBootstrapRecordFileIndex linked-list of ranges with a std::vector<int32_t> and adapt all related functions
- use unique_ptr for bsr->next and bsr->fi
- replace Bsnprintf() and PoolMem::strcat() in write_findex() with std::string and *one* call to PoolMem::strcat()