### PR TITLE
Fixed JobDetails joblog messages order

### DIFF
--- a/webui/module/Job/src/Job/Model/JobModel.php
+++ b/webui/module/Job/src/Job/Model/JobModel.php
@@ -175,6 +175,7 @@ class JobModel
          $cmd = 'list joblog jobid='.$id.'';
          $limit = 1000;
          $offset = 0;
+         $id = 1;
          $retval = array();
          while (true) {
             $result = $bsock->send_command($cmd . ' limit=' . $limit . ' offset=' . $offset, 2);
@@ -190,6 +191,9 @@ class JobModel
                if ( empty($log['result']['joblog']) && $log['result']['meta']['range']['filtered'] === 0 ) {
                   return $retval;
                } else {
+                  foreach($log['result']['joblog'] as &$joblog) {
+                     $joblog["id"] = $id++;
+                  }
                   $retval = array_merge($retval, $log['result']['joblog']);
                }
             }

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -83,7 +83,7 @@ $this->headTitle($title);
          <div class="panel-body">
             <table class="table table-no-bordered table-hover" id="joblog">
                <thead class="bg-primary">
-                  <th><?php echo $this->translate("Id"); ?></th>
+                  <th>#</th>
                   <th><?php echo $this->translate("Timestamp"); ?></th>
                   <th><?php echo $this->translate("Message"); ?></th>
                </thead>

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -83,6 +83,7 @@ $this->headTitle($title);
          <div class="panel-body">
             <table class="table table-no-bordered table-hover" id="joblog">
                <thead class="bg-primary">
+                  <th><?php echo $this->translate("Id"); ?></th>
                   <th><?php echo $this->translate("Timestamp"); ?></th>
                   <th><?php echo $this->translate("Message"); ?></th>
                </thead>
@@ -248,12 +249,15 @@ $this->headTitle($title);
          pageList: [ <?php echo $_SESSION['bareos']['dt_lengthmenu']; ?> ],
          pageSize: <?php echo $_SESSION['bareos']['dt_pagelength']; ?>,
          search: true,
-         sortName: 'time',
+         sortName: 'id',
          sortOrder: 'desc',
          columns: [
-            {
-               field: 'time',
+            { 
+               field: 'id',
                sortable: true,
+            },
+            {
+               field: 'time'
             },
             {
                field: 'logtext',


### PR DESCRIPTION
When you have multiple log messages with the same time the display order is weird. For example, lets say we have this joblogs in this order returned from bconsole:

- A 13:11
- B 13:11
- C 13:11
- D 13:12
- E 13:12

If we order them by desc time, we expect to have:

- E
- D
- C
- B
- A

But we are getting:

- D
- E
- A
- B
- C

By adding an Id to each message we can solve this problem.