### PR TITLE
findlib: parent dirs should have consistent mode

### DIFF
--- a/core/src/findlib/mkpath.cc
+++ b/core/src/findlib/mkpath.cc
@@ -257,7 +257,7 @@ bool makepath(Attributes* attr,
   /*
    * Set for final component
    */
-  if (i < ndir && new_dir[i++]) { SetOwnMod(attr, path, owner, group, mode); }
+  if (i < ndir && new_dir[i++] && !keep_dir_modes) { SetOwnMod(attr, path, owner, group, mode); }
 
   ok = true;
 bail_out:


### PR DESCRIPTION
Previously when creating parent directories Bareos handled the deepest
parent directory special and set permissions on it.
This surfaced when selecting only files, but not directories to restore.
In that case the directory that contains the files got a mode that was
derived from the file mode of the file being restored when the parent
directory was created.
While this in itself is already inconsistent, the effective mode was
also calculated by adding S_IWUSR and S_IXUSR which did not take group
or other in account.

This patch now makes sure that no permission on parent directories is
set explicitly, so you just get what the effective uid, gid and umask
will produce.