### PR TITLE
Use system default ciphers like written here:

### DIFF
--- a/core/src/lib/tls_openssl_private.cc
+++ b/core/src/lib/tls_openssl_private.cc
@@ -49,7 +49,7 @@ std::mutex TlsOpenSslPrivate::file_access_mutex_;
 /* No anonymous ciphers, no <128 bit ciphers, no export ciphers, no MD5 ciphers
  */
 const std::string TlsOpenSslPrivate::tls_default_ciphers_{
-    "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"};
+    "PROFILE=SYSTEM"};
 
 
 TlsOpenSslPrivate::TlsOpenSslPrivate()


### PR DESCRIPTION
Don't use an self default cipher suite.
Instant use the system default one.
This will be default on RHEL and Fedora
https://docs.fedoraproject.org/en-US/packaging-guidelines/CryptoPolicies