### PR TITLE
fd-plugins: Check return value of endRestoreFile

### DIFF
--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1113,6 +1113,7 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
   char* cmd;
   char* p = name;
   bool start;
+  bool retval = true;
   bpContext* ctx = nullptr;
   alist* plugin_ctx_list;
 
@@ -1140,7 +1141,15 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
       Dmsg2(debuglevel, "End plugin data plugin=%p ctx=%p\n", plugin,
             jcr->plugin_ctx);
       if (b_ctx->restoreFileStarted) {
-        PlugFunc(plugin)->endRestoreFile(jcr->plugin_ctx);
+        /* PlugFunc(plugin)->endRestoreFile(jcr->plugin_ctx); */
+        bRC ret = PlugFunc(plugin)->endRestoreFile(jcr->plugin_ctx);
+        Dmsg1(0, "endRestoreFile ret: %d\n", ret);
+        if (ret < 0) {
+          Jmsg2(jcr, M_FATAL, 0,
+                "Return value of endRestoreFile invalid: %d, plugin=%s\n", ret,
+                jcr->plugin_ctx->plugin->file);
+          retval = false;
+        }
       }
       b_ctx->restoreFileStarted = false;
       b_ctx->createFileCalled = false;
@@ -1212,7 +1221,7 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
   Jmsg1(jcr, M_WARNING, 0, _("Plugin=%s not found.\n"), cmd);
 
 bail_out:
-  return start;
+  return retval;
 }
 
 /**

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1144,7 +1144,7 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
         /* PlugFunc(plugin)->endRestoreFile(jcr->plugin_ctx); */
         bRC ret = PlugFunc(plugin)->endRestoreFile(jcr->plugin_ctx);
         Dmsg1(0, "endRestoreFile ret: %d\n", ret);
-        if (ret < 0) {
+        if (ret == PYTHON_UNDEFINED_RETURN_VALUE) {
           Jmsg2(jcr, M_FATAL, 0,
                 "Return value of endRestoreFile invalid: %d, plugin=%s\n", ret,
                 jcr->plugin_ctx->plugin->file);

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -1077,7 +1077,7 @@ void DoRestore(JobControlRecord* jcr)
       case STREAM_PLUGIN_NAME:
         if (!ClosePreviousStream(jcr, rctx)) { goto bail_out; }
         Dmsg1(50, "restore stream_plugin_name=%s\n", sd->msg);
-        PluginNameStream(jcr, sd->msg);
+        if (!PluginNameStream(jcr, sd->msg)) { goto bail_out; }
         break;
 
       case STREAM_RESTORE_OBJECT:

--- a/core/src/lib/plugins.h
+++ b/core/src/lib/plugins.h
@@ -41,6 +41,7 @@
  */
 typedef enum
 {
+  PYTHON_UNDEFINED_RETURN_VALUE = -1,
   bRC_OK = 0,     /* OK */
   bRC_Stop = 1,   /* Stop calling other plugins */
   bRC_Error = 2,  /* Some kind of error */


### PR DESCRIPTION
When omitting return bRCs['bRC_OK'] in the end_restore_file method
of a Python plugin, it resulted in seemingly unrelated Python
errors like "TypeError: an integer is required" in subsequent calls
of Python funtions.

Now the return value is checked and if it is invalid, an appropriate
error message will be generated.