### PR TITLE
add a SECURITY.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ policy at
 
   * https://www.bareos.org/en/howto-contribute.html
 
+### Security policy
+If you want to report a security-related problem, please take a look at our [security policy](https://github.com/bareos/bareos/security/policy).
+
 ### Mailing lists
 
 The Bareos project offers two mailing lists: bareos-users and bareos-devel.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | GitHub Sources     | Binary Packages    |
+| ------- | ------------------ |------------------- |
+| master  | :heavy_check_mark: | :heavy_check_mark: |
+| 19.2.x  | :heavy_check_mark: | :white_check_mark: |
+| 18.2.x  | :heavy_check_mark: | :white_check_mark: |
+| 17.2.x  | :heavy_check_mark: | :white_check_mark: |
+| 16.2.x  | :x:                | :x:                |
+| 15.2.x  | :x:                | :x:                |
+| 14.2.x  | :x:                | :x:                |
+| 13.2.x  | :x:                | :x:                |
+| 12.4.x  | :x:                | :x:                |
+
+Besides the master-branch of the project, we maintain the three newest major releases.
+Binary packages of maintenance releases for the major-branches are usually only shipped to customers with a subscription.
+However, if such a release fixes a critical issue, we may consider releasing binary packages to the general public.
+
+## Reporting a security issue
+
+If you find a security-related problem in Bareos, please report it via e-mail to security@bareos.org.
+We will try to respond to you within two days.
+Please be patient with us.
+
+Together with you, we will then determine a CVSS score and find out which versions of Bareos are vulnerable.
+Based on that information we will decide what actions we will take.

--- a/docs/manuals/source/Appendix/FAQ.rst
+++ b/docs/manuals/source/Appendix/FAQ.rst
@@ -3,6 +3,15 @@
 FAQ
 ===
 
+General Questions
+-----------------
+
+How do I report a security issue?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The process for handling security-related problems is described in our GitHub `security policy`_.
+
+.. _security policy: https://github.com/bareos/bareos/security/policy
+
 .. _bareos-1825-updatefaq:
 
 Bareos 18.2.5 FAQ

--- a/docs/manuals/source/DeveloperGuide/generaldevel.rst
+++ b/docs/manuals/source/DeveloperGuide/generaldevel.rst
@@ -85,6 +85,12 @@ The same applies to a support request (we answer only bugs), you might give the 
 .. _bareos-users:       https://groups.google.com/forum/#!forum/bareos-users
 .. _commercial support: https://www.bareos.com/en/Support.html
 
+Reporting security issues
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to report a security-related problem, please take a look at our `security policy`_.
+
+.. _security policy: https://github.com/bareos/bareos/security/policy
 
 Memory Leaks
 ------------


### PR DESCRIPTION
Previously there was no central source of information how to report a security problem. This patch now adds SECURITY.md describing the preliminary process.