### PR TITLE
Fix ndmp link error on Fedora 31

### DIFF
--- a/core/src/ndmp/CMakeLists.txt
+++ b/core/src/ndmp/CMakeLists.txt
@@ -192,5 +192,5 @@ set_target_properties(
 )
 if(build_ndmjob)
   add_executable(ndmjob ${NDMJOB_SRCS})
-  target_link_libraries(ndmjob bareosndmp)
+  target_link_libraries(ndmjob bareosndmp bareos)
 endif()


### PR DESCRIPTION
Second fix for https://bugs.bareos.org/view.php?id=1170