### PR TITLE
Improve JobLogs formatting

### DIFF
--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -578,6 +578,7 @@ function jobActionButtonsFormatter(value, row, index, basePath) {
             case 'C':
                return jobDetailsButton + '&nbsp;' + jobRestoreButton;
             case 'R':
+            case 'O':
                return jobDetailsButton;
          }
          break;

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -577,8 +577,7 @@ function jobActionButtonsFormatter(value, row, index, basePath) {
                return jobDetailsButton + '&nbsp;' + jobRerunButton + '&nbsp;' + jobRestoreButton;
             case 'C':
                return jobDetailsButton + '&nbsp;' + jobRestoreButton;
-            case 'R':
-            case 'O':
+            default:
                return jobDetailsButton;
          }
          break;
@@ -589,6 +588,8 @@ function jobActionButtonsFormatter(value, row, index, basePath) {
          switch(row.type) {
             case 'B':
                return jobDetailsButton + '&nbsp;' + jobRerunButton;
+            default:
+               return jobDetailsButton;
          }
          break;
       case 'F':
@@ -623,7 +624,7 @@ function jobActionButtonsFormatter(value, row, index, basePath) {
          }
          break;
       default:
-         return '';
+         return jobDetailsButton;
    }
 }
 

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -490,18 +490,11 @@ function formatFilesetName(value, row, index, basePath) {
 function formatLogMessage(value) {
    var msg = (value).replace(/\n/g, "<br />");
 
-   if(msg.search("Error") > 0) {
-      return msg.replace(/Error/g, '<span class="bg-danger text-danger">Error</span>');
-   }
-   else if(msg.search("error") > 0) {
-      return msg.replace(/error/g, '<span class="bg-danger text-danger">error</span>');
-   }
-   else if(msg.search("Warning") > 0) {
-      return msg.replace(/Warning/g, '<span class="bg-warning text-warning">Warning</span>');
-   }
-   else {
-      return msg;
-   }
+   msg = msg.replace(/(e)rror(s?)/gi, '<span class="bg-danger text-danger">$1rror$2</span>');
+   msg = msg.replace(/(w)arning(s?)/gi, '<span class="bg-warning text-warning">$1arning$2</span>');
+   msg = msg.replace(/jobid=([0-9]*)/gi, '<a class="bg-info text-info" href="' +  basePath + '/job/details/$1">JobId=$1</a>');
+
+   return msg;
 }
 
 function formatAutochangerStatus(value) {


### PR DESCRIPTION
This improves the JobLog message formating, as described in https://github.com/bareos/bareos/commit/a24e244dbca224662cc2bd86959cc05938eccbcf. 

This benefits AFAIK Consolidation, Migration and Copy Jobs, and those type of Jobs didn't have the **details** button so I added it. I modified the code that selects what buttons to show depending on the Job status and type so every job have at least the **details** button. It doesn't make sense to me to have a row without taht button at least.

This change makes it very simple and obvious the way to keep adding formatting rules when needed.