### PR TITLE
dird: display who triggered the job in job reports

### DIFF
--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -41,6 +41,7 @@ set(DIRD_OBJECTS_SRCS
     inc_conf.cc
     job.cc
     jobq.cc
+    job_trigger.cc
     migrate.cc
     msgchan.cc
     ndmp_dma_storage.cc

--- a/core/src/dird/admin.cc
+++ b/core/src/dird/admin.cc
@@ -121,10 +121,11 @@ void AdminCleanup(JobControlRecord* jcr, int TermCode)
          "  Start time:             %s\n"
          "  End time:               %s\n"
          "  Bareos binary info:     %s\n"
+         "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt, jcr->impl->jr.JobId,
        jcr->impl->jr.Job, schedt, sdt, edt, kBareosVersionStrings.JoblogMessage,
-       TermMsg);
+       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave AdminCleanup()\n");
 }

--- a/core/src/dird/archive.cc
+++ b/core/src/dird/archive.cc
@@ -121,10 +121,12 @@ void ArchiveCleanup(JobControlRecord* jcr, int TermCode)
          "  Start time:             %s\n"
          "  End time:               %s\n"
          "  Bareos binary info:     %s\n"
+         "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt,
        jcr->impl->jr.JobId, jcr->impl->jr.Job, schedt, sdt, edt,
-       kBareosVersionStrings.JoblogMessage, TermMsg);
+       kBareosVersionStrings.JoblogMessage,
+       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave ArchiveCleanup()\n");
 }

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -1193,6 +1193,7 @@ void GenerateBackupSummary(JobControlRecord *jcr, ClientDbRecord *cr, int msg_ty
         "%s"                                        /* Daemon status info */
         "%s"                                        /* SecureErase status */
         "  Bareos binary info:     %s\n"
+        "  Job triggered by:       %s\n"
         "  Termination:            %s\n\n"),
         BAREOS, my_name, kBareosVersionStrings.Full,
         kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -1221,6 +1222,7 @@ void GenerateBackupSummary(JobControlRecord *jcr, ClientDbRecord *cr, int msg_ty
         daemon_status.c_str(),
         secure_erase_status.c_str(),
         kBareosVersionStrings.JoblogMessage,
+        JobTriggerToString(jcr->impl->job_trigger).c_str(),
         TermMsg);
 
   /* clang-format on */

--- a/core/src/dird/consolidate.cc
+++ b/core/src/dird/consolidate.cc
@@ -385,10 +385,12 @@ void ConsolidateCleanup(JobControlRecord* jcr, int TermCode)
          "  Start time:             %s\n"
          "  End time:               %s\n"
          "  Bareos binary info:     %s\n"
+         "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt,
        jcr->impl->jr.JobId, jcr->impl->jr.Job, schedt, sdt, edt,
-       kBareosVersionStrings.JoblogMessage, TermMsg);
+       kBareosVersionStrings.JoblogMessage,
+       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave ConsolidateCleanup()\n");
 }

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -26,6 +26,7 @@
 
 #include "cats/cats.h"
 #include "dird/client_connection_handshake_mode.h"
+#include "dird/job_trigger.h"
 
 typedef struct s_tree_root TREE_ROOT;
 
@@ -158,6 +159,7 @@ struct JobControlRecordPrivate {
   bool HasSelectedJobs{};               /**< Migration/Copy Job did actually select some JobIds */
   directordaemon::ClientConnectionHandshakeMode connection_handshake_try_{
     directordaemon::ClientConnectionHandshakeMode::kUndefined};
+  JobTrigger job_trigger{JobTrigger::kUndefined};
 };
 /* clang-format on */
 

--- a/core/src/dird/job_trigger.cc
+++ b/core/src/dird/job_trigger.cc
@@ -1,0 +1,38 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "include/bareos.h"
+#include "dird/job_trigger.h"
+
+std::string JobTriggerToString(JobTrigger trig)
+{
+  switch (trig) {
+    case JobTrigger::kScheduler:
+      return _("Scheduler");
+    case JobTrigger::kClient:
+      return _("Client");
+    case JobTrigger::kUser:
+      return _("User");
+    default:
+    case JobTrigger::kUndefined:
+      return _("Unknown");
+  }
+}

--- a/core/src/dird/job_trigger.h
+++ b/core/src/dird/job_trigger.h
@@ -1,0 +1,37 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#ifndef BAREOS_SRC_DIRD_JOB_TRIGGER_H_
+#define BAREOS_SRC_DIRD_JOB_TRIGGER_H_
+
+#include <string>
+
+enum class JobTrigger
+{
+  kUndefined,
+  kScheduler,
+  kClient,
+  kUser,
+};
+
+std::string JobTriggerToString(JobTrigger trig);
+
+
+#endif  // BAREOS_SRC_DIRD_JOB_TRIGGER_H_

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1765,6 +1765,7 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
            "  SD Errors:              %d\n"
            "  SD termination status:  %s\n"
            "  Bareos binary info:     %s\n"
+           "  Job triggered by:       %s\n"
            "  Termination:            %s\n\n"),
          BAREOS, my_name, kBareosVersionStrings.Full,
          kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -1798,7 +1799,8 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
          mig_jcr ? mig_jcr->VolumeName : _("*None*"), jcr->VolSessionId,
          jcr->VolSessionTime, edit_uint64_with_commas(mr->VolBytes, ec4),
          edit_uint64_with_suffix(mr->VolBytes, ec5), jcr->impl->SDErrors,
-         sd_term_msg, kBareosVersionStrings.JoblogMessage, term_code);
+         sd_term_msg, kBareosVersionStrings.JoblogMessage,
+         JobTriggerToString(jcr->impl->job_trigger).c_str(), term_code);
   } else {
     /*
      * Copy/Migrate selection only Job.
@@ -1814,13 +1816,15 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
            "  Elapsed time:           %s\n"
            "  Priority:               %d\n"
            "  Bareos binary info:     %s\n"
+           "  Job triggered by:       %s\n"
            "  Termination:            %s\n\n"),
          BAREOS, my_name, kBareosVersionStrings.Full,
          kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
          edit_uint64(jcr->impl->jr.JobId, ec8), jcr->impl->jr.Job,
          jcr->impl->res.catalog->resource_name_, jcr->impl->res.catalog_source,
          sdt, edt, edit_utime(RunTime, elapsed, sizeof(elapsed)),
-         jcr->JobPriority, kBareosVersionStrings.JoblogMessage, term_code);
+         jcr->JobPriority, kBareosVersionStrings.JoblogMessage,
+         JobTriggerToString(jcr->impl->job_trigger).c_str(), term_code);
   }
 }
 

--- a/core/src/dird/restore.cc
+++ b/core/src/dird/restore.cc
@@ -563,6 +563,7 @@ void GenerateRestoreSummary(JobControlRecord* jcr,
              "  Rate:                   %.1f KB/s\n"
              "  SD termination status:  %s\n"
              "  Bareos binary info:     %s\n"
+             "  Job triggered by:       %s\n"
              "  Termination:            %s\n\n"),
            BAREOS, my_name, kBareosVersionStrings.Full,
            kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -572,7 +573,8 @@ void GenerateRestoreSummary(JobControlRecord* jcr,
            edit_uint64_with_commas((uint64_t)jcr->impl->ExpectedFiles, ec1),
            edit_uint64_with_commas((uint64_t)jcr->impl->jr.JobFiles, ec2),
            edit_uint64_with_commas(jcr->impl->jr.JobBytes, ec3), (float)kbps,
-           sd_term_msg, kBareosVersionStrings.JoblogMessage, TermMsg);
+           sd_term_msg, kBareosVersionStrings.JoblogMessage,
+           JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
       break;
     default:
       if (me->secure_erase_cmdline) {
@@ -608,6 +610,7 @@ void GenerateRestoreSummary(JobControlRecord* jcr,
              "  SD termination status:  %s\n"
              "%s"
              "  Bareos binary info:     %s\n"
+             "  Job triggered by:       %s\n"
              "  Termination:            %s\n\n"),
            BAREOS, my_name, kBareosVersionStrings.Full,
            kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -619,7 +622,7 @@ void GenerateRestoreSummary(JobControlRecord* jcr,
            edit_uint64_with_commas(jcr->impl->jr.JobBytes, ec3), (float)kbps,
            jcr->JobErrors, fd_term_msg, sd_term_msg,
            secure_erase_status.c_str(), kBareosVersionStrings.JoblogMessage,
-           TermMsg);
+           JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
       break;
   }
 }

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,8 @@
 #include "dird/dird_conf.h"
 #include "dird/get_database_connection.h"
 #include "dird/job.h"
+#include "dird/job_trigger.h"
+#include "dird/jcr_private.h"
 #include "dird/run_on_incoming_connect_interval.h"
 #include "dird/scheduler.h"
 
@@ -115,7 +117,7 @@ void RunOnIncomingConnectInterval::RunJobIfIntervalExceeded(
 
   if (!job_ran_before || interval_time_exceeded) {
     Dmsg1(800, "Add job %s to scheduler queue.", job->resource_name_);
-    scheduler_.AddJobWithNoRunResourceToQueue(job);
+    scheduler_.AddJobWithNoRunResourceToQueue(job, JobTrigger::kClient);
   }
 }
 

--- a/core/src/dird/scheduler.cc
+++ b/core/src/dird/scheduler.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -71,9 +71,10 @@ Scheduler::Scheduler(std::unique_ptr<SchedulerTimeAdapter> time_adapter,
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::AddJobWithNoRunResourceToQueue(JobResource* job)
+void Scheduler::AddJobWithNoRunResourceToQueue(JobResource* job,
+                                               JobTrigger job_trigger)
 {
-  impl_->AddJobWithNoRunResourceToQueue(job);
+  impl_->AddJobWithNoRunResourceToQueue(job, job_trigger);
 }
 
 void Scheduler::Run()

--- a/core/src/dird/scheduler.h
+++ b/core/src/dird/scheduler.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,6 +23,8 @@
 
 #ifndef BAREOS_DIRD_SCHEDULER_H_
 #define BAREOS_DIRD_SCHEDULER_H_
+
+#include "dird/job_trigger.h"
 
 #include <memory>
 #include <functional>
@@ -45,7 +47,7 @@ class Scheduler {
   void Run();
   void Terminate();
   void ClearQueue();
-  void AddJobWithNoRunResourceToQueue(JobResource* job);
+  void AddJobWithNoRunResourceToQueue(JobResource* job, JobTrigger job_trigger);
   static Scheduler& GetMainScheduler() noexcept;
 
  private:

--- a/core/src/dird/scheduler_job_item_queue.cc
+++ b/core/src/dird/scheduler_job_item_queue.cc
@@ -84,7 +84,8 @@ SchedulerJobItem SchedulerJobItemQueue::TopItem() const
 
 void SchedulerJobItemQueue::EmplaceItem(JobResource* job,
                                         RunResource* run,
-                                        time_t runtime)
+                                        time_t runtime,
+                                        JobTrigger job_trigger)
 {
   if (job == nullptr) {
     throw std::invalid_argument("Invalid Argument: JobResource is undefined");
@@ -97,7 +98,7 @@ void SchedulerJobItemQueue::EmplaceItem(JobResource* job,
                      : default_priority;
 
   std::lock_guard<std::mutex> lg(impl_->mutex);
-  impl_->priority_queue.emplace(job, run, runtime, priority);
+  impl_->priority_queue.emplace(job, run, runtime, priority, job_trigger);
 }
 
 bool SchedulerJobItemQueue::Empty() const

--- a/core/src/dird/scheduler_job_item_queue.h
+++ b/core/src/dird/scheduler_job_item_queue.h
@@ -23,6 +23,7 @@
 #define BAREOS_SRC_DIRD_SCHEDULER_JOB_ITEM_QUEUE_H_
 
 #include "include/bareos.h"
+#include "dird/job_trigger.h"
 
 #include <queue>
 #include <vector>
@@ -45,8 +46,13 @@ struct SchedulerJobItem {
   SchedulerJobItem(JobResource* job_in,
                    RunResource* run_in,
                    time_t runtime_in,
-                   int priority_in) noexcept
-      : job(job_in), run(run_in), runtime(runtime_in), priority(priority_in)
+                   int priority_in,
+                   JobTrigger job_kickoff_in) noexcept
+      : job(job_in)
+      , run(run_in)
+      , runtime(runtime_in)
+      , priority(priority_in)
+      , job_trigger(job_kickoff_in)
   {
     is_valid = job && runtime;
   };
@@ -64,6 +70,7 @@ struct SchedulerJobItem {
   time_t runtime{0};
   int priority{10};
   bool is_valid{false};
+  JobTrigger job_trigger{JobTrigger::kUndefined};
 };
 
 class SchedulerJobItemQueue {
@@ -73,7 +80,10 @@ class SchedulerJobItemQueue {
 
   SchedulerJobItem TopItem() const;
   SchedulerJobItem TakeOutTopItem();
-  void EmplaceItem(JobResource* job, RunResource* run, time_t runtime);
+  void EmplaceItem(JobResource* job,
+                   RunResource* run,
+                   time_t runtime,
+                   JobTrigger job_trigger);
   bool Empty() const;
   void Clear();
 

--- a/core/src/dird/scheduler_private.h
+++ b/core/src/dird/scheduler_private.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -46,7 +46,7 @@ class SchedulerPrivate {
 
   void WaitForJobsToRun();
   void FillSchedulerJobQueueOrSleep();
-  void AddJobWithNoRunResourceToQueue(JobResource* job);
+  void AddJobWithNoRunResourceToQueue(JobResource* job, JobTrigger job_trigger);
 
   std::unique_ptr<SchedulerTimeAdapter> time_adapter;
   SchedulerJobItemQueue prioritised_job_item_queue;
@@ -63,7 +63,8 @@ class SchedulerPrivate {
   void AddJobToQueue(JobResource* job,
                      RunResource* run,
                      time_t now,
-                     time_t runtime);
+                     time_t runtime,
+                     JobTrigger job_trigger);
 };
 
 }  // namespace directordaemon

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -523,6 +523,8 @@ try_again:
           (int)jcr->JobId, JobId, jcr->impl->res.pool->resource_name_,
           jcr->JobPriority);
 
+    jcr->impl->job_trigger = JobTrigger::kUser;
+
     /*
      * For interactive runs we send a message to the audit log
      */

--- a/core/src/dird/verify.cc
+++ b/core/src/dird/verify.cc
@@ -568,6 +568,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
              "  FD termination status:  %s\n"
              "  SD termination status:  %s\n"
              "  Bareos binary info:     %s\n"
+             "  Job triggered by:       %s\n"
              "  Termination:            %s\n\n"),
            BAREOS, my_name, kBareosVersionStrings.Full,
            kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -578,7 +579,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
            edit_uint64_with_commas(jcr->impl->ExpectedFiles, ec1),
            edit_uint64_with_commas(jcr->JobFiles, ec2), jcr->JobErrors,
            fd_term_msg, sd_term_msg, kBareosVersionStrings.JoblogMessage,
-           TermMsg);
+           JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
       break;
     default:
       Jmsg(jcr, msg_type, 0,
@@ -597,6 +598,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
              "  Non-fatal FD errors:    %d\n"
              "  FD termination status:  %s\n"
              "  Bareos binary info:     %s\n"
+             "  Job triggered by:       %s\n"
              "  Termination:            %s\n\n"),
            BAREOS, my_name, kBareosVersionStrings.Full,
            kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
@@ -605,7 +607,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
            jcr->impl->res.client->resource_name_, jcr->impl->previous_jr.JobId,
            Name, sdt, edt, edit_uint64_with_commas(jcr->JobFiles, ec1),
            jcr->JobErrors, fd_term_msg, kBareosVersionStrings.JoblogMessage,
-           TermMsg);
+           JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
       break;
   }
 

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -1,7 +1,7 @@
 /*
   BAREOS® - Backup Archiving REcovery Open Sourced
 
-  Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+  Copyright (C) 2019-2020 Bareos GmbH & Co. KG
 
   This program is Free Software; you can redistribute it and/or
   modify it under the terms of version three of the GNU Affero General Public
@@ -339,7 +339,7 @@ TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
       my_config->GetResWithName(R_JOB, "backup-bareos-fd"))};
   ASSERT_TRUE(job) << "Job Resource \"backup-bareos-fd\" not found";
 
-  scheduler->AddJobWithNoRunResourceToQueue(job);
+  scheduler->AddJobWithNoRunResourceToQueue(job, JobTrigger::kUndefined);
 
   scheduler_thread.join();
   ASSERT_EQ(counter_of_number_of_jobs_run, 1);


### PR DESCRIPTION
This commit introduces an enum class named JobTrigger used in
JobControlRecords. The purpose is storing and tracking down by whom a
job has been triggered and to display its value in job report summaries.

Currently the following values are defined, kScheduler, kUser and
kClient. The default is kUnknown.

The commit also adjusts all the different job summary generators
to display the JobTrigger in a human readable format.