### PR TITLE
added `configure delete <resource>`

### DIFF
--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1033,6 +1033,10 @@ const char* GetUsageStringForConsoleConfigureCommand()
       }
     }
     /*
+     * subcommand: delete
+     */
+    configure_usage_string->strcat("delete <resource>");
+    /*
      * subcommand: export
      */
     configure_usage_string->strcat("export client=<client>");


### PR DESCRIPTION
This PR add the functionality to delete a resources and it's corresponding configfile via bconsole.
This is particulary useful if Bareos is confirgured automatically via "API".

If a resource should be deleted the code first tries to guess its config file name and then tries to remove() it, if that fails the command is aborted. Then the resource is removed from the current configuration. Of course, like if one removes a file manually, the config reload could be impossible due to a missing resource afterwards.
