### PR TITLE
oVirt plugin: fix restore problem to local disk

### DIFF
--- a/core/src/plugins/filed/BareosFdPluginOvirt.py
+++ b/core/src/plugins/filed/BareosFdPluginOvirt.py
@@ -259,11 +259,16 @@ class BareosFdPluginOvirt(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             "create_file() entry point in Python called with %s\n" % (restorepkt),
         )
 
-        # process includes/excludes for restore, note that it is more
-        # efficient to mark only the disks to restore, as skipping
-        # here can not prevent from receiving the data from bareos-sd
-        # which is useless for excluded disks.
-        if not restorepkt.ofname.endswith(".ovf"):
+        # Process includes/excludes for restore to oVirt.  Note that it is more
+        # efficient to mark only the disks to restore, as skipping here can not
+        # prevent from receiving the data from bareos-sd which is useless for
+        # excluded disks.
+        #
+        # When restoring locally, all disks will be restored without filtering.
+        if (
+            not restorepkt.ofname.endswith(".ovf")
+            and not self.options.get("local") == "yes"
+        ):
             disk_alias = self.ovirt.get_ovf_disk_alias_by_basename(
                 context, restorepkt.ofname
             )

--- a/docs/manuals/source/TasksAndConcepts/Plugins.rst
+++ b/docs/manuals/source/TasksAndConcepts/Plugins.rst
@@ -812,9 +812,11 @@ exclude_disk_aliases
    Also note that disk alias names are not unique, so if two disks of a VM have the same
    alias name, they will be excluded both. Excluded disks will be already excluded from
    the snapshot.
+   On *local* restore, both **include_disk_aliases** and **exclude_disk_aliases** are ignored
+   and *all* disk that were backed up will be restored.
 
 overwrite
-   When restoring disks of an existing VM, the option **overwrite=yes** must be explictly
+   When restoring disks of an existing VM, the option **overwrite=yes** must be explicitly
    passed to force overwriting. To prevent from accidentally overwriting an existing VM,
    the plugin will return an error message if this option is not passed.
 


### PR DESCRIPTION
Fix local restore problem introduced with commit 112020886099.

During local restore, the restore is cancelled with a KeyError:

    File "BareosFdWrapper.py", line 66, in create_file
      return bareos_fd_plugin_object.create_file(context, restorepkt)
    File "BareosFdPluginOvirt.py", line 268, in create_file
      context, restorepkt.ofname
    File "BareosFdPluginOvirt.py", line 1521, in get_ovf_disk_alias_by_basename
      return self.ovf_disks_by_alias_and_fileref[relname]["disk-alias"]
  KeyError: ('testvm1_thin_cow-3b0d105b-0803-4964-be21-ede95153761c/524941fd-ef79-494f-9831-1d49cff9ed76',)

The cause is that the disk alias filtering uses information that is not
fetched from the oVirt Server during local install, as it is not
contacted at all.

During local install, no disks are filtered and every disk backed up will be
restored.

Fixes #1246: oVirt plugin fails to restore to local disk with KeyError