### PR TITLE
lib: IsNameValid(): disallow leading and trailing spaces

### DIFF
--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2013 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -498,9 +498,8 @@ bool IsAnInteger(const char* n)
 }
 
 /*
- * Check if BAREOS Resoure Name is valid
+ * Check if BAREOS Resource Name is valid
  *
- * Check if the Volume name has legal characters
  * If ua is non-NULL send the message
  */
 bool IsNameValid(const char* name, POOLMEM*& msg)
@@ -512,11 +511,15 @@ bool IsNameValid(const char* name, POOLMEM*& msg)
    */
   const char* accept = ":.-_/ ";
 
-  /*
-   * No name is invalid
-   */
+  /* Empty name is invalid */
   if (!name) {
     if (msg) { Mmsg(msg, _("Empty name not allowed.\n")); }
+    return false;
+  }
+
+  /* check for beginning space */
+  if (name[0] == ' ') {
+    if (msg) { Mmsg(msg, _("Name cannot start with space.\n")); }
     return false;
   }
 
@@ -538,10 +541,14 @@ bool IsNameValid(const char* name, POOLMEM*& msg)
   }
 
   if (len == 0) {
-    if (msg) {
-      Mmsg(msg, _("Volume name must be at least one character long.\n"));
-    }
+    if (msg) { Mmsg(msg, _("Name must be at least one character long.\n")); }
     return false;
+  } else {
+    /* check for ending space */
+    if (*(p - 1) == ' ') {
+      if (msg) { Mmsg(msg, _("Name cannot end with space.\n")); }
+      return false;
+    }
   }
 
   return true;

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -443,3 +443,14 @@ ENDIF()
 
 gtest_discover_tests(scheduler TEST_PREFIX gtest:)
 
+####### test_is_name_valid  #####################################
+add_executable(test_is_name_valid test_is_name_valid.cc)
+
+target_link_libraries(test_is_name_valid
+   bareos
+   ${GTEST_LIBRARIES}
+   ${GTEST_MAIN_LIBRARIES}
+)
+
+gtest_discover_tests(test_is_name_valid TEST_PREFIX gtest:)
+

--- a/core/src/tests/test_is_name_valid.cc
+++ b/core/src/tests/test_is_name_valid.cc
@@ -1,0 +1,64 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "gtest/gtest.h"
+#include "include/bareos.h"
+#include "lib/edit.h"
+
+POOLMEM* msg = GetPoolMemory(PM_FNAME);
+
+TEST(is_name_valid, is_name_valid)
+{
+  EXPECT_EQ(true, IsNameValid("STRING_CONTAINING_ALLOWED_CHARS :.-_/", msg));
+  EXPECT_EQ(true, IsNameValid("A name_has_space_at_second_place"));
+  EXPECT_EQ(true, IsNameValid("name_has_space_as_second_last Z"));
+  EXPECT_EQ(
+      true,
+      IsNameValid(
+          "STRING_WITH_MAX_ALLOWED_LENGTH......................................"
+          "...........................................................",
+          msg));
+
+
+  EXPECT_EQ(false, IsNameValid("illegalch@racter", msg));
+  EXPECT_STREQ("Illegal character \"@\" in name.\n", msg);
+
+  EXPECT_EQ(false, IsNameValid("", msg));
+  EXPECT_STREQ("Name must be at least one character long.\n", msg);
+
+  EXPECT_EQ(false, IsNameValid(nullptr, msg));
+  EXPECT_STREQ("Empty name not allowed.\n", msg);
+
+  EXPECT_EQ(false, IsNameValid(" name_starts_with_space", msg));
+  EXPECT_STREQ("Name cannot start with space.\n", msg);
+
+  EXPECT_EQ(false, IsNameValid("name_ends_with_space ", msg));
+  EXPECT_STREQ("Name cannot end with space.\n", msg);
+
+  EXPECT_EQ(
+      false,
+      IsNameValid(
+          "STRING_WITH_MAX_ALLOWED_LENGTH_PLUS_ONE............................."
+          "............................................................",
+          msg));
+  EXPECT_STREQ("Name too long.\n", msg);
+}
+

--- a/core/src/tests/test_is_name_valid.cc
+++ b/core/src/tests/test_is_name_valid.cc
@@ -30,13 +30,9 @@ TEST(is_name_valid, is_name_valid)
   EXPECT_EQ(true, IsNameValid("STRING_CONTAINING_ALLOWED_CHARS :.-_/", msg));
   EXPECT_EQ(true, IsNameValid("A name_has_space_at_second_place"));
   EXPECT_EQ(true, IsNameValid("name_has_space_as_second_last Z"));
-  EXPECT_EQ(
-      true,
-      IsNameValid(
-          "STRING_WITH_MAX_ALLOWED_LENGTH......................................"
-          "...........................................................",
-          msg));
 
+  std::string string_maximum_length(MAX_NAME_LENGTH - 1, '.');
+  EXPECT_EQ(true, IsNameValid(string_maximum_length.c_str(), msg));
 
   EXPECT_EQ(false, IsNameValid("illegalch@racter", msg));
   EXPECT_STREQ("Illegal character \"@\" in name.\n", msg);
@@ -53,12 +49,10 @@ TEST(is_name_valid, is_name_valid)
   EXPECT_EQ(false, IsNameValid("name_ends_with_space ", msg));
   EXPECT_STREQ("Name cannot end with space.\n", msg);
 
-  EXPECT_EQ(
-      false,
-      IsNameValid(
-          "STRING_WITH_MAX_ALLOWED_LENGTH_PLUS_ONE............................."
-          "............................................................",
-          msg));
+  EXPECT_EQ(false, IsNameValid(" ", msg));
+  EXPECT_STREQ("Name cannot start with space.\n", msg);
+
+  std::string string_too_long(MAX_NAME_LENGTH, '.');
+  EXPECT_EQ(false, IsNameValid(string_too_long.c_str(), msg));
   EXPECT_STREQ("Name too long.\n", msg);
 }
-


### PR DESCRIPTION
Names with leading and trailing space are now illegal.
Also added a unit test that checks that IsNameValid() works
as expected.