### PR TITLE
Segfaults in CrlReloaderGetBySubject

### DIFF
--- a/core/src/lib/tls_openssl_crl.cc
+++ b/core/src/lib/tls_openssl_crl.cc
@@ -271,6 +271,9 @@ static int CrlReloaderGetBySubject(X509_LOOKUP* lookup,
   ret->type = 0;
   ret->data.crl = NULL;
   for (cnt = 0; cnt < MAX_CRLS; cnt++) {
+
+    if ( data->crls[cnt] == NULL ) { continue; }
+
     if (CrlEntryExpired(data->crls[cnt]) && !CrlReloaderReloadIfNewer(lookup)) {
       goto bail_out;
     }


### PR DESCRIPTION

In case none of the CRLs match the name and less than MAX_CRLS  were loaded, we will got segfault in X509_NAME_cmp because  data->crls[cnt] is null

Signed-off-by: Adrian Brzezinski <adrian.brzezinski@eo.pl>