### PR TITLE
cats: do not move vector for backend directories

### DIFF
--- a/core/src/cats/cats_backends.cc
+++ b/core/src/cats/cats_backends.cc
@@ -63,9 +63,9 @@ static struct backend_interface_mapping_t {
 static alist* loaded_backends = NULL;
 static std::vector<std::string> backend_dirs;
 
-void DbSetBackendDirs(std::vector<std::string>&& new_backend_dirs)
+void DbSetBackendDirs(std::vector<std::string>& new_backend_dirs)
 {
-  backend_dirs = std::move(new_backend_dirs);
+  backend_dirs = new_backend_dirs;
 }
 
 static inline backend_interface_mapping_t* lookup_backend_interface_mapping(

--- a/core/src/cats/cats_backends.h
+++ b/core/src/cats/cats_backends.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -74,7 +74,7 @@ struct backend_shared_library_t {
 #endif
 
 #if defined(HAVE_DYNAMIC_CATS_BACKENDS)
-void DbSetBackendDirs(std::vector<std::string>&& new_backend_dirs);
+void DbSetBackendDirs(std::vector<std::string>& new_backend_dirs);
 #endif
 void DbFlushBackends(void);
 BareosDb* db_init_database(JobControlRecord* jcr,

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -1089,7 +1089,7 @@ int main(int argc, char* argv[])
 
       SetWorkingDirectory(me->working_directory);
 #if defined(HAVE_DYNAMIC_CATS_BACKENDS)
-      DbSetBackendDirs(std::move(me->backend_directories));
+      DbSetBackendDirs(me->backend_directories);
 #endif
 
       /*
@@ -1156,7 +1156,7 @@ int main(int argc, char* argv[])
 
 #if defined(HAVE_DYNAMIC_CATS_BACKENDS)
     backend_directories.emplace_back(backend_directory);
-    DbSetBackendDirs(std::move(backend_directories));
+    DbSetBackendDirs(backend_directories);
 #endif
   }
 

--- a/core/src/dird/dbcopy/dbcopy.cc
+++ b/core/src/dird/dbcopy/dbcopy.cc
@@ -111,7 +111,7 @@ class DbCopy {
       throw std::runtime_error("Could not find director resource.");
     }
 
-    DbSetBackendDirs(std::move(directordaemon::me->backend_directories));
+    DbSetBackendDirs(directordaemon::me->backend_directories);
   }
 
   void ConnectToDatabases()

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -375,7 +375,7 @@ int main(int argc, char* argv[])
     Dmsg1(100, "backend path: %s\n", backend_dir.c_str());
   }
 
-  DbSetBackendDirs(std::move(me->backend_directories));
+  DbSetBackendDirs(me->backend_directories);
 #endif
   LoadDirPlugins(me->plugin_directory, me->plugin_names);
 

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -357,7 +357,7 @@ int main(int argc, char* argv[])
 
 #if defined(HAVE_DYNAMIC_CATS_BACKENDS)
   backend_directories.emplace_back(backend_directory);
-  DbSetBackendDirs(std::move(backend_directories));
+  DbSetBackendDirs(backend_directories);
 #endif
 
   db = db_init_database(NULL, db_driver, db_name, db_user, db_password, db_host,

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -111,7 +111,9 @@ void CatalogTest::SetUp()
 
     ASSERT_NE(jcr->impl->res.catalog, nullptr);
 
-    DbSetBackendDirs(std::vector<std::string>{backend_dir});
+    auto backenddir = std::vector<std::string>{backend_dir};
+    DbSetBackendDirs(backenddir);
+
     db = directordaemon::GetDatabaseConnection(jcr);
 
     ASSERT_NE(db, nullptr);


### PR DESCRIPTION
Fixes a bug where "show director" does not list the configured backend directories.