### PR TITLE
webui: fix a wrong find_element_by_xpath call

### DIFF
--- a/webui/tests/selenium/webui-selenium-test.py
+++ b/webui/tests/selenium/webui-selenium-test.py
@@ -499,7 +499,7 @@ class SeleniumTest(unittest.TestCase):
         #)
         self.enter_input("consolename", self.username)
         self.enter_input("password", self.password)
-        driver.find_element_by_xpath('(//button[@type="button"])[2]').click()
+        driver.find_element_by_xpath('(//button[@type="button"])[1]').click()
         driver.find_element_by_link_text("English").click()
         driver.find_element_by_xpath('//input[@id="submit"]').click()
         try:


### PR DESCRIPTION
After recent login dialog changes, the button number we need to click
changed from 2 to 1 in our test environment.