### PR TITLE
packaging: make specfiles compatible to docker

### DIFF
--- a/python-bareos/packaging/python-bareos.spec
+++ b/python-bareos/packaging/python-bareos.spec
@@ -9,6 +9,11 @@
 %if 0%{?with_python2}
 %global PYVER 2
 %define noarch 0
+%if 0%{?rhel_version} >= 800 || 0%{?fedora} >= 31
+%define pypkg python2
+%else
+%define pypkg python
+%endif
 %else
 %global PYVER 3
 %define noarch 1
@@ -26,13 +31,13 @@ License:        AGPL-3.0
 URL:            https://github.com/bareos/python-bareos/
 Vendor:         The Bareos Team
 #Source0:        http://pypi.python.org/packages/source/e/%%{srcname}/%%{srcname}-%%{version}.tar.gz
-Source:         %{name}-%{version}.tar.gz
+Source:         %{name}-%{version}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-root
 %global debug_package %{nil}
 %if %{with python2}
-BuildRequires:  python-devel
-BuildRequires:  python-setuptools
-Requires:       python-dateutil
+BuildRequires:  %{pypkg}-devel
+BuildRequires:  %{pypkg}-setuptools
+Requires:       %{pypkg}-dateutil
 %endif
 %if %{with python3}
 BuildRequires:  python3-devel
@@ -49,6 +54,10 @@ Bareos - Backup Archiving Recovery Open Sourced - Python module
 
 This packages contains a python module to interact with a Bareos backup system.
 It also includes some tools based on this module.
+
+%if 0%{?opensuse_version} || 0%{?sle_version}
+%debug_package
+%endif
 
 %define pyX_sitelib %(%{pyXcmd} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 

--- a/regress/packaging/bareos-regress.spec
+++ b/regress/packaging/bareos-regress.spec
@@ -40,6 +40,9 @@ Bareos source code has been released under the AGPL version 3 license.
 This package contains Bareos regression tests.
 Don't use them on productive systems.
 
+%if 0%{?opensuse_version} || 0%{?sle_version}
+%debug_package
+%endif
 
 %prep
 %setup

--- a/vmware/packaging/bareos-vmware.spec
+++ b/vmware/packaging/bareos-vmware.spec
@@ -12,7 +12,7 @@ License:        AGPL-3.0
 URL:            http://www.bareos.org/
 Vendor:         The Bareos Team
 %define         sourcename bareos-vmware-%{version}
-Source:         %{sourcename}.tar.gz
+Source:         %{sourcename}.tar.bz2
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 BuildRequires:  bareos-vmware-vix-disklib-devel
@@ -32,7 +32,9 @@ Requires:       bareos-vmware-vix-disklib
 Uses vStorage API to connect to VMWare and dump data like virtual disks snapshots
 to be used by other programs.
 
-
+%if 0%{?opensuse_version} || 0%{?sle_version}
+%debug_package
+%endif
 
 %package -n     bareos-vmware-plugin
 Summary:        Bareos VMware plugin
@@ -100,9 +102,13 @@ chmod +x %{our_find_requires}
 %setup -q -n %{sourcename}
 
 %build
-cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr .
+CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ;
+CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ;
 
-make
+cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_VERBOSE_MAKEFILE=ON .
+
+%__make CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS" %{?_smp_mflags};
+
 
 %install
 %make_install

--- a/webui/packaging/obs/bareos-webui.spec
+++ b/webui/packaging/obs/bareos-webui.spec
@@ -9,7 +9,7 @@ Group:         Productivity/Archiving/Backup
 License:       AGPL-3.0+
 URL:           http://www.bareos-webui.org/
 Vendor:        The Bareos Team
-Source:        %{name}-%{version}.tar.gz
+Source:        %{name}-%{version}.tar.bz2
 BuildRoot:     %{_tmppath}/%{name}-%{version}-build
 BuildArch:     noarch
 


### PR DESCRIPTION
This PR changes the specfiles so we can build bareos in simple docker containers.
Mostly this moves changes that were done in OBS project configuration into the specfiles.