### PR TITLE
display numeric values of UID and GID in addition to user and group names

### DIFF
--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -160,6 +160,8 @@ static int BvfsStat(UaContext* ua, char* lstat, int32_t* LinkFI)
   ua->send->ObjectKeyValue("ino", statp.st_ino);
   ua->send->ObjectKeyValue("mode", statp.st_mode);
   ua->send->ObjectKeyValue("nlink", statp.st_nlink);
+  ua->send->ObjectKeyValue("uid", statp.st_uid);
+  ua->send->ObjectKeyValue("gid", statp.st_gid);
   ua->send->ObjectKeyValue(
       "user", ua->guid->uid_to_name(statp.st_uid, en1, sizeof(en1)));
   ua->send->ObjectKeyValue(

--- a/core/src/dird/ua_tree.cc
+++ b/core/src/dird/ua_tree.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -796,10 +796,17 @@ static inline void ls_output(guid_list* guid,
 
   if (dot_cmd) {
     encode_time(statp->st_mtime, time_str);
-    Mmsg(buf, "%s,%d,%s,%s,%s,%s,%c,%s", mode_str, (uint32_t)statp->st_nlink,
-         guid->uid_to_name(statp->st_uid, en1, sizeof(en1)),
-         guid->gid_to_name(statp->st_gid, en2, sizeof(en2)),
-         edit_int64(statp->st_size, ec1), time_str, *tag, fname);
+    Mmsg(buf, "%s,%d,%d(%s),%d(%s),%s,%s,%c,%s",
+      mode_str,
+      (uint32_t)statp->st_nlink,
+      (uint32_t)statp->st_uid,
+      guid->uid_to_name(statp->st_uid, en1, sizeof(en1)),
+      (uint32_t)statp->st_gid,
+      guid->gid_to_name(statp->st_gid, en2, sizeof(en2)),
+      edit_int64(statp->st_size, ec1),
+      time_str,
+      *tag,
+      fname);
   } else {
     time_t time;
 
@@ -814,11 +821,17 @@ static inline void ls_output(guid_list* guid,
      */
     encode_time(time, time_str);
 
-    Mmsg(buf, "%s  %2d %-8.8s %-8.8s  %12.12s  %s %c%s", mode_str,
-         (uint32_t)statp->st_nlink,
-         guid->uid_to_name(statp->st_uid, en1, sizeof(en1)),
-         guid->gid_to_name(statp->st_gid, en2, sizeof(en2)),
-         edit_int64(statp->st_size, ec1), time_str, *tag, fname);
+    Mmsg(buf, "%s  %2d %d (%-.8s) %d (%-.8s)  %12.12s  %s %c %s",
+      mode_str,
+      (uint32_t)statp->st_nlink,
+      (uint32_t)statp->st_uid,
+      guid->uid_to_name(statp->st_uid, en1, sizeof(en1)),
+      (uint32_t)statp->st_gid,
+      guid->gid_to_name(statp->st_gid, en2, sizeof(en2)),
+      edit_int64(statp->st_size, ec1),
+      time_str,
+      *tag,
+      fname);
   }
 }
 

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -400,7 +400,7 @@ $this->headTitle($title);
                header: '<?php echo $this->translate("User"); ?>',
                headerClass: 'jsTreeGridHeader',
                value: function(node) {
-                  return formatJSTreeGridUserItem(node.data.stat.user);
+                  return formatJSTreeGridUserItem(node);
                }
             },
             {
@@ -408,7 +408,7 @@ $this->headTitle($title);
                header: '<?php echo $this->translate("Group"); ?>',
                headerClass: 'jsTreeGridHeader',
                value: function(node) {
-                  return formatJSTreeGridGroupItem(node.data.stat.group);
+                  return formatJSTreeGridGroupItem(node);
                }
             },
             {

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -292,6 +292,11 @@ function getFileVersions(pathid, filename) {
                "<td class='text-left'>" + formatJSTreeGridModeItem(data[id].stat.mode) + "</td>" +
                "</tr>" +
                "<tr>" +
+               "<td class='text-left'>UID:GID </td>" +
+               "<td></td>" +
+               `<td class='text-left'>${data[id].stat.uid}:${data[id].stat.gid}</td>` +
+               "</tr>" +
+               "<tr>" +
                "<td class='text-left'>User:Group </td>" +
                "<td></td>" +
                `<td class='text-left'>${data[id].stat.user}:${data[id].stat.group}</td>` +

--- a/webui/public/js/jstreegrid-helper.js
+++ b/webui/public/js/jstreegrid-helper.js
@@ -131,12 +131,12 @@ function setSymbolicModeNotationSpecialPermissions(value) {
    }
 }
 
-function formatJSTreeGridUserItem(user) {
-   return user;
+function formatJSTreeGridUserItem(node) {
+   return node.data.stat.uid + ' (' + node.data.stat.user + ')';
 }
 
-function formatJSTreeGridGroupItem(group) {
-   return group;
+function formatJSTreeGridGroupItem(node) {
+   return node.data.stat.gid + ' (' + node.data.stat.group + ')';
 }
 
 function formatJSTreeGridModeItem(mode) {


### PR DESCRIPTION
Unfortunately the processed user and group names by the methods uid_to_name and gid_to_name can be fuzzy. Thus we display the numeric values UID and GID as well.