### PR TITLE
Fix ordering of rpcgen

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -19,6 +19,12 @@
 
 cmake_minimum_required(VERSION 3.0)
 project(bareos C CXX)
+
+# disable in-source builds
+if("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")
+  message(FATAL_ERROR "In-source builds are not allowed.")
+endif()
+
 SET(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME common)
 
 INCLUDE(GNUInstallDirs)

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -66,6 +66,7 @@ set(DIRD_RESTYPES catalog client console counter director fileset job jobdefs me
 
 #dird_objects is also used as library for unittests
 add_library(dird_objects STATIC ${DIRD_OBJECTS_SRCS})
+target_link_libraries(dird_objects ${NDMP_LIBS})
 
 add_executable(bareos-dir ${DIRDSRCS})
 

--- a/core/src/ndmp/CMakeLists.txt
+++ b/core/src/ndmp/CMakeLists.txt
@@ -37,7 +37,6 @@ set(RPC_GEN_FILES ndmp0.h ndmp0_xdr.c
                 ndmp9.h ndmp9_xdr.c
 )
 
-
 set(INCLUDE_FILES = ndmagents.h ndmlib.h ndmp_ammend.h ndmp_msg_buf.h ndmp_translate.h
 		ndmp0_enum_strs.h ndmp0.h ndmp2_enum_strs.h ndmp2_translate.h ndmp2.h
 		ndmp3_enum_strs.h ndmp3_translate.h ndmp3.h ndmp4_enum_strs.h
@@ -82,37 +81,24 @@ ELSE()
 ENDIF()
 
 # create files with rpcgen
-
-STRING(COMPARE EQUAL ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR} IN_SOURCE_BUILD)
-foreach(NDMP_VERSION 0 1 2 3 4 9)
-   IF(IN_SOURCE_BUILD)
-      ADD_CUSTOM_COMMAND(
-         PRE_BUILD
-         OUTPUT ndmp${NDMP_VERSION}.h ndmp${NDMP_VERSION}_xdr.c
-         COMMAND  ${RPCGEN} ${RPCGEN_PARAMS} ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.x
-
-         DEPENDS ${RPCGEN} ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.x
-         )
-   ELSE()
-      ADD_CUSTOM_COMMAND(
-         PRE_BUILD
-         OUTPUT ndmp${NDMP_VERSION}.h ndmp${NDMP_VERSION}_xdr.c
-         COMMAND  ${RPCGEN} ${RPCGEN_PARAMS} ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.x
-         COMMAND  test -e ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.h && cp ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.h ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}_xdr.c ${CMAKE_CURRENT_BINARY_DIR} || :
-         COMMAND  test -e ndmp${NDMP_VERSION}.h && cp ndmp${NDMP_VERSION}.h ndmp${NDMP_VERSION}_xdr.c ${CMAKE_CURRENT_SOURCE_DIR} || :
-         DEPENDS ${RPCGEN} ${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.x
-         )
-   ENDIF()
+foreach(NDMP_VERSION 0 2 3 4 9)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/ndmp${NDMP_VERSION}.x ${CMAKE_CURRENT_BINARY_DIR}/ndmp${NDMP_VERSION}.x COPYONLY)
+  add_custom_command(
+    OUTPUT ndmp${NDMP_VERSION}.h ndmp${NDMP_VERSION}_xdr.c
+    COMMAND  ${RPCGEN} ${RPCGEN_PARAMS} ndmp${NDMP_VERSION}.x
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    DEPENDS ${RPCGEN} ${CMAKE_CURRENT_BINARY_DIR}/ndmp${NDMP_VERSION}.x
+  )
 endforeach()
 
-add_library(bareosndmp SHARED ${LIBBAREOSNDMP_SRCS})
+add_library(bareosndmp SHARED ${LIBBAREOSNDMP_SRCS} ${RPC_GEN_FILES})
+target_include_directories(bareosndmp PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 target_link_libraries(bareosndmp ${WRAP_LIBS} ${TIRPC_LIBRARIES})
 
-INSTALL(TARGETS bareosndmp DESTINATION ${libdir})
+install(TARGETS bareosndmp DESTINATION ${libdir})
 
 set_target_properties(bareosndmp PROPERTIES VERSION "${BAREOS_NUMERIC_VERSION}"
                                           SOVERSION "${SOVERSION}"
-
                                           )
 IF(build_ndmjob)
   add_executable(ndmjob ${NDMJOB_SRCS})

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -176,6 +176,7 @@ IF(HAVE_DARWIN_OS)
 ENDIF()
 
 add_library(stored_objects STATIC ${SDSRCS})
+target_link_libraries(stored_objects ${NDMP_LIBS})
 
 add_executable(bareos-sd stored.cc)
 


### PR DESCRIPTION
Previously rpcgen was called using add_custom_command in PRE_BUILD
mode. That mode doesn't work reliably.
We now generate files that the bareosndmp target can depend on. This
should get the build ordering right every time.

This PR also disables in-source builds so we don't need to consider in-source builds when running rpcgen.