### PR TITLE
core: add nullptr-guard to CreateAttriburesRecord()

### DIFF
--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -1021,6 +1021,11 @@ bool BareosDb::CreateAttributesRecord(JobControlRecord* jcr,
   /*
    * Make sure we have an acceptable attributes record.
    */
+  if (!ar) {
+    Mmsg0(errmsg, _("Attempt to create file attributes record with no data\n"));
+    Jmsg(jcr, M_FATAL, 0, "%s", errmsg);
+    return false;
+  }
   if (!(ar->Stream == STREAM_UNIX_ATTRIBUTES ||
         ar->Stream == STREAM_UNIX_ATTRIBUTES_EX)) {
     Mmsg1(errmsg, _("Attempt to put non-attributes into catalog. Stream=%d\n"),


### PR DESCRIPTION
This is a nullptr-guard I had added to 18.2 based on a customer's ticket.
Should we implement this in master and if so: should we backport?