### PR TITLE
docs: encryption: use same name for example certificate.

### DIFF
--- a/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
@@ -88,9 +88,9 @@ Generate a File Daemon Key Pair for each FD:
 
 ::
 
-     openssl genrsa -out fd-example.key 2048
-     openssl req -new -key fd-example.key -x509 -out fd-example.cert
-     cat fd-example.key fd-example.cert >fd-example.pem
+     openssl genrsa -out example-fd.key 2048
+     openssl req -new -key example-fd.key -x509 -out example-fd.cert
+     cat example-fd.key example-fd.cert >example-fd.pem
 
 
 

--- a/docs/manuals/source/include/config/FdClientPki.conf
+++ b/docs/manuals/source/include/config/FdClientPki.conf
@@ -4,7 +4,7 @@ FileDaemon {
    # encryption configuration
    PKI Signatures = Yes                          # Enable Data Signing
    PKI Encryption = Yes                          # Enable Data Encryption
-   PKI Keypair    = "/etc/bareos/client1-fd.pem" # Public and Private Keys
+   PKI Keypair    = "/etc/bareos/example-fd.pem" # Public and Private Keys
    PKI Master Key = "/etc/bareos/master.cert"    # ONLY the Public Key
    PKI Cipher     = aes128                       # specify desired PKI Cipher here
 }


### PR DESCRIPTION
The name used in the documentation how to create the certificates was
"fd-example", while the example configuration file used "client1-fd".

Now both use "example-fd", as the filedaemons usually are called
"<name>-fd" everywhere.