### PR TITLE
Document limitations of droplet backend and max block size

### DIFF
--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -93,6 +93,12 @@ The name and media type must correspond to those settings in the |dir| :ref:`Dir
 
 -  :config:option:`sd/device/MediaType`\  = :config:option:`dir/storage/MediaType`\ 
 
+.. limitation:: Droplet Backend does not support block interleaving
+
+  The current implementation has a known Bug that may lead to bogus data on your S3 volumes when you set :config:option:`sd/device/MaximumConccurentJobs` to a value other than 1.
+  Because of this the default for a backend of type Droplet is set to 1 and the |sd| will refuse to start if you set it to a value greater than 1.
+
+
 A device for the usage of AWS S3 object storage with a bucket named :file:`backup-bareos` located in EU Central 1 (Frankfurt, Germany), would look like this:
 
 .. code-block:: bareosconfig

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumBlockSize.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumBlockSize.rst.inc
@@ -1,12 +1,18 @@
-The Storage daemon will always attempt to write blocks of the specified size (in-bytes) to the archive device. As a consequence, this statement specifies both the default block size and the maximum block size. The size written never exceed the given size. If adding data to a block would cause it to exceed the given maximum size, the block will be written to the archive device, and the new data will begin a new block.
+The Storage daemon will always attempt to write blocks of the specified size (in bytes) to the archive device.
+As a consequence, this statement specifies both the default block size and the maximum block size.
+The size written never exceeds the given size.
+If adding data to a block would cause it to exceed the given maximum size, the block will be written to the archive device, and the new data will begin a new block.
 
 If no value is specified or zero is specified, the Storage daemon will use a default block size of 64,512 bytes (126 \* 512).
 
-
-
-   .. warning::
-
-      If your are using LTO drives, changing the block size after labeling the tape will result into unreadable tapes.
-
 Please read chapter :ref:`Tapespeed and blocksizes`, to see how to tune this value in a safe manner.
 
+.. limitation:: Setting Maximum Block Size for non-tapes is not supported
+
+   This setting has only been tested with tape drives.
+   The use with every other storage backend is untested and therefore unsupported and discouraged.
+      
+.. warning::
+   After setting this value the device may write volumes with the new setting.
+   Such volumes can only be read by a device with the same or a larger maximum block size configured.
+   You must make sure that all devices with the same :config:option:`sd/device/MediaType` have the same value applied.


### PR DESCRIPTION
This PR improves the description of the limits in which droplet backend and max block size operate safely.