### PR TITLE
webui: Fix sorting of job selection in restore module

### DIFF
--- a/webui/module/Client/src/Client/Controller/ClientController.php
+++ b/webui/module/Client/src/Client/Controller/ClientController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -454,10 +454,10 @@ class ClientController extends AbstractActionController
         echo $e->getMessage();
       }
     }
-    elseif($data == "backups" && isset($client)) {
+    elseif($data == "jobs" && isset($client)) {
       try {
         $this->bsock = $this->getServiceLocator()->get('director');
-        $result = $this->getClientModel()->getClientBackups($this->bsock, $client, null, 'desc', null);
+        $result = $this->getClientModel()->getClientJobs($this->bsock, $client, null, 'desc', null);
         $this->bsock->disconnect();
       }
       catch(Exception $e) {

--- a/webui/module/Client/src/Client/Model/ClientModel.php
+++ b/webui/module/Client/src/Client/Model/ClientModel.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2017 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -100,6 +100,39 @@ class ClientModel
     * @return array
     */
    public function getClientBackups(&$bsock=null, $client=null, $fileset=null, $order=null, $limit=null)
+   {
+      if(isset($bsock, $client)) {
+         $cmd = 'llist backups client="'.$client.'"';
+         if ($fileset != null) {
+            $cmd .= ' fileset="'.$fileset.'"';
+         }
+         if ($order != null) {
+            $cmd .= ' order='.$order;
+         }
+         if ($limit != null) {
+            $cmd .= ' limit='.$limit;
+         }
+         $result = $bsock->send_command($cmd, 2);
+         $backups = \Zend\Json\Json::decode($result, \Zend\Json\Json::TYPE_ARRAY);
+         return $backups['result']['backups'];
+      }
+      else {
+         throw new \Exception('Missing argument.');
+      }
+   }
+
+   /**
+    * Get Client Jobs by llist jobs command
+    *
+    * @param $bsock
+    * @param $client
+    * @param $fileset
+    * @param $order
+    * @param $limit
+    *
+    * @return array
+    */
+   public function getClientJobs(&$bsock=null, $client=null, $fileset=null, $order=null, $limit=null)
    {
       if(isset($bsock, $client)) {
          $cmd = 'llist jobs client="'.$client.'"';

--- a/webui/module/Client/view/client/client/details.phtml
+++ b/webui/module/Client/view/client/client/details.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2017 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -153,7 +153,7 @@ $this->headTitle($title);
          locale: '<?php echo str_replace('_','-', $_SESSION['bareos']['locale']); ?>',
          cookie: <?php echo $_SESSION['bareos']['dt_statesave']; ?>,
          cookieIdTable: 'client_clientbackups',
-         url: '<?php echo $this->url('client', array('action' => 'getData'), null) . '?data=backups&client='.$this->client; ?>',
+         url: '<?php echo $this->url('client', array('action' => 'getData'), null) . '?data=jobs&client='.$this->client; ?>',
          method: 'get',
          dataType: 'json',
          pagination : true,


### PR DESCRIPTION
A recent bconsole command change in the getClientBackups method
of the client model lead to a wrong population of the backup job
selection to choose from in the restore module.

To fix this issue the population of the backup job selection list is
still done by the getClientBackups method but with the proper bconsole
command as it has been before.

The client details action now calls the getClientJobs method of the
client model to get a job list with all status instead a list of
successful backup jobs only.

Fixes #1174: reversed sort order on the restore client selection