### PR TITLE
systemtests: remove tray-monitor configuration

### DIFF
--- a/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-client-initiated-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test-with-tls-cert/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-encrypt-signature-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-notls/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-passive-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bareos-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/backup-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/bconsole-status-client/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/config-syntax-crash/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/copy-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/dbcopy-mysql-postgresql-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/multiplied-device-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-bareos-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-dir-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-ovirt-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-percona-xtrabackup-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-local-fileset-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = localhost
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = localhost
-}

--- a/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-fd-plugin-postgres-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = localhost
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/python-sd-plugin-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/scheduler-backup-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/virtualfull/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/volume-pruning-test/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}

--- a/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/client/FileDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Client {
-  Name = @basename@-fd
-  Address = @hostname@
-  Password = "@mon_fd_password@"          # password for FileDaemon
-}

--- a/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/director/Director-local.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/director/Director-local.conf.in
@@ -1,4 +1,0 @@
-Director {
-  Name = bareos-dir
-  Address = @hostname@
-}

--- a/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/monitor/bareos-mon.conf.in
@@ -1,7 +1,0 @@
-Monitor {
-  # Name to establish connections to Director Console, Storage Daemon and File Daemon.
-  Name = bareos-mon
-  # Password to access the Director
-  Password = "@mon_dir_password@"         # password for the Directors
-  RefreshInterval = 30 seconds
-}

--- a/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/tray-monitor.d/storage/StorageDaemon-local.conf.in
@@ -1,5 +1,0 @@
-Storage {
-  Name = bareos-sd
-  Address = @hostname@
-  Password = "@mon_sd_password@"          # password for StorageDaemon
-}


### PR DESCRIPTION
No tray-monitor configuration is needed for the systemtests, so we can
safely remove them.