### PR TITLE
webui: Display all available job records in the client details view

### DIFF
--- a/webui/module/Client/src/Client/Model/ClientModel.php
+++ b/webui/module/Client/src/Client/Model/ClientModel.php
@@ -102,7 +102,7 @@ class ClientModel
    public function getClientBackups(&$bsock=null, $client=null, $fileset=null, $order=null, $limit=null)
    {
       if(isset($bsock, $client)) {
-         $cmd = 'llist backups client="'.$client.'"';
+         $cmd = 'llist jobs client="'.$client.'"';
          if ($fileset != null) {
             $cmd .= ' fileset="'.$fileset.'"';
          }
@@ -114,7 +114,7 @@ class ClientModel
          }
          $result = $bsock->send_command($cmd, 2);
          $backups = \Zend\Json\Json::decode($result, \Zend\Json\Json::TYPE_ARRAY);
-         return $backups['result']['backups'];
+         return $backups['result']['jobs'];
       }
       else {
          throw new \Exception('Missing argument.');

--- a/webui/module/Client/view/client/client/details.phtml
+++ b/webui/module/Client/view/client/client/details.phtml
@@ -68,7 +68,7 @@ $this->headTitle($title);
 
 <div class="panel panel-default">
 <div class="panel-heading">
-<h3 class="panel-title"><?php echo $this->translate("Last successful backups"); ?></h3>
+<h3 class="panel-title"><?php echo $this->translate("Job list"); ?></h3>
 </div>
 
 <div class="panel-body">


### PR DESCRIPTION
"llist backups" delivers records of successful backup jobs only.

This commit changes the underlying bconsole command in the client model
from "llist backups" to "llist jobs" to get all job records regardless
of their job status.