### PR TITLE
Fix nullptr cornercase in mtx-changer parser

### DIFF
--- a/src/dird/sd_cmds.c
+++ b/src/dird/sd_cmds.c
@@ -349,7 +349,7 @@ dlist *native_get_vol_list(UAContext *ua, STORERES *store, bool listall, bool sc
        * See if this is a parsable string from either list or listall
        * e.g. at least f1:f2
        */
-      if (!field1 && !field2) {
+      if (!field1 || !field2) {
          goto parse_error;
       }
 


### PR DESCRIPTION
In special cases wrong output from mtx-changer could lead to a director crash. This patch fixed this problem.