### PR TITLE
Avoid listing duplicate volume records

### DIFF
--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -343,7 +343,7 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
          edit_int64(JobId, ed1));
   } else {
     Mmsg(cmd,
-         "SELECT Media.VolumeName "
+         "SELECT DISTINCT Media.VolumeName "
          "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId "
          "AND JobMedia.JobId=%s",
          edit_int64(JobId, ed1));

--- a/webui/module/Job/src/Job/Model/JobModel.php
+++ b/webui/module/Job/src/Job/Model/JobModel.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2017 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -210,7 +210,7 @@ class JobModel
     */
    public function getJobMedia(&$bsock=null, $jobid=null)
    {
-      $cmd = 'llist jobmedia jobid='.$jobid;
+      $cmd = 'list volumes jobid='.$jobid;
       $result = $bsock->send_command($cmd, 2);
       if(preg_match('/Failed to send result as json. Maybe result message to long?/', $result)) {
          //return false;
@@ -219,7 +219,7 @@ class JobModel
       }
       else {
          $jobmedia = \Zend\Json\Json::decode($result, \Zend\Json\Json::TYPE_ARRAY);
-         return $jobmedia['result']['jobmedia'];
+         return $jobmedia['result']['volumes'];
       }
    }
 

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link   https://github.com/bareos/bareos for the canonical source repository
- * @copyright   Copyright (c) 2013-2017 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright   Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -172,31 +172,6 @@ $this->headTitle($title);
       return html.join('');
    }
 
-   function detailFormatterJobMedia(index, row) {
-      var html = [];
-      html.push('<div class="container-fluid">');
-      html.push('<table class="table table-bordered">');
-      html.push('<tr>');
-      html.push('<th><?php echo $this->translate("First Index"); ?></th>');
-      html.push('<td>' + row.firstindex + '</td>');
-      html.push('</tr>');
-      html.push('<tr>');
-      html.push('<th><?php echo $this->translate("Last Index"); ?></th>');
-      html.push('<td>' + row.lastindex + '</td>');
-      html.push('</tr>');
-      html.push('<tr>');
-      html.push('<th><?php echo $this->translate("Start Block"); ?></th>');
-      html.push('<td>' + row.startblock + '</td>');
-      html.push('</tr>');
-      html.push('<tr>');
-      html.push('<th><?php echo $this->translate("End Block"); ?></th>');
-      html.push('<td>' + row.endblock + '</td>');
-      html.push('</tr>');
-      html.push('</table>');
-      html.push('</div>');
-      return html.join('');
-   }
-
    function getJobDetails() {
       jobdetails = $('#jobdetails').bootstrapTable({
          locale: '<?php echo str_replace('_','-', $_SESSION['bareos']['locale']); ?>',
@@ -345,8 +320,6 @@ $this->headTitle($title);
          search: true,
          sortName: 'volumename',
          sortOrder: 'asc',
-         detailView: true,
-         detailFormatter: 'detailFormatterJobMedia',
          columns: [
             {
                field: 'volumename',


### PR DESCRIPTION
When the same job is spread and split into pieces over a volume and not written sequential, the command "list volumes jobid=xyz" delivered multiple entries. This PR fixes that behavior by adding a DISTINCT to the underlying SQL query.

The underlying SQL query of "llist volumes jobid=xyz" (vertical list type) is untouched, so you are still able to get all records and their references to the jobmedia table.

Also it fixes the listing of volumes used by a job in the webui by making use of the changed command as described above.
