### PR TITLE
Improve the VirtualFull run job

### DIFF
--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -451,6 +451,11 @@ class JobController extends AbstractActionController
     $storages = $this->getStorageModel()->getStorages($this->bsock);
     $pools = $this->getPoolModel()->getDotPools($this->bsock, null);
 
+    foreach($pools as &$pool) {
+      $nextpool = $this->getPoolModel()->getPoolNextPool($this->bsock, $pool["name"]);
+      $pool["nextpool"] = $nextpool;
+    }
+
     // build form
     $form = new RunJobForm($clients, $jobs, $filesets, $storages, $pools, $jobdefaults);
 
@@ -477,6 +482,7 @@ class JobController extends AbstractActionController
         $storage = $form->getInputFilter()->getValue('storage');
         $pool = $form->getInputFilter()->getValue('pool');
         $level = $form->getInputFilter()->getValue('level');
+        $nextpool = $form->getInputFilter()->getValue('nextpool');
         $priority = $form->getInputFilter()->getValue('priority');
         $backupformat = null; // $form->getInputFilter()->getValue('backupformat');
         $when = $form->getInputFilter()->getValue('when');
@@ -495,7 +501,7 @@ class JobController extends AbstractActionController
               )
             );
           } else {
-            $result = $this->getJobModel()->runCustomJob($this->bsock, $jobname, $client, $fileset, $storage, $pool, $level, $priority, $backupformat, $when);
+            $result = $this->getJobModel()->runCustomJob($this->bsock, $jobname, $client, $fileset, $storage, $pool, $level, $nextpool, $priority, $backupformat, $when);
             $this->bsock->disconnect();
             $s = strrpos($result, "=") + 1;
             $jobid = rtrim( substr( $result, $s ) );

--- a/webui/module/Job/src/Job/Form/RunJobForm.php
+++ b/webui/module/Job/src/Job/Form/RunJobForm.php
@@ -306,6 +306,41 @@ class RunJobForm extends Form
          ));
       }
 
+      // NextPool
+      if(isset($jobdefaults['pool'])) {
+        $this->add(array(
+           'name' => 'nextpool',
+           'type' => 'select',
+           'options' => array(
+              'label' => _('Next Pool'),
+              'empty_option' => '',
+              'value_options' => $this->getPoolList()
+           ),
+           'attributes' => array(
+              'class' => 'form-control selectpicker show-tick',
+              'data-live-search' => 'true',
+              'id' => 'nextpool',
+              'value' => $this->getNextPool($jobdefaults['pool'])
+           )
+        ));
+      } else {
+          $this->add(array(
+            'name' => 'nextpool',
+            'type' => 'select',
+            'options' => array(
+                'label' => _('Next Pool'),
+                'empty_option' => '',
+                'value_options' => $this->getPoolList()
+            ),
+            'attributes' => array(
+                'class' => 'form-control selectpicker show-tick',
+                'data-live-search' => 'true',
+                'id' => 'nextpool',
+                'value' => null
+            )
+          ));
+      }
+
 /*
       // Backup Format
       $this->add(array(
@@ -417,5 +452,25 @@ class RunJobForm extends Form
       $selectData['Incremental'] = 'Incremental';
       $selectData['VirtualFull'] = 'VirtualFull';
       return $selectData;
+   }
+
+   private function getNextPool($pool_name)
+   {
+      foreach($this->pools as $pool) {
+        if($pool["name"] === $pool_name) {
+          return $pool["nextpool"];
+        }
+      }
+   }
+
+   public function getPoolNextPoolMapping()
+   {
+      $mapping = [];
+
+      foreach($this->pools as $pool) {
+        $mapping[$pool["name"]] =  $pool["nextpool"];
+      }
+
+      return json_encode($mapping);
    }
 }

--- a/webui/module/Job/src/Job/Model/Job.php
+++ b/webui/module/Job/src/Job/Model/Job.php
@@ -144,6 +144,17 @@ class Job implements InputFilterAwareInterface
          ));
 
          $inputFilter->add(array(
+            'name' => 'nextpool',
+            'required' => false,
+            'filters' => array(
+               array('name' => 'StripTags'),
+               array('name' => 'StringTrim'),
+            ),
+            'validators' => array(
+            )
+         ));
+
+         $inputFilter->add(array(
             'name' => 'priority',
             'required' => false,
             'filters' => array(

--- a/webui/module/Job/src/Job/Model/JobModel.php
+++ b/webui/module/Job/src/Job/Model/JobModel.php
@@ -466,13 +466,14 @@ class JobModel
     * @param $storage
     * @param $pool
     * @param $level
+    * @param $nextpool
     * @param $priority
     * @param $backupformat
     * @param $when
     *
     * @return string
     */
-   public function runCustomJob(&$bsock=null, $jobname=null, $client=null, $fileset=null, $storage=null, $pool=null, $level=null, $priority=null, $backupformat=null, $when=null)
+   public function runCustomJob(&$bsock=null, $jobname=null, $client=null, $fileset=null, $storage=null, $pool=null, $level=null, $nextpool=null, $priority=null, $backupformat=null, $when=null)
    {
       if(isset($bsock, $jobname)) {
          $cmd = 'run job="' . $jobname . '"';
@@ -490,6 +491,9 @@ class JobModel
          }
          if(!empty($level)) {
             $cmd .= ' level="' . $level . '"';
+         }
+         if(!empty($nextpool)) {
+            $cmd .= ' nextpool="' . $nextpool . '"';
          }
          if(!empty($priority)) {
             $cmd .= ' priority="' . $priority . '"';

--- a/webui/module/Job/view/job/job/run.phtml
+++ b/webui/module/Job/view/job/job/run.phtml
@@ -105,6 +105,13 @@ $this->headTitle($title);
    </div>
 
    <div class="form-group">
+      <label class="control-label col-md-2"><?php echo $this->formLabel($form->get('nextpool')); ?></label>
+      <div class="control-input col-md-6">
+         <?php echo $this->formSelect($form->get('nextpool')); ?>
+      </div>
+   </div>
+
+   <div class="form-group">
       <label class="control-label col-md-2"><?php echo $this->formLabel($form->get('priority')); ?></label>
       <div class="control-input col-md-6">
          <?php echo $this->formInput($form->get('priority')); ?>
@@ -162,6 +169,8 @@ $this->headTitle($title);
 
 <script type="text/javascript">
 
+   let pool_nextpool_mapping = JSON.parse('<?php echo $form->getPoolNextPoolMapping(); ?>');
+
    function updateQueryParams(k, v) {
       var p = [];
       var params = [];
@@ -177,8 +186,34 @@ $this->headTitle($title);
       return params.join('&');
    }
 
+   function hasNextPoolOption() {
+      return $('#level').selectpicker('val') == "VirtualFull" || 
+         $('#type').val() == "Copy" ||
+         $('#type').val() == "Migrate"
+   }
+
    $('#job').change(function(event) {
       window.location.href = window.location.pathname + '?' + updateQueryParams('jobname', this.value);
+   });
+
+   $('#pool').change(function(event) {
+      if(hasNextPoolOption()) {
+         let nextpool = pool_nextpool_mapping[$('#pool').selectpicker('val')];
+
+         if(nextpool) {
+            $('#nextpool').selectpicker('val', nextpool);
+         }
+      }
+   });
+
+   $('#level').change(function() {
+      if(hasNextPoolOption()) {
+         $("#nextpool").parents(".form-group").fadeIn();
+         $('#pool').change();
+      } else {
+         $("#nextpool").parents(".form-group").hide();
+         $('#nextpool').selectpicker('val', '');
+      }
    });
 
    $(function() {
@@ -186,6 +221,9 @@ $this->headTitle($title);
          format: 'YYYY-MM-DD HH:mm:ss',
          sideBySide: true
       });
+
+      // This will enable/disable the Next Pool select based on the Level value on load
+      $('#level').change();
    });
 
 </script>

--- a/webui/module/Pool/src/Pool/Model/PoolModel.php
+++ b/webui/module/Pool/src/Pool/Model/PoolModel.php
@@ -132,4 +132,27 @@ class PoolModel
          throw new \Exception('Missing argument.');
       }
    }
+
+   /**
+    * Get the NextPool value from a Pool model definition
+    *
+    * @param $bsock
+    * @param $pool
+    *
+    * @return array
+    */
+   public function getPoolNextPool(&$bsock=null, $pool=null)
+   {
+      if(isset($bsock, $pool)) {
+         $cmd = 'show pool="'.$pool.'"';
+         $result = $bsock->send_command($cmd, 0);
+         
+         $matches = [];
+         preg_match('/\s*Next\s*Pool\s*=\s*("|\')?(?<value>.*)(?(1)\1|)/i', $result, $matches);
+         return $matches["value"];
+      }
+      else {
+         throw new \Exception('Missing argument.');
+      }
+   }
 }


### PR DESCRIPTION
Based on this https://github.com/bareos/bareos/pull/508#issuecomment-627312701

Now you can select a NextPool value for your VirtualFull Backup, Copy or Migrate job. It considers this:

- If the **Type** is Backup:
  - If the selected **Level** is other than VirtualFull, the **Next Pool** field will be hidden and empty.
  - If the selected **Level** is VirtualFull, the **Next Pool** field will shown and populated with the Next Pool of the currently selected pool if it is defined, empty otherwise.
  - If the selected **Pool** changes and the **Level** is VirtualFull, the **Next Pool** field will be updated to the next pool for the recently selected pool if it is defined, keep the one currently selected otherwise.
  - If the selected **Pool** changes and the **Level** is not VirtualFull, it does nothing. 

- If the **Type** is Copy or Migrate:
  - If the selected **Pool** changes, the **Next Pool** field will be updated to the next pool for the recently selected pool if it is defined, keep the one currently selected otherwise. 