### PR TITLE
Fix issue 1192: Authorization key rejected by Storage daemon since upgrading director and storage daemons (Bareos 18.2)

### DIFF
--- a/core/src/lib/try_tls_handshake_as_a_server.cc
+++ b/core/src/lib/try_tls_handshake_as_a_server.cc
@@ -54,6 +54,7 @@ static ConnectionHandshakeMode GetHandshakeMode(BareosSocket *bs,
       Dmsg0(200, "Could not read out cleartext configuration\n");
       return ConnectionHandshakeMode::CloseConnection;
     }
+    Dmsg2(200, "TlsPolicy for %s is %u\n", client_name.c_str(), tls_policy);
     if (r_code_str == std::string("R_CLIENT")) {
       if (tls_policy == kBnetTlsRequired) {
         return ConnectionHandshakeMode::CloseConnection;


### PR DESCRIPTION
This is a work-in-progress