### PR TITLE
Fix Segfault in SpoolDevice::~SpoolDevice()

### DIFF
--- a/core/src/lib/signal.cc
+++ b/core/src/lib/signal.cc
@@ -165,9 +165,8 @@ extern "C" void SignalHandler(int sig)
     }
     if (*working_directory == 0) { strcpy((char*)working_directory, "/tmp/"); }
     if (chdir(working_directory) != 0) { /* dump in working directory */
-      BErrNo be;
       Pmsg2(000, "chdir to %s failed. ERR=%s\n", working_directory,
-            be.bstrerror());
+            strerror(errno));
       strcpy((char*)working_directory, "/tmp/");
     }
     SecureErase(NULL, "./core"); /* get rid of any old core file */
@@ -196,8 +195,7 @@ extern "C" void SignalHandler(int sig)
         fprintf(stderr, _("Calling: %s %s %s %s\n"), btpath, exepath, pid_buf,
                 working_directory);
         if (execv(btpath, argv) != 0) {
-          BErrNo be;
-          printf(_("execv: %s failed: ERR=%s\n"), btpath, be.bstrerror());
+          printf(_("execv: %s failed: ERR=%s\n"), btpath, strerror(errno));
         }
         exit(-1);
       default: /* parent */

--- a/core/src/stored/spool.cc
+++ b/core/src/stored/spool.cc
@@ -412,9 +412,6 @@ static bool DespoolData(DeviceControlRecord* dcr, bool commit)
     V(dcr->dev->spool_mutex);
   }
 
-  FreeMemory(rdev->dev_name);
-  FreePoolMemory(rdev->errmsg);
-
   /*
    * null the jcr
    * rdev will be freed by its smart pointer

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -621,6 +621,7 @@ set(SYSTEM_TESTS
     backup-bareos-encrypt-signature-test-with-tls-cert
     backup-bareos-notls
     backup-bareos-passive-test
+    backup-bareos-spool-test
     backup-bareos-test
     backup-bscan
     bconsole-status-client

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = @hostname@
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_dir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,6 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  SpoolData = yes
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_fd@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Client {
+  Name = @basename@-fd
+  Address = @hostname@
+  Password = "@mon_fd_password@"          # password for FileDaemon
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Address = @hostname@
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Monitor {
+  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
+  Name = bareos-mon
+  # Password to access the Director
+  Password = "@mon_dir_password@"         # password for the Directors
+  RefreshInterval = 30 seconds
+}

--- a/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-spool-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = bareos-sd
+  Address = @hostname@
+  Password = "@mon_sd_password@"          # password for StorageDaemon
+}

--- a/systemtests/tests/backup-bareos-spool-test/testrunner
+++ b/systemtests/tests/backup-bareos-spool-test/testrunner
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+# Directory to backup.
+# This directory will be created by setup_data "$@"().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backed up.
+# Data will be placed at "${tmp}/data/".
+setup_data "$@"
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bareos "$@"
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+check_restore_diff ${BackupDirectory}
+end_test


### PR DESCRIPTION
This series of patches adds a new systemtest that runs a backup with data spooling enabled to show a crash in that configuration. It also fixes the crash triggered by the systemtest.
Last, but not least, it fixes a deadlock in signalhandler that surfaced during testing.