### PR TITLE
tests: make tests compile on rhel7

### DIFF
--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -212,10 +212,9 @@ static void SimulateClientConnect(std::string client_name,
 
 static void RunSchedulerAndSimulateClientConnect(BareosDb& db)
 {
-  auto tts{std::make_unique<TestTimeSource>()};
-  auto ta{std::make_unique<TimeAdapter>(std::move(tts))};
-
-  Scheduler scheduler(std::move(ta), SchedulerJobCallback);
+  Scheduler scheduler(
+      std::make_unique<TimeAdapter>(std::make_unique<TestTimeSource>()),
+      SchedulerJobCallback);
 
   std::thread scheduler_thread(scheduler_loop, &scheduler);
 

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -159,7 +159,7 @@ void SimulatedTimeSource::ExecuteJob(JobControlRecord* jcr)
 
   // auto tm = *std::gmtime(&t);
   // std::cout << "Executing job: " << jcr->Job << std::endl;
-  // std::cout << std::put_time(&tm, "%d-%m-%Y %H:%M:%S") << std::endl;
+  // std::cout << put_time(&tm, "%d-%m-%Y %H:%M:%S") << std::endl;
 }
 
 static int CalculateAverage()
@@ -217,7 +217,7 @@ TEST_F(SchedulerTest, hourly)
     for (const auto& t : list_of_job_execution_time_stamps) {
       auto tm = *std::gmtime(&t);
       std::cout << "Hour " << hour << ": "
-                << std::put_time(&tm, "%d-%m-%Y %H:%M:%S");
+                << put_time(&tm, "%d-%m-%Y %H:%M:%S");
       if (hour) {
         std::cout << " - " << list_of_time_gaps_between_adjacent_jobs[hour]
                   << " sec";
@@ -267,7 +267,7 @@ TEST_F(SchedulerTest, on_time)
     EXPECT_TRUE(is_two_o_clock);
     EXPECT_TRUE(is_monday);
     if (debug || !is_two_o_clock || !is_monday) {
-      std::cout << std::put_time(&tm, "%A, %d-%m-%Y %H:%M:%S ") << std::endl;
+      std::cout << put_time(&tm, "%A, %d-%m-%Y %H:%M:%S ") << std::endl;
     }
   }
 
@@ -295,7 +295,7 @@ TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
   counter_of_number_of_jobs_run = 0;
   maximum_number_of_jobs_run = 1;
 
-  auto scheduler_thread{std::thread([]() { scheduler->Run(); })};
+  std::thread scheduler_thread{[]() { scheduler->Run(); }};
 
   JobResource* job{dynamic_cast<JobResource*>(
       my_config->GetResWithName(R_JOB, "backup-bareos-fd"))};

--- a/core/src/tests/scheduler_time_source.h
+++ b/core/src/tests/scheduler_time_source.h
@@ -28,9 +28,18 @@
 #include <atomic>
 #include <condition_variable>
 #include <thread>
+#include <iomanip>
 #include <iostream>
 
 static bool debug{false};
+
+/* libstdc++ on rhel7 does not have put_time, so we add it here */
+std::string put_time(const std::tm* tmb, const char* fmt) {
+  size_t maxlen = strlen(fmt)+100;
+  std::vector<char> s(maxlen);
+  strftime(s.data(), s.size(), fmt, tmb);
+  return std::string{s.data()};
+}
 
 class SimulatedTimeSource : public directordaemon::TimeSource {
  public:
@@ -41,7 +50,7 @@ class SimulatedTimeSource : public directordaemon::TimeSource {
 
     if (debug) {
       time_t t{clock_value_};
-      std::cout << std::put_time(
+      std::cout << put_time(
                        gmtime(&t),
                        "Start simulated Clock at time: %d-%m-%Y %H:%M:%S")
                 << std::endl;


### PR DESCRIPTION
Some of the newer tests did not compile on rhel7 with the shipped gcc.
These changes ensure compatibility with the old gcc 4.8.5.