### PR TITLE
cats: add support for MySQL 8

### DIFF
--- a/core/src/cats/mysql.cc
+++ b/core/src/cats/mysql.cc
@@ -148,7 +148,11 @@ bool BareosDbMysql::OpenDatabase(JobControlRecord* jcr)
 {
   bool retval = false;
   int errstat;
+#if LIBMYSQL_VERSION_ID > 80000
+  bool reconnect = 1;
+#else
   my_bool reconnect = 1;
+#endif
 
   P(mutex);
   if (connected_) {


### PR DESCRIPTION
The MySQL 8 client library removed the my_bool type. The replacement
is the default bool type.
This patch adds an ifdef that selects the correct type depending on the
MySQL client version.