### PR TITLE
Fix login form problems

### DIFF
--- a/webui/module/Auth/view/auth/auth/login.phtml
+++ b/webui/module/Auth/view/auth/auth/login.phtml
@@ -37,6 +37,12 @@ $this->headTitle($title);
 <!-- Login form -->
 <div class="col-md-4">
 
+   <div class="progress">
+   <div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="width: 100%;">
+   Loading versions...
+   </div>
+   </div>
+   
    <div class="panel panel-default">
    <div class="panel-body">
    <div class="container-fluid">
@@ -194,6 +200,7 @@ function getVersions() {
 
    var update_url = window.location.protocol + "//download.bareos.com/release-info/bareos-release-info.js?callback=jsonCallback";
 
+   $(".panel.panel-default").hide();
    var v = $.ajax({
       method: "GET",
       url: update_url,
@@ -208,6 +215,8 @@ function getVersions() {
          return result;
       },
       complete: function(result) {
+         $(".panel.panel-default").show();
+         $(".progress").hide();
          return result;
       }
    });


### PR DESCRIPTION
Hides a the login form and shows a "loading" message while it does the Ajax call to get the versions. This avoids the problem that happens when you load the login form and click login too quickly (it logs in incorrectly) and also the visual effect of the dirctor and locale empty selects.