### PR TITLE
python-fd plugins: allow to set since_time from plugins

### DIFF
--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -132,7 +132,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr,
   if (!CryptoSessionStart(jcr, cipher)) { return false; }
 
   SetFindOptions((FindFilesPacket*)jcr->impl->ff, jcr->impl->incremental,
-                 jcr->impl->mtime);
+                 jcr->impl->since_time);
 
   /**
    * In accurate mode, we overload the find_one check function
@@ -565,7 +565,7 @@ int SaveFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool top_level)
       break;
     case FT_DIRBEGIN:
       jcr->impl->num_files_examined--; /* correct file count */
-      return 1;                         /* not used */
+      return 1;                        /* not used */
     case FT_NORECURSE:
       Jmsg(jcr, M_INFO, 1,
            _("     Recursion turned off. Will not descend from %s into %s\n"),
@@ -1234,7 +1234,7 @@ static int send_data(JobControlRecord* jcr,
      */
     if (bctx.encrypted_len > 0) {
       sd->message_length = bctx.encrypted_len; /* set encrypted length */
-      sd->msg = jcr->impl->crypto.crypto_buf; /* set correct write buffer */
+      sd->msg = jcr->impl->crypto.crypto_buf;  /* set correct write buffer */
       if (!sd->send()) {
         if (!jcr->IsJobCanceled()) {
           Jmsg1(jcr, M_FATAL, 0, _("Network send error to SD. ERR=%s\n"),

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -245,8 +245,7 @@ static char OKsecureerase[] = "2000 OK FDSecureEraseCmd %s\n";
 static char OKsession[] = "2000 OK session\n";
 static char OKstore[] = "2000 OK storage\n";
 static char OKstoreend[] = "2000 OK storage end\n";
-static char OKjob[] =
-    "2000 OK Job %s (%s) %s,%s,%s";
+static char OKjob[] = "2000 OK Job %s (%s) %s,%s,%s";
 static char OKsetdebugv0[] =
     "2000 OK setdebug=%d trace=%d hangup=%d tracefile=%s\n";
 static char OKsetdebugv1[] =
@@ -1542,8 +1541,8 @@ static bool LevelCmd(JobControlRecord* jcr)
 
     Dmsg2(100, "adj=%lld since_time=%lld\n", adj, since_time);
     jcr->impl->incremental = true; /* set incremental or decremental backup */
-    jcr->impl->mtime = since_time; /* set since time */
-    GeneratePluginEvent(jcr, bEventSince, (void*)(time_t)jcr->impl->mtime);
+    jcr->impl->since_time = since_time; /* set since time */
+    GeneratePluginEvent(jcr, bEventSince, (void*)(time_t)jcr->impl->since_time);
   } else {
     Jmsg1(jcr, M_FATAL, 0, _("Unknown backup level: %s\n"), level);
     FreeMemory(level);

--- a/core/src/filed/estimate.cc
+++ b/core/src/filed/estimate.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2001-2008 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,7 +47,7 @@ int MakeEstimate(JobControlRecord* jcr)
   jcr->setJobStatus(JS_Running);
 
   SetFindOptions((FindFilesPacket*)jcr->impl->ff, jcr->impl->incremental,
-                 jcr->impl->mtime);
+                 jcr->impl->since_time);
   /* in accurate mode, we overwrite the find_one check function */
   if (jcr->accurate) {
     SetFindChangedFunction((FindFilesPacket*)jcr->impl->ff, AccurateCheckFile);

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -2126,9 +2126,9 @@ static bRC bareosGetValue(bpContext* ctx, bVariable var, void* value)
               jcr->JobStatus);
         break;
       case bVarSinceTime:
-        *((int*)value) = (int)jcr->impl->mtime;
+        *((int*)value) = (int)jcr->impl->since_time;
         Dmsg1(debuglevel, "fd-plugin: return bVarSinceTime=%d\n",
-              (int)jcr->impl->mtime);
+              (int)jcr->impl->since_time);
         break;
       case bVarAccurate:
         *((int*)value) = (int)jcr->accurate;
@@ -2180,6 +2180,9 @@ static bRC bareosSetValue(bpContext* ctx, bVariable var, void* value)
   if (!jcr) { return bRC_Error; }
 
   switch (var) {
+    case bVarSinceTime:
+      jcr->impl->since_time = (*(int*)value);
+      break;
     case bVarLevel:
       jcr->setJobLevel(*(int*)value);
       break;
@@ -2187,6 +2190,8 @@ static bRC bareosSetValue(bpContext* ctx, bVariable var, void* value)
       if (!AccurateMarkFileAsSeen(jcr, (char*)value)) { return bRC_Error; }
       break;
     default:
+      Jmsg1(jcr, M_ERROR, 0,
+            "Warning: bareosSetValue not implemented for var %d.\n", var);
       break;
   }
 

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -65,7 +65,7 @@ extern "C" char* job_code_callback_filed(JobControlRecord* jcr,
       if (jcr->impl->director) { return jcr->impl->director->resource_name_; }
       break;
     case 'm':
-      return edit_uint64(jcr->impl->mtime, str);
+      return edit_uint64(jcr->impl->since_time, str);
   }
 
   return NULL;

--- a/core/src/filed/jcr_private.h
+++ b/core/src/filed/jcr_private.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -55,7 +55,7 @@ struct JobControlRecordPrivate {
   xattr_data_t* xattr_data{};     /**< Extended Attributes for backup/restore */
   int32_t last_type{};            /**< Type of last file saved/verified */
   bool incremental{};             /**< Set if incremental for SINCE */
-  utime_t mtime{};                /**< Begin time for SINCE */
+  utime_t since_time{};           /**< Begin time for SINCE */
   int listing{};                  /**< Job listing in estimate */
   int32_t Ticket{};               /**< Ticket */
   char* big_buf{};                /**< I/O buffer */

--- a/core/src/filed/verify.cc
+++ b/core/src/filed/verify.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -71,7 +71,7 @@ void DoVerify(JobControlRecord* jcr)
           DEFAULT_NETWORK_BUFFER_SIZE);
   }
   SetFindOptions((FindFilesPacket*)jcr->impl->ff, jcr->impl->incremental,
-                 jcr->impl->mtime);
+                 jcr->impl->since_time);
   Dmsg0(10, "Start find files\n");
   /* Subroutine VerifyFile() is called for each file */
   FindFiles(jcr, (FindFilesPacket*)jcr->impl->ff, VerifyFile, NULL);
@@ -117,7 +117,7 @@ static int VerifyFile(JobControlRecord* jcr,
       break;
     case FT_DIRBEGIN:
       jcr->impl->num_files_examined--; /* correct file count */
-      return 1;                         /* ignored */
+      return 1;                        /* ignored */
     case FT_REPARSE:
     case FT_JUNCTION:
     case FT_DIREND:

--- a/core/src/plugins/filed/python-fd.cc
+++ b/core/src/plugins/filed/python-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2015 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -2561,7 +2561,7 @@ static PyObject* PyBareosGetValue(PyObject* self, PyObject* args)
 
 /**
  * Callback function which is exposed as a part of the additional methods which
- * allow a Python plugin to get certain internal values of the current Job.
+ * allow a Python plugin to set certain internal values of the current Job.
  */
 static PyObject* PyBareosSetValue(PyObject* self, PyObject* args)
 {
@@ -2574,7 +2574,9 @@ static PyObject* PyBareosSetValue(PyObject* self, PyObject* args)
     goto bail_out;
   }
 
+  ctx = PyGetbpContext(pyCtx);
   switch (var) {
+    case bVarSinceTime:
     case bVarLevel: {
       int value = 0;
 
@@ -2594,7 +2596,6 @@ static PyObject* PyBareosSetValue(PyObject* self, PyObject* args)
       break;
     }
     default:
-      ctx = PyGetbpContext(pyCtx);
       Dmsg(ctx, debuglevel,
            "python-fd: PyBareosSetValue unknown variable requested %d\n", var);
       break;

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/python-modules/BareosFdPluginLocalFilesetWithRestoreObjects.py
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/python-modules/BareosFdPluginLocalFilesetWithRestoreObjects.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2019 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -25,7 +25,7 @@
 # the backup fileset
 
 import bareosfd
-from bareos_fd_consts import bJobMessageType, bFileType, bRCs
+from bareos_fd_consts import bJobMessageType, bFileType, bRCs, bVariable
 import os
 import re
 import hashlib
@@ -63,6 +63,8 @@ class BareosFdPluginLocalFilesetWithRestoreObjects(
         self.deny = None
         self.object_index_seq = int((time.time() - 1546297200) * 10)
         self.sha256sums_by_filename = {}
+        bareosfd.SetValue(context,bVariable["bVarSinceTime"],999)
+
 
     def filename_is_allowed(self, context, filename, allowregex, denyregex):
         """

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/python-modules/BareosFdPluginLocalFilesetWithRestoreObjects.py
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/python-modules/BareosFdPluginLocalFilesetWithRestoreObjects.py
@@ -64,6 +64,13 @@ class BareosFdPluginLocalFilesetWithRestoreObjects(
         self.object_index_seq = int((time.time() - 1546297200) * 10)
         self.sha256sums_by_filename = {}
         bareosfd.SetValue(context,bVariable["bVarSinceTime"],999)
+        triple_nine = bareosfd.GetValue(context,bVariable["bVarSinceTime"])
+        if triple_nine != 999:
+            bareosfd.JobMessage(
+                context,
+                bJobMessageType["M_ERROR"],
+                "Wrong value for since time (should be 999 but is %d)\n" % triple_nine
+            )
 
 
     def filename_is_allowed(self, context, filename, allowregex, denyregex):


### PR DESCRIPTION
Now the since_time of the current backup job can be set 
using SetValue from the Python plugin.