### PR TITLE
dev/franku/master/messages pathlength

### DIFF
--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -67,7 +67,7 @@ struct ResourceTable {
  * Common Resource definitions
  */
 #define MAX_RES_NAME_LENGTH \
-  MAX_NAME_LENGTH - 1 /* maximum resource name length */
+  (MAX_NAME_LENGTH - 1) /* maximum resource name length */
 
 /*
  * Config item flags.

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -368,27 +368,26 @@ void ConfigurationParser::StoreMsgs(LEX* lc,
         Dmsg0(900, "done with dest codes\n");
         break;
       case MessageDestinationCode::kFile:
-      case MessageDestinationCode::kAppend:
-        dest = GetPoolMemory(PM_MESSAGE);
-
+      case MessageDestinationCode::kAppend: {
         /*
          * Pick up a single destination.
          */
-        token = LexGetToken(lc, BCT_NAME); /* Scan destination */
-        PmStrcpy(dest, lc->str);
+        token = LexGetToken(lc, BCT_STRING); /* Scan destination */
+        std::string dest_file_path(lc->str);
         dest_len = lc->str_len;
         token = LexGetToken(lc, BCT_SKIP_EOL);
-        Dmsg1(900, "StoreMsgs dest=%s:\n", NPRT(dest));
+        Dmsg1(900, "StoreMsgs dest=%s:\n", dest_file_path.c_str());
         if (token != BCT_EQUALS) {
           scan_err1(lc, _("expected an =, got: %s"), lc->str);
           return;
         }
         ScanTypes(lc, message_resource,
-                  static_cast<MessageDestinationCode>(item->code), dest,
-                  std::string(), message_resource->timestamp_format_);
-        FreePoolMemory(dest);
+                  static_cast<MessageDestinationCode>(item->code),
+                  dest_file_path, std::string(),
+                  message_resource->timestamp_format_);
         Dmsg0(900, "done with dest codes\n");
         break;
+      }
       default:
         scan_err1(lc, _("Unknown item code: %d\n"), item->code);
         return;

--- a/systemtests/tests/messages-resource/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/messages-resource/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -2,7 +2,7 @@ Messages {
   Name = Standard
   Description = "Message delivery for all reasonable directions"
   Console = all
-  Append = "@logdir@/append" = all
+  Append = "@logdir@/append-to-a-very-long-file-12345678901234567890123456789012345678901234567890abcdefghijklmnopqrstuvwxyz12345678901234567890abcdefg" = all
   Catalog = all
   Syslog = all
   Stdout = all

--- a/systemtests/tests/messages-resource/testrunner
+++ b/systemtests/tests/messages-resource/testrunner
@@ -21,7 +21,7 @@ syslog_file="${BAREOS_LOG_DIR}"/syslog
 dblog_file="${BAREOS_LOG_DIR}"/dblog
 stdout_file="${BAREOS_LOG_DIR}"/stdout
 stderr_file="${BAREOS_LOG_DIR}"/stderr
-extra_append_file="${BAREOS_LOG_DIR}"/append
+extra_append_file="${BAREOS_LOG_DIR}"/append-to-a-very-long-file-12345678901234567890123456789012345678901234567890abcdefghijklmnopqrstuvwxyz12345678901234567890abcdefg
 mail_file="${BAREOS_LOG_DIR}"/mail
 operator_file="${BAREOS_LOG_DIR}"/operator
 


### PR DESCRIPTION
When using an append file in the messages resource the pathlength was limited to 128 characters. With this fix the pathlength is unlimited. 