### PR TITLE
tests: added full cmake support for bconsole pam test

### DIFF
--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -169,23 +169,21 @@ set(SYSTEM_TESTS
   copy-remote-bscan
 )
 
-IF(PAM_WRAPPER_LIBRARIES)
-    find_program(PAMTESTER pamtester)
-    IF(PAMTESTER)
-        set(ENV{PAM_WRAPPER_LIBRARIES} "${PAM_WRAPPER_LIBRARIES}")
-        execute_process(
-            COMMAND           "${CMAKE_BINARY_DIR}/systemtests/tests/bconsole-pam/bin/check_pam_exec_available.sh"
-            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/systemtests/tests/bconsole-pam/"
-            RESULT_VARIABLE   PAM_EXEC_AVAILABLE_RC
-        )
-        IF(${PAM_EXEC_AVAILABLE_RC} EQUAL "0")
-            set(PAM_EXEC_FOUND TRUE)
-            list(APPEND SYSTEM_TESTS "bconsole-pam")
-        ENDIF()
-        
-        MESSAGE( STATUS "PAM_EXEC_FOUND:     " ${PAM_EXEC_FOUND} )
-
+IF(PAM_WRAPPER_LIBRARIES) # BareosFindLibrary(pam_wrapper)
+  find_program(PAMTESTER pamtester)
+  IF(PAMTESTER)
+    set(ENV{PAM_WRAPPER_LIBRARIES} "${PAM_WRAPPER_LIBRARIES}")
+    execute_process(
+      COMMAND           "${CMAKE_SOURCE_DIR}/systemtests/tests/bconsole-pam/bin/check_pam_exec_available.sh"
+      WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/systemtests/tests/bconsole-pam/"
+      RESULT_VARIABLE   PAM_EXEC_AVAILABLE_RC
+    )
+    IF(${PAM_EXEC_AVAILABLE_RC} EQUAL "0")
+      set(PAM_EXEC_FOUND TRUE)
+      list(APPEND SYSTEM_TESTS "bconsole-pam")
     ENDIF()
+    MESSAGE( STATUS "PAM_EXEC_FOUND:     " ${PAM_EXEC_FOUND} )
+  ENDIF()
 ENDIF()
 
 

--- a/systemtests/tests/bconsole-pam/bin/check_pam_exec_available.sh
+++ b/systemtests/tests/bconsole-pam/bin/check_pam_exec_available.sh
@@ -13,7 +13,7 @@ set -e
 set -u
 
 export PAM_WRAPPER=1
-export PAM_WRAPPER_SERVICE_DIR=etc/pam.d/bareos
+export PAM_WRAPPER_SERVICE_DIR=etc/pam.d/bareos_discover_pam_exec
 
 if ! [ -e "${PAM_WRAPPER_SERVICE_DIR}" ]; then
     echo "PAM service file ${PAM_WRAPPER_SERVICE_DIR} not found"
@@ -28,6 +28,6 @@ fi
 # PAM_WRAPPER_LIBRARIES will be set my cmake
 USERNAME="user"
 PASSWORD="user"
-echo "$PASSWORD" | LD_PRELOAD=${PAM_WRAPPER_LIBRARIES} pamtester bareos "$USERNAME" authenticate
+echo "$PASSWORD" | LD_PRELOAD=${PAM_WRAPPER_LIBRARIES} pamtester bareos_discover_pam_exec "$USERNAME" authenticate
 
 exit $?

--- a/systemtests/tests/bconsole-pam/etc/pam.d/bareos_discover_pam_exec
+++ b/systemtests/tests/bconsole-pam/etc/pam.d/bareos_discover_pam_exec
@@ -1,0 +1,5 @@
+#
+# PAM settings for service bareos.
+#
+auth        required     pam_exec.so  expose_authtok debug quiet bin/pam_exec_check.sh
+


### PR DESCRIPTION
When cmake executes _check_pam_exec_available.sh_ there is no _CMAKE_BINARY_DIR_, yet. Therefore the script and the _pam.d_ subdirectory do not exist in the build tree, yet. 

Therefore I changed the paths to _CMAKE_SOURCE_DIR_ in the command for _PAM_EXEC_AVAILABLE_RC_ to make the shell script available for cmake in the first pass when it discovers _pam_exec_. For exactly this case I created an additional pam configuration file _etc/pam.d/bareos_discover_pam_exec_. 

Besides that the code indentation in CMakeLists.txt should be 2 blanks. 