### PR TITLE
core: make native_get_vol_list() retrieve loaded volumes again

### DIFF
--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -482,7 +482,7 @@ dlist *native_get_vol_list(UaContext *ua, StorageResource *store, bool listall, 
             break;
          case 'F':
             vl->slot_status = slot_status_full;
-            switch (vl->slot_type) {
+            switch (vl->slot_status) {
             case slot_type_storage:
             case slot_type_import:
                if (field4) {


### PR DESCRIPTION
Fixes #1111 import/export and status slots commands don't see tapes loaded in drives anymore

This patch fixes a regression introduced by c3a587f4
Previously volumes loaded in a tape drive were not visible to the director
which lead to several issues. This patch restores the old behaviour.