### PR TITLE
Fixes #1118: Incorrect and ugly default mail values

### DIFF
--- a/core/cmake/BareosSetVariableDefaults.cmake
+++ b/core/cmake/BareosSetVariableDefaults.cmake
@@ -574,15 +574,15 @@ ENDIF()
 
 
 IF(NOT DEFINED job_email)
-   SET(job_email "root@localhost")
+   SET(job_email "root")
 ENDIF()
 
 IF(NOT DEFINED dump_email)
-   SET(dump_email "root@localhost")
+   SET(dump_email "root")
 ENDIF()
 
 IF(NOT DEFINED smtp_host)
-   SET(smtp_host "root@localhost")
+   SET(smtp_host "localhost")
 ENDIF()
 
 IF(DEFINED traymonitor)


### PR DESCRIPTION
Fixes #1118: Incorrect default value for smtp_host and ugly default values for job_email and dump_email in BareosSetVariableDefaults.cmake

This patch fixes default mail values for smtp_host, job_email and dump_email.