### PR TITLE
Fix Bug #1175: bareos crashes with invalid character in ACL

### DIFF
--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3026,7 +3026,7 @@ static void StoreAcl(LEX* lc, ResourceItem* item, int index, int pass)
   for (;;) {
     LexGetToken(lc, BCT_STRING);
     if (pass == 1) {
-      if (!IsAclEntryValid(lc->str, msg.data())) {
+      if (!IsAclEntryValid(lc->str, msg)) {
         Emsg1(M_ERROR, 0, _("Cannot store Acl: %s\n"), msg.data());
         return;
       }

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -448,6 +448,7 @@ class PoolMem;
 int Mmsg(POOLMEM*& msgbuf, const char* fmt, ...);
 int Mmsg(PoolMem& msgbuf, const char* fmt, ...);
 int Mmsg(PoolMem*& msgbuf, const char* fmt, ...);
+int Mmsg(std::vector<char>& msgbuf, const char* fmt, ...);
 
 class JobControlRecord;
 void d_msg(const char* file, int line, int level, const char* fmt, ...);

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -598,8 +598,7 @@ bool IsAclEntryValid(const char* acl, std::vector<char>& msg)
 {
   int len;
   const char* p;
-  const char* accept = "!*.:_-'/"; /* Special characters to accept */
-
+  const char* accept = "!()[]|+?*.:_-'/"; /* Special characters to accept */
 
   if (!acl) {
     Mmsg(msg, _("Empty acl not allowed.\n"));

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -594,7 +594,7 @@ char* add_commas(char* val, char* buf)
  * check if acl entry is valid
  * valid acl entries contain only A-Z 0-9 and !*.:_-'/
  */
-bool IsAclEntryValid(const char* acl, char* msg)
+bool IsAclEntryValid(const char* acl, std::vector<char>& msg)
 {
   int len;
   const char* p;
@@ -602,7 +602,7 @@ bool IsAclEntryValid(const char* acl, char* msg)
 
 
   if (!acl) {
-    if (msg) { Mmsg(msg, _("Empty acl not allowed.\n")); }
+    Mmsg(msg, _("Empty acl not allowed.\n"));
     return false;
   }
 
@@ -611,18 +611,18 @@ bool IsAclEntryValid(const char* acl, char* msg)
     if (B_ISALPHA(*p) || B_ISDIGIT(*p) || strchr(accept, (int)(*p))) {
       continue;
     }
-    if (msg) { Mmsg(msg, _("Illegal character \"%c\" in acl.\n"), *p); }
+    Mmsg(msg, _("Illegal character \"%c\" in acl.\n"), *p);
     return false;
   }
 
   len = p - acl;
   if (len >= MAX_NAME_LENGTH) {
-    if (msg) { Mmsg(msg, _("Acl too long.\n")); }
+    Mmsg(msg, _("Acl too long.\n"));
     return false;
   }
 
   if (len == 0) {
-    if (msg) { Mmsg(msg, _("Acl must be at least one character long.\n")); }
+    Mmsg(msg, _("Acl must be at least one character long.\n"));
     return false;
   }
 
@@ -631,13 +631,7 @@ bool IsAclEntryValid(const char* acl, char* msg)
 
 bool IsAclEntryValid(const char* acl)
 {
-  bool retval;
-  POOLMEM* msg = GetPoolMemory(PM_NAME);
-
-  retval = IsAclEntryValid(acl, msg);
-
-  FreePoolMemory(msg);
-
-  return retval;
+  std::vector<char> msg;
+  return IsAclEntryValid(acl, msg);
 }
 

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -21,6 +21,8 @@
 #ifndef BAREOS_LIB_EDIT_H_
 #define BAREOS_LIB_EDIT_H_
 
+#include <vector>
+
 uint64_t str_to_uint64(const char* str);
 #define str_to_uint16(str) ((uint16_t)str_to_uint64(str))
 #define str_to_uint32(str) ((uint32_t)str_to_uint64(str))
@@ -43,7 +45,7 @@ bool Is_a_number_list(const char* n);
 bool IsAnInteger(const char* n);
 bool IsNameValid(const char* name, POOLMEM*& msg);
 bool IsNameValid(const char* name);
-bool IsAclEntryValid(const char* acl, char* msg);
+bool IsAclEntryValid(const char* acl, std::vector<char>& msg);
 bool IsAclEntryValid(const char* acl);
 
 #endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -36,8 +36,9 @@
 #include "lib/rwlock.h"
 #include "lib/message_destination_info.h"
 
-#include <string>
 #include <functional>
+#include <string>
+#include <vector>
 
 class JobControlRecord;
 

--- a/core/src/tests/test_acl_entry_syntax.cc
+++ b/core/src/tests/test_acl_entry_syntax.cc
@@ -28,14 +28,15 @@
 
 #include "lib/edit.h"
 
-POOLMEM* msg = GetPoolMemory(PM_FNAME);
 
 TEST(acl_entry_syntax_test, acl_entry_syntax_test)
 {
+  std::vector<char> msg;
+
   EXPECT_EQ(true, IsAclEntryValid("list", msg));
 
   EXPECT_EQ(false, IsAclEntryValid("list,add", msg));
-  EXPECT_STREQ("Illegal character \",\" in acl.\n", msg);
+  EXPECT_STREQ("Illegal character \",\" in acl.\n", msg.data());
 
   EXPECT_EQ(true, IsAclEntryValid("STRING.CONTAINING.ALLOWED.CHARS!*.", msg));
 
@@ -43,16 +44,16 @@ TEST(acl_entry_syntax_test, acl_entry_syntax_test)
   EXPECT_EQ(true, IsAclEntryValid(string_maximum_length.c_str(), msg));
 
   EXPECT_EQ(false, IsAclEntryValid("illegalch@racter", msg));
-  EXPECT_STREQ("Illegal character \"@\" in acl.\n", msg);
+  EXPECT_STREQ("Illegal character \"@\" in acl.\n", msg.data());
 
   EXPECT_EQ(false, IsAclEntryValid("", msg));
-  EXPECT_STREQ("Acl must be at least one character long.\n", msg);
+  EXPECT_STREQ("Acl must be at least one character long.\n", msg.data());
 
   EXPECT_EQ(false, IsAclEntryValid(nullptr, msg));
-  EXPECT_STREQ("Empty acl not allowed.\n", msg);
+  EXPECT_STREQ("Empty acl not allowed.\n", msg.data());
 
   std::string string_too_long(MAX_NAME_LENGTH, '.');
   EXPECT_EQ(false, IsAclEntryValid(string_too_long.c_str(), msg));
 
-  EXPECT_STREQ("Acl too long.\n", msg);
+  EXPECT_STREQ("Acl too long.\n", msg.data());
 }

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -605,6 +605,7 @@ set(SYSTEM_TESTS
     virtualfull
     virtualfull-bscan
     backup-bscan
+    config-syntax-crash
     copy-bscan
     copy-remote-bscan
     bconsole-status-client

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_dir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = "|!(){}" # invalid chars
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@                # N.B. Use a fully qualified name here (do not use "localhost" here).
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_fd@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/device/FileStorage.conf.in
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = @archivedir@
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = localhost
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = localhost
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = localhost
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/config-syntax-crash/testrunner
+++ b/systemtests/tests/config-syntax-crash/testrunner
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Start and stop the daemons to make sure our configuration does not crash them.
+# This checks
+# - an invalid entry in an ACL
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+start_test
+
+start_bareos
+stop_bareos
+
+end_test


### PR DESCRIPTION
Bareos crashed when an invalid ACL syntax was detected. This patch adds a systemtest to check for this behaviour and a fix for the problem.