### PR TITLE
Make embedded paths reproducible

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -48,6 +48,7 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
+include(CheckCCompilerFlag)
 include(CheckCXXCompilerFlag)
 CHECK_CXX_COMPILER_FLAG(-Wsuggest-override compiler_will_suggest_override)
 
@@ -63,6 +64,23 @@ endif()
 CHECK_CXX_COMPILER_FLAG(-Werror=format-security compiler_error_format_security)
 if (${compiler_error_format_security})
    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=format-security")
+endif()
+
+option(DEBUG_PREFIX_MAP "remap absolute debug paths to relative if compiler supports it" ON)
+CHECK_C_COMPILER_FLAG(-fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=. c_compiler_debug_prefix_map)
+CHECK_CXX_COMPILER_FLAG(-fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=. cxx_compiler_debug_prefix_map)
+if(DEBUG_PREFIX_MAP AND c_compiler_debug_prefix_map AND cxx_compiler_debug_prefix_map)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdebug-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
+endif()
+
+CHECK_C_COMPILER_FLAG(-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=. c_compiler_macro_prefix_map)
+CHECK_CXX_COMPILER_FLAG(-fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=. cxx_compiler_macro_prefix_map)
+if (c_compiler_macro_prefix_map)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
+endif()
+if (cxx_compiler_macro_prefix_map)
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fmacro-prefix-map=${CMAKE_CURRENT_SOURCE_DIR}=.")
 endif()
 
 # warn on sign-conversion

--- a/core/debian/rules
+++ b/core/debian/rules
@@ -29,6 +29,7 @@ STORAGE_DAEMON_GROUP = $(DAEMON_GROUP)
 BAREOS_VERSION := $(shell dpkg-parsechangelog | egrep '^Version:' | sed 's/Version: //g')
 
 define CONFIGURE_COMMON
+  -DDEBUG_PREFIX_MAP:BOOL=OFF \
   -Dsbin-perm=755 \
   -Dsbindir=/usr/sbin \
   -Dbindir=/usr/bin \

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -710,7 +710,9 @@ This package contains required files for Bareos regression testing.
 
 
 %prep
-%setup
+# this is a hack so we always build in "bareos" and not in "bareos-version"
+%setup -c -n bareos
+mv bareos-*/* .
 
 %build
 # Cleanup defined in Fedora Packaging:Guidelines

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -737,14 +737,15 @@ CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ;
 
 # use our own cmake call instead of cmake macro as it is different on different platforms/versions
 cmake  .. \
-      -DCMAKE_VERBOSE_MAKEFILE=ON \
-      -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-      -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib \
-      -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
-      -DLIB_INSTALL_DIR:PATH=/usr/lib \
-      -DSYSCONF_INSTALL_DIR:PATH=/etc \
-      -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
-      -DBUILD_SHARED_LIBS:BOOL=ON \
+  -DCMAKE_VERBOSE_MAKEFILE=ON \
+  -DCMAKE_INSTALL_PREFIX:PATH=/usr \
+  -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib \
+  -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
+  -DLIB_INSTALL_DIR:PATH=/usr/lib \
+  -DSYSCONF_INSTALL_DIR:PATH=/etc \
+  -DSHARE_INSTALL_PREFIX:PATH=/usr/share \
+  -DBUILD_SHARED_LIBS:BOOL=ON \
+  -DDEBUG_PREFIX_MAP:BOOL=OFF \
   -Dprefix=%{_prefix}\
   -Dlibdir=%{library_dir} \
   -Dsbindir=%{_sbindir} \

--- a/docs/manuals/source/DeveloperGuide/BuildAndTestBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/BuildAndTestBareos.rst
@@ -62,6 +62,32 @@ please refer to the corresponding build desciptions:
   * RPM Packages: `core/platforms/packaging/bareos.spec <https://github.com/bareos/bareos/blob/master/core/platforms/packaging/bareos.spec>`__
 
 
+Using ccache (compiler cache)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bareos can be built using ccache and using it will improve build times for repeated builds a lot.
+Running cmake will autodetect and use ccache if it is available.
+To get the most out of ccache, you should configure it to work correctly with Bareos.
+
+base_dir
+   Set this to a common directory where your checked out sources and cmake binary-dir live.
+   Your homedirectoy is probably a good starting point.
+   This setting lets ccache ignore the path to files below this ``base_dir``.
+   This makes sure you will get a cache hit even if the path to the source files changes.
+hash_dir
+   By disabling this, the current working directory will be ignored.
+   In case of cmake the working directory does not matter, so ignoring this should be safe and will improve cache hits
+sloppiness = file_macro
+   This makes sure the value that ``__FILE__`` expands to is ignored when caching.
+   You may end up with binaries that contain other paths in ``__FILE__``, but Bareos only uses this to determine a relative path so this should not hurt.
+   If you're using a modern compiler that supports ``-ffile-prefix-map`` this should not be required anymore.
+
+.. code-block:: ini
+  :caption: Example ccache.conf
+
+  base_dir = /path/to/common/topdir
+  hash_dir = false
+  sloppiness = file_macro
 
 Systemtests
 ~~~~~~~~~~~


### PR DESCRIPTION
Using cmake __FILE__ will point to the absolute path of the source.
This leads to two issues:
- object files change depending on where you checkout the sources
- local paths of the build-system leak into the resulting binaries

This PR adds and applies script that can add a preprocessor directive to every source file, so __FILE__ evaluates to a relative path.