### PR TITLE
Close connection pool sockets properly

### DIFF
--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -144,7 +144,6 @@ class DirectorResource
   bool optimize_for_size = false;  /* Optimize daemon for minimum memory size */
   bool optimize_for_speed = false; /* Optimize daemon for speed which may need
                               more memory */
-  bool nokeepalive = false;        /* Don't use SO_KEEPALIVE on sockets */
   bool omit_defaults = false; /* Omit config variables with default values when
                          dumping the config */
   bool ndmp_snooping = false; /* NDMP Protocol specific snooping enabled */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -134,7 +134,6 @@ static bool connect_outbound_to_file_daemon(JobControlRecord* jcr,
   }
 
   fd = new BareosSocketTCP;
-  if (me->nokeepalive) { fd->ClearKeepalive(); }
   heart_beat = get_heartbeat_interval(jcr->impl->res.client);
 
   char name[MAX_NAME_LENGTH + 100];

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -131,6 +131,11 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
+static void CleanupConnectionPool()
+{
+  if (client_connections) { client_connections->cleanup(); }
+}
+
 extern "C" void* connect_thread(void* arg)
 {
   SetJcrInThreadSpecificData(nullptr);
@@ -141,7 +146,8 @@ extern "C" void* connect_thread(void* arg)
   sock_fds = new alist(10, not_owned_by_alist);
   BnetThreadServerTcp((dlist*)arg, me->MaxConnections, sock_fds, thread_list,
                       me->nokeepalive, HandleConnectionRequest, my_config,
-                      &server_state, UserAgentShutdownCallback);
+                      &server_state, UserAgentShutdownCallback,
+                      CleanupConnectionPool);
 
   return NULL;
 }

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -145,9 +145,8 @@ extern "C" void* connect_thread(void* arg)
    */
   sock_fds = new alist(10, not_owned_by_alist);
   BnetThreadServerTcp((dlist*)arg, me->MaxConnections, sock_fds, thread_list,
-                      me->nokeepalive, HandleConnectionRequest, my_config,
-                      &server_state, UserAgentShutdownCallback,
-                      CleanupConnectionPool);
+                      HandleConnectionRequest, my_config, &server_state,
+                      UserAgentShutdownCallback, CleanupConnectionPool);
 
   return NULL;
 }

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -1630,7 +1630,6 @@ static bool StorageCmd(JobControlRecord* jcr)
   BareosSocket* dir = jcr->dir_bsock;
   BareosSocket* storage_daemon_socket = new BareosSocketTCP;
 
-  if (me->nokeepalive) { storage_daemon_socket->ClearKeepalive(); }
   Dmsg1(100, "StorageCmd: %s", dir->msg);
   sd_auth_key.check_size(dir->message_length);
   if (sscanf(dir->msg, storaddrv1cmd, stored_addr, &stored_port, &tls_policy,
@@ -2290,8 +2289,6 @@ static BareosSocket* connect_to_director(JobControlRecord* jcr,
 
   std::unique_ptr<BareosSocket> director_socket =
       std::make_unique<BareosSocketTCP>();
-
-  if (me->nokeepalive) { director_socket->ClearKeepalive(); }
 
   director_socket->SetSourceAddress(me->FDsrc_addr);
 

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -116,7 +116,6 @@ class ClientResource
   alist* pki_signing_key_files = nullptr;          /* PKI Signing Key Files */
   alist* pki_master_key_files = nullptr;           /* PKI Master Key Files */
   crypto_cipher_t pki_cipher = CRYPTO_CIPHER_NONE; /* PKI Cipher to use */
-  bool nokeepalive = false;     /* Don't use SO_KEEPALIVE on sockets */
   bool always_use_lmdb = false; /* Use LMDB for accurate data */
   uint32_t lmdb_threshold = 0;  /* Switch to using LDMD when number of accurate
                                entries exceeds treshold. */

--- a/core/src/filed/socket_server.cc
+++ b/core/src/filed/socket_server.cc
@@ -133,8 +133,8 @@ void StartSocketServer(dlist* addrs)
    */
   sock_fds = new alist(10, not_owned_by_alist);
   BnetThreadServerTcp(addrs, me->MaxConnections, sock_fds, thread_list,
-                      me->nokeepalive, HandleConnectionRequest, my_config,
-                      nullptr, UserAgentShutdownCallback);
+                      HandleConnectionRequest, my_config, nullptr,
+                      UserAgentShutdownCallback);
 }
 
 void StopSocketServer(bool wait)

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -138,7 +138,8 @@ void BnetThreadServerTcp(
     void* HandleConnectionRequest(ConfigurationParser* config, void* bsock),
     ConfigurationParser* config,
     std::atomic<BnetServerState>* const server_state,
-    void* UserAgentShutdownCallback(void* bsock))
+    void* UserAgentShutdownCallback(void* bsock),
+    void CustomCallback())
 {
   int newsockfd;
   socklen_t clilen;
@@ -292,6 +293,7 @@ void BnetThreadServerTcp(
   if (server_state) { server_state->store(BnetServerState::kStarted); }
 
   while (!quit) {
+    if (CustomCallback) { CustomCallback(); }
 #ifndef HAVE_POLL
     unsigned int maxfd = 0;
     fd_set sockset;

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -135,11 +135,12 @@ void BnetThreadServerTcp(
     alist* sockfds,
     ThreadList& thread_list,
     bool nokeepalive,
-    void* HandleConnectionRequest(ConfigurationParser* config, void* bsock),
+    std::function<void*(ConfigurationParser* config, void* bsock)>
+        HandleConnectionRequest,
     ConfigurationParser* config,
     std::atomic<BnetServerState>* const server_state,
-    void* UserAgentShutdownCallback(void* bsock),
-    void CustomCallback())
+    std::function<void*(void* bsock)> UserAgentShutdownCallback,
+    std::function<void()> CustomCallback)
 {
   int newsockfd;
   socklen_t clilen;

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -55,8 +55,10 @@
 #elif HAVE_SYS_POLL_H
 #include <sys/poll.h>
 #endif
+
 #include <atomic>
 #include <array>
+#include <vector>
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 static std::atomic<bool> quit{false};
@@ -150,10 +152,10 @@ static void RemoveDuplicateAddresses(dlist* addr_list)
 
 static void LogAllAddresses(dlist* addr_list)
 {
-  std::array<char, 256 * 10> allbuf;
+  std::vector<char> buf(256 * addr_list->size());
 
   Dmsg1(100, "Addresses %s\n",
-        BuildAddressesString(addr_list, allbuf.data(), allbuf.size()));
+        BuildAddressesString(addr_list, buf.data(), buf.size()));
 }
 
 static int OpenSocketAndBind(IPADDR* ipaddr,
@@ -173,11 +175,13 @@ static int OpenSocketAndBind(IPADDR* ipaddr,
   if (fd < 0) {
     BErrNo be;
     std::array<char, 256> buf1;
-    std::array<char, 256 * 10> buf2;
+    std::vector<char> buf2(256 * addr_list->size());
+
     Emsg3(M_ABORT, 0,
           _("Cannot open stream socket. ERR=%s. Current %s All %s\n"),
           be.bstrerror(), ipaddr->build_address_str(buf1.data(), buf1.size()),
           BuildAddressesString(addr_list, buf2.data(), buf2.size()));
+
     return -1;
   }
 

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2016 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -56,6 +56,7 @@
 #include <sys/poll.h>
 #endif
 
+#include <algorithm>
 #include <atomic>
 #include <array>
 #include <vector>
@@ -303,14 +304,14 @@ void BnetThreadServerTcp(
   while (!quit) {
     if (CustomCallback) { CustomCallback(); }
 #ifndef HAVE_POLL
-    unsigned int maxfd = 0;
+    int maxfd = 0;
     fd_set sockset;
     FD_ZERO(&sockset);
 
     s_sockfd* fd_ptr = nullptr;
     foreach_alist (fd_ptr, sockfds) {
       FD_SET((unsigned)fd_ptr->fd, &sockset);
-      if ((unsigned)fd_ptr->fd > maxfd) { maxfd = fd_ptr->fd; }
+      maxfd = std::max(fd_ptr->fd, maxfd);
     }
 
     struct timeval timeout {

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -47,7 +47,8 @@ void BnetThreadServerTcp(
     void* HandleConnectionRequest(ConfigurationParser* config, void* bsock),
     ConfigurationParser* config,
     std::atomic<BnetServerState>* const server_state = nullptr,
-    void* UserAgentShutdownCallback(void* bsock) = nullptr);
+    void* UserAgentShutdownCallback(void* bsock) = nullptr,
+    void CustomCallback() = nullptr);
 void BnetStopAndWaitForThreadServerTcp(pthread_t tid);
 
 #endif  // BAREOS_LIB_BNET_SEVER_TCP_H_

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -22,6 +22,7 @@
 #define BAREOS_LIB_BNET_SEVER_TCP_H_
 
 #include <atomic>
+#include <functional>
 
 class ConfigurationParser;
 class ThreadList;
@@ -44,11 +45,13 @@ void BnetThreadServerTcp(
     alist* sockfds,
     ThreadList& thread_list,
     bool nokeepalive,
-    void* HandleConnectionRequest(ConfigurationParser* config, void* bsock),
+    std::function<void*(ConfigurationParser* config, void* bsock)>
+        HandleConnectionRequest,
     ConfigurationParser* config,
     std::atomic<BnetServerState>* const server_state = nullptr,
-    void* UserAgentShutdownCallback(void* bsock) = nullptr,
-    void CustomCallback() = nullptr);
+    std::function<void*(void* bsock)> UserAgentShutdownCallback = nullptr,
+    std::function<void()> CustomCallback = nullptr);
+
 void BnetStopAndWaitForThreadServerTcp(pthread_t tid);
 
 #endif  // BAREOS_LIB_BNET_SEVER_TCP_H_

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -44,7 +44,6 @@ void BnetThreadServerTcp(
     int max_clients,
     alist* sockfds,
     ThreadList& thread_list,
-    bool nokeepalive,
     std::function<void*(ConfigurationParser* config, void* bsock)>
         HandleConnectionRequest,
     ConfigurationParser* config,

--- a/core/src/lib/bsock.h
+++ b/core/src/lib/bsock.h
@@ -264,8 +264,6 @@ class BareosSocket {
   bool UseBwlimit() { return bwlimit_ > 0; }
   void SetBwlimitBursting() { use_bursting_ = true; }
   void clear_bwlimit_bursting() { use_bursting_ = false; }
-  void SetKeepalive() { use_keepalive_ = true; }
-  void ClearKeepalive() { use_keepalive_ = false; }
   void SetSpooling() { spool_ = true; }
   void ClearSpooling() { spool_ = false; }
   void SetTimedOut() { timed_out_ = true; }

--- a/core/src/lib/connection_pool.cc
+++ b/core/src/lib/connection_pool.cc
@@ -39,13 +39,13 @@ Connection::Connection(const char* name,
                        bool authenticated)
 {
   tid_ = pthread_self();
-  connect_time_ = time(NULL);
+  connect_time_ = time(nullptr);
   in_use_ = false;
   authenticated_ = authenticated;
   bstrncpy(name_, name, sizeof(name_));
   protocol_version_ = protocol_version;
   socket_ = socket;
-  pthread_mutex_init(&mutex_, NULL);
+  pthread_mutex_init(&mutex_, nullptr);
 }
 
 Connection::~Connection() { pthread_mutex_destroy(&mutex_); }
@@ -82,18 +82,6 @@ bool Connection::check(int timeout_data)
 }
 
 /*
- * Wait until an error occurs
- * or the connection is requested by some other thread.
- */
-bool Connection::wait(int timeout)
-{
-  bool ok = true;
-
-  while (ok && (!in_use_)) { ok = check(timeout); }
-  return ok;
-}
-
-/*
  * Request to take over the connection (socket) from another thread.
  */
 bool Connection::take()
@@ -118,8 +106,8 @@ ConnectionPool::ConnectionPool()
   /*
    * Initialize mutex and condition variable objects.
    */
-  pthread_mutex_init(&add_mutex_, NULL);
-  pthread_cond_init(&add_cond_var_, NULL);
+  pthread_mutex_init(&add_mutex_, nullptr);
+  pthread_cond_init(&add_cond_var_, nullptr);
 }
 
 ConnectionPool::~ConnectionPool()
@@ -131,7 +119,7 @@ ConnectionPool::~ConnectionPool()
 
 void ConnectionPool::cleanup()
 {
-  Connection* connection = NULL;
+  Connection* connection = nullptr;
   int i = 0;
   for (i = connections_->size() - 1; i >= 0; i--) {
     connection = (Connection*)connections_->get(i);
@@ -147,13 +135,13 @@ void ConnectionPool::cleanup()
 
 alist* ConnectionPool::get_as_alist()
 {
-  this->cleanup();
+  cleanup();
   return connections_;
 }
 
 bool ConnectionPool::add(Connection* connection)
 {
-  this->cleanup();
+  cleanup();
   Dmsg1(120, "add connection: %s\n", connection->name());
   P(add_mutex_);
   connections_->append(connection);
@@ -171,20 +159,15 @@ Connection* ConnectionPool::add_connection(const char* name,
       new Connection(name, fd_protocol_version, socket, authenticated);
   if (!add(connection)) {
     delete (connection);
-    return NULL;
+    return nullptr;
   }
   return connection;
 }
 
-bool ConnectionPool::exists(const char* name)
-{
-  return (get_connection(name) != NULL);
-}
-
 Connection* ConnectionPool::get_connection(const char* name)
 {
-  Connection* connection = NULL;
-  if (!name) { return NULL; }
+  Connection* connection = nullptr;
+  if (!name) { return nullptr; }
   foreach_alist (connection, connections_) {
     if (connection->check() && connection->authenticated() &&
         connection->bsock() && (!connection->in_use()) &&
@@ -193,24 +176,15 @@ Connection* ConnectionPool::get_connection(const char* name)
       return connection;
     }
   }
-  return NULL;
-}
-
-Connection* ConnectionPool::get_connection(const char* name,
-                                           int timeout_in_seconds)
-{
-  struct timespec timeout;
-
-  ConvertTimeoutToTimespec(timeout, timeout_in_seconds);
-  return get_connection(name, timeout);
+  return nullptr;
 }
 
 Connection* ConnectionPool::get_connection(const char* name, timespec& timeout)
 {
-  Connection* connection = NULL;
+  Connection* connection = nullptr;
   int errstat = 0;
 
-  if (!name) { return NULL; }
+  if (!name) { return nullptr; }
 
   while ((!connection) && (errstat == 0)) {
     connection = get_connection(name);
@@ -246,8 +220,7 @@ int ConnectionPool::WaitForNewConnection(timespec& timeout)
 bool ConnectionPool::remove(Connection* connection)
 {
   bool removed = false;
-  int i = 0;
-  for (i = connections_->size() - 1; i >= 0; i--) {
+  for (int i = connections_->size() - 1; i >= 0; i--) {
     if (connections_->get(i) == connection) {
       connections_->remove(i);
       removed = true;
@@ -261,8 +234,8 @@ bool ConnectionPool::remove(Connection* connection)
 Connection* ConnectionPool::remove(const char* name, int timeout_in_seconds)
 {
   bool done = false;
-  Connection* result = NULL;
-  Connection* connection = NULL;
+  Connection* result = nullptr;
+  Connection* connection = nullptr;
   struct timespec timeout;
 
   ConvertTimeoutToTimespec(timeout, timeout_in_seconds);
@@ -274,9 +247,9 @@ Connection* ConnectionPool::remove(const char* name, int timeout_in_seconds)
     connection = get_connection(name, timeout);
     if (!connection) {
       /*
-       * NULL is returned only on timeout (or other internal errors).
+       * nullptr is returned only on timeout (or other internal errors).
        */
-      return NULL;
+      return nullptr;
     }
     if (connection->take()) {
       result = connection;

--- a/core/src/lib/connection_pool.cc
+++ b/core/src/lib/connection_pool.cc
@@ -76,6 +76,8 @@ bool Connection::check(int timeout_data)
   }
   unlock();
 
+  if (!ok) { socket_->close(); }
+
   return ok;
 }
 
@@ -133,7 +135,7 @@ void ConnectionPool::cleanup()
   int i = 0;
   for (i = connections_->size() - 1; i >= 0; i--) {
     connection = (Connection*)connections_->get(i);
-    Dmsg2(120, "checking connection %s (%d)\n", connection->name(), i);
+    Dmsg2(800, "checking connection %s (%d)\n", connection->name(), i);
     if (!connection->check()) {
       Dmsg2(120, "connection %s (%d) is terminated => removed\n",
             connection->name(), i);

--- a/core/src/lib/connection_pool.h
+++ b/core/src/lib/connection_pool.h
@@ -75,6 +75,7 @@ class ConnectionPool {
                              bool authenticated = true);
   Connection* remove(const char* name, int timeout_in_seconds = 0);
   alist* get_as_alist();
+  void cleanup();
 
  private:
   alist* connections_;
@@ -82,7 +83,6 @@ class ConnectionPool {
   bool add(Connection* connection);
   bool remove(Connection* connection);
   bool exists(const char* name);
-  void cleanup();
   Connection* get_connection(const char* name);
   Connection* get_connection(const char* name, int timeout_seconds);
   Connection* get_connection(const char* name, timespec& timeout);

--- a/core/src/lib/connection_pool.h
+++ b/core/src/lib/connection_pool.h
@@ -48,12 +48,11 @@ class Connection {
   time_t ConnectTime() { return connect_time_; }
 
   bool check(int timeout = 0);
-  bool wait(int timeout = 60);
   bool take();
-  void lock() { P(mutex_); }
-  void unlock() { V(mutex_); }
 
  private:
+  void lock() { P(mutex_); }
+  void unlock() { V(mutex_); }
   pthread_t tid_;
   BareosSocket* socket_;
   char name_[MAX_NAME_LENGTH];
@@ -82,9 +81,7 @@ class ConnectionPool {
   int WaitForNewConnection(timespec& timeout);
   bool add(Connection* connection);
   bool remove(Connection* connection);
-  bool exists(const char* name);
   Connection* get_connection(const char* name);
-  Connection* get_connection(const char* name, int timeout_seconds);
   Connection* get_connection(const char* name, timespec& timeout);
   pthread_mutex_t add_mutex_;
   pthread_cond_t add_cond_var_;

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -1647,7 +1647,6 @@ static bool ReplicateCmd(JobControlRecord* jcr)
   std::unique_ptr<BareosSocket> storage_daemon_socket =
       std::make_unique<BareosSocketTCP>();
 
-  if (me->nokeepalive) { storage_daemon_socket->ClearKeepalive(); }
   Dmsg1(100, "ReplicateCmd: %s", dir->msg);
   sd_auth_key.check_size(dir->message_length);
 
@@ -1764,7 +1763,6 @@ static bool PassiveCmd(JobControlRecord* jcr)
   jcr->passive_client = true;
 
   fd = new BareosSocketTCP;
-  if (me->nokeepalive) { fd->ClearKeepalive(); }
   fd->SetSourceAddress(me->SDsrc_addr);
 
   /*

--- a/core/src/stored/socket_server.cc
+++ b/core/src/stored/socket_server.cc
@@ -148,8 +148,8 @@ void StartSocketServer(dlist* addrs)
 
   sock_fds = new alist(10, not_owned_by_alist);
   BnetThreadServerTcp(addrs, me->MaxConnections, sock_fds, thread_list,
-                      me->nokeepalive, HandleConnectionRequest, my_config,
-                      nullptr, UserAgentShutdownCallback);
+                      HandleConnectionRequest, my_config, nullptr,
+                      UserAgentShutdownCallback);
 }
 
 void StopSocketServer()

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -126,7 +126,6 @@ class StorageResource
   bool allow_bw_bursting = false; /**< Allow bursting with bandwidth limiting */
   bool ndmp_enable = false;       /**< Enable NDMP protocol listener */
   bool ndmp_snooping = false;     /**< Enable NDMP protocol snooping */
-  bool nokeepalive = false;       /**< Don't use SO_KEEPALIVE on sockets */
   bool collect_dev_stats = false; /**< Collect Device Statistics */
   bool collect_job_stats = false; /**< Collect Job Statistics */
   bool device_reserve_by_mediatype = false; /**< Allow device reservation based


### PR DESCRIPTION
- added CustomCallback to the bnet server that runs once a second
- the CustomCallback runs connection_pool->cleanup()
- cleanup() closes a socket as soon as it is not used anymore