### PR TITLE
run command: use specified since time

### DIFF
--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -478,7 +478,7 @@ static void SendSinceTime(JobControlRecord* jcr)
   utime_t stime;
   BareosSocket* fd = jcr->file_bsock;
 
-  stime = StrToUtime(jcr->stime);
+  stime = StrToUtime(jcr->starttime_string);
   fd->fsend(levelcmd, "", NT_("since_utime "), edit_uint64(stime, ed1), 0,
             NT_("prev_job="), jcr->impl->PrevJob);
 

--- a/core/src/include/jcr.h
+++ b/core/src/include/jcr.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -177,7 +177,8 @@ class JobControlRecord {
   POOLMEM* client_name{};       /**< Client name */
   POOLMEM* JobIds{};            /**< User entered string of JobIds */
   POOLMEM* RestoreBootstrap{};  /**< Bootstrap file to restore */
-  POOLMEM* stime{};             /**< start time for incremental/differential */
+  POOLMEM* starttime_string{};  /**< start time for incremental/differential
+                                  as string "yyyy-mm-dd hh:mm:ss" */
   char* sd_auth_key{};          /**< SD auth key */
   TlsPolicy sd_tls_policy{kBnetTlsNone};      /**< SD Tls Policy */
   MessagesResource* jcr_msgs{}; /**< Copy of message resource -- actually used */

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -587,7 +587,7 @@ const char* job_type_to_str(int type)
 const char* job_replace_to_str(int replace)
 {
   const char* str = NULL;
-  switch(replace) {
+  switch (replace) {
     case REPLACE_ALWAYS:
       str = _("always");
       break;
@@ -1032,8 +1032,8 @@ POOLMEM* edit_job_codes(JobControlRecord* jcr,
           str = to;
           break;
         case 's': /* Since time */
-          if (jcr && jcr->stime) {
-            str = jcr->stime;
+          if (jcr && jcr->starttime_string) {
+            str = jcr->starttime_string;
           } else {
             str = _("*None*");
           }


### PR DESCRIPTION
The option "since" already existed in the run command, but was not
used anywhere.

Now it is possible to run a job in the following way:

run job=backup-bareos-fd since="2020-04-01 11:11:11"

This will run the given job and use the given since time.
No further calculations like checking for previous backups or considering
the backup level.

The jcr member stime was renamed to starttime_string to make it clear
that a string contaning a timestamp in text form is stored here, in
opposite to a string containing a unix timestamp.