### PR TITLE
enable testing of deprecated databases (MySQL and SQLite)

### DIFF
--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -81,12 +81,25 @@ fi
 
 case ${db_type} in
    sqlite3)
-      echo "The SQLite database backend is deprecated. Please use PostgreSQL instead."
-      retval=1
+      if [ -n "$BAREOS_TEST_RUNNING" ]; then
+         sqlite3 $* ${working_dir}/${db_name}.db ".tables"
+         # Allow non root access
+         chown ${dir_user}:${dir_group} ${working_dir}/${db_name}.db
+         chmod 0640 ${working_dir}/${db_name}.db
+         retval=0
+      else
+         echo "The SQLite database backend is deprecated. Please use PostgreSQL instead."
+         retval=1
+      fi
       ;;
    mysql)
-      echo "The MySQL database backend is deprecated. Please use PostgreSQL instead."
-      retval=1
+      if [ -n "$BAREOS_TEST_RUNNING" ]; then
+         mysql $* -e "CREATE DATABASE ${db_name};"
+         retval=$?
+      else
+         echo "The MySQL database backend is deprecated. Please use PostgreSQL instead."
+         retval=1
+      fi
       ;;
    postgresql)
       #

--- a/core/src/cats/make_bareos_tables.in
+++ b/core/src/cats/make_bareos_tables.in
@@ -110,14 +110,30 @@ fi
 
 case ${db_type} in
    sqlite3)
-      echo "The SQLite database backend is deprecated. Please use PostgreSQL instead."
-      echo "Creation of Bareos SQLite tables aborted."
-      retval=1
+      if [ -n "$BAREOS_TEST_RUNNING" ]; then
+         sqlite3 $* ${working_dir}/${db_name}.db < ${temp_sql_schema}
+         chmod 640 ${working_dir}/${db_name}.db
+         retval=0
+      else
+         echo "The SQLite database backend is deprecated. Please use PostgreSQL instead."
+         echo "Creation of Bareos SQLite tables aborted."
+         retval=1
+      fi
       ;;
    mysql)
-      echo "The MySQL database backend is deprecated. Please use PostgreSQL instead."
-      echo "Creation of Bareos MySQL tables aborted."
-      retval=1
+      if [ -n "$BAREOS_TEST_RUNNING" ]; then
+         mysql $* --database=${db_name} -f < ${temp_sql_schema}
+         retval=$?
+         if test $retval = 0; then
+            echo "Creation of Bareos MySQL tables succeeded."
+         else
+            echo "Creation of Bareos MySQL tables failed."
+         fi
+      else
+         echo "The MySQL database backend is deprecated. Please use PostgreSQL instead."
+         echo "Creation of Bareos MySQL tables aborted."
+         retval=1
+      fi
       ;;
    postgresql)
       PGOPTIONS='--client-min-messages=warning' psql -f ${temp_sql_schema} -d ${db_name} $*

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -114,3 +114,6 @@ if [ -d /usr/lib/postgresql  ]; then
 else
   export PATH=/sbin:/usr/sbin:$PATH
 fi
+
+# enable deprecated database handling in scripts
+export BAREOS_TEST_RUNNING=yes

--- a/systemtests/tests/dbcopy-mysql-postgresql/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/dbcopy-mysql-postgresql/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -5,8 +5,6 @@ FileSet {
     Options {
       Signature = MD5 # calculate md5 checksum per file
     }
-   #File = "@sbindir@"
     File=<@tmpdir@/file-list
-    Plugin = "python:module_path=@python_plugin_module_src_test_dir_relative@:module_name=bareos-fd-local-fileset-with-restoreobjects:filename=@tmpdir@/file-list-python-plugin"
   }
 }


### PR DESCRIPTION
The ability to create deprecated catalog databases was removed before. Unfortunately, we still need to be able to create those databases for our own tests.

This PR enables the creation of deprecated databases for only when running in our test environment. Otherwise, the creation will be denied like before. 