### PR TITLE
dev/pstorz/master/fix traymon missing dll

### DIFF
--- a/core/platforms/win32/winbareos-nsi.spec
+++ b/core/platforms/win32/winbareos-nsi.spec
@@ -70,9 +70,8 @@ BuildRequires:  mingw64-libwinpthread1
 BuildRequires:  mingw32-libqt5-qtbase
 BuildRequires:  mingw64-libqt5-qtbase
 
-# needs to be added if qt is built with icu support
-#BuildRequires:  mingw32-icu
-#BuildRequires:  mingw64-icu
+BuildRequires:  mingw32-icu
+BuildRequires:  mingw64-icu
 
 
 BuildRequires:  mingw32-lzo
@@ -180,6 +179,9 @@ for flavor in %{flavors}; do
       Qt5Core.dll \
       Qt5Gui.dll \
       Qt5Widgets.dll \
+      icui18n56.dll \
+      icudata56.dll \
+      icuuc56.dll \
       libfreetype-6.dll \
       libglib-2.0-0.dll \
       libintl-8.dll \

--- a/core/platforms/win32/winbareos-nsi.spec
+++ b/core/platforms/win32/winbareos-nsi.spec
@@ -156,11 +156,6 @@ for flavor in %{flavors}; do
    done
 
 
-# needs to be added to following files if qt is built with icu support
-#      icui18n56.dll \
-#      icudata56.dll \
-#      icuuc56.dll \
-
    for file in \
       libcrypto-*.dll \
       libfastlz.dll \

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -942,12 +942,9 @@ SectionIn 1 2 3
   File "Qt5Core.dll"
   File "Qt5Gui.dll"
   File "Qt5Widgets.dll"
-
-# needs to be added if qt is built with icu support
-#  File "icui18n56.dll"
-#  File "icudata56.dll"
-#  File "icuuc56.dll"
-
+  File "icui18n56.dll"
+  File "icudata56.dll"
+  File "icuuc56.dll"
   File "libfreetype-6.dll"
   File "libglib-2.0-0.dll"
   File "libintl-8.dll"
@@ -2177,12 +2174,9 @@ ConfDeleteSkip:
   Delete "$INSTDIR\Qt5Core.dll"
   Delete "$INSTDIR\Qt5Gui.dll"
   Delete "$INSTDIR\Qt5Widgets.dll"
-
-# needs to be added if qt is built with icu support
-#  Delete "$INSTDIR\icui18n56.dll"
-#  Delete "$INSTDIR\icudata56.dll"
-#  Delete "$INSTDIR\icuuc56.dll"
-
+  Delete "$INSTDIR\icui18n56.dll"
+  Delete "$INSTDIR\icudata56.dll"
+  Delete "$INSTDIR\icuuc56.dll"
   Delete "$INSTDIR\libfreetype-6.dll"
   Delete "$INSTDIR\libglib-2.0-0.dll"
   Delete "$INSTDIR\libintl-8.dll"


### PR DESCRIPTION
We had created a special qt5 version that does not depend on icu to save space.
This commit reverts this change as we are now using the "standard" built qt5 version and thus
need to install the icu libraries again.