### PR TITLE
webui: fix restore job form element population (backport to 19.2)

### DIFF
--- a/webui/module/Restore/src/Restore/Form/RestoreForm.php
+++ b/webui/module/Restore/src/Restore/Form/RestoreForm.php
@@ -244,7 +244,7 @@ class RestoreForm extends Form
          ));
       }
       else {
-         if(!empty($this->restore_params['client']) && count($this->getRestoreJobList()) == 1) {
+         if(!empty($this->restore_params['client']) && count($this->getRestoreJobList()) > 0) {
             $this->add(array(
                'name' => 'restorejob',
                'type' => 'select',


### PR DESCRIPTION
This commit fixes the issue that the form field "restore job" is not
populated correctly after client selection and stays disabled if the
configured restore job number is greater than 1 due to a wrong
comparison-operator.

Fixes #1206: form field restore job is not populated after client selection

(cherry picked from commit e7dbde2a3510673d6a1ff3ad543a4ba70cc365c5)