### PR TITLE
core: reset cache on invalidate vol_list->contents (Backport to 18.2)

### DIFF
--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -555,6 +555,9 @@ static inline void FreeVolList(changer_vol_list_t *vol_list)
 {
    vol_list_t *vl;
 
+   // make sure cache is treated as empty
+   vol_list->timestamp = 0;
+
    if (vol_list->contents) {
       foreach_dlist(vl, vol_list->contents) {
          if (vl->VolName) {


### PR DESCRIPTION
Fixes #1112: After mount/unmount of tape "status slots" shows empty list

Previously the cache timestamp on vol_list->contents was not reset when
the list has been emptied. This lead to strange behaviour with empty
vol_lists showing up.
This patch now resets timestamp to zero when clearing vol_list->contents
so the cache is always rebuilt if contents had been cleared.

(cherry picked from commit c8dff08c03ed07d51bb5cda6deaed68878d20997)