### PR TITLE
chunked_device: bugfix WaitUntilChunksWritten() (bareos-19.2)

### DIFF
--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -1272,12 +1272,10 @@ bool chunked_device::is_written()
  */
 bool chunked_device::WaitUntilChunksWritten()
 {
-  bool retval = true;
-
   if (current_chunk_->need_flushing) {
     if (!FlushChunk(false /* release */, false /* move_to_next_chunk */)) {
       dev_errno = EIO;
-      retval = false;
+      return false;
     }
   }
 
@@ -1285,7 +1283,7 @@ bool chunked_device::WaitUntilChunksWritten()
     Bmicrosleep(DEFAULT_RECHECK_INTERVAL_WRITE_BUFFER, 0);
   }
 
-  return retval;
+  return true;
 }
 
 


### PR DESCRIPTION
Don't wait, if flushing failed.