### PR TITLE
core: make systemtests work on FreeBSD

### DIFF
--- a/core/scripts/bareos-ctl-funcs
+++ b/core/scripts/bareos-ctl-funcs
@@ -32,7 +32,7 @@ pidofproc() {
 
    # Next try "pgrep"
    if [ ! -z "${PGREP}" -a -x "${PGREP}" ] ; then
-      pid=`${PGREP} $1`
+      pid=`${PGREP} $base`
       if [ "$pid" != "" ] ; then
          echo $pid
          return 0
@@ -144,7 +144,7 @@ status() {
 
    # Next try "pgrep"
    if [ ! -z "${PGREP}" -a -x "${PGREP}" ] ; then
-      pid=`${PGREP} $1`
+      pid=`${PGREP} $base`
       if [ "$pid" != "" ] ; then
          echo "$base (pid $pid) is running..."
          return 0


### PR DESCRIPTION
The scripts used by the systemtests for the bareos startup/shutdown were flawed. This PR changes the pgrep behaviour so the running processes are actually found.