### PR TITLE
webui: improve the selection of a specific file version restore

### DIFF
--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -308,6 +308,9 @@ function getFileVersions(pathid, filename) {
             });
             row.append(col1, col2, col3, col4);
             $('#file-versions-list').append(row)
+            if(data.length == 1) {
+               document.getElementById(rowId).checked = true;
+            }
          });
       },
       error: function() {


### PR DESCRIPTION
In the restore view tab "restore specific file versions" make a
preselection in the version listing if there is only a single version
for the specific file available.