### PR TITLE
acl: check for acl syntax

### DIFF
--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -63,6 +63,7 @@
 #include "lib/parse_conf.h"
 #include "lib/keyword_table_s.h"
 #include "lib/util.h"
+#include "lib/edit.h"
 #include "lib/tls_resource_items.h"
 
 #include <cassert>
@@ -3021,10 +3022,14 @@ static void StoreAcl(LEX* lc, ResourceItem* item, int index, int pass)
     }
   }
   list = alistvalue[item->code];
-
+  std::vector<char> msg(256);
   for (;;) {
     LexGetToken(lc, BCT_STRING);
     if (pass == 1) {
+      if (!IsAclEntryValid(lc->str, msg.data())) {
+        Emsg1(M_ERROR, 0, _("Cannot store Acl: %s\n"), msg.data());
+        return;
+      }
       list->append(strdup(lc->str));
       Dmsg2(900, "Appended to %d %s\n", item->code, lc->str);
     }

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -589,3 +589,55 @@ char* add_commas(char* val, char* buf)
 
   return buf;
 }
+
+/*
+ * check if acl entry is valid
+ * valid acl entries contain only A-Z 0-9 and !*.:_-'/
+ */
+bool IsAclEntryValid(const char* acl, char* msg)
+{
+  int len;
+  const char* p;
+  const char* accept = "!*.:_-'/"; /* Special characters to accept */
+
+
+  if (!acl) {
+    if (msg) { Mmsg(msg, _("Empty acl not allowed.\n")); }
+    return false;
+  }
+
+  /* Restrict the characters permitted in acl */
+  for (p = acl; *p; p++) {
+    if (B_ISALPHA(*p) || B_ISDIGIT(*p) || strchr(accept, (int)(*p))) {
+      continue;
+    }
+    if (msg) { Mmsg(msg, _("Illegal character \"%c\" in acl.\n"), *p); }
+    return false;
+  }
+
+  len = p - acl;
+  if (len >= MAX_NAME_LENGTH) {
+    if (msg) { Mmsg(msg, _("Acl too long.\n")); }
+    return false;
+  }
+
+  if (len == 0) {
+    if (msg) { Mmsg(msg, _("Acl must be at least one character long.\n")); }
+    return false;
+  }
+
+  return true;
+}
+
+bool IsAclEntryValid(const char* acl)
+{
+  bool retval;
+  POOLMEM* msg = GetPoolMemory(PM_NAME);
+
+  retval = IsAclEntryValid(acl, msg);
+
+  FreePoolMemory(msg);
+
+  return retval;
+}
+

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,5 +43,7 @@ bool Is_a_number_list(const char* n);
 bool IsAnInteger(const char* n);
 bool IsNameValid(const char* name, POOLMEM*& msg);
 bool IsNameValid(const char* name);
+bool IsAclEntryValid(const char* acl, char* msg);
+bool IsAclEntryValid(const char* acl);
 
 #endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -454,3 +454,13 @@ target_link_libraries(test_is_name_valid
 
 gtest_discover_tests(test_is_name_valid TEST_PREFIX gtest:)
 
+####### test_acl_entry_syntax  #####################################
+add_executable(test_acl_entry_syntax test_acl_entry_syntax.cc)
+
+target_link_libraries(test_acl_entry_syntax
+   bareos
+   ${GTEST_LIBRARIES}
+   ${GTEST_MAIN_LIBRARIES}
+)
+
+gtest_discover_tests(test_acl_entry_syntax TEST_PREFIX gtest:)

--- a/core/src/tests/test_acl_entry_syntax.cc
+++ b/core/src/tests/test_acl_entry_syntax.cc
@@ -33,12 +33,10 @@ TEST(acl_entry_syntax_test, acl_entry_syntax_test)
   EXPECT_STREQ("Illegal character \",\" in acl.\n", msg);
 
   EXPECT_EQ(true, IsAclEntryValid("STRING.CONTAINING.ALLOWED.CHARS!*.", msg));
-  EXPECT_EQ(
-      true,
-      IsAclEntryValid(
-          "STRING.WITH.MAX.ALLOWED.LENGTH......................................"
-          "...........................................................",
-          msg));
+
+  std::string string_maximum_length(MAX_NAME_LENGTH - 1, '.');
+  EXPECT_EQ(true, IsAclEntryValid(string_maximum_length.c_str(), msg));
+
   EXPECT_EQ(false, IsAclEntryValid("illegalch@racter", msg));
   EXPECT_STREQ("Illegal character \"@\" in acl.\n", msg);
 
@@ -48,12 +46,8 @@ TEST(acl_entry_syntax_test, acl_entry_syntax_test)
   EXPECT_EQ(false, IsAclEntryValid(nullptr, msg));
   EXPECT_STREQ("Empty acl not allowed.\n", msg);
 
+  std::string string_too_long(MAX_NAME_LENGTH, '.');
+  EXPECT_EQ(false, IsAclEntryValid(string_too_long.c_str(), msg));
 
-  EXPECT_EQ(
-      false,
-      IsAclEntryValid(
-          "STRING.WITH.MAX.ALLOWED.LENGTH.PLUS.ONE............................."
-          "............................................................",
-          msg));
   EXPECT_STREQ("Acl too long.\n", msg);
 }

--- a/core/src/tests/test_acl_entry_syntax.cc
+++ b/core/src/tests/test_acl_entry_syntax.cc
@@ -1,0 +1,59 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "gtest/gtest.h"
+#include "include/bareos.h"
+#include "lib/edit.h"
+
+POOLMEM* msg = GetPoolMemory(PM_FNAME);
+
+TEST(acl_entry_syntax_test, acl_entry_syntax_test)
+{
+  EXPECT_EQ(true, IsAclEntryValid("list", msg));
+
+  EXPECT_EQ(false, IsAclEntryValid("list,add", msg));
+  EXPECT_STREQ("Illegal character \",\" in acl.\n", msg);
+
+  EXPECT_EQ(true, IsAclEntryValid("STRING.CONTAINING.ALLOWED.CHARS!*.", msg));
+  EXPECT_EQ(
+      true,
+      IsAclEntryValid(
+          "STRING.WITH.MAX.ALLOWED.LENGTH......................................"
+          "...........................................................",
+          msg));
+  EXPECT_EQ(false, IsAclEntryValid("illegalch@racter", msg));
+  EXPECT_STREQ("Illegal character \"@\" in acl.\n", msg);
+
+  EXPECT_EQ(false, IsAclEntryValid("", msg));
+  EXPECT_STREQ("Acl must be at least one character long.\n", msg);
+
+  EXPECT_EQ(false, IsAclEntryValid(nullptr, msg));
+  EXPECT_STREQ("Empty acl not allowed.\n", msg);
+
+
+  EXPECT_EQ(
+      false,
+      IsAclEntryValid(
+          "STRING.WITH.MAX.ALLOWED.LENGTH.PLUS.ONE............................."
+          "............................................................",
+          msg));
+  EXPECT_STREQ("Acl too long.\n", msg);
+}


### PR DESCRIPTION
We now check the syntax of acls. Now commas in the
acl elements are forbidden so that accidentally
quoting the acl definition is detected.

This commit also adds a unit test making sure the acl check works
as expected.