### PR TITLE
breg: fix crash when setting regexwhere

### DIFF
--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -416,7 +416,7 @@ static void match_kw(regex_t* preg, const char* what, int len, POOLMEM*& buf)
 {
   int rc, size;
   int nmatch = 20;
-  regmatch_t pmatch[20];
+  regmatch_t pmatch[20]{};
 
   if (len <= 0) { return; }
   rc = regexec(preg, what, nmatch, pmatch, 0);
@@ -436,7 +436,7 @@ static void match_kw(regex_t* preg, const char* what, int len, POOLMEM*& buf)
 /* fill the items list with the output of the help command */
 void GetArguments(const char* what)
 {
-  regex_t preg;
+  regex_t preg{};
   POOLMEM* buf;
   int rc;
   init_items();

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -911,7 +911,7 @@ static void CleanUpOldFiles()
   int len = strlen(me->working_directory);
   POOLMEM* cleanup = GetPoolMemory(PM_MESSAGE);
   POOLMEM* basename = GetPoolMemory(PM_MESSAGE);
-  regex_t preg1;
+  regex_t preg1{};
   char prbuf[500];
   BErrNo be;
 

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -458,7 +458,7 @@ static void ScanIncludeOptions(LEX* lc, int keyword, char* opts, int optlen)
 static void StoreRegex(LEX* lc, ResourceItem* item, int index, int pass)
 {
   int token, rc;
-  regex_t preg;
+  regex_t preg{};
   char prbuf[500];
   const char* type;
   int newsize;

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -681,7 +681,7 @@ static bool regex_find_jobids(JobControlRecord* jcr,
   dlist* item_chain;
   uitem* item = NULL;
   uitem* last_item = NULL;
-  regex_t preg;
+  regex_t preg{};
   char prbuf[500];
   int rc;
   bool ok = false;

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -89,10 +89,10 @@ static inline bool FindInAclList(alist* list,
                                  int len)
 {
   int rc;
-  regex_t preg;
+  regex_t preg{};
   int nmatch = 1;
   bool retval = false;
-  regmatch_t pmatch[1];
+  regmatch_t pmatch[1]{};
   const char* list_value;
 
   /*

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -1058,7 +1058,7 @@ static bool AskForFileregex(UaContext* ua, RestoreContext* rx)
       if (ua->cmd[0] == '\0') {
         break;
       } else {
-        regex_t* fileregex_re = NULL;
+        regex_t* fileregex_re{};
         int rc;
         char errmsg[500] = "";
 

--- a/core/src/lib/breg.h
+++ b/core/src/lib/breg.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -68,7 +68,7 @@ class BareosRegex {
   /* private */
   POOLMEM* expr = nullptr;     /**< search epression */
   POOLMEM* subst = nullptr;    /**< substitution */
-  regex_t preg;                /**< regex_t result of regcomp() */
+  regex_t preg = {};           /**< regex_t result of regcomp() */
   regmatch_t regs[BREG_NREGS]; /**< contains match */
   char* eor = nullptr;         /**< end of regexp in expr */
 

--- a/core/src/lib/breg.h
+++ b/core/src/lib/breg.h
@@ -66,11 +66,11 @@ class BareosRegex {
   void debug();
 
   /* private */
-  POOLMEM* expr = nullptr;     /**< search epression */
-  POOLMEM* subst = nullptr;    /**< substitution */
-  regex_t preg = {};           /**< regex_t result of regcomp() */
-  regmatch_t regs[BREG_NREGS]; /**< contains match */
-  char* eor = nullptr;         /**< end of regexp in expr */
+  POOLMEM* expr = nullptr;       /**< search epression */
+  POOLMEM* subst = nullptr;      /**< substitution */
+  regex_t preg{};                /**< regex_t result of regcomp() */
+  regmatch_t regs[BREG_NREGS]{}; /**< contains match */
+  char* eor = nullptr;           /**< end of regexp in expr */
 
   char* ReturnFname(const char* fname, int len); /**< return fname as result */
   char* EditSubst(const char* fname, regmatch_t pmatch[]);

--- a/core/src/lib/bregex.cc
+++ b/core/src/lib/bregex.cc
@@ -1354,7 +1354,7 @@ too_complex:
 
 int regcomp(regex_t* bufp, const char* regex, int cflags)
 {
-  new (bufp) regex_t();
+  memset(bufp, 0, sizeof(regex_t));
   bufp->cflags = cflags;
   if (bufp->cflags & REG_ICASE) {
     char *p, *lcase = strdup(regex);
@@ -1396,7 +1396,7 @@ int regexec(regex_t* preg,
 {
   int status;
   int len = strlen(string);
-  struct re_registers regs;
+  re_registers regs{};
 
   status = ReSearch(preg, (unsigned char*)string, len, 0, len, &regs);
   if (status >= 0) { re_registers_to_regmatch(&regs, pmatch, nmatch); }

--- a/core/src/lib/bregex.h
+++ b/core/src/lib/bregex.h
@@ -79,8 +79,8 @@ extern "C" {
 #define regoff_t int
 
 typedef struct {
-  regoff_t rm_so = 0;
-  regoff_t rm_eo = 0;
+  regoff_t rm_so;
+  regoff_t rm_eo;
 } regmatch_t;
 
 
@@ -94,26 +94,26 @@ typedef struct {
 
 /* clang-format off */
 struct regex_t {
-  unsigned char* buffer = nullptr;  /* compiled pattern */
-  int allocated = 0;                /* allocated size of compiled pattern */
-  int used = 0;                     /* actual length of compiled pattern */
-  unsigned char* fastmap = nullptr; /* fastmap[ch] is true if ch can start pattern */
-  unsigned char* translate = nullptr; /* translation to apply during compilation/matching */
-  unsigned char fastmap_accurate = 0; /* true if fastmap is valid */
-  unsigned char can_be_null = 0;      /* true if can match empty string */
-  unsigned char uses_registers = 0;   /* registers are used and need to be initialized */
-  int num_registers = 0;    /* number of registers used */
-  unsigned char anchor = 0; /* anchor: 0=none 1=begline 2=begbuf */
-  char* errmsg = nullptr;
-  int cflags = 0;           /* compilation flags */
-  POOLMEM* lcase = nullptr; /* used by REG_ICASE */
+  unsigned char* buffer;  /* compiled pattern */
+  int allocated;                /* allocated size of compiled pattern */
+  int used;                     /* actual length of compiled pattern */
+  unsigned char* fastmap; /* fastmap[ch] is true if ch can start pattern */
+  unsigned char* translate; /* translation to apply during compilation/matching */
+  unsigned char fastmap_accurate; /* true if fastmap is valid */
+  unsigned char can_be_null;      /* true if can match empty string */
+  unsigned char uses_registers;   /* registers are used and need to be initialized */
+  int num_registers;    /* number of registers used */
+  unsigned char anchor; /* anchor: 0=none 1=begline 2=begbuf */
+  char* errmsg;
+  int cflags;           /* compilation flags */
+  POOLMEM* lcase; /* used by REG_ICASE */
 };
 /* clang-format on */
 
 
 typedef struct re_registers {
-  int start[RE_NREGS]{0}; /* start offset of region */
-  int end[RE_NREGS]{0};   /* end offset of region */
+  int start[RE_NREGS]; /* start offset of region */
+  int end[RE_NREGS];   /* end offset of region */
 } * regexp_registers_t;
 
 /* bit definitions for syntax */

--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -53,7 +53,7 @@ static const char* secure_erase_cmdline = NULL;
 int SaferUnlink(const char* pathname, const char* regx)
 {
   int rc;
-  regex_t preg1;
+  regex_t preg1{};
   char prbuf[500];
   int rtn;
 

--- a/core/src/lib/parse_bsr.cc
+++ b/core/src/lib/parse_bsr.cc
@@ -560,8 +560,9 @@ static storagedaemon::BootStrapRecord* store_fileregex(
   if (bsr->fileregex) free(bsr->fileregex);
   bsr->fileregex = strdup(lc->str);
 
-  if (bsr->fileregex_re == NULL)
+  if (bsr->fileregex_re == NULL) {
     bsr->fileregex_re = (regex_t*)malloc(sizeof(regex_t));
+  }
 
   rc = regcomp(bsr->fileregex_re, bsr->fileregex, REG_EXTENDED | REG_NOSUB);
   if (rc != 0) {

--- a/core/src/lib/var.cc
+++ b/core/src/lib/var.cc
@@ -949,8 +949,8 @@ static int op_search_and_replace(var_t* var,
     /* regular expression pattern based operation */
     tokenbuf_t mydata;
     tokenbuf_t myreplace;
-    regex_t preg;
-    regmatch_t pmatch[10];
+    regex_t preg{};
+    regmatch_t pmatch[10]{};
     int regexec_flag;
 
     /* copy pattern and data to own buffer to make sure they are EOS-terminated

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -445,7 +445,7 @@ static void CleanUpOldFiles()
   int len = strlen(me->working_directory);
   POOLMEM* cleanup = GetPoolMemory(PM_MESSAGE);
   POOLMEM* basename = GetPoolMemory(PM_MESSAGE);
-  regex_t preg1;
+  regex_t preg1{};
   char prbuf[500];
   BErrNo be;
 

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -55,7 +55,7 @@ static void usage()
 
 int main(int argc, char* const* argv)
 {
-  regex_t preg;
+  regex_t preg{};
   char prbuf[500];
   char* fname = NULL;
   int rc, ch;


### PR DESCRIPTION
When manually setting the regular expression during restore like with:

OK to run? (yes/mod/no): mod
->11: File Relocation
->4: Enter a regexp
->Please enter a valid regexp (!from!to!): !what!with!
->6: Use this ?

The director crashed. This happens because the member regex_t preg of
the class BareosRegex was not zero initialized correctly.
This caused the freeing of random memory in void regfree(regex_t* preg).

Now all members of class BareosRegex are zero initialized and the
problem is fixed.

This problem also causes the filedaemon to crash when regexwhere is specified
in the restore job configuration. On the second restore run the filedaemon
crashes.

Fixes# 1211: bareos director and bareos fd crash when regexwhere is specified