### PR TITLE
webui: replace !empty() with strlen()>0

### DIFF
--- a/webui/config/autoload/global.php.in
+++ b/webui/config/autoload/global.php.in
@@ -35,7 +35,7 @@
  * file.
  */
 
-if(!empty(getenv('BAREOS_WEBUI_CONFDIR'))) {
+if(strlen(getenv('BAREOS_WEBUI_CONFDIR')) > 0) {
    $directors_ini = getenv('BAREOS_WEBUI_CONFDIR')."/directors.ini";
    $configuration_ini = getenv('BAREOS_WEBUI_CONFDIR')."/configuration.ini";
 } else {


### PR DESCRIPTION
In PHP versions prior to 5.5 (as e.g. on RHEL/CentOS 7) empty() can only
be used with variables and not function return values.