### PR TITLE
vmware: alter shebangs to refer to python2

### DIFF
--- a/vmware/vmware_cbt_tool/vmware_cbt_tool.py
+++ b/vmware/vmware_cbt_tool/vmware_cbt_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/vmware/vmware_plugin/BareosFdPluginVMware.py
+++ b/vmware/vmware_plugin/BareosFdPluginVMware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/vmware/vmware_plugin/bareos-fd-vmware.py
+++ b/vmware/vmware_plugin/bareos-fd-vmware.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #


### PR DESCRIPTION
previously the shebangs referred to "python" which could mean python2
or python3. The Red Hat brp-mangle-shebangs script that is run during
an rpmbuild treats this as an error.
This patch changes the shebangs to refert to python2 explicitly.