### PR TITLE
dird: fix RunScript parsing

### DIFF
--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -591,7 +591,7 @@ static ResourceItem runscript_items[] = {
  { "FailJobOnError", CFG_TYPE_RUNSCRIPT_BOOL, ITEM(res_runscript,fail_on_error), 0, 0, NULL, NULL, NULL },
  { "AbortJobOnError", CFG_TYPE_RUNSCRIPT_BOOL, ITEM(res_runscript,fail_on_error), 0, 0, NULL, NULL, NULL },
  { "RunsWhen", CFG_TYPE_RUNSCRIPT_WHEN, ITEM(res_runscript,when), 0, 0, NULL, NULL, NULL },
- { "RunsOnClient", CFG_TYPE_RUNSCRIPT_TARGET, ITEMC(res_runscript), 0, 0, NULL, NULL, NULL }, /* TODO */
+ { "RunsOnClient", CFG_TYPE_RUNSCRIPT_TARGET, ITEMC(res_runscript), 0, 0, NULL, NULL, NULL },
  {nullptr, 0, 0, nullptr, 0, 0, nullptr, nullptr, nullptr}
 };
 
@@ -3220,6 +3220,14 @@ static void StoreRunscript(LEX* lc, ResourceItem* item, int index, int pass)
 
   res_runscript = new RunScript();
 
+  /*
+   * Run on client by default.
+   * Set this here, instead of in the class constructor,
+   * as the class is also used by other daemon,
+   * where the default differs.
+   */
+  if (res_runscript->target.empty()) { res_runscript->SetTarget("%c"); }
+
   while ((token = LexGetToken(lc, BCT_SKIP_EOL)) != BCT_EOF) {
     if (token == BCT_EOB) { break; }
 
@@ -3261,9 +3269,6 @@ static void StoreRunscript(LEX* lc, ResourceItem* item, int index, int pass)
   }
 
   if (pass == 2) {
-    // Run on client by default
-    if (res_runscript->target.empty()) { res_runscript->SetTarget("%c"); }
-
     alist** runscripts = GetItemVariablePointer<alist**>(*item);
     if (!*runscripts) { *runscripts = new alist(10, not_owned_by_alist); }
 

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -2,6 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2011 Free Software Foundation Europe e.V.
+   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -130,8 +131,11 @@ int RunScripts(JobControlRecord* jcr,
   }
 
   foreach_alist (script, runscripts) {
-    Dmsg2(200, "runscript: try to run %s:%s\n", NSTDPRNT(script->target),
-          NSTDPRNT(script->command));
+    Dmsg5(200,
+          "runscript: try to run (Target=%s, OnSuccess=%i, OnFailure=%i, "
+          "CurrentJobStatus=%c, command=%s)\n",
+          NSTDPRNT(script->target), script->on_success, script->on_failure,
+          jcr->JobStatus, NSTDPRNT(script->command));
     runit = false;
 
     if (!script->IsLocal()) {
@@ -215,8 +219,6 @@ void RunScript::SetCommand(const std::string& cmd, int acmd_type)
 void RunScript::SetTarget(const std::string& client_name)
 {
   Dmsg1(500, "runscript: setting target = %s\n", NSTDPRNT(client_name));
-
-  if (client_name.empty()) { return; }
 
   target = client_name;
 }

--- a/core/src/lib/runscript.h
+++ b/core/src/lib/runscript.h
@@ -37,7 +37,6 @@ class alist;
 
 /* Usage:
  *
- * #define USE_RUNSCRIPT
  * #include "lib/runscript.h"
  *
  * RunScript *script = new RunScript;
@@ -45,7 +44,7 @@ class alist;
  * script->on_failure = true;
  * script->when = SCRIPT_After;
  *
- * script->run("LabelBefore");  // the label must contain "Before" or "After"
+ * script->Run("LabelBefore");  // the label must contain "Before" or "After"
  * special keyword FreeRunscript(script);
  */
 
@@ -81,7 +80,9 @@ class RunScript : public BareosResource {
   RunScript(const RunScript& other) = default;
 
   std::string command;       /* Command string */
-  std::string target;        /* Host target */
+  std::string target;        /* Host target. Values:
+                                Empty string: run locally.
+                                "%c": (Client’s name). Run on client. */
   int when = SCRIPT_Never;   /* SCRIPT_Before|Script_After BEFORE/AFTER JOB*/
   int cmd_type = 0;          /* Command type -- Shell, Console */
   char level = 0;            /* Base|Full|Incr...|All (NYI) */

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-client-server.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-client-server.conf.in
@@ -1,0 +1,27 @@
+Job {
+  Name = "admin-runscript-client-server"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    #Runs On Client = Yes
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-client.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-client.conf.in
@@ -1,0 +1,16 @@
+Job {
+  Name = "admin-runscript-client"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    #Runs On Client = Yes
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-server.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/admin-runscript-server.conf.in
@@ -1,0 +1,16 @@
+Job {
+  Name = "admin-runscript-server"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"    
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-client-defaults.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-client-defaults.conf.in
@@ -1,0 +1,16 @@
+Job {
+  Name = "backup-bareos-fd-runscript-client-defaults"
+  JobDefs = "DefaultJob"
+  Type = Backup
+  RunScript {
+    RunsWhen = Before
+    #Runs On Failure = Yes
+    #Runs On Client = Yes
+    #FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-client.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-client.conf.in
@@ -1,0 +1,16 @@
+Job {
+  Name = "backup-bareos-fd-runscript-client"
+  JobDefs = "DefaultJob"
+  Type = Backup
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    Runs On Client = Yes
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-server.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd-runscript-server.conf.in
@@ -1,0 +1,16 @@
+Job {
+  Name = "backup-bareos-fd-runscript-server"
+  JobDefs = "DefaultJob"
+  Type = Backup
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n    Job name
+    # %t    Job type (Backup, …)
+    # %i    Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"    
+  }
+}

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/jobdefs/jobdefs-runscript1.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/jobdefs/jobdefs-runscript1.conf.in
@@ -1,0 +1,17 @@
+JobDefs {
+  Name = "jobdefs-runscript1"
+  Type = Admin
+  Messages = Standard
+  RunScript {
+    RunsWhen = Before
+    Runs On Client = No
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n	Job name
+    # %t	Job type (Backup, …)
+    # %i	Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'jobdefs=jobdefs-runscript1' 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"
+  }
+  Jobdefs = "DefaultJob"
+}
+

--- a/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/jobdefs/jobdefs-runscript2.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/bareos-dir.d/jobdefs/jobdefs-runscript2.conf.in
@@ -1,0 +1,17 @@
+JobDefs {
+  Name = "jobdefs-runscript2"
+  Type = Admin
+  Messages = Standard
+  RunScript {
+    RunsWhen = Before
+    Runs On Client = No
+    FailJobOnError = Yes
+    # %d    Daemon’s name (Such as host-dir or host-fd)
+    # %n	Job name
+    # %t	Job type (Backup, …)
+    # %i	Job Id
+    Command = "@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/write.sh @working_dir@/jobid-%i-runscript.log 'jobdefs=jobdefs-runscript2' 'daemon=%d' 'jobname=%n' 'jobtype=%t' 'jobid=%i'"    
+  }
+  JobDefs = "jobdefs-runscript1"
+}
+

--- a/systemtests/tests/python-bareos-test/write.sh
+++ b/systemtests/tests/python-bareos-test/write.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+file=$1
+shift
+
+printf "date=%s\n" "$(LANG=C date)" | tee --append $file
+for i in "$@"; do
+    echo "$i" | tee --append $file
+done


### PR DESCRIPTION
This commit fixes a bug introduced during the recent months.
Without this patch, all RunScripts are configured to "Runs On Client = Yes".
Because of this, Admin and Console RunScripts did not work and are silently ignored.

With this change, RunScripts can by set to run locally or on the Client (Runs On Client = Yes/No).

A systemtest for this is included in PR #314 .