### PR TITLE
dird: changed the initialization order of job queue and socket server

### DIFF
--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -427,9 +427,6 @@ int main(int argc, char* argv[])
 
   InitConsoleMsg(working_directory);
 
-  Dmsg0(200, "Start UA server\n");
-  if (!StartSocketServer(me->DIRaddrs)) { TerminateDird(0); }
-
   StartWatchdog(); /* start network watchdog thread */
 
   if (me->jcr_watchdog_time) {
@@ -445,6 +442,9 @@ int main(int argc, char* argv[])
   //   InitDeviceResources();
 
   StartStatisticsThread();
+
+  Dmsg0(200, "Start UA server\n");
+  if (!StartSocketServer(me->DIRaddrs)) { TerminateDird(0); }
 
   Dmsg0(200, "wait for next job\n");
   /* Main loop -- call scheduler to get next job to run */


### PR DESCRIPTION
This should prevent errors like following during systemtests for example.

run job=backup-bareos-fd yes
Using Catalog "MyCatalog"
Job failed.
You have messages.
wait
messages
09-Jul 15:54 bareos-dir JobId 1: No prior Full backup Job record found.
09-Jul 15:54 bareos-dir JobId 1: No prior or suitable Full backup found in catalog. Doing FULL backup.
09-Jul 15:54 bareos-dir JobId 1: Error: dird/jobq.cc:239 Jobq_add queue not initialized.
09-Jul 15:54 bareos-dir JobId 1: Fatal error: Could not add job queue: ERR=Invalid argument
quit
