### PR TITLE
Fix bscan handling of restore object data

### DIFF
--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -872,6 +872,7 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
       }
       rop.FileIndex = mjcr->FileId;
       rop.JobId = mjcr->JobId;
+      rop.FileType = FT_RESTORE_FIRST;
 
 
       if (update_db) { db->CreateRestoreObjectRecord(mjcr, &rop); }


### PR DESCRIPTION
When reading restore object data from a volume, bscan must set
ObjectType to 25 (FT_RESTORE_FIRST). This affects all plugins
that use restore objects.

I've noticed that the FileIndex column of the RestoreObject table does not get filled with sequential/unique values like it was after the original backup. However, this is obviously
irrelevant as the restore works successfully with this patch.