### PR TITLE
Fix hearbeat thread shutdown race condition

### DIFF
--- a/core/src/filed/jcr_private.h
+++ b/core/src/filed/jcr_private.h
@@ -26,6 +26,8 @@
 
 #include "include/bareos.h"
 
+#include <atomic>
+
 struct acl_data_t;
 struct xattr_data_t;
 
@@ -68,7 +70,8 @@ struct JobControlRecordPrivate {
   uint32_t StartBlock{};
   uint32_t EndBlock{};
   pthread_t heartbeat_id{};       /**< Id of heartbeat thread */
-  volatile bool hb_started{};     /**< Heartbeat running */
+  std::atomic<bool> hb_initialized_once{};    /**< Heartbeat initialized */
+  std::atomic<bool> hb_started{};             /**< Heartbeat running */
   std::shared_ptr<BareosSocket> hb_bsock;     /**< Duped SD socket */
   std::shared_ptr<BareosSocket> hb_dir_bsock; /**< Duped DIR socket */
   alist* RunScripts{};            /**< Commands to run before and after job */

--- a/core/src/filed/jcr_private.h
+++ b/core/src/filed/jcr_private.h
@@ -71,7 +71,7 @@ struct JobControlRecordPrivate {
   uint32_t EndBlock{};
   pthread_t heartbeat_id{};       /**< Id of heartbeat thread */
   std::atomic<bool> hb_initialized_once{};    /**< Heartbeat initialized */
-  std::atomic<bool> hb_started{};             /**< Heartbeat running */
+  std::atomic<bool> hb_running{};             /**< Heartbeat running */
   std::shared_ptr<BareosSocket> hb_bsock;     /**< Duped SD socket */
   std::shared_ptr<BareosSocket> hb_dir_bsock; /**< Duped DIR socket */
   alist* RunScripts{};            /**< Commands to run before and after job */


### PR DESCRIPTION
This is a quick fix for the heartbeat shutdown where it could happen that the thread is already down but the stopping thread is still waiting for it to start. However this works the complete heartbeat code should be refactored again. 

The fix uses a new variable that is only set if the thread has been started once.  

Otherwise I left the code as much as before as I could. 