### PR TITLE
Make 16.2 build in docker containers

### DIFF
--- a/autoconf/bareos/os.m4
+++ b/autoconf/bareos/os.m4
@@ -169,10 +169,7 @@ else
    then
       LSB_DISTRIBUTOR=`lsb_release -i -s`
       case ${LSB_DISTRIBUTOR} in
-         "SUSE LINUX")
-            DISTNAME=suse
-            ;;
-         "openSUSE project")
+         *SUSE*)
             DISTNAME=suse
             ;;
          CentOS)

--- a/configure
+++ b/configure
@@ -17853,10 +17853,7 @@ else
    then
       LSB_DISTRIBUTOR=`lsb_release -i -s`
       case ${LSB_DISTRIBUTOR} in
-         "SUSE LINUX")
-            DISTNAME=suse
-            ;;
-         "openSUSE project")
+         *SUSE*)
             DISTNAME=suse
             ;;
          CentOS)

--- a/platforms/packaging/bareos.spec
+++ b/platforms/packaging/bareos.spec
@@ -137,7 +137,7 @@ BuildRequires: ceph-devel
 BuildRequires: git-core
 %endif
 
-Source0: %{name}-%{version}.tar.gz
+Source0: %{name}-%{version}.tar.bz2
 
 #BuildRequires: elfutils
 BuildRequires: gcc


### PR DESCRIPTION
This PR updates the SPECfile (and autoconf) so we can build Bareos 16.2 in our new Docker Build-Container infrastructure