### PR TITLE
Revert "cleanup: removed deprecated OpenSSL functions from build"

### DIFF
--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1608,7 +1608,6 @@ void OpensslPostErrors(JobControlRecord* jcr, int type, const char* errstring)
  *  Returns: thread ID
  *
  */
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
 static unsigned long GetOpensslThreadId(void)
 {
 #ifdef HAVE_WIN32
@@ -1623,12 +1622,10 @@ static unsigned long GetOpensslThreadId(void)
   return ((unsigned long)pthread_self());
 #endif /* not HAVE_WIN32 */
 }
-#endif /* #if OPENSSL_VERSION_NUMBER < 0x10000000L */
 
 /*
  * Allocate a dynamic OpenSSL mutex
  */
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
 static struct CRYPTO_dynlock_value* openssl_create_dynamic_mutex(
     const char* file,
     int line)
@@ -1674,12 +1671,10 @@ static void OpensslDestroyDynamicMutex(struct CRYPTO_dynlock_value* dynlock,
 
   free(dynlock);
 }
-#endif /* OPENSSL_VERSION_NUMBER < 0x10000000L */
 
 /*
  * (Un)Lock a static OpenSSL mutex
  */
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
 static void openssl_update_static_mutex(int mode,
                                         int i,
                                         const char* file,
@@ -1691,7 +1686,6 @@ static void openssl_update_static_mutex(int mode,
     V(mutexes[i]);
   }
 }
-#endif /* OPENSSL_VERSION_NUMBER < 0x10000000L */
 
 /*
  * Initialize OpenSSL thread support
@@ -1705,9 +1699,7 @@ int OpensslInitThreads(void)
 
 
   /* Set thread ID callback */
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
   CRYPTO_set_id_callback(GetOpensslThreadId);
-#endif
 
   /* Initialize static locking */
   numlocks = CRYPTO_num_locks();
@@ -1721,7 +1713,6 @@ int OpensslInitThreads(void)
     }
   }
 
-#if OPENSSL_VERSION_NUMBER < 0x10000000L
   /* Set static locking callback */
   CRYPTO_set_locking_callback(openssl_update_static_mutex);
 
@@ -1729,7 +1720,6 @@ int OpensslInitThreads(void)
   CRYPTO_set_dynlock_create_callback(openssl_create_dynamic_mutex);
   CRYPTO_set_dynlock_lock_callback(OpensslUpdateDynamicMutex);
   CRYPTO_set_dynlock_destroy_callback(OpensslDestroyDynamicMutex);
-#endif
 
   return 0;
 }


### PR DESCRIPTION
This reverts commit f8252e4e153180f18cdd3b7db0ca0e55ab8ed750.
Disabling the callbacks breaks openssl thread-safety on openssl 1.0.