### PR TITLE
univention: revise sources.list template

### DIFF
--- a/core/platforms/univention/conffiles/etc/apt/sources.list.d/60_bareos.list.in
+++ b/core/platforms/univention/conffiles/etc/apt/sources.list.d/60_bareos.list.in
@@ -1,6 +1,7 @@
 @%@UCRWARNING=#@%@
 
 @!@
+import requests
 import subprocess
 import sys
 from   urllib import quote
@@ -13,18 +14,41 @@ if username and password:
     bareos_major_version  = @BAREOS_VERSION_MAJOR@.@BAREOS_VERSION_MINOR@
 
     ucs_version = configRegistry.get('version/version')
-    bareos_univention_dist = '@OBS_DISTRIBUTION@'
+    bareos_univention_dist = 'Univention_{version}'.format(version=ucs_version)
 
     bareos_com_url = "https://{username}:{password}@download.bareos.com/bareos/release/{version}/{dist}".format(username=quote(username), password=password, version=bareos_major_version, dist=bareos_univention_dist)
-
-    sys.stderr.write("importing bareos.com release key: ")
-    cmd = subprocess.Popen(['apt-key', 'add', '/etc/bareos/bareos-release.key'], stdout=sys.stderr, stderr=sys.stderr)
-    rc = cmd.wait()
-
-    print "deb {url} /".format(url=bareos_com_url)
-
+    try:
+        r = requests.get("{baseurl}/Release".format(baseurl=bareos_com_url))
+        if r.status_code == 200:
+            sys.stderr.write("importing bareos.com release key: ")
+            cmd = subprocess.Popen(['apt-key', 'add', '/etc/bareos/bareos-release.key'], stdout=sys.stderr, stderr=sys.stderr)
+            rc = cmd.wait()
+            print "deb {url} /".format(url=bareos_com_url)
+        else:
+            print "# The bareos.com repository is disabled."
+            print "# deb {url} / ".format(url=bareos_com_url)
+            print ""
+            if r.status_code == 401:
+                print "# Login to download.bareos.com failed. Please check the"
+                print "# credentials specified in the UCR variables"
+                print "# 'bareos/subscription/username' and"
+                print "# 'bareos/subscription/password'."
+            elif r.status_code == 404:
+                print "# This Bareos version has not been released for your"
+                print "# Specific version of UCS."
+            else:
+                print "# An unexpected error has occured while contacting"
+                print "# server download.bareos.com"
+            sys.stderr.write("failed to enable the bareos.com repository\n")
+    except Exception as e:
+        msg = repr(e)
+        print "# The bareos.com repository is disabled."
+        print "# deb {url} / ".format(url=bareos_com_url)
+        print "# An exception occured when contacting download.bareos.com"
+        print "# {msg}".format(msg=msg)
+        sys.stderr.write("An exception occured when contacting download.bareos.com\n")
+        sys.stderr.write("{msg}\n".format(msg=msg))
 else:
-
     print "# The bareos.com repository is disabled."
     print "# To enable it, you must have a valid Bareos subscription."
     print "# Specify your Bareos credentials in the UCR variables"


### PR DESCRIPTION
Previously the sources.list template in univention required building in
open build-service, as one of the OBS variables had been used. This
patch now makes the template independent of OBS and also ensures that
you'll get a reasonable error-message in the generated sources.list if
something goes wrong (e.g. you provided wrong credentials).

As this change will be a requirement to build Univention packages in the future, we will have to discuss to which branches this should be backported.