### PR TITLE
webui: Notify user about Bvfs cache update

### DIFF
--- a/webui/config/autoload/global.php.in
+++ b/webui/config/autoload/global.php.in
@@ -117,6 +117,13 @@ function read_configuration_ini($configuration, $configuration_ini)
       $arr['dashboard']['autorefresh_interval'] = 60000;
    }
 
+   if( array_key_exists('restore', $configuration) && array_key_exists('filetree_refresh_timeout', $configuration['restore']) && isset($configuration['restore']['filetree_refresh_timeout']) ) {
+      $arr['restore']['filetree_refresh_timeout'] = $configuration['restore']['filetree_refresh_timeout'];
+   }
+   else {
+      $arr['restore']['filetree_refresh_timeout'] = 120000;
+   }
+
    return $arr;
 }
 

--- a/webui/install/configuration.ini.in
+++ b/webui/install/configuration.ini.in
@@ -45,3 +45,8 @@ save_previous_state=false
 ; Default: none
 labelpooltype=scratch
 
+[restore]
+; Restore filetree refresh timeout after n milliseconds
+; Default: 120000 milliseconds
+filetree_refresh_timeout=120000
+

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -207,6 +207,9 @@ class AuthController extends AbstractActionController
       }
       // Push dashboard configuration settings into SESSION context.
       $_SESSION['bareos']['dashboard_autorefresh_interval'] = $configuration['configuration']['dashboard']['autorefresh_interval'];
+      // Push restore configuration settings into SESSION context.
+      $_SESSION['bareos']['filetree_refresh_timeout'] = $configuration['configuration']['restore']['filetree_refresh_timeout'];
+
       if($this->params()->fromQuery('req')) {
          $redirect = $this->params()->fromQuery('req');
          $request = $this->getRequest();

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -343,10 +343,22 @@ $this->headTitle($title);
 
    }
 
+   function displayBvfsCacheUpdateInfo() {
+      $('#filebrowser').append("<br>");
+      $('#filebrowser').append("<div id='alert-bvfs' class='alert alert-info' role='alert'>");
+      $('#alert-bvfs').append("Update the Bvfs cache frequently to avoid timeouts.<br>");
+      $('#alert-bvfs').append("Please read the Bareos Documentation for further details.");
+      $('#filebrowser').append("</div>");
+   }
+
    $(".search-input").keyup(function() {
       var searchString = $(this).val();
       console.log(searchString);
       $('#filebrowser').jstree('search', searchString);
+   });
+
+   $("#filebrowser").bind("loading.jstree", function() {
+      displayBvfsCacheUpdateInfo();
    });
 
    $('#filebrowser').jstree({
@@ -363,6 +375,7 @@ $this->headTitle($title);
                "<p><b>Data:</b></p>" +
                "<pre><code>" + e.data + "</code></pre>"
             );
+            displayBvfsCacheUpdateInfo();
          },
          'data' :{
             'url' : '<?php echo $this->basePath() . "/restore/filebrowser?type=" . $this->restore_params['type'] . "&jobid=" . $this->restore_params['jobid'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
@@ -370,6 +383,7 @@ $this->headTitle($title);
             'data' : function (node) {
                return { 'id' : node.id };
             },
+            timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
          },
       },
        'state' : {

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -466,10 +466,22 @@ function updateRestoreParams(k, v) {
    return params.join('&');
 }
 
+function displayBvfsCacheUpdateInfo() {
+   $('#filebrowser').append("<br>");
+   $('#filebrowser').append("<div id='alert-bvfs' class='alert alert-info' role='alert'>");
+   $('#alert-bvfs').append("Update the Bvfs cache frequently to avoid timeouts.<br>");
+   $('#alert-bvfs').append("Please read the Bareos Documentation for further details.");
+   $('#filebrowser').append("</div>");
+}
+
 $(".search-input").keyup(function () {
    var searchString = $(this).val();
    console.log(searchString);
    $('#filebrowser').jstree('search', searchString);
+});
+
+$("#filebrowser").bind("loading.jstree", function() {
+   displayBvfsCacheUpdateInfo();
 });
 
 $('#filebrowser').jstree({
@@ -486,6 +498,7 @@ $('#filebrowser').jstree({
             "<p><b>Data:</b></p>" +
             "<pre><code>" + e.data + "</code></pre>"
          );
+         displayBvfsCacheUpdateInfo();
       },
       'multiple': false,
       'data': {
@@ -497,6 +510,7 @@ $('#filebrowser').jstree({
                'state': {'checkbox_disabled': true}
             };
          },
+         timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
       },
    },
    'state' : {


### PR DESCRIPTION
Display an bvfs update cache notification in the restore file tree
container while loading the tree and in case of an error after tree
loading failed.

The tree node loading timeout is now configurable by the
node_loading_timeout parameter in restore section of the
configuration.ini file. The default of the parameter is
set to 120 seconds.

[restore]
; Restore file tree node loading timeout after n milliseconds
; Default: 120000 milliseconds
node_loading_timeout=120000