### PR TITLE
dird: make UA tree command auditing possible

### DIFF
--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -136,7 +136,7 @@ struct JobControlRecordPrivate {
   int64_t spool_size{};                 /**< Spool size for this job */
   volatile bool sd_msg_thread_done{};   /**< Set when Storage message thread done */
   bool IgnoreDuplicateJobChecking{};    /**< Set in migration jobs */
-  bool IgnoreLevelPoolOverides{};       /**< Set if a cmdline pool was specified */
+  bool IgnoreLevelPoolOverrides{};       /**< Set if a cmdline pool was specified */
   bool IgnoreClientConcurrency{};       /**< Set in migration jobs */
   bool IgnoreStorageConcurrency{};      /**< Set in migration jobs */
   bool spool_data{};                    /**< Spool data in SD */

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1258,7 +1258,7 @@ void ApplyPoolOverrides(JobControlRecord* jcr, bool force)
    * If a cmdline pool override is given ignore any level pool overrides.
    * Unless a force is given then we always apply any overrides.
    */
-  if (!force && jcr->impl->IgnoreLevelPoolOverides) { return; }
+  if (!force && jcr->impl->IgnoreLevelPoolOverrides) { return; }
 
   /*
    * If only a pool override and no level overrides are given in run entry

--- a/core/src/dird/ua.h
+++ b/core/src/dird/ua.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -152,6 +152,7 @@ class UaContext {
    */
   bool AuditEventWanted(bool audit_event_enabled);
   void LogAuditEventCmdline();
+  void LogAuditEventInfoMsg(const char* fmt, ...);
 
   /*
    * The below are in ua_output.c

--- a/core/src/dird/ua_audit.cc
+++ b/core/src/dird/ua_audit.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -142,4 +142,26 @@ void UaContext::LogAuditEventCmdline()
   Emsg3(M_AUDIT, 0, _("Console [%s] from [%s] cmdline %s\n"), user_name, host,
         cmd);
 }
+
+void UaContext::LogAuditEventInfoMsg(const char* fmt, ...)
+{
+  va_list arg_ptr;
+  const char* user_name;
+  const char* host;
+  PoolMem message(PM_MESSAGE);
+
+  if (!me->auditing) { return; }
+
+  va_start(arg_ptr, fmt);
+  message.Bvsprintf(fmt, arg_ptr);
+  va_end(arg_ptr);
+
+  user_name =
+      user_acl ? user_acl->corresponding_resource->resource_name_ : "default";
+  host = UA_sock ? UA_sock->host() : "unknown";
+
+  Emsg3(M_AUDIT, 0, _("Console [%s] from [%s] info message %s\n"),
+      user_name, host, message.c_str());
+}
+
 } /* namespace directordaemon */

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1134,7 +1134,11 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
     }
   }
 
-  ua->InfoMsg(_("\nBuilding directory tree for JobId(s) %s ...  "), rx->JobIds);
+  ua->InfoMsg(
+      _("\nBuilding directory tree for JobId(s) %s ...  "), rx->JobIds);
+
+  ua->LogAuditEventInfoMsg(
+      _("Building directory tree for JobId(s) %s"), rx->JobIds);
 
   if (!ua->db->GetFileList(ua->jcr, rx->JobIds, false /* do not use md5 */,
                            true /* get delta */, InsertTreeHandler,

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -2,7 +2,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -524,6 +524,15 @@ try_again:
           jcr->JobPriority);
 
     FreeJcr(jcr); /* release jcr */
+
+    /*
+     * For interactive runs we send a message to the audit log
+     */
+    if (jcr->impl->IgnoreLevelPoolOverides) {
+      char buf[50];
+      ua->LogAuditEventInfoMsg(
+          _("Job queued. JobId=%s"), edit_int64(jcr->JobId, buf));
+    }
 
     if (JobId == 0) {
       ua->ErrorMsg(_("Job failed.\n"));

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -505,7 +505,7 @@ try_again:
    * For interactive runs we set IgnoreLevelPoolOverrides as we already
    * performed the actual overrrides.
    */
-  jcr->impl->IgnoreLevelPoolOverides = true;
+  jcr->impl->IgnoreLevelPoolOverrides = true;
 
   if (ua->cmd[0] == 0 || bstrncasecmp(ua->cmd, NT_("yes"), strlen(ua->cmd)) ||
       bstrncasecmp(ua->cmd, _("yes"), strlen(ua->cmd))) {
@@ -528,7 +528,7 @@ try_again:
     /*
      * For interactive runs we send a message to the audit log
      */
-    if (jcr->impl->IgnoreLevelPoolOverides) {
+    if (jcr->impl->IgnoreLevelPoolOverrides) {
       char buf[50];
       ua->LogAuditEventInfoMsg(
           _("Job queued. JobId=%s"), edit_int64(jcr->JobId, buf));
@@ -859,12 +859,12 @@ static bool ResetRestoreContext(UaContext* ua,
   /*
    * See if an explicit pool override was performed.
    * If so set the pool_source to command line and
-   * set the IgnoreLevelPoolOverides so any level Pool
+   * set the IgnoreLevelPoolOverrides so any level Pool
    * overrides are ignored.
    */
   if (rc.pool_name) {
     PmStrcpy(jcr->impl->res.pool_source, _("command line"));
-    jcr->impl->IgnoreLevelPoolOverides = true;
+    jcr->impl->IgnoreLevelPoolOverrides = true;
   } else if (!rc.level_override &&
              jcr->impl->res.pool != jcr->impl->res.job->pool) {
     PmStrcpy(jcr->impl->res.pool_source, _("user input"));


### PR DESCRIPTION
1. Introduce a new boolean named audit_event in the struct cmdstruct
of the TreeContext to mark commands which require auditing.

2. Introduce a condition in the UserSelectFilesFromTree function to
call LogAuditEventCmdline if the given command wants an audit event.