### PR TITLE
webui: Notify user about Bvfs cache update

### DIFF
--- a/webui/config/autoload/global.php.in
+++ b/webui/config/autoload/global.php.in
@@ -112,6 +112,13 @@ function read_configuration_ini($configuration, $configuration_ini)
       $arr['dashboard']['autorefresh_interval'] = 60000;
    }
 
+   if( array_key_exists('restore', $configuration) && array_key_exists('filetree_refresh_timeout', $configuration['restore']) && isset($configuration['restore']['filetree_refresh_timeout']) ) {
+      $arr['restore']['filetree_refresh_timeout'] = $configuration['restore']['filetree_refresh_timeout'];
+   }
+   else {
+      $arr['restore']['filetree_refresh_timeout'] = 120000;
+   }
+
    return $arr;
 }
 

--- a/webui/install/configuration.ini.in
+++ b/webui/install/configuration.ini.in
@@ -45,3 +45,8 @@ save_previous_state=false
 ; Default: none
 labelpooltype=scratch
 
+[restore]
+; Restore filetree refresh timeout after n milliseconds
+; Default: 120000 milliseconds
+filetree_refresh_timeout=120000
+

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -207,6 +207,9 @@ class AuthController extends AbstractActionController
       }
       // Push dashboard configuration settings into SESSION context.
       $_SESSION['bareos']['dashboard_autorefresh_interval'] = $configuration['configuration']['dashboard']['autorefresh_interval'];
+      // Push restore configuration settings into SESSION context.
+      $_SESSION['bareos']['filetree_refresh_timeout'] = $configuration['configuration']['restore']['filetree_refresh_timeout'];
+
       if($this->params()->fromQuery('req')) {
          $redirect = $this->params()->fromQuery('req');
          $request = $this->getRequest();

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -269,10 +269,22 @@ $this->headTitle($title);
 
    }
 
+   function displayBvfsCacheUpdateInfo() {
+      $('#filebrowser').append("<br>");
+      $('#filebrowser').append("<div id='alert-bvfs' class='alert alert-info' role='alert'>");
+      $('#alert-bvfs').append("Update the Bvfs cache frequently to avoid timeouts.<br>");
+      $('#alert-bvfs').append("Please read the Bareos Documentation for further details.");
+      $('#filebrowser').append("</div>");
+   }
+
    $(".search-input").keyup(function() {
       var searchString = $(this).val();
       console.log(searchString);
       $('#filebrowser').jstree('search', searchString);
+   });
+
+   $("#filebrowser").bind("loading.jstree", function() {
+      displayBvfsCacheUpdateInfo();
    });
 
    $('#filebrowser').jstree({
@@ -280,8 +292,16 @@ $this->headTitle($title);
       'core' : {
          'animation': false,
          'force_text': true,
-         'error': function () {
-            alert('Oops, something went wrong, probably too many files.')
+         'error': function (e) {
+            $('#filebrowser').html(
+               "<h4>There was an error while loading data for this tree.</h4>" +
+               "<p><b>Error: </b>" + e.error + "</p>" +
+               "<p><b>Plugin: </b>" + e.plugin + "</p>" +
+               "<p><b>Reason: </b> " + e.reason + "</p>" +
+               "<p><b>Data:</b></p>" +
+               "<pre><code>" + e.data + "</code></pre>"
+            );
+            displayBvfsCacheUpdateInfo();
          },
          'data' :{
             'url' : '<?php echo $this->basePath() . "/restore/filebrowser?type=" . $this->restore_params['type'] . "&jobid=" . $this->restore_params['jobid'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
@@ -290,6 +310,7 @@ $this->headTitle($title);
                return { 'id' : node.id };
             },
          },
+         timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
       },
       'grid' : {
          width: '100%',


### PR DESCRIPTION
Display an bvfs update cache notification in the restore file tree
container while loading the tree and in case of an error after tree
loading failed.

The tree node loading timeout is now configurable by the
node_loading_timeout parameter in restore section of the
configuration.ini file. The default of the parameter is
set to 120 seconds.

[restore]
; Restore file tree node loading timeout after n milliseconds
; Default: 120000 milliseconds
node_loading_timeout=120000