### PR TITLE
python-bareos: fixes the upload url for PyPI.org (bareos-19.2)

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yml
+++ b/.github/workflows/publish-release-to-pypi.yml
@@ -45,6 +45,5 @@ jobs:
     - name: "Publish to pypi.org"
       uses: pypa/gh-action-pypi-publish@v1.1.0
       with:
-        repository_url: https://pypi.org/legacy/
         password: ${{ secrets.pypi_password }}
         packages_dir: python-bareos/dist/


### PR DESCRIPTION
To upload packages to PyPI.org, the URL https://upload.pypi.org/legacy/ must be used.
However, our configuration has set      https://pypi.org/legacy/.

This commit removes the parameter repository_url altogether,
because the default is already the correct URL.