### PR TITLE
cmake: Use date command on cmake <3.10 so %B works

### DIFF
--- a/core/cmake/BareosTimeFunctions.cmake
+++ b/core/cmake/BareosTimeFunctions.cmake
@@ -16,7 +16,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 function(timestamp_at at result format)
-  if(CMAKE_VERSION VERSION_GREATER 3.8.0)
+  if(CMAKE_VERSION VERSION_GREATER 3.10.0)
     set(old_epoch "$ENV{SOURCE_DATE_EPOCH}")
     set(ENV{SOURCE_DATE_EPOCH} "${at}")
     string(TIMESTAMP out "${format}" UTC)
@@ -33,7 +33,7 @@ function(timestamp_at at result format)
     if(out STREQUAL "")
       message(
         FATAL_ERROR
-          "Cannot use SOURCE_DATE_EPOCH (cmake < 3.8) and your 'date' command is not compatible with Bareos' timestamp_at()."
+          "Cannot use SOURCE_DATE_EPOCH (cmake < 3.10) and your 'date' command is not compatible with Bareos' timestamp_at()."
       )
     endif()
   endif()


### PR DESCRIPTION
Previously cmake fell back on using the date command in favour of
TIMESTAMP when the cmake version was 3.8 or older. This lead to a case
where a literal %B was added in the Bareos date when building with
cmake 3.8 to 3.10.
This patch makes cmake fall back to use the date command on versions up
to 3.10.