### PR TITLE
python-bareos: publish to PyPI.org by using Github Actions

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -1,0 +1,50 @@
+name: "[Release] python-bareos -> https://pypi.org/"
+
+on:
+  push:
+    tags:
+      - Release/*
+
+jobs:
+  build-and-publish:
+    name: "Build python-bareos and publish it to https://pypi.org/"
+    runs-on: ubuntu-18.04
+    
+    steps:
+    - name: "Checkout source"
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+      
+    - name: "Checkout tags"
+      # for get-version.sh, an unshallow git checkout with tags is needed.
+      run:  git fetch --tag
+
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+        
+    - name: "Build python package"
+      run: |
+        pip install --user wheel
+        cd python-bareos
+        # sdist mangles around with version information.
+        # We replace ~pre with dev, as this will not be modified.
+        # (pre will be replaced with rc).
+        ../docs/manuals/source/get-version.sh > bareos/VERSION.txt
+        printf "Version: %s\n" $(cat bareos/VERSION.txt)
+        python setup.py sdist bdist_wheel
+
+    - name: "Create artifact"
+      # creating an artifact is not required for publishing to pypi.
+      uses: actions/upload-artifact@v2
+      with:
+        path: python-bareos/dist/
+
+    - name: "Publish to pypi.org"
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        repository_url: https://pypi.org/legacy/
+        password: ${{ secrets.pypi_password }}
+        packages_dir: python-bareos/dist/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,59 @@
+name: "python-bareos -> https://test.pypi.org/"
+
+#
+# build a python-bareos dev package
+# for every change in master,
+# affecting python-bareos.
+#
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - python-bareos/**
+      - .github/workflows/publish-to-test-pypi.yml
+
+jobs:
+  build-and-publish:
+    name: "Build python-bareos and publish it to https://test.pypi.org/"
+    runs-on: ubuntu-18.04
+    
+    steps:
+    - name: "Checkout source"
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+      
+    - name: "Checkout tags"
+      # for get-version.sh, an unshallow git checkout with tags is needed.
+      run:  git fetch --tag
+
+    - name: "Set up Python"
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+        
+    - name: "Build python package"
+      run: |
+        pip install --user wheel
+        cd python-bareos
+        # sdist mangles around with version information.
+        # We replace ~pre with dev, as this will not be modified.
+        # (pre will be replaced with rc).
+        ../docs/manuals/source/get-version.sh > bareos/VERSION.txt
+        printf "Version: %s\n" $(cat bareos/VERSION.txt)
+        python setup.py sdist bdist_wheel
+
+    - name: "Create artifact"
+      # creating an artifact is not required for publishing to pypi.
+      uses: actions/upload-artifact@v2
+      with:
+        path: python-bareos/dist/
+
+    - name: "Publish to test.pypi.org"
+      uses: pypa/gh-action-pypi-publish@v1.1.0
+      with:
+        repository_url: https://test.pypi.org/legacy/
+        password: ${{ secrets.test_pypi_password }}
+        packages_dir: python-bareos/dist/

--- a/python-bareos/setup.py
+++ b/python-bareos/setup.py
@@ -11,7 +11,9 @@ def get_version():
         with open(
             os.path.join(base_dir, "bareos", "VERSION.txt")
         ) as version_file:
-            __version__ = version_file.read().strip()
+            # read version
+            # and adapt it according to https://www.python.org/dev/peps/pep-0440/.
+            __version__ = version_file.read().strip().replace('~pre','.dev')
     except IOError:
         # Fallback version.
         # First protocol implemented

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -660,7 +660,6 @@ endif()
 
 # python-bareos-test does not work on installed files
 if(PYTHON AND NOT RUN_SYSTEMTESTS_ON_INSTALLED_FILES)
-
   list(APPEND SYSTEM_TESTS "python-bareos-test")
 else()
   list(APPEND SYSTEM_TESTS_DISABLED "python-bareos-test")

--- a/systemtests/tests/python-bareos-test/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos-test/python-bareos-unittest.py
@@ -71,8 +71,9 @@ class PythonBareosBase(unittest.TestCase):
 
 
 class PythonBareosModuleTest(PythonBareosBase):
-    def versiontuple(self, v):
-        return tuple(map(int, (v.split("."))))
+    def versiontuple(self, versionstring):
+        version, separator, suffix = versionstring.partition('~')
+        return tuple(map(int, (version.split("."))))
 
     def test_exception_connection_error(self):
         """


### PR DESCRIPTION
This PR adds 2 Github Action workflows.

Both create python-bareos packages and publish them at pypi.org.
- publish-to-test-pypi.yml
  Build and publish python-bareos dev packages onto https://test.pypi.org 
  for every change in the python-bareos subdirectory published on master.
- publish-release-to-pypi.yml
  Build and publish python-bareos packages onto https://pypi.org 
  for every release tag.
The required PyPI API keys are already set at this project settings.
 
Both workflows have been tested at https://github.com/joergsteffens/bareos/commits/dev/joergs/master/github-action-publish-to-pypi

This PR should also be backported for bareos-19.2.