### PR TITLE
Fix bogus errors in TLS sessions

### DIFF
--- a/core/src/lib/tls_openssl.cc
+++ b/core/src/lib/tls_openssl.cc
@@ -333,6 +333,14 @@ void TlsOpenSsl::TlsBsockShutdown(BareosSocket* bsock)
 
   int ssl_error = SSL_get_error(d_->openssl_, err_shutdown);
 
+  /*
+   * There may be more errors on the thread-local error-queue.
+   * As we just shutdown our context and looked at the errors that we were
+   * interested in we clear the queue so nobody else gets to read an error
+   * that may have occured here.
+   */
+  ERR_clear_error(); // empties the current thread's openssl error queue
+
   SSL_free(d_->openssl_);
   d_->openssl_ = nullptr;
 

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -167,6 +167,7 @@ set(SYSTEM_TESTS
   backup-bscan
   copy-bscan
   copy-remote-bscan
+  bconsole-status-client
 )
 
 IF(PAM_WRAPPER_LIBRARIES) # BareosFindLibrary(pam_wrapper)

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,19 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@xx" # Intentionally broken
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@plugindir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/bconsole-status-client/testrunner
+++ b/systemtests/tests/bconsole-status-client/testrunner
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=bconsole-status-client
+. ./environment
+. "${scripts}/functions"
+
+"${scripts}/cleanup"
+"${scripts}/setup"
+
+
+# Directory to backup.
+# This directory will be created by setup_data().
+BackupDirectory="${tmp}/data"
+
+start_test
+rm -f "$tmp/log2.out"
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+status client=bareos-fd
+
+@$out $tmp/log2.out
+messages
+quit
+END_OF_DATA
+
+run_bareos
+stop_bareos
+
+# if log2.out has not been written, bconsole crashed or disconnected
+# after status client command
+test -f "$tmp/log2.out" || exit 2
+
+end_test


### PR DESCRIPTION
Previously if a TLS session failed, the next TLS operation in the same thread saw the error of that failing session and was also terminated.
This PR fixes this behaviour by clearing the error-queue.

As the original issue that lead to this behaviour occured during a status client command to
a) a 17.2 or older client
b) a client with a mismatching password
we also add a systemtest that checks the correct behaviour when trying to status a client with a mismatching password (which eventually runs into a TLS handshake error)