### PR TITLE
Fix nullptr cornercase in mtx-changer parser

### DIFF
--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -359,7 +359,7 @@ dlist* native_get_vol_list(UaContext* ua,
      * See if this is a parsable string from either list or listall
      * e.g. at least f1:f2
      */
-    if (!field1 && !field2) { goto parse_error; }
+    if (!field1 || !field2) { goto parse_error; }
 
     vl = (vol_list_t*)malloc(sizeof(vol_list_t));
     memset(vl, 0, sizeof(vol_list_t));


### PR DESCRIPTION
Previously when mtx-changer provided text with no colons in it, field2 was a nullptr. This nullptr wasn't checked correctly and lead to a crash.
The code did not match the comment, because it didn't check that f1 and f2 were set, but that f1 *or* f2 were set.
This patch now makes the code behave as described in the comment above.