### PR TITLE
droplet: only allow configuration maximum concurrent jobs of 0 or 1

### DIFF
--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -246,6 +246,7 @@ static inline Device *init_dev(JobControlRecord *jcr, DeviceResource *device, bo
             device->device_name, device->dev_type);
       return NULL;
    }
+
    dev->ClearSlot();         /* unknown */
 
    /*

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
@@ -1,2 +1,6 @@
 This directive specifies the maximum number of Jobs that can run concurrently on a specified Device. Using this directive, it is possible to have different Jobs using multiple drives, because when the Maximum Concurrent Jobs limit is reached, the Storage Daemon will start new Jobs on any other available compatible drive. This facilitates writing to multiple drives with multiple Jobs that all use the same Pool.
 
+.. warning::
+
+   If :config:option:`sd/device/DeviceType` is "Droplet" then Maximum Concurrent Jobs is limited to 1.
+


### PR DESCRIPTION
There is a known bug when using Storage Backend Droplet with multiple simultaneous jobs (interleaving).
This workaround only allows settings of 0 or 1.
If the default is used (0), it will be set automatically to 1.
If any other value is specified, the bareos-sd will not start at all.