### PR TITLE
Backport to 18.2: Fix bogus errors in TLS sessions #232

### DIFF
--- a/core/src/lib/tls_openssl.cc
+++ b/core/src/lib/tls_openssl.cc
@@ -324,6 +324,14 @@ void TlsOpenSsl::TlsBsockShutdown(BareosSocket *bsock)
 
   int ssl_error = SSL_get_error(d_->openssl_, err_shutdown);
 
+  /*
+   * There may be more errors on the thread-local error-queue.
+   * As we just shutdown our context and looked at the errors that we were
+   * interested in we clear the queue so nobody else gets to read an error
+   * that may have occured here.
+   */
+  ERR_clear_error(); // empties the current thread's openssl error queue
+
   SSL_free(d_->openssl_);
   d_->openssl_ = nullptr;
 


### PR DESCRIPTION
If during or before SSL_shutdown() errors occured that were saved in the
thread-local openssl error queue, these were not read and thus retained
on the queue until another tls session read them.
This lead to bogus error detection. Now we simply clear all errors from
the queue after we're done with our openssl context, so the errors do
not "leak" into another context anymore.

(cherry picked from commit cf3e1064f495b0592e0202edb2cec7e358c5b378)