### PR TITLE
dird: show command: add test to compare lists of resources types

### DIFF
--- a/core/src/dird/show_cmd_available_resources.h
+++ b/core/src/dird/show_cmd_available_resources.h
@@ -1,0 +1,57 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
+   Copyright (C) 2011-2016 Planets Communications B.V.
+   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_SRC_DIRD_SHOW_CMD_AVAILABLE_RESOURCES_H_
+#define BAREOS_SRC_DIRD_SHOW_CMD_AVAILABLE_RESOURCES_H_
+
+#include <include/bareos.h>
+#include "dird/dird_conf.h"
+
+namespace directordaemon {
+
+static struct {
+  const char* res_name;
+  int type;
+} show_cmd_available_resources[] = {{NT_("directors"), R_DIRECTOR},
+                                    {NT_("clients"), R_CLIENT},
+                                    {NT_("counters"), R_COUNTER},
+                                    {NT_("devices"), R_DEVICE},
+                                    {NT_("jobs"), R_JOB},
+                                    {NT_("jobdefs"), R_JOBDEFS},
+                                    {NT_("storages"), R_STORAGE},
+                                    {NT_("catalogs"), R_CATALOG},
+                                    {NT_("schedules"), R_SCHEDULE},
+                                    {NT_("filesets"), R_FILESET},
+                                    {NT_("pools"), R_POOL},
+                                    {NT_("messages"), R_MSGS},
+                                    {NT_("profiles"), R_PROFILE},
+                                    {NT_("consoles"), R_CONSOLE},
+                                    {NT_("users"), R_USER},
+                                    {NT_("all"), -1},
+                                    {NT_("help"), -2},
+                                    {NULL, 0}};
+
+
+}  // namespace directordaemon
+
+#endif  // BAREOS_SRC_DIRD_SHOW_CMD_AVAILABLE_RESOURCES_H_

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -40,6 +40,7 @@
 #include "dird/ua_db.h"
 #include "dird/ua_output.h"
 #include "dird/ua_select.h"
+#include "dird/show_cmd_available_resources.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
 
@@ -203,31 +204,6 @@ static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
   }
 }
 
-
-struct showstruct {
-  const char* res_name;
-  int type;
-};
-
-static struct showstruct avail_resources[] = {{NT_("directors"), R_DIRECTOR},
-                                              {NT_("clients"), R_CLIENT},
-                                              {NT_("counters"), R_COUNTER},
-                                              {NT_("devices"), R_DEVICE},
-                                              {NT_("jobs"), R_JOB},
-                                              {NT_("jobdefs"), R_JOBDEFS},
-                                              {NT_("storages"), R_STORAGE},
-                                              {NT_("catalogs"), R_CATALOG},
-                                              {NT_("schedules"), R_SCHEDULE},
-                                              {NT_("filesets"), R_FILESET},
-                                              {NT_("pools"), R_POOL},
-                                              {NT_("messages"), R_MSGS},
-                                              {NT_("profiles"), R_PROFILE},
-                                              {NT_("consoles"), R_CONSOLE},
-                                              {NT_("users"), R_USER},
-                                              {NT_("all"), -1},
-                                              {NT_("help"), -2},
-                                              {NULL, 0}};
-
 /**
  *  Displays Resources
  *
@@ -298,9 +274,10 @@ bool show_cmd(UaContext* ua, const char* cmd)
        */
       recurse = 1;
       len = strlen(res_name);
-      for (j = 0; avail_resources[j].res_name; j++) {
-        if (bstrncasecmp(res_name, _(avail_resources[j].res_name), len)) {
-          type = avail_resources[j].type;
+      for (j = 0; show_cmd_available_resources[j].res_name; j++) {
+        if (bstrncasecmp(res_name, _(show_cmd_available_resources[j].res_name),
+                         len)) {
+          type = show_cmd_available_resources[j].type;
           if (type > 0) {
             res = my_config->res_head_[type - my_config->r_first_];
           } else {
@@ -315,9 +292,10 @@ bool show_cmd(UaContext* ua, const char* cmd)
        */
       recurse = 0;
       len = strlen(res_name);
-      for (j = 0; avail_resources[j].res_name; j++) {
-        if (bstrncasecmp(res_name, _(avail_resources[j].res_name), len)) {
-          type = avail_resources[j].type;
+      for (j = 0; show_cmd_available_resources[j].res_name; j++) {
+        if (bstrncasecmp(res_name, _(show_cmd_available_resources[j].res_name),
+                         len)) {
+          type = show_cmd_available_resources[j].type;
           res = (BareosResource*)ua->GetResWithName(type, ua->argv[i], true);
           if (!res) { type = -3; }
           break;
@@ -331,8 +309,8 @@ bool show_cmd(UaContext* ua, const char* cmd)
         break;
       case -2:
         ua->SendMsg(_("Keywords for the show command are:\n"));
-        for (j = 0; avail_resources[j].res_name; j++) {
-          ua->ErrorMsg("%s\n", _(avail_resources[j].res_name));
+        for (j = 0; show_cmd_available_resources[j].res_name; j++) {
+          ua->ErrorMsg("%s\n", _(show_cmd_available_resources[j].res_name));
         }
         goto bail_out;
       case -3:

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -311,3 +311,18 @@ target_link_libraries(thread_list
 
 gtest_discover_tests(thread_list TEST_PREFIX gtest:)
 
+####### ua_available_resources_equals_config_resources  #####################################
+add_executable(show_cmd_available_resources_equals_config_resources show_cmd_available_resources_equals_config_resources.cc)
+
+target_link_libraries(show_cmd_available_resources_equals_config_resources
+   dird_objects
+   bareos
+   bareosfind
+   bareoscats
+   bareossql
+   ${GTEST_LIBRARIES}
+   ${GTEST_MAIN_LIBRARIES}
+)
+
+gtest_discover_tests(show_cmd_available_resources_equals_config_resources TEST_PREFIX gtest:)
+

--- a/core/src/tests/show_cmd_available_resources_equals_config_resources.cc
+++ b/core/src/tests/show_cmd_available_resources_equals_config_resources.cc
@@ -1,0 +1,56 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "gtest/gtest.h"
+#include "include/bareos.h"
+#include "lib/parse_conf.h"
+#include "dird/dird_globals.h"
+#include "dird/dird_conf.h"
+#include "dird/ua_output.h"
+#include "dird/show_cmd_available_resources.h"
+
+#include <set>
+
+using namespace directordaemon;
+
+TEST(available_resources_equals_config_resources, check_contents)
+{
+  std::unique_ptr<ConfigurationParser> my_config(
+      InitDirConfig(nullptr, M_ERROR_TERM));
+
+  std::set<uint32_t> set_of_config_resources;
+
+  for (int i = 0; my_config->resources_[i].name; i++) {
+    set_of_config_resources.insert(my_config->resources_[i].rcode);
+  }
+
+  std::set<uint32_t> set_of_show_cmd_resources;
+
+  for (int i = 0; show_cmd_available_resources[i].res_name; i++) {
+    if (show_cmd_available_resources[i].type > 0) {
+      set_of_show_cmd_resources.insert(show_cmd_available_resources[i].type);
+    }
+  }
+
+  EXPECT_EQ(set_of_config_resources, set_of_show_cmd_resources)
+      << "The list of resources for the show command does not match the list "
+         "of configured resources in dird_conf.cc.";
+}


### PR DESCRIPTION
The show command uses a list of resource types as a collection of all types that can be found in the director configuration. Since this is a design drawback, someone can easily forget to add an entry to this list as soon as the configuration parser's list of resources gets modified. 

At the current point of development it is easier to create a test instead of refactoring overall code.

This pullrequest adds a test to show up a missing entry. 