### PR TITLE
droplet: only allow configuration maximum concurrent jobs of 0 or 1

### DIFF
--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -538,9 +538,37 @@ static void ConfigBeforeCallback(ConfigurationParser& my_config)
   my_config.InitializeQualifiedResourceNameTypeConverter(map);
 }
 
+static void CheckDropletDevices(ConfigurationParser& my_config)
+{
+  BareosResource* p = nullptr;
+
+  while ((p = my_config.GetNextRes(R_DEVICE, p)) != nullptr) {
+    DeviceResource* device = dynamic_cast<DeviceResource*>(p);
+    if (device && device->dev_type == B_DROPLET_DEV) {
+      if (device->max_concurrent_jobs == 0) {
+        /*
+         * 0 is the general default. However, for this dev_type, only 1 works.
+         * So we set it to this value.
+         */
+        Jmsg1(nullptr, M_WARNING, 0,
+              _("device %s is set to the default 'Maximum Concurrent Jobs' = "
+                "1.\n"),
+              device->device_name);
+        device->max_concurrent_jobs = 1;
+      } else if (device->max_concurrent_jobs > 1) {
+        Jmsg2(nullptr, M_ERROR_TERM, 0,
+              _("device %s is configured with 'Maximum Concurrent Jobs' = %d, "
+                "however only 1 is supported.\n"),
+              device->device_name, device->max_concurrent_jobs);
+      }
+    }
+  }
+}
+
 static void ConfigReadyCallback(ConfigurationParser& my_config)
 {
   MultiplyConfiguredDevices(my_config);
+  CheckDropletDevices(my_config);
 }
 
 ConfigurationParser* InitSdConfig(const char* configfile, int exit_code)

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
@@ -1,2 +1,6 @@
 This directive specifies the maximum number of Jobs that can run concurrently on a specified Device. Using this directive, it is possible to have different Jobs using multiple drives, because when the Maximum Concurrent Jobs limit is reached, the Storage Daemon will start new Jobs on any other available compatible drive. This facilitates writing to multiple drives with multiple Jobs that all use the same Pool.
 
+.. warning::
+
+   If :config:option:`sd/device/DeviceType` is "Droplet" then Maximum Concurrent Jobs is limited to 1.
+


### PR DESCRIPTION
There is a known bug when using Storage Backend Droplet with multiple simultaneous jobs (interleaving).
This workaround only allows settings of 0 or 1.
If the default is used (0), it will be set automatically to 1.
If any other value is specified, the bareos-sd will not start at all.

Check droplet devices immediately after configparser-run