### PR TITLE
cmake: repair building on macos

### DIFF
--- a/core/src/console/CMakeLists.txt
+++ b/core/src/console/CMakeLists.txt
@@ -23,7 +23,7 @@ IF(HAVE_WIN32)
    LIST(APPEND BCONSSRCS ../win32/console/consoleres.rc)
 ENDIF()
 
-include_directories(${Readline_INCLUDE_DIR})
+include_directories(${Readline_INCLUDE_DIR} ${OPENSSL_INCLUDE_DIR})
 
 IF(HAVE_PAM)
    include_directories(${PAM_INCLUDE_DIRS})

--- a/core/src/filed/CMakeLists.txt
+++ b/core/src/filed/CMakeLists.txt
@@ -46,6 +46,7 @@ IF(HAVE_WIN32)
    LIST(APPEND FDSRCS ../win32/filed/filedres.rc)
 ENDIF()
 
+include_directories(${OPENSSL_INCLUDE_DIR})
 
 add_library(fd_objects STATIC ${FDSRCS})
 

--- a/core/src/findlib/CMakeLists.txt
+++ b/core/src/findlib/CMakeLists.txt
@@ -25,6 +25,7 @@ IF(HAVE_WIN32)
    LIST(APPEND BAREOSFIND_SRCS ../win32/findlib/win32.cc)
 ENDIF()
 
+include_directories(${OPENSSL_INCLUDE_DIR})
 
 add_library(bareosfind SHARED ${BAREOSFIND_SRCS})
 

--- a/core/src/plugins/filed/CMakeLists.txt
+++ b/core/src/plugins/filed/CMakeLists.txt
@@ -38,6 +38,7 @@ ELSE()
    include_directories(/usr/include/python2.7)
 ENDIF()
 
+include_directories(${OPENSSL_INCLUDE_DIR})
 
 
 #set(DLLIBS dl)

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -99,9 +99,11 @@ set(mon_sd_password "mon_sd_password")
 set(python_plugin_module_src_dir ${CMAKE_SOURCE_DIR}/core/src/plugins)
 set(plugindirtmp ${PROJECT_BINARY_DIR}/plugindirtmp)
 set(rscripts ${PROJECT_BINARY_DIR}/scripts)
-get_target_property(dir_plugin_binary_path python-dir BINARY_DIR)
 get_target_property(fd_plugin_binary_path python-fd BINARY_DIR)
-get_target_property(sd_plugin_binary_path python-sd BINARY_DIR)
+if(NOT client-only)
+  get_target_property(dir_plugin_binary_path python-dir BINARY_DIR)
+  get_target_property(sd_plugin_binary_path python-sd BINARY_DIR)
+endif()
 
 set(sbindir ${PROJECT_BINARY_DIR}/sbin)
 

--- a/webui/CMakeLists.txt
+++ b/webui/CMakeLists.txt
@@ -105,14 +105,15 @@ ELSE()
  MESSAGE("PHP not found")
 ENDIF()
 
-INSTALL(FILES version.php init_autoloader.php DESTINATION ${SHARE_INSTALL_PREFIX}/bareos-webui)
-INSTALL(DIRECTORY tests config data module public vendor DESTINATION ${SHARE_INSTALL_PREFIX}/bareos-webui)
+IF(NOT client-only)
+  INSTALL(FILES version.php init_autoloader.php DESTINATION ${SHARE_INSTALL_PREFIX}/bareos-webui)
+  INSTALL(DIRECTORY tests config data module public vendor DESTINATION ${SHARE_INSTALL_PREFIX}/bareos-webui)
 
-INSTALL(FILES install/bareos/bareos-dir.d/console/admin.conf.example DESTINATION ${confdir}/bareos-dir.d/console/)
-INSTALL(FILES install/bareos/bareos-dir.d/profile/webui-admin.conf DESTINATION ${confdir}/bareos-dir.d/profile/)
-INSTALL(FILES install/apache/bareos-webui.conf DESTINATION ${HTTPD_CONF}/)
+  INSTALL(FILES install/bareos/bareos-dir.d/console/admin.conf.example DESTINATION ${confdir}/bareos-dir.d/console/)
+  INSTALL(FILES install/bareos/bareos-dir.d/profile/webui-admin.conf DESTINATION ${confdir}/bareos-dir.d/profile/)
+  INSTALL(FILES install/apache/bareos-webui.conf DESTINATION ${HTTPD_CONF}/)
 
-INSTALL(FILES install/directors.ini DESTINATION ${webuiconfdir})
-INSTALL(FILES install/configuration.ini DESTINATION ${webuiconfdir})
-
+  INSTALL(FILES install/directors.ini DESTINATION ${webuiconfdir})
+  INSTALL(FILES install/configuration.ini DESTINATION ${webuiconfdir})
+ENDIF()
 


### PR DESCRIPTION
Previously the CMAKE configuration did not allow to build with client-only
anymore. Also the OPENSSL_INCLUDE_DIR was not set in every case where it
might be neccessary.
This is now fixed. You can now build on a recent mac with homebrew compiler
and libraries again.