### PR TITLE
Dev/fbergkemper/bareos 18.2/story 3083

### DIFF
--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -88,7 +88,7 @@ class AuthController extends AbstractActionController
             $this->bsock = $this->getServiceLocator()->get('director');
             $this->bsock->set_config($config['directors'][$director]);
             $this->bsock->set_user_credentials($username, $password);
-            error_log($username);
+            //error_log($username);
 
             if($this->bsock->connect_and_authenticate()) {
                $_SESSION['bareos']['director'] = $director;

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -88,7 +88,6 @@ class AuthController extends AbstractActionController
             $this->bsock = $this->getServiceLocator()->get('director');
             $this->bsock->set_config($config['directors'][$director]);
             $this->bsock->set_user_credentials($username, $password);
-            //error_log($username);
 
             if($this->bsock->connect_and_authenticate()) {
                $_SESSION['bareos']['director'] = $director;

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos-webui for the canonical source repository
- * @copyright Copyright (c) 2013-2017 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -91,7 +91,7 @@ class AuthController extends AbstractActionController
       $bareos_updates = $form->getInputFilter()->getValue('bareos_updates');
 
       $config = $this->getServiceLocator()->get('Config');
-      
+
       $this->bsock = $this->getServiceLocator()->get('director');
       $this->bsock->set_config($config['directors'][$director]);
       $this->bsock->set_user_credentials($username, $password);
@@ -99,7 +99,7 @@ class AuthController extends AbstractActionController
       if(!$this->bsock->connect_and_authenticate()) {
          $err_msg = "Sorry, can not authenticate. Wrong username and/or password.";
          return $this->createNewLoginForm($form,$err_msg,$this->bsock);
-      } 
+      }
 
       $_SESSION['bareos']['director'] = $director;
       $_SESSION['bareos']['username'] = $username;

--- a/webui/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
+++ b/webui/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
@@ -460,7 +460,9 @@ class BareosBSock implements BareosBSockInterface
          return false;
       }
 
-      error_log("console_name: ".$this->config['console_name']);
+      if($this->config['debug']) {
+         error_log("console_name: ".$this->config['console_name']);
+      }
 
       $port = $this->config['port'];
       $remote = "tcp://" . $this->config['host'] . ":" . $port;
@@ -581,13 +583,17 @@ class BareosBSock implements BareosBSockInterface
             return false;
           }
           $recv = self::receive();
-          error_log($recv);
+          if($this->config['debug']) {
+             error_log($recv);
+          }
       }
 
       if (!strncasecmp($recv, "1000", 4)) {
-        $recv = self::receive();
-        error_log($recv);
-        return true;
+         $recv = self::receive();
+         if($this->config['debug']) {
+            error_log($recv);
+         }
+         return true;
       }
 
       return false;


### PR DESCRIPTION
Backport from master branch:

webui: Better error message if user has no permission to the ".api" command
    
- Fixes #1095: webui: when login as a user without the permission to the ".api" command, the webui show a wrong and ugly error message
- restructured loginAction in AuthController
- createForm() also ends the session now, Univention will be handled like Debian

The backport includes two other commits as a dependency from master as well.

commit 3b10065bfe86a58d0113f3b4264e3dcda67a2efc
commit 4315e20f93e868ebada13c89c9586cb1ebd8e2d8
