### PR TITLE
fix get last_lsn value

### DIFF
--- a/core/src/plugins/filed/BareosFdPluginPerconaXtraBackup.py
+++ b/core/src/plugins/filed/BareosFdPluginPerconaXtraBackup.py
@@ -234,7 +234,7 @@ class BareosFdPercona(BareosFdPluginBaseclass):
                     conn.close()
                     for line in info.split("\n"):
                         if line.startswith("Log sequence number"):
-                            last_lsn = int(line.split(" ")[3])
+                            last_lsn = int(line.split(" ")[-1])
                 except Exception as e:
                     JobMessage(
                         context,


### PR DESCRIPTION
Use last(right) element when split string by space. In some cases there may be more than one space.