### PR TITLE
Overhaul add_new_unit_test.sh and add documentation

### DIFF
--- a/core/src/tests/add_new_unit_test.sh
+++ b/core/src/tests/add_new_unit_test.sh
@@ -28,5 +28,8 @@ if ! sed -e "s/@testname@/$testname/g" test_cmakelists_template.txt.in >> CMakeL
   exit 1
 fi
 
+echo "Don't forget to add your new file to the git index with"
+echo "     git add $testname.cc"
+
 exit 0
 

--- a/core/src/tests/add_new_unit_test.sh
+++ b/core/src/tests/add_new_unit_test.sh
@@ -2,59 +2,28 @@
 
 # create and add an empty unittest file
 
-if [ "x$1" = "x" ]; then
-  echo "You should enter: $0 testname"
+if [ $# -ne 1 ]; then
+  echo "usage: $0 <testname>"
+  exit 1
+fi
+testname="$1"
+
+if [ -f "$testname.cc" ]; then
+  echo "Filename for test already exists: $testname.cc"
   exit 1
 fi
 
-if [ -f "$1.cc" ]; then
-  echo "Filename for test already exists: $1.cc"
+if grep -qw "$testname.cc" CMakeLists.txt; then
+  echo "$testname.cc already exists in CMakeLists.txt"
   exit 1
 fi
 
-if grep -w "$1.cc" CMakeLists.txt; then
-  echo "$1.cc already exists in CMakeLists.txt"
+if ! sed -e "s/@year@/$(date +%Y)/" test_template.cc.in > "$testname.cc"; then
+  echo "File creation failed: $testname.cc"
   exit 1
 fi
 
-file_created="false"
-if cat > "$1.cc" <<EOF
-/*
-   BAREOS® - Backup Archiving REcovery Open Sourced
-
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
-
-   This program is Free Software; you can redistribute it and/or
-   modify it under the terms of version three of the GNU Affero General Public
-   License as published by the Free Software Foundation, which is
-   listed in the file LICENSE.
-
-   This program is distributed in the hope that it will be useful, but
-   WITHOUT ANY WARRANTY; without even the implied warranty of
-   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-   Affero General Public License for more details.
-
-   You should have received a copy of the GNU Affero General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
-   02110-1301, USA.
-*/
-
-#include "gtest/gtest.h"
-
-EOF
-then
-  if git add "$1.cc"; then
-    file_created="true"
-  fi
-fi #if cat > "$1.cc" <<EOF
-
-if ! "$file_created"; then
-  echo "File creation failed: $1.cc"
-  exit 1
-fi
-
-if ! sed "s/@replace@/$1/g" < test_cmakelists_template.txt.in >> CMakeLists.txt; then
+if ! sed -e "s/@testname@/$testname/g" test_cmakelists_template.txt.in >> CMakeLists.txt; then
   echo "Adding to CMakeLists.txt failed"
   exit 1
 fi

--- a/core/src/tests/test_cmakelists_template.txt.in
+++ b/core/src/tests/test_cmakelists_template.txt.in
@@ -1,11 +1,11 @@
-####### test_@replace@  #####################################
-add_executable(test_@replace@ @replace@.cc)
+####### @testname@  #####################################
+add_executable(@testname@ @testname@.cc)
 
-target_link_libraries(test_@replace@
+target_link_libraries(@testname@
    bareos
    ${GTEST_LIBRARIES}
    ${GTEST_MAIN_LIBRARIES}
 )
 
-gtest_discover_tests(test_@replace@ TEST_PREFIX gtest:)
+gtest_discover_tests(@testname@ TEST_PREFIX gtest:)
 

--- a/core/src/tests/test_template.cc.in
+++ b/core/src/tests/test_template.cc.in
@@ -1,0 +1,23 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) @year@-@year@ Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "gtest/gtest.h"
+

--- a/docs/manuals/source/DeveloperGuide.rst
+++ b/docs/manuals/source/DeveloperGuide.rst
@@ -19,6 +19,7 @@ Developer Guide
    DeveloperGuide/api.rst
    DeveloperGuide/tls-techdoc.rst
    DeveloperGuide/pam-techdoc.rst
+   DeveloperGuide/tests.rst
    DeveloperGuide/regression.rst
    DeveloperGuide/mempool.rst
    DeveloperGuide/netprotocol.rst

--- a/docs/manuals/source/DeveloperGuide/tests.rst
+++ b/docs/manuals/source/DeveloperGuide/tests.rst
@@ -1,0 +1,13 @@
+Tests
+=====
+
+Unit Tests
+----------
+Bareos unit tests are usually written in C++ using Google Test.
+The unit tests reside in ``core/src/tests`` and are compiled with the rest of Bareos if Google Test is available on your system.
+Unit tests can be run using ``make test`` or ``ctest``.
+
+Adding a new Test
+~~~~~~~~~~~~~~~~~
+To add a new test, you create your sourcefiles in ``core/src/tests`` and register the test in ``CMakeLists.txt`` in that directory.
+There is also a helper script ``add_new_unit_test.sh`` that will setup a test from a template and register it in ``CMakeLists.txt``.


### PR DESCRIPTION
This PR changes some things in add_new_unit_test. The C++ template is now in its own file, the git add command is gone and the test is now named as I would expect it.
I also added some short docs on where to find, how to build and how to add a new unit test.