### PR TITLE
spelling: fixed the wrong "backuped" to "backed up"

### DIFF
--- a/core/README.NDMP
+++ b/core/README.NDMP
@@ -31,7 +31,7 @@ The core fileindex handling code is rewritten to use callback
 functions for doing the real work. This way we can hook in
 internal functions into the core file indexing process which
 happens after a backup and before a restore to fill the
-files which have been backuped or restored.
+files which have been backed up or restored.
 
 Some missing initialization, commission and decommission is
 added although it is empty it is better to have a consistent
@@ -280,8 +280,8 @@ Client {
   Port = 10000
   Protocol = NDMPv4                   # Need to specify protocol before password as protocol determines password encoding used.
   Auth Type = Clear                   # Clear == Clear Text, MD5 == Challenge protocol
-  Username = "ndmp"                   # username of the NDMP user on the DATA AGENT e.g. storage box being backuped.
-  Password = "test"                   # password of the NDMP user on the DATA AGENT e.g. storage box being backuped.
+  Username = "ndmp"                   # username of the NDMP user on the DATA AGENT e.g. storage box being backed up.
+  Password = "test"                   # password of the NDMP user on the DATA AGENT e.g. storage box being backed up.
 }
 
 #

--- a/core/src/dird/ndmp_dma_generic.cc
+++ b/core/src/dird/ndmp_dma_generic.cc
@@ -336,7 +336,7 @@ bool NdmpBuildClientJob(JobControlRecord* jcr,
   }
 
   /*
-   * The data_agent is the client being backuped or restored using NDMP.
+   * The data_agent is the client being backed up or restored using NDMP.
    */
   ASSERT(client->password_.encoding == p_encoding_clear);
   if (!fill_ndmp_agent_config(jcr, &job->data_agent, client->Protocol,

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -241,7 +241,7 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
     }
 
     /*
-     * Tell the data engine what was backuped.
+     * Tell the data engine what was backed up.
      */
     pv.name = ndmp_env_keywords[NDMP_ENV_KW_FILESYSTEM];
     pv.value = ndmp_filesystem;

--- a/core/src/filed/accurate.cc
+++ b/core/src/filed/accurate.cc
@@ -138,7 +138,7 @@ bool AccurateFinish(JobControlRecord* jcr)
 
 /**
  * This function is called for each file seen in fileset.
- * We check in file_list hash if fname have been backuped
+ * We check in file_list hash if fname have been backed up
  * the last time. After we can compare Lstat field.
  * Full Lstat usage have been removed on 6612
  *

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -2472,7 +2472,7 @@ static bRC bareosNewPreInclude(bpContext* ctx)
 }
 
 /**
- * Check if a file have to be backuped using Accurate code
+ * Check if a file have to be backed up using Accurate code
  */
 static bRC bareosCheckChanges(bpContext* ctx, struct save_pkt* sp)
 {

--- a/core/src/findlib/shadowing.cc
+++ b/core/src/findlib/shadowing.cc
@@ -26,7 +26,7 @@
 /**
  * @file
  * Detect fileset shadowing e.g. when an include entry pulls in data
- * which is already being backuped by another include pattern. Currently
+ * which is already being backed up by another include pattern. Currently
  * we support both local and global shadowing. Where local shadowing is
  * when the shadowing occurs within one include block and global when
  * between multiple include blocks.

--- a/core/src/plugins/filed/BareosFdPluginLDAP.py
+++ b/core/src/plugins/filed/BareosFdPluginLDAP.py
@@ -313,7 +313,7 @@ class BareosLDAPWrapper:
 
     def get_next_file_to_backup(self, context, savepkt):
         '''
-        Find out the next file that should be backuped
+        Find out the next file that should be backed up
         '''
         # When file_to_backup is not None we should return the LDIF.
         if self.file_to_backup:

--- a/core/src/plugins/filed/cephfs-conf.d/bareos-dir.d/fileset/plugin-cephfs.conf.example
+++ b/core/src/plugins/filed/cephfs-conf.d/bareos-dir.d/fileset/plugin-cephfs.conf.example
@@ -7,7 +7,7 @@ FileSet {
       xattrsupport = yes
     }
     # adapt this to your environment
-    #   basedir: optional, othewrwise all data will be backuped
+    #   basedir: optional, othewrwise all data will be backed up
     Plugin = "cephfs:conffile=<ceph_conf_file>:basedir=<basedir>:"
   }
 }

--- a/core/src/plugins/filed/python-fd.cc
+++ b/core/src/plugins/filed/python-fd.cc
@@ -2943,7 +2943,7 @@ bail_out:
 
 /**
  * Callback function which is exposed as a part of the additional methods which
- * allow a Python plugin to issue a check if a file have to be backuped using
+ * allow a Python plugin to issue a check if a file have to be backed up using
  * Accurate code.
  */
 static PyObject* PyBareosCheckChanges(PyObject* self, PyObject* args)

--- a/core/src/plugins/filed/python-fd.h
+++ b/core/src/plugins/filed/python-fd.h
@@ -732,7 +732,7 @@ static PyMethodDef BareosFDMethods[] = {
     {"NewPreInclude", PyBareosNewPreInclude, METH_VARARGS,
      "Add new pre include block"},
     {"CheckChanges", PyBareosCheckChanges, METH_VARARGS,
-     "Check if a file have to be backuped using Accurate code"},
+     "Check if a file have to be backed up using Accurate code"},
     {"AcceptFile", PyBareosAcceptFile, METH_VARARGS,
      "Check if a file would be saved using current Include/Exclude code"},
     {"SetSeenBitmap", PyBareosSetSeenBitmap, METH_VARARGS,

--- a/docs/manuals/source/Appendix/BackwardCompatibility.rst
+++ b/docs/manuals/source/Appendix/BackwardCompatibility.rst
@@ -127,7 +127,7 @@ Proceed with the following steps:
 
       /usr/lib/bareos/create_bareos_database
 
--  Insert backuped db into new database:
+-  Insert backed up db into new database:
 
    .. code-block:: shell-session
 

--- a/docs/manuals/source/Appendix/Howtos.rst
+++ b/docs/manuals/source/Appendix/Howtos.rst
@@ -186,7 +186,7 @@ instance
    Defines the instance within the database server.
 
 database
-   Defines the database that should get backuped.
+   Defines the database that should get backed up.
 
 username and password
    Username and Password are required, when the connection is done using a MSSQL user. If the systemaccount the bareos-fd runs with has succifient permissions, this is not required.

--- a/docs/manuals/source/DeveloperGuide/api.rst
+++ b/docs/manuals/source/DeveloperGuide/api.rst
@@ -482,7 +482,7 @@ Bvfs API
 --------
 
 The BVFS (Bareos Virtual File System) do provide a API for browsing the
-backuped files in the catalog and select files for restoring.
+backed up files in the catalog and select files for restoring.
 
 The Bvfs module works correctly with BaseJobs, Copy and Migration jobs.
 
@@ -822,7 +822,7 @@ Example for directory browsing using bvfs
     130 0   0   A A A A A A A A A A A A A A ..
     1   23  123 z GiuU EH9 C GHH GHH A BAA BAA I BWA5Px BaIDUN BaIDUN A A C sbin/
 
-    # the first really backuped path is /sbin/ (pathid=1)
+    # the first really backed up path is /sbin/ (pathid=1)
     # as it has values other than 0 for FileId, JobId and LStat.
     # Now we check, if it has futher subdirectories.
     *.bvfs_lsdir jobid=1 pathid=1
@@ -843,4 +843,4 @@ Example for directory browsing using bvfs
     1   18  123 z Gli+ IHo B GHH GHH A NVkY BAA BrA BaIDUJ BaIDUJ BaIDUJ A A C  928EB+EJGFtWD7wQ8bVjew  Full-0001   0
     1   1067    127 z Glnc IHo B GHH GHH A NVkY BAA BrA BaKDT2 BaKDT2 BaKDT2 A A C  928EB+EJGFtWD7wQ8bVjew  Incremental-0007    0
 
-    # multiple versions of the file bareos-dir have been backuped.
+    # multiple versions of the file bareos-dir have been backed up.

--- a/docs/manuals/source/TasksAndConcepts/CatalogMaintenance.rst
+++ b/docs/manuals/source/TasksAndConcepts/CatalogMaintenance.rst
@@ -604,7 +604,7 @@ Job Retention = <time-period-specification>
    :index:`\ <single: Job; Retention>`\  :index:`\ <single: Retention; Job>`\  The Job Retention record defines the length of time that Bareos will keep Job records in the Catalog database. When this time period expires, and if AutoPrune is set to yes Bareos will prune (remove) Job records that are older than the specified Job Retention period. Note, if a Job record is selected for pruning, all associated File and JobMedia records will also be pruned regardless of the File Retention
    period set. As a consequence, you normally will set the File retention period to be less than the Job retention period.
 
-   As mentioned above, once the File records are removed from the database, you will no longer be able to restore individual files from the Job. However, as long as the Job record remains in the database, you will be able to restore all the files backuped for the Job. As a consequence, it is generally a good idea to retain the Job records much longer than the File records.
+   As mentioned above, once the File records are removed from the database, you will no longer be able to restore individual files from the Job. However, as long as the Job record remains in the database, you will be able to restore all the files backed up for the Job. As a consequence, it is generally a good idea to retain the Job records much longer than the File records.
 
    The retention period is specified in seconds, but as a convenience, there are a number of modifiers that permit easy specification in terms of minutes, hours, days, weeks, months, quarters, or years. See the :ref:`Configuration chapter <Time>` of this manual for additional details of modifier specification.
 

--- a/docs/manuals/source/TasksAndConcepts/FileDeduplicationUsingBaseJobs.rst
+++ b/docs/manuals/source/TasksAndConcepts/FileDeduplicationUsingBaseJobs.rst
@@ -8,7 +8,7 @@ File Deduplication using Base Jobs
 A base job is sort of like a Full save except that you will want the FileSet to contain only files that are unlikely to change in the future (i.e. a snapshot of most of your system after installing it). After the base job has been run, when you are doing a Full save, you specify one or more Base jobs to be used. All files that have been backed up in the Base job/jobs but not modified will then be excluded from the backup. During a restore, the Base jobs will be automatically pulled in where
 necessary.
 
-Imagine having 100 nearly identical Windows or Linux machine containing the OS and user files. Now for the OS part, a Base job will be backed up once, and rather than making 100 copies of the OS, there will be only one. If one or more of the systems have some files updated, no problem, they will be automatically backuped.
+Imagine having 100 nearly identical Windows or Linux machine containing the OS and user files. Now for the OS part, a Base job will be backed up once, and rather than making 100 copies of the OS, there will be only one. If one or more of the systems have some files updated, no problem, they will be automatically backed up.
 
 A new Job directive :strong:`Base=JobX,JobY,...`\  permits to specify the list of files that will be used during Full backup as base.
 

--- a/docs/manuals/source/TasksAndConcepts/NdmpBackupsWithBareos.rst
+++ b/docs/manuals/source/TasksAndConcepts/NdmpBackupsWithBareos.rst
@@ -246,8 +246,8 @@ In our example we connect to a Isilon storage appliance emulator:
      Port = 10000            # Default port for NDMP
      Protocol = NDMPv4       # Need to specify protocol before password as protocol determines password encoding used
      Auth Type = Clear       # Cleartext Authentication
-     Username = "ndmpadmin"  # username of the NDMP user on the DATA AGENT e.g. storage box being backuped.
-     Password = "secret"     # password of the NDMP user on the DATA AGENT e.g. storage box being backuped.
+     Username = "ndmpadmin"  # username of the NDMP user on the DATA AGENT e.g. storage box being backed up.
+     Password = "secret"     # password of the NDMP user on the DATA AGENT e.g. storage box being backed up.
    }
 
 Verify, that you can access your Primary Storage System via Bareos:
@@ -1395,7 +1395,7 @@ To be able to do scheduled backups, we need to configure a backup job that will 
       FileSet = isilon
    }
 
-As we also need to be able to do a restore of the backuped data, we also need to define an adequate restore job:
+As we also need to be able to do a restore of the backed up data, we also need to define an adequate restore job:
 
 .. code-block:: bareosconfig
    :caption: bareos-dir.d/Job/ndmp-native-restore-job.conf

--- a/regress/tests/1-example-test
+++ b/regress/tests/1-example-test
@@ -29,7 +29,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-2disk
+++ b/regress/tests/2drive-2disk
@@ -16,7 +16,7 @@ BackupDirectory="${tmp}/data"
 
 scripts/cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-2job-test
+++ b/regress/tests/2drive-2job-test
@@ -16,7 +16,7 @@ BackupDirectory="${tmp}/data"
 
 scripts/cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-3pool-test
+++ b/regress/tests/2drive-3pool-test
@@ -25,7 +25,7 @@ start_test
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-concurrent-test
+++ b/regress/tests/2drive-concurrent-test
@@ -21,7 +21,7 @@ start_test
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-incremental-2disk
+++ b/regress/tests/2drive-incremental-2disk
@@ -29,7 +29,7 @@ start_test
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/2drive-offline-test
+++ b/regress/tests/2drive-offline-test
@@ -24,7 +24,7 @@ start_test
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/2drive-swap-test
+++ b/regress/tests/2drive-swap-test
@@ -21,7 +21,7 @@ start_test
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/accurate-test
+++ b/regress/tests/accurate-test
@@ -35,7 +35,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/acl-xattr-test
+++ b/regress/tests/acl-xattr-test
@@ -116,7 +116,7 @@ cp ${conf}/bareos-dir.conf  $cwd/tmp/1
 sed -f ${outf} ${cwd}/tmp/1 >${conf}/bareos-dir.conf
 
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/action-on-purge-test
+++ b/regress/tests/action-on-purge-test
@@ -23,7 +23,7 @@ scripts/copy-test-confs
 sed 's/Pool Type = Backup/Pool Type = Backup; ActionOnPurge = Truncate/' $conf/bareos-dir.conf > $tmp/1
 cp $tmp/1 $conf/bareos-dir.conf
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/allowcompress-test
+++ b/regress/tests/allowcompress-test
@@ -15,7 +15,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/always-incremental-test
+++ b/regress/tests/always-incremental-test
@@ -16,7 +16,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/ansi-label-tape
+++ b/regress/tests/ansi-label-tape
@@ -22,7 +22,7 @@ scripts/copy-tape-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/auto-label-test
+++ b/regress/tests/auto-label-test
@@ -13,7 +13,7 @@ copy_test_confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-bareos-client-initiated-connection-test
+++ b/regress/tests/backup-bareos-client-initiated-connection-test
@@ -14,7 +14,7 @@ scripts/copy-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-bareos-passive-test
+++ b/regress/tests/backup-bareos-passive-test
@@ -31,7 +31,7 @@ change_jobname BackupClient1FileList $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-bareos-tape
+++ b/regress/tests/backup-bareos-tape
@@ -19,7 +19,7 @@ scripts/copy-tape-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-bareos-test
+++ b/regress/tests/backup-bareos-test
@@ -25,7 +25,7 @@ change_jobname BackupClient1FileList $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-to-null
+++ b/regress/tests/backup-to-null
@@ -19,7 +19,7 @@ scripts/copy-fifo-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/backup-win32-tape
+++ b/regress/tests/backup-win32-tape
@@ -17,7 +17,7 @@ scripts/copy-win32-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bad-label-changer
+++ b/regress/tests/bad-label-changer
@@ -27,7 +27,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/base-job-test
+++ b/regress/tests/base-job-test
@@ -31,7 +31,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/po.tgz
 

--- a/regress/tests/bextract-test
+++ b/regress/tests/bextract-test
@@ -16,7 +16,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/big-fileset-test
+++ b/regress/tests/big-fileset-test
@@ -18,7 +18,7 @@ change_jobname MonsterFileSet $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 # TODO: use a larger data directory.
 setup_data data/small.tgz

--- a/regress/tests/big-virtual-changer-test
+++ b/regress/tests/big-virtual-changer-test
@@ -24,7 +24,7 @@ CLIENT=2drive2disk
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 # TODO: use a larger data directory.
 setup_data data/small.tgz

--- a/regress/tests/big-vol-test
+++ b/regress/tests/big-vol-test
@@ -17,7 +17,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/block-size-tape
+++ b/regress/tests/block-size-tape
@@ -19,7 +19,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/broken-media-bug-2-test
+++ b/regress/tests/broken-media-bug-2-test
@@ -40,7 +40,7 @@ hugefile=${BackupDirectory}/hugefile
 hugefilesize=300
 
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/broken-media-bug-test
+++ b/regress/tests/broken-media-bug-test
@@ -26,7 +26,7 @@ scripts/cleanup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bscan-fast-tape
+++ b/regress/tests/bscan-fast-tape
@@ -23,7 +23,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bscan-tape
+++ b/regress/tests/bscan-tape
@@ -21,7 +21,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bscan-test
+++ b/regress/tests/bscan-test
@@ -20,7 +20,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bsr-opt-test
+++ b/regress/tests/bsr-opt-test
@@ -18,7 +18,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bsr-read-test
+++ b/regress/tests/bsr-read-test
@@ -18,7 +18,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bug-1227
+++ b/regress/tests/bug-1227
@@ -15,7 +15,7 @@ scripts/cleanup-tape
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bug-897
+++ b/regress/tests/bug-897
@@ -21,7 +21,7 @@ rm -f ${cwd}/tmp/RUN_FD_FAILED
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/bvfs-test
+++ b/regress/tests/bvfs-test
@@ -47,7 +47,7 @@ copy_configs
 # the default fileset FS_TESTJOB backups all file and directories defined in "${tmp}/file-list".
 echo "${BackupDirectory}" >${tmp}/file-list
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/comment-test
+++ b/regress/tests/comment-test
@@ -14,7 +14,7 @@ ${rscripts}/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmpsrc}"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/compress-encrypt-test
+++ b/regress/tests/compress-encrypt-test
@@ -14,7 +14,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/compressed-test
+++ b/regress/tests/compressed-test
@@ -15,7 +15,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-job-test
+++ b/regress/tests/copy-job-test
@@ -21,7 +21,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-jobspan-test
+++ b/regress/tests/copy-jobspan-test
@@ -25,7 +25,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-time-test
+++ b/regress/tests/copy-time-test
@@ -21,7 +21,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-uncopied-test
+++ b/regress/tests/copy-uncopied-test
@@ -23,7 +23,7 @@ sed 's/Migrate/Copy/g' ${cwd}/tmp/1 > ${cwd}/bin/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-upgrade-test
+++ b/regress/tests/copy-upgrade-test
@@ -22,7 +22,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/copy-volume-test
+++ b/regress/tests/copy-volume-test
@@ -23,7 +23,7 @@ sed 's/Migrate/Copy/g' ${cwd}/tmp/1 > ${cwd}/bin/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/data-encrypt-aes256-test
+++ b/regress/tests/data-encrypt-aes256-test
@@ -32,7 +32,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/data-encrypt-blowfish-test
+++ b/regress/tests/data-encrypt-blowfish-test
@@ -32,7 +32,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/data-encrypt-camellia256-test
+++ b/regress/tests/data-encrypt-camellia256-test
@@ -32,7 +32,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/data-encrypt-test
+++ b/regress/tests/data-encrypt-test
@@ -16,7 +16,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/dbcheck-test
+++ b/regress/tests/dbcheck-test
@@ -70,7 +70,7 @@ copy_configs
 # the default fileset FS_TESTJOB backups all file and directories defined in "${tmp}/file-list".
 echo "${BackupDirectory}" >${tmp}/file-list
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/debug-test
+++ b/regress/tests/debug-test
@@ -14,7 +14,7 @@ rm -f ${cwd}/working/*trace*
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/delete-test
+++ b/regress/tests/delete-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/differential-test
+++ b/regress/tests/differential-test
@@ -15,7 +15,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/duplicate-job-test
+++ b/regress/tests/duplicate-job-test
@@ -43,7 +43,7 @@ sed -f $outf $tmp/1 >> $conf/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/eighty-simultaneous-jobs-tape
+++ b/regress/tests/eighty-simultaneous-jobs-tape
@@ -16,7 +16,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/eot-fail-tape
+++ b/regress/tests/eot-fail-tape
@@ -20,7 +20,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/errors-test
+++ b/regress/tests/errors-test
@@ -18,7 +18,7 @@ rm -f ${cwd}/tmp/*.log
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/estimate-test
+++ b/regress/tests/estimate-test
@@ -19,7 +19,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/exclude-dir-test
+++ b/regress/tests/exclude-dir-test
@@ -42,7 +42,7 @@ sed 's/FileSet="CompressedSet"/FileSet=ExcludeDir/' $conf/bareos-dir.conf >$tmp/
 cp -f $tmp/1 $conf/bareos-dir.conf
 change_jobname CompressedTest $JobName
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/fast-two-pool-test
+++ b/regress/tests/fast-two-pool-test
@@ -20,7 +20,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 # TODO: use larger backup data set.
 setup_data data/small.tgz

--- a/regress/tests/fileregexp-test
+++ b/regress/tests/fileregexp-test
@@ -27,7 +27,7 @@ change_jobname BackupClient1FileList $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/fileset-multiple-include-blocks
+++ b/regress/tests/fileset-multiple-include-blocks
@@ -81,7 +81,7 @@ stop_bareos
 check_two_logs
 
 # check for differences between original files and restored files
-# gives an error, because top-level data directory is not backuped
+# gives an error, because top-level data directory is not backed up
 # (and has therefore other permissions)
 for i in $DataDirs; do
    check_restore_diff ${BackupDirectory}/data$i

--- a/regress/tests/fileset-multiple-options-blocks
+++ b/regress/tests/fileset-multiple-options-blocks
@@ -81,7 +81,7 @@ stop_bareos
 check_two_logs
 
 # check for differences between original files and restored files
-# gives an error, because top-level data directory is not backuped
+# gives an error, because top-level data directory is not backed up
 # (and has therefore other permissions)
 check_restore_diff ${BackupDirectory}/data1
 check_restore_diff ${BackupDirectory}/data2

--- a/regress/tests/fixed-block-size-tape
+++ b/regress/tests/fixed-block-size-tape
@@ -32,7 +32,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/four-concurrent-jobs-tape
+++ b/regress/tests/four-concurrent-jobs-tape
@@ -17,7 +17,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/four-concurrent-jobs-test
+++ b/regress/tests/four-concurrent-jobs-test
@@ -16,7 +16,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/four-jobs-tape
+++ b/regress/tests/four-jobs-tape
@@ -18,7 +18,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/four-jobs-test
+++ b/regress/tests/four-jobs-test
@@ -15,7 +15,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/incremental-2disk
+++ b/regress/tests/incremental-2disk
@@ -19,7 +19,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 echo "${BackupDirectory}/ficheriro1.txt" >${tmp}/restore-list

--- a/regress/tests/incremental-2media
+++ b/regress/tests/incremental-2media
@@ -20,7 +20,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/incremental-2media-tape
+++ b/regress/tests/incremental-2media-tape
@@ -34,7 +34,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/incremental-changer
+++ b/regress/tests/incremental-changer
@@ -20,7 +20,7 @@ scripts/prepare-two-tapes
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 echo "${BackupDirectory}/ficheriro1.txt" >${tmp}/restore-list

--- a/regress/tests/incremental-tape
+++ b/regress/tests/incremental-tape
@@ -17,7 +17,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 echo "${BackupDirectory}/ficheriro1.txt" >${tmp}/restore-list

--- a/regress/tests/incremental-test
+++ b/regress/tests/incremental-test
@@ -15,7 +15,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lan-addr-test
+++ b/regress/tests/lan-addr-test
@@ -57,7 +57,7 @@ sed -f ${outf} ${cwd}/tmp/1 > ${conf}/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lan-addr-test-passive
+++ b/regress/tests/lan-addr-test-passive
@@ -58,7 +58,7 @@ sed -f ${outf} ${cwd}/tmp/1 > ${conf}/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lz4-encrypt-test
+++ b/regress/tests/lz4-encrypt-test
@@ -22,7 +22,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lz4-test
+++ b/regress/tests/lz4-test
@@ -22,7 +22,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lz4hc-encrypt-test
+++ b/regress/tests/lz4hc-encrypt-test
@@ -24,7 +24,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lz4hc-test
+++ b/regress/tests/lz4hc-test
@@ -24,7 +24,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lzfast-encrypt-test
+++ b/regress/tests/lzfast-encrypt-test
@@ -26,7 +26,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lzfast-test
+++ b/regress/tests/lzfast-test
@@ -22,7 +22,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lzo-encrypt-test
+++ b/regress/tests/lzo-encrypt-test
@@ -22,7 +22,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/lzo-test
+++ b/regress/tests/lzo-test
@@ -22,7 +22,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/manual-two-vol-tape
+++ b/regress/tests/manual-two-vol-tape
@@ -33,7 +33,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxbytes-test
+++ b/regress/tests/maxbytes-test
@@ -24,7 +24,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxruntime-test
+++ b/regress/tests/maxruntime-test
@@ -19,7 +19,7 @@ WHEN=`date '+%Y-%m-%d %H:%M:%S'`
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxtime-test
+++ b/regress/tests/maxtime-test
@@ -17,7 +17,7 @@ WHEN=`date '+%Y-%m-%d %H:%M:%S'`
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxuseduration-test
+++ b/regress/tests/maxuseduration-test
@@ -18,7 +18,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxvol-test
+++ b/regress/tests/maxvol-test
@@ -23,7 +23,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/maxvol2-test
+++ b/regress/tests/maxvol2-test
@@ -18,7 +18,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/memory-bug-tape
+++ b/regress/tests/memory-bug-tape
@@ -19,7 +19,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/messages-test
+++ b/regress/tests/messages-test
@@ -35,7 +35,7 @@ sed -f ${outf} $tmp/1 >${conf}/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-job-purge-test
+++ b/regress/tests/migration-job-purge-test
@@ -22,7 +22,7 @@ $bperl -e 'add_attribute("$conf/bareos-dir.conf", "PurgeMigrationJob", "yes", "J
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-job-test
+++ b/regress/tests/migration-job-test
@@ -20,7 +20,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-jobspan-test
+++ b/regress/tests/migration-jobspan-test
@@ -20,7 +20,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-occupancy-test
+++ b/regress/tests/migration-occupancy-test
@@ -18,7 +18,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-time-test
+++ b/regress/tests/migration-time-test
@@ -18,7 +18,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-volume-sd-sd-test
+++ b/regress/tests/migration-volume-sd-sd-test
@@ -33,7 +33,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/migration-volume-test
+++ b/regress/tests/migration-volume-test
@@ -18,7 +18,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/multi-drive-group-test
+++ b/regress/tests/multi-drive-group-test
@@ -42,7 +42,7 @@ disable_plugins
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/multi-drive-test
+++ b/regress/tests/multi-drive-test
@@ -32,7 +32,7 @@ disable_plugins
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/multi-drive1-test
+++ b/regress/tests/multi-drive1-test
@@ -39,7 +39,7 @@ disable_plugins
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/multi-storage-test
+++ b/regress/tests/multi-storage-test
@@ -40,7 +40,7 @@ disable_plugins
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/multi2-storage-test
+++ b/regress/tests/multi2-storage-test
@@ -46,7 +46,7 @@ disable_plugins
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/prune-base-job-test
+++ b/regress/tests/prune-base-job-test
@@ -29,7 +29,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/prune-config-test
+++ b/regress/tests/prune-config-test
@@ -23,7 +23,7 @@ $bperl -e 'print get_resource("$conf/bareos-dir.conf", "Job", "NightlySave")' | 
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/prune-copy-test
+++ b/regress/tests/prune-copy-test
@@ -17,7 +17,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/prune-migration-test
+++ b/regress/tests/prune-migration-test
@@ -18,7 +18,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/prune-test
+++ b/regress/tests/prune-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 # po.tgz: build/po/*
 setup_data data/po.tgz

--- a/regress/tests/query-test
+++ b/regress/tests/query-test
@@ -18,7 +18,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/recycle-test
+++ b/regress/tests/recycle-test
@@ -21,7 +21,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/relabel-tape
+++ b/regress/tests/relabel-tape
@@ -19,7 +19,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/rerun-test
+++ b/regress/tests/rerun-test
@@ -18,7 +18,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restart-accurate-job-test
+++ b/regress/tests/restart-accurate-job-test
@@ -16,7 +16,7 @@ $bperl -e "add_attribute('$conf/bareos-dir.conf', 'Accurate', 'yes', 'Job', 'Res
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 touch $BackupDirectory/testfile

--- a/regress/tests/restart-base-job-test
+++ b/regress/tests/restart-base-job-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restart-job-test
+++ b/regress/tests/restart-job-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restore-by-file-tape
+++ b/regress/tests/restore-by-file-tape
@@ -25,7 +25,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restore-by-file-test
+++ b/regress/tests/restore-by-file-test
@@ -16,7 +16,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restore-disk-seek-test
+++ b/regress/tests/restore-disk-seek-test
@@ -40,8 +40,8 @@ done
 #
 find "${BackupDirectory}" -type f | sort | uniq >${tmp}/restore-list
 
-# add more data to be backuped.
-# Use a tgz to setup data to be backuped.
+# add more data to be backed up.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restore-seek-tape
+++ b/regress/tests/restore-seek-tape
@@ -40,8 +40,8 @@ done
 #
 find "${BackupDirectory}" -type f | sort | uniq >${tmp}/restore-list
 
-# add more data to be backuped.
-# Use a tgz to setup data to be backuped.
+# add more data to be backed up.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/restore2-by-file-test
+++ b/regress/tests/restore2-by-file-test
@@ -14,7 +14,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/runscript-test
+++ b/regress/tests/runscript-test
@@ -20,7 +20,7 @@ touch ${cwd}/tmp/log1.out
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/scratch-pool-test
+++ b/regress/tests/scratch-pool-test
@@ -25,7 +25,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/scratchpool-pool-test
+++ b/regress/tests/scratchpool-pool-test
@@ -27,7 +27,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/scsi-crypto-test
+++ b/regress/tests/scsi-crypto-test
@@ -35,7 +35,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/short-incremental-test
+++ b/regress/tests/short-incremental-test
@@ -15,7 +15,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/small-file-size-tape
+++ b/regress/tests/small-file-size-tape
@@ -21,7 +21,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/source-addr-test
+++ b/regress/tests/source-addr-test
@@ -23,7 +23,7 @@ BackupDirectory="${tmp}/data"
 # Remove old configuration, working and tmp files. Setup the database.
 cleanup
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data".
 setup_data data/small.tgz
 

--- a/regress/tests/span-vol-test
+++ b/regress/tests/span-vol-test
@@ -16,7 +16,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-autoxflate-test
+++ b/regress/tests/sparse-autoxflate-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-compressed-test
+++ b/regress/tests/sparse-compressed-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-encrypt-test
+++ b/regress/tests/sparse-encrypt-test
@@ -15,7 +15,7 @@ scripts/copy-crypto-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-file-test
+++ b/regress/tests/sparse-file-test
@@ -16,7 +16,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-lzo-test
+++ b/regress/tests/sparse-lzo-test
@@ -22,7 +22,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/sparse-test
+++ b/regress/tests/sparse-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/status-schedule-test
+++ b/regress/tests/status-schedule-test
@@ -14,7 +14,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/strip-test
+++ b/regress/tests/strip-test
@@ -13,7 +13,7 @@ scripts/copy-strip-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/subscription-test
+++ b/regress/tests/subscription-test
@@ -17,7 +17,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/test-plugin-test
+++ b/regress/tests/test-plugin-test
@@ -22,7 +22,7 @@ file=encrypt-bug.jpg
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/three-pool-recycle-test
+++ b/regress/tests/three-pool-recycle-test
@@ -26,7 +26,7 @@ sed "s%Client Run Before Job%#Client Run Before Job%" ${cwd}/tmp/1 >${cwd}/bin/b
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/three-pool-test
+++ b/regress/tests/three-pool-test
@@ -21,7 +21,7 @@ CLIENT=2drive2disk
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/tls-client-initiated-connection-backup-test
+++ b/regress/tests/tls-client-initiated-connection-backup-test
@@ -18,7 +18,7 @@ copy_configs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/tls-duplicate-job-test
+++ b/regress/tests/tls-duplicate-job-test
@@ -35,7 +35,7 @@ copy_configs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/tls-passive-test
+++ b/regress/tests/tls-passive-test
@@ -28,7 +28,7 @@ copy_configs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/tls-test
+++ b/regress/tests/tls-test
@@ -28,7 +28,7 @@ copy_configs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/truncate-bug-tape
+++ b/regress/tests/truncate-bug-tape
@@ -17,7 +17,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/truncate-command-test
+++ b/regress/tests/truncate-command-test
@@ -41,7 +41,7 @@ copy_configs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/two-jobs-test
+++ b/regress/tests/two-jobs-test
@@ -16,7 +16,7 @@ change_jobname CompressedTest $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/two-pool-changer
+++ b/regress/tests/two-pool-changer
@@ -25,7 +25,7 @@ echo "Done prepare two tapes"
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 # TODO: us a larger data set.
 setup_data data/small.tgz

--- a/regress/tests/two-pool-test
+++ b/regress/tests/two-pool-test
@@ -21,7 +21,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/two-vol-test
+++ b/regress/tests/two-vol-test
@@ -15,7 +15,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/two-volume-changer
+++ b/regress/tests/two-volume-changer
@@ -27,7 +27,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/two-volume-test
+++ b/regress/tests/two-volume-test
@@ -21,7 +21,7 @@ scripts/prepare-disk-changer
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/verify-cat-test
+++ b/regress/tests/verify-cat-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/verify-vol-tape
+++ b/regress/tests/verify-vol-tape
@@ -18,7 +18,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/verify-vol-test
+++ b/regress/tests/verify-vol-test
@@ -14,7 +14,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/verify-voltocat-test
+++ b/regress/tests/verify-voltocat-test
@@ -15,7 +15,7 @@ scripts/copy-test-confs
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/virtual-backup-test
+++ b/regress/tests/virtual-backup-test
@@ -19,7 +19,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/virtual-backup2-test
+++ b/regress/tests/virtual-backup2-test
@@ -19,7 +19,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/flat-c.tgz
 

--- a/regress/tests/virtual-changer-test
+++ b/regress/tests/virtual-changer-test
@@ -33,7 +33,7 @@ CLIENT=2drive2disk
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/virtualfull-extreme-concurrency-bug-test
+++ b/regress/tests/virtualfull-extreme-concurrency-bug-test
@@ -25,7 +25,7 @@ cp scripts/virtualfull-extreme-bacula-dir.conf ${conf}/bareos-dir.conf
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/vol-duration-changer
+++ b/regress/tests/vol-duration-changer
@@ -26,7 +26,7 @@ change_jobname NightlySave $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/win32-backup-tape
+++ b/regress/tests/win32-backup-tape
@@ -19,7 +19,7 @@ change_jobname $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/regress/tests/win32-to-linux-tape
+++ b/regress/tests/win32-to-linux-tape
@@ -19,7 +19,7 @@ change_job $JobName
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data data/small.tgz
 

--- a/systemtests/tests/backup-bareos-passive-test/testrunner
+++ b/systemtests/tests/backup-bareos-passive-test/testrunner
@@ -18,7 +18,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/backup-bareos-test/testrunner
+++ b/systemtests/tests/backup-bareos-test/testrunner
@@ -18,7 +18,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/backup-bscan/testrunner
+++ b/systemtests/tests/backup-bscan/testrunner
@@ -18,7 +18,7 @@ JobName=backup-bareos-fd
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/bconsole-pam/testrunner
+++ b/systemtests/tests/bconsole-pam/testrunner
@@ -31,7 +31,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 #setup_data
 

--- a/systemtests/tests/copy-bscan/testrunner
+++ b/systemtests/tests/copy-bscan/testrunner
@@ -20,7 +20,7 @@ JobName=backup-bareos-fd
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/copy-remote-bscan/testrunner
+++ b/systemtests/tests/copy-remote-bscan/testrunner
@@ -31,7 +31,7 @@ my_stop_bareos() {
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/multiplied-device-test/testrunner
+++ b/systemtests/tests/multiplied-device-test/testrunner
@@ -18,7 +18,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/python-bareos-test/testrunner
+++ b/systemtests/tests/python-bareos-test/testrunner
@@ -18,7 +18,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/testrunner
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/testrunner
@@ -25,7 +25,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/virtualfull-bscan/testrunner
+++ b/systemtests/tests/virtualfull-bscan/testrunner
@@ -21,7 +21,7 @@ JobName=backup-bareos-fd
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/virtualfull/testrunner
+++ b/systemtests/tests/virtualfull/testrunner
@@ -18,7 +18,7 @@ JobName=backup-bareos-fd
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 

--- a/systemtests/tests/webui-selenium/testrunner.in
+++ b/systemtests/tests/webui-selenium/testrunner.in
@@ -18,7 +18,7 @@ ${scripts}/setup
 # This directory will be created by setup_data().
 BackupDirectory="${tmp}/data"
 
-# Use a tgz to setup data to be backuped.
+# Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
 setup_data
 


### PR DESCRIPTION
We have the word backuped in many places while the correct
spelling is "backed up". This commit fixes this.

See: https://en.wiktionary.org/wiki/backuped

  backuped: simple past tense and past participle of backup, Misspelling of backed up.