### PR TITLE
dird: ignore duplicate job checking on virtual fulls started by consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Enable c++17 support [PR #741]
 - webui: Localization updated [PR #776]
 - running cmake for the core-directory only is now forbidden [PR #767]
+- dird: ignore duplicate job checking on virtual fulls started by consolidation [PR #552]
 
 ### Deprecated
 

--- a/core/src/dird/consolidate.cc
+++ b/core/src/dird/consolidate.cc
@@ -108,6 +108,9 @@ bool DoConsolidate(JobControlRecord* jcr)
   jcr->impl->jr.JobId = jcr->JobId;
   jcr->impl->fname = (char*)GetPoolMemory(PM_FNAME);
 
+  // do not cancel virtual fulls started by consolidation
+  jcr->impl->IgnoreDuplicateJobChecking = true;
+
   // Print Job Start message
   Jmsg(jcr, M_INFO, 0, _("Start Consolidate JobId %d, Job=%s\n"), jcr->JobId,
        jcr->Job);

--- a/docs/manuals/source/TasksAndConcepts/AlwaysIncrementalBackupScheme.rst
+++ b/docs/manuals/source/TasksAndConcepts/AlwaysIncrementalBackupScheme.rst
@@ -137,6 +137,7 @@ The :config:option:`dir/job = Consolidate`\  job evaluates all jobs configured w
 
 The always incremental jobs need to be executed during the backup window (usually at night), while the consolidation jobs should be scheduled during the daytime when no backups are executed.
 
+Virtual backup jobs of a consolidation are not affected by :config:option:`dir/job/AllowDuplicateJobs`\ settings.
 
 
 .. warning::

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-AllowDuplicateJobs.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-AllowDuplicateJobs.rst.inc
@@ -24,3 +24,5 @@ If this directive is enabled duplicate jobs will be run. If the directive is set
    :config:option:`dir/job/CancelRunningDuplicates`\
 
 If none of these directives is set to :strong:`yes`, Allow Duplicate Jobs is set to :strong:`no` and two jobs are present, then the current job (the second one started) will be cancelled.
+
+Virtual backup jobs of a consolidation are not affected by the directive. In those cases the directive is going to be ignored.

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -593,25 +593,25 @@ endforeach()
 
 set(tests_dir ${PROJECT_BINARY_DIR}/tests)
 set(SYSTEM_TESTS
-    client-initiated
-    config-dump
-    encrypt-signature
-    encrypt-signature-tls-cert
-    filesets
-    notls
-    passive
-    spool
+    ai-consolidate-ignore-duplicate-job
     bareos
     bareos-acl
-    bscan
     bconsole-status-client
+    bscan
+    client-initiated
+    config-dump
     config-syntax-crash
     copy-archive-job
     copy-bscan
     copy-remote-bscan
     deprecation
+    encrypt-signature
+    encrypt-signature-tls-cert
+    filesets
     list-backups
     multiplied-device
+    notls
+    passive
     reload-add-client
     reload-add-duplicate-job
     reload-add-empty-job
@@ -619,6 +619,7 @@ set(SYSTEM_TESTS
     reload-add-uncommented-string
     reload-unchanged-config
     scheduler-backup
+    spool
     upgrade-database
     virtualfull
     virtualfull-bscan

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -589,6 +589,14 @@ check_two_logs()
    fi
 }
 
+check_job_canceled()
+{
+    grep "^  Termination: *Backup Canceled" "${tmp}/log1.out" >/dev/null 2>&1
+    if test $? -eq 0; then
+      bstat=2
+    fi
+}
+
 check_log()
 {
    LOG=$1

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = @hostname@
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_dir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+   #File = "@sbindir@"
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/Consolidate.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/Consolidate.conf
@@ -1,0 +1,10 @@
+Job {
+    Name = "Consolidate"
+    Type = "Consolidate"
+    Accurate = "yes"
+    JobDefs = "DefaultJob"
+    AllowDuplicateJobs = yes
+    CancelLowerLevelDuplicates = no
+    CancelQueuedDuplicates = no
+    Cancel Running Duplicates = no
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,10 @@
+Job {
+  Name = "ai-backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  Accurate = yes
+  AlwaysIncremental = yes
+  AlwaysIncrementalJobRetention = 1 seconds
+  AlwaysIncrementalKeepNumber = 1
+  AlwaysIncrementalMaxFullAge = 1 seconds
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,17 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = AI-Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = AI-Consolidated
+  AllowDuplicateJobs = no
+  CancelLowerLevelDuplicates = yes
+  CancelQueuedDuplicates = yes
+  CancelRunningDuplicates = no
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Consolidated.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Consolidated.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = AI-Consolidated
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  Auto Prune = yes                    # Prune expired volumes
+  Volume Retention = 360 days         # How long should jobs be kept?
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Label Format = "AI-Consolidated-"
+  Volume Use Duration = 23h
+  Storage = File
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Incremental.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Incremental.conf
@@ -1,0 +1,12 @@
+Pool {
+  Name = AI-Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  Auto Prune = yes                    # Prune expired volumes
+  Volume Retention = 360 days         # How long should jobs be kept?
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Label Format = "AI-Incremental-"
+  Volume Use Duration = 23h
+  Storage = File
+  Next Pool = AI-Consolidated         # consolidated jobs go to this pool
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,10 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Device = FileStorage2
+  Media Type = File
+  SD Port = @sd_port@
+  Maximum Concurrent Jobs= 10
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_fd@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,23 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}
+
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
@@ -1,0 +1,65 @@
+#!/bin/sh
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=ai-backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+# Directory to backup.
+# This directory will be created by setup_data "$@"().
+BackupDirectory="${tmp}/data"
+
+# Use a tgz to setup data to be backed up.
+# Data will be placed at "${tmp}/data/".
+setup_data "$@"
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=100 storage=File
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName level=Full yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-1'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-2'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-3'"
+run job=$JobName level=Incremental yes
+wait
+run job=Consolidate yes
+wait
+status director
+status client
+status storage=File
+list jobs
+wait
+messages
+wait
+quit
+END_OF_DATA
+
+run_bareos "$@"
+
+stop_bareos
+
+check_job_canceled
+
+end_test


### PR DESCRIPTION
- Ignore AllowDuplicateJobs directive on generated virtual backup jobs by a consolidate job
- The test checks if we end up with a canceled virtual full after consolidation. The test fails if the virtual full is canceled.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
