### PR TITLE
systemtests: setup_data: exit immediately, if it fails.

### DIFF
--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -115,7 +115,7 @@ setup_data()
   data_dir="${tmp}/data"
 
   [ -d "$data_dir" ] || mkdir "$data_dir"
-  echo "${data_dir}" >"${tmp}/file-list"
+  echo "$data_dir" >"$tmp/file-list"
 
   for tar in "../../data/small.tgz" "../../data/weird-files.tar.gz"; do
    if [ ! -f "$tar" ]; then

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -115,16 +115,16 @@ setup_data()
   data_dir="${tmp}/data"
 
   [ -d "$data_dir" ] || mkdir "$data_dir"
+  echo "${data_dir}" >"${tmp}/file-list"
 
   for tar in "../../data/small.tgz" "../../data/weird-files.tar.gz"; do
    if [ ! -f "$tar" ]; then
     set_error "setup_data: $tar not found."
-    return 1
+    exit 1
    fi
-   tar --directory="$data_dir" -xf "$tar" || return 1
+   tar --directory="$data_dir" -xf "$tar" || exit 1
   done
 
-  echo "${data_dir}" >"${tmp}/file-list"
 
   return 0
 }


### PR DESCRIPTION
Before, it just returns an error code (1).
However, this code have never been checked,
making it hard to find the real problem of failing tests.