### PR TITLE
add infrastructure for configuration warnings

### DIFF
--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -395,7 +395,16 @@ int main(int argc, char* argv[])
     goto bail_out;
   }
 
-  if (test_config) { TerminateDird(0); }
+  if (test_config) {
+    if (my_config->HasWarnings()) {
+      /* messaging not initialized, so Jmsg with  M_WARNING doesn't work */
+      fprintf(stderr, _("There are configuration warnings:\n"));
+      for (auto& warning : my_config->GetWarnings()) {
+        fprintf(stderr, " * %s\n", warning.c_str());
+      }
+    }
+    TerminateDird(0);
+  }
 
   if (!InitializeSqlPooling()) {
     Jmsg((JobControlRecord*)NULL, M_ERROR_TERM, 0,
@@ -578,6 +587,7 @@ bool DoReloadConfig()
   Dmsg0(100, "Reloading config file\n");
 
   my_config->err_type_ = M_ERROR;
+  my_config->ClearWarnings();
   bool ok = my_config->ParseConfig();
 
   if (!ok || !CheckResources() || !CheckCatalog(UPDATE_CATALOG) ||

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -470,8 +470,8 @@ static struct ua_cmdstruct commands[] = {
     {NT_("status"), StatusCmd, _("Report status"),
      NT_("all | dir=<dir-name> | director | scheduler | "
          "schedule=<schedule-name> | client=<client-name> |\n"
-         "\tstorage=<storage-name> slots | days=<nr_days> | job=<job-name> |\n"
-         "\tsubscriptions"),
+         "storage=<storage-name> slots | days=<nr_days> | job=<job-name> |\n"
+         "subscriptions | configuration"),
      true, true},
     {NT_("setbandwidth"), SetbwlimitCmd, _("Sets bandwidth"),
      NT_("client=<client-name> | storage=<storage-name> | jobid=<jobid> |\n"

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -259,7 +259,16 @@ int main(int argc, char* argv[])
   }
 #endif
 
-  if (test_config) { TerminateFiled(0); }
+  if (test_config) {
+    if (my_config->HasWarnings()) {
+      /* messaging not initialized, so Jmsg with  M_WARNING doesn't work */
+      fprintf(stderr, _("There are configuration warnings:\n"));
+      for (auto& warning : my_config->GetWarnings()) {
+        fprintf(stderr, " * %s\n", warning.c_str());
+      }
+    }
+    TerminateFiled(0);
+  }
 
   SetThreadConcurrency(me->MaxConcurrentJobs * 2 + 10);
 

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -68,7 +68,7 @@ if(NOT client-only)
       scsi_tapealert.h
       serial.h
       sha1.h
-      status.h
+      status_packet.h
       thread_list.h
       tls.h
       tls_conf.h
@@ -152,6 +152,7 @@ set(BAREOS_SRCS
     serial.cc
     sha1.cc
     signal.cc
+    status_packet.cc
     thread_list.cc
     thread_specific_data.cc
     timer_thread.cc

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -711,3 +711,19 @@ bool ConfigurationParser::GetPathOfNewResource(PoolMem& path,
 
   return true;
 }
+
+void ConfigurationParser::AddWarning(const std::string& warning) {
+  warnings_ << warning;
+}
+
+void ConfigurationParser::ClearWarnings() {
+  warnings_.clear();
+}
+
+bool ConfigurationParser::HasWarnings() const {
+  return !warnings_.empty();
+}
+
+const BStringList& ConfigurationParser::GetWarnings() const {
+  return warnings_;
+}

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -29,6 +29,7 @@
 
 #include "include/bareos.h"
 #include "include/bc_types.h"
+#include "lib/bstringlist.h"
 #include "lib/parse_conf_callbacks.h"
 #include "lib/s_password.h"
 #include "lib/tls_conf.h"
@@ -317,6 +318,11 @@ class ConfigurationParser {
       TlsPolicy& tls_policy_out) const;
   std::string CreateOwnQualifiedNameForNetworkDump() const;
 
+  void AddWarning(const std::string& warning);
+  void ClearWarnings();
+  bool HasWarnings() const;
+  const BStringList& GetWarnings() const;
+
  private:
   ConfigurationParser(const ConfigurationParser&) = delete;
   ConfigurationParser operator=(const ConfigurationParser&) = delete;
@@ -343,6 +349,7 @@ class ConfigurationParser {
   ParseConfigBeforeCb_t ParseConfigBeforeCb_;
   ParseConfigReadyCb_t ParseConfigReadyCb_;
   bool parser_first_run_;
+  BStringList warnings_;
 
 
   const char* GetDefaultConfigDir();

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -130,11 +130,12 @@ ConfigParserStateMachine::ScanResource(int token)
           }
         }
 
-        if (item->flags & CFG_ITEM_DEPRECATED) {
-          scan_warn2(lexical_parser_,
-                     _("using deprecated keyword %s on line %d"), item->name,
-                     lexical_parser_->line_no);
-          // only warning
+        if (parser_pass_number_ == 1 &&
+            item->flags & CFG_ITEM_DEPRECATED) {
+          my_config_.AddWarning(
+              std::string("using deprecated keyword ") + item->name +
+              " on line " + std::to_string(lexical_parser_->line_no) +
+              " of file " + lexical_parser_->fname);
         }
 
         Dmsg1(800, "calling handler for %s\n", item->name);

--- a/core/src/lib/status_packet.cc
+++ b/core/src/lib/status_packet.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -18,23 +18,17 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
-#ifndef BAREOS_STORED_SPOOL_H_
-#define BAREOS_STORED_SPOOL_H_
 
-class StatusPacket;
+#include <lib/status_packet.h>
+#include <lib/bsock.h>
 
-namespace storagedaemon {
-
-bool BeginDataSpool(DeviceControlRecord* dcr);
-bool DiscardDataSpool(DeviceControlRecord* dcr);
-bool CommitDataSpool(DeviceControlRecord* dcr);
-bool AreAttributesSpooled(JobControlRecord* jcr);
-bool BeginAttributeSpool(JobControlRecord* jcr);
-bool DiscardAttributeSpool(JobControlRecord* jcr);
-bool CommitAttributeSpool(JobControlRecord* jcr);
-bool WriteBlockToSpoolFile(DeviceControlRecord* dcr);
-void ListSpoolStats(StatusPacket* sp);
-
-} /* namespace storagedaemon */
-
-#endif  // BAREOS_STORED_SPOOL_H_
+void StatusPacket::send(const char* msg, int len)
+{
+  if (bs) {
+    memcpy(bs->msg, msg, len + 1);
+    bs->message_length = len + 1;
+    bs->send();
+  } else {
+    callback(msg, len, context);
+  }
+}

--- a/core/src/lib/status_packet.h
+++ b/core/src/lib/status_packet.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2008-2008 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -30,8 +30,13 @@
  * the output can be sent directly to a BareosSocket.
  */
 
-#ifndef BAREOS_LIB_STATUS_H_
-#define BAREOS_LIB_STATUS_H_
+#ifndef BAREOS_LIB_STATUS_PACKET_H_
+#define BAREOS_LIB_STATUS_PACKET_H_
+
+#include <include/bareos.h>
+#include <string>
+
+class BareosSocket;
 
 /**
  * Packet to send to OutputStatus()
@@ -47,5 +52,8 @@ class StatusPacket {
                    int len,
                    void* context) = nullptr; /* Win32 */
   bool api = false;                          /* set if we want API output */
+  void send(const char* msg, int len);
+  void send(PoolMem& msg, int len) { send(msg.c_str(), len); }
+  void send(const std::string& msg) { send(msg.c_str(), msg.length()); }
 };
 #endif

--- a/core/src/plugins/stored/scsicrypto-sd.cc
+++ b/core/src/plugins/stored/scsicrypto-sd.cc
@@ -63,7 +63,6 @@
 #include "stored/stored.h"
 #include "stored/jcr_private.h"
 #include "lib/berrno.h"
-#include "lib/status.h"
 #include "lib/crypto_wrap.h"
 #include "lib/scsi_crypto.h"
 

--- a/core/src/stored/spool.cc
+++ b/core/src/stored/spool.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,6 +36,7 @@
 #include "lib/berrno.h"
 #include "lib/bsock.h"
 #include "lib/edit.h"
+#include "lib/status_packet.h"
 #include "lib/util.h"
 #include "include/jcr.h"
 
@@ -82,8 +83,7 @@ enum
   RB_OK
 };
 
-void ListSpoolStats(void sendit(const char* msg, int len, void* sarg),
-                    void* arg)
+void ListSpoolStats(StatusPacket* sp)
 {
   char ed1[30], ed2[30];
   PoolMem msg(PM_MESSAGE);
@@ -100,7 +100,7 @@ void ListSpoolStats(void sendit(const char* msg, int len, void* sarg),
                spool_stats.total_data_jobs,
                edit_uint64_with_commas(spool_stats.max_data_size, ed2));
 
-    sendit(msg.c_str(), len, arg);
+    sp->send(msg, len);
   }
   if (spool_stats.attr_jobs || spool_stats.max_attr_size) {
     len = Mmsg(msg,
@@ -111,7 +111,7 @@ void ListSpoolStats(void sendit(const char* msg, int len, void* sarg),
                spool_stats.total_attr_jobs,
                edit_uint64_with_commas(spool_stats.max_attr_size, ed2));
 
-    sendit(msg.c_str(), len, arg);
+    sp->send(msg, len);
   }
 }
 

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -275,7 +275,16 @@ int main(int argc, char* argv[])
 
   InitReservationsLock();
 
-  if (test_config) { TerminateStored(0); }
+  if (test_config) {
+    if (my_config->HasWarnings()) {
+      /* messaging not initialized, so Jmsg with  M_WARNING doesn't work */
+      fprintf(stderr, _("There are configuration warnings:\n"));
+      for (auto& warning : my_config->GetWarnings()) {
+        fprintf(stderr, " * %s\n", warning.c_str());
+      }
+    }
+    TerminateStored(0);
+  }
 
   MyNameIs(0, (char**)NULL, me->resource_name_); /* Set our real name */
 

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1172,7 +1172,7 @@ status
       :caption: status
 
       status [all | dir=<dir-name> | director | scheduler | schedule=<schedule-name> |
-              client=<client-name> | storage=<storage-name> slots | subscriptions]
+              client=<client-name> | storage=<storage-name> slots | subscriptions | configuration]
 
    If you do a status dir, the console will list any currently running jobs, a summary of all jobs scheduled to be run in the next 24 hours, and a listing of the last ten terminated jobs with their statuses. The scheduled jobs summary will include the Volume name to be used. You should be aware of two things: 1. to obtain the volume name, the code goes through the same code that will be used when the job runs, but it does not do pruning nor recycling of Volumes; 2. The Volume listed is at best a
    guess. The Volume actually used may be different because of the time difference (more durations may expire when the job runs) and another job could completely fill the Volume requiring a new one.
@@ -1354,6 +1354,9 @@ status
       }
 
    Not configuring the directive at all also disables it, as the default value for the Subscriptions directive is zero.
+
+
+   Using the console command :bcommand:`status configuration` will show a list of deprecated configuration settings that were detected when loading the director's configuration.
 
 time
    :index:`\ <single: Console; Command; time>`\  The time command shows the current date, time and weekday.


### PR DESCRIPTION
This PR will add a list of warnings to the configuration parser along with some utility functions. This list can then be filled during (and after) parsing the configuration.
It will also add a few ways to see these deprecation warnings.