### PR TITLE
winbareos: compress using solid compression

### DIFF
--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -67,7 +67,7 @@ $\r$\n\
 $\r$\n\
 [/? (this help dialog)]"
 
-SetCompressor lzma
+SetCompressor /solid lzma
 
 # variable definitions
 Var LocalHostAddress


### PR DESCRIPTION
Previously individual NSIS installer files have been compressed one
by one. By enabling solid compression the compressor is only run once
for the whole package.
This saves both time and space.