### PR TITLE
webui: lock restore form elements during jsTree loading events

### DIFF
--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -348,6 +348,11 @@ $this->headTitle($title);
 
    $("#filebrowser").bind("loading.jstree", function() {
       displayBvfsCacheUpdateInfo();
+      $('#spinner').fadeIn('slow');
+   });
+
+   $("#filebrowser").bind("ready.jstree", function() {
+      $('#spinner').fadeOut('slow');
    });
 
    $('#filebrowser').jstree({


### PR DESCRIPTION
Fade in the loading spinner after the jsTree loading text is shown and
before loading starts (loading.jstree Event).

Fade out the loading spinner after all nodes are finished loading
(ready.jstree Event).

https://www.jstree.com/api/