### PR TITLE
allow backup/restore of cephfs mounts (Backport for Bareos 19.2)

### DIFF
--- a/cmake/BareosCheckAcl.cmake
+++ b/cmake/BareosCheckAcl.cmake
@@ -1,0 +1,34 @@
+# BAREOS® - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or modify it under
+# the terms of version three of the GNU Affero General Public License as
+# published by the Free Software Foundation and included in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# Extract version information and commit timestamp if run in a git checkout
+
+find_program(SETFACL_PROG setfacl)
+find_program(GETFACL_PROG getfacl)
+
+set(SETFACL_WORKS NO)
+if(SETFACL_PROG AND GETFACL_PROG)
+  file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/acl-test-file.txt")
+  exec_program(${SETFACL_PROG}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ARGS "-m user:0:rw- acl-test-file.txt"
+    RETURN_VALUE SETFACL_RETURN)
+  if(SETFACL_RETURN EQUAL 0)
+    set(SETFACL_WORKS YES)
+  endif()
+endif()
+

--- a/cmake/BareosCheckAcl.cmake
+++ b/cmake/BareosCheckAcl.cmake
@@ -22,7 +22,7 @@ find_program(GETFACL_PROG getfacl)
 
 set(SETFACL_WORKS NO)
 if(SETFACL_PROG AND GETFACL_PROG)
-  file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/acl-test-file.txt")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/acl-test-file.txt" "Just a testfile")
   exec_program(${SETFACL_PROG}
     ${CMAKE_CURRENT_BINARY_DIR}
     ARGS "-m user:0:rw- acl-test-file.txt"

--- a/cmake/BareosCheckXattr.cmake
+++ b/cmake/BareosCheckXattr.cmake
@@ -1,0 +1,34 @@
+# BAREOS® - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or modify it under
+# the terms of version three of the GNU Affero General Public License as
+# published by the Free Software Foundation and included in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# Extract version information and commit timestamp if run in a git checkout
+
+find_program(SETFATTR_PROG setfattr)
+find_program(GETFATTR_PROG getfattr)
+
+set(SETFATTR_WORKS NO)
+if(SETFATTR_PROG AND GETFATTR_PROG)
+  file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/xattr-test-file.txt")
+  exec_program(${SETFATTR_PROG}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ARGS "--name=user.cmake-check --value=xattr-value xattr-test-file.txt"
+    RETURN_VALUE SETFATTR_RETURN)
+  if(SETFATTR_RETURN EQUAL 0)
+    set(SETFATTR_WORKS YES)
+  endif()
+endif()
+

--- a/cmake/BareosCheckXattr.cmake
+++ b/cmake/BareosCheckXattr.cmake
@@ -22,7 +22,7 @@ find_program(GETFATTR_PROG getfattr)
 
 set(SETFATTR_WORKS NO)
 if(SETFATTR_PROG AND GETFATTR_PROG)
-  file(TOUCH "${CMAKE_CURRENT_BINARY_DIR}/xattr-test-file.txt")
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/xattr-test-file.txt" "Just a testfile")
   exec_program(${SETFATTR_PROG}
     ${CMAKE_CURRENT_BINARY_DIR}
     ARGS "--name=user.cmake-check --value=xattr-value xattr-test-file.txt"

--- a/core/src/dird/ua_purge.h
+++ b/core/src/dird/ua_purge.h
@@ -30,8 +30,8 @@ bool IsVolumePurged(UaContext* ua, MediaDbRecord* mr, bool force = false);
 bool MarkMediaPurged(UaContext* ua, MediaDbRecord* mr);
 void PurgeFilesFromVolume(UaContext* ua, MediaDbRecord* mr);
 bool PurgeJobsFromVolume(UaContext* ua, MediaDbRecord* mr, bool force = false);
-void PurgeFilesFromJobs(UaContext* ua, char* jobs);
-void PurgeJobsFromCatalog(UaContext* ua, char* jobs);
+void PurgeFilesFromJobs(UaContext* ua, const char* jobs);
+void PurgeJobsFromCatalog(UaContext* ua, const char* jobs);
 void PurgeJobListFromCatalog(UaContext* ua, del_ctx& del);
 void PurgeFilesFromJobList(UaContext* ua, del_ctx& del);
 

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -145,8 +145,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr,
   StartHeartbeatMonitor(jcr);
 
   if (have_acl) {
-    jcr->impl->acl_data = (acl_data_t*)malloc(sizeof(acl_data_t));
-    memset(jcr->impl->acl_data, 0, sizeof(acl_data_t));
+    jcr->impl->acl_data = std::make_unique<AclData>();
     jcr->impl->acl_data->u.build =
         (acl_build_data_t*)malloc(sizeof(acl_build_data_t));
     memset(jcr->impl->acl_data->u.build, 0, sizeof(acl_build_data_t));
@@ -191,8 +190,6 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr,
   if (have_acl && jcr->impl->acl_data) {
     FreePoolMemory(jcr->impl->acl_data->u.build->content);
     free(jcr->impl->acl_data->u.build);
-    free(jcr->impl->acl_data);
-    jcr->impl->acl_data = NULL;
   }
 
   if (have_xattr && jcr->impl->xattr_data) {
@@ -465,9 +462,9 @@ static inline bool DoBackupAcl(JobControlRecord* jcr, FindFilesPacket* ff_pkt)
   jcr->impl->acl_data->last_fname = jcr->impl->last_fname;
 
   if (jcr->IsPlugin()) {
-    retval = PluginBuildAclStreams(jcr, jcr->impl->acl_data, ff_pkt);
+    retval = PluginBuildAclStreams(jcr, jcr->impl->acl_data.get(), ff_pkt);
   } else {
-    retval = BuildAclStreams(jcr, jcr->impl->acl_data, ff_pkt);
+    retval = BuildAclStreams(jcr, jcr->impl->acl_data.get(), ff_pkt);
   }
 
   switch (retval) {

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1472,7 +1472,7 @@ bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
  * Plugin specific callback for getting XATTR information.
  */
 BxattrExitCode PluginBuildXattrStreams(JobControlRecord* jcr,
-                                       struct xattr_data_t* xattr_data,
+                                       struct XattrData* xattr_data,
                                        FindFilesPacket* ff_pkt)
 {
   Plugin* plugin;
@@ -1600,7 +1600,7 @@ bail_out:
  * Plugin specific callback for setting XATTR information.
  */
 BxattrExitCode PluginParseXattrStreams(JobControlRecord* jcr,
-                                       struct xattr_data_t* xattr_data,
+                                       struct XattrData* xattr_data,
                                        int stream,
                                        char* content,
                                        uint32_t content_length)

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1383,7 +1383,7 @@ bool PluginSetAttributes(JobControlRecord* jcr,
  * Plugin specific callback for getting ACL information.
  */
 bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
-                                     acl_data_t* acl_data,
+                                     AclData* acl_data,
                                      FindFilesPacket* ff_pkt)
 {
   Plugin* plugin;
@@ -1430,7 +1430,7 @@ bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
  * Plugin specific callback for setting ACL information.
  */
 bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
-                                        acl_data_t* acl_data,
+                                        AclData* acl_data,
                                         int stream,
                                         char* content,
                                         uint32_t content_length)

--- a/core/src/filed/fd_plugins.h
+++ b/core/src/filed/fd_plugins.h
@@ -290,10 +290,10 @@ bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
                                         char* content,
                                         uint32_t content_length);
 BxattrExitCode PluginBuildXattrStreams(JobControlRecord* jcr,
-                                       struct xattr_data_t* xattr_data,
+                                       struct XattrData* xattr_data,
                                        FindFilesPacket* ff_pkt);
 BxattrExitCode PluginParseXattrStreams(JobControlRecord* jcr,
-                                       struct xattr_data_t* xattr_data,
+                                       struct XattrData* xattr_data,
                                        int stream,
                                        char* content,
                                        uint32_t content_length);

--- a/core/src/filed/fd_plugins.h
+++ b/core/src/filed/fd_plugins.h
@@ -282,10 +282,10 @@ bool PluginSetAttributes(JobControlRecord* jcr,
                          Attributes* attr,
                          BareosWinFilePacket* ofd);
 bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
-                                     acl_data_t* acl_data,
+                                     AclData* acl_data,
                                      FindFilesPacket* ff_pkt);
 bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
-                                        acl_data_t* acl_data,
+                                        AclData* acl_data,
                                         int stream,
                                         char* content,
                                         uint32_t content_length);

--- a/core/src/filed/jcr_private.h
+++ b/core/src/filed/jcr_private.h
@@ -27,7 +27,7 @@
 #include "include/bareos.h"
 
 struct acl_data_t;
-struct xattr_data_t;
+struct XattrData;
 
 namespace filedaemon {
 class BareosAccurateFilelist;
@@ -52,7 +52,7 @@ struct JobControlRecordPrivate {
   POOLMEM* last_fname{};          /**< Last file saved/verified */
   POOLMEM* job_metadata{};        /**< VSS job metadata */
   acl_data_t* acl_data{};         /**< ACLs for backup/restore */
-  xattr_data_t* xattr_data{};     /**< Extended Attributes for backup/restore */
+  std::unique_ptr<XattrData> xattr_data{};     /**< Extended Attributes for backup/restore */
   int32_t last_type{};            /**< Type of last file saved/verified */
   bool incremental{};             /**< Set if incremental for SINCE */
   utime_t mtime{};                /**< Begin time for SINCE */

--- a/core/src/filed/jcr_private.h
+++ b/core/src/filed/jcr_private.h
@@ -26,7 +26,7 @@
 
 #include "include/bareos.h"
 
-struct acl_data_t;
+struct AclData;
 struct XattrData;
 
 namespace filedaemon {
@@ -51,7 +51,7 @@ struct JobControlRecordPrivate {
   uint32_t num_files_examined{};  /**< Files examined this job */
   POOLMEM* last_fname{};          /**< Last file saved/verified */
   POOLMEM* job_metadata{};        /**< VSS job metadata */
-  acl_data_t* acl_data{};         /**< ACLs for backup/restore */
+  std::unique_ptr<AclData> acl_data{};         /**< ACLs for backup/restore */
   std::unique_ptr<XattrData> xattr_data{};     /**< Extended Attributes for backup/restore */
   int32_t last_type{};            /**< Type of last file saved/verified */
   bool incremental{};             /**< Set if incremental for SINCE */

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -73,14 +73,14 @@
  * platform.
  */
 bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
-                               acl_data_t* acl_data,
+                               AclData* acl_data,
                                FindFilesPacket* ff_pkt)
 {
   return bacl_exit_fatal;
 }
 
 bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
-                                 acl_data_t* acl_data,
+                                 AclData* acl_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length)
@@ -92,7 +92,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
  * Send an ACL stream to the SD.
  */
 bacl_exit_code SendAclStream(JobControlRecord* jcr,
-                             acl_data_t* acl_data,
+                             AclData* acl_data,
                              int stream)
 {
   BareosSocket* sd = jcr->store_bsock;
@@ -188,7 +188,7 @@ static int os_access_acl_streams[3] = {STREAM_ACL_AIX_TEXT, STREAM_ACL_AIX_AIXC,
 static int os_default_acl_streams[1] = {-1};
 
 static bacl_exit_code aix_build_acl_streams(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             FindFilesPacket* ff_pkt)
 {
   mode_t mode;
@@ -345,7 +345,7 @@ bail_out:
  * the file is located on.
  */
 static inline bool aix_query_acl_support(JobControlRecord* jcr,
-                                         acl_data_t* acl_data,
+                                         AclData* acl_data,
                                          uint64_t aclType,
                                          acl_type_t* pacl_type_info)
 {
@@ -368,7 +368,7 @@ static inline bool aix_query_acl_support(JobControlRecord* jcr,
 }
 
 static bacl_exit_code aix_parse_acl_streams(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             int stream,
                                             char* content,
                                             uint32_t content_length)
@@ -508,7 +508,7 @@ static int os_access_acl_streams[1] = {STREAM_ACL_AIX_TEXT};
 static int os_default_acl_streams[1] = {-1};
 
 static bacl_exit_code aix_build_acl_streams(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             FindFilesPacket* ff_pkt)
 {
   char* acl_text;
@@ -523,7 +523,7 @@ static bacl_exit_code aix_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code aix_parse_acl_streams(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             int stream,
                                             char* content,
                                             uint32_t content_length)
@@ -540,11 +540,11 @@ static bacl_exit_code aix_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     aix_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -759,7 +759,7 @@ static bool AclIsTrivial(acl_t acl)
  * Generic wrapper around acl_get_file call.
  */
 static bacl_exit_code generic_get_acl_from_os(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               bacl_type acltype)
 {
   acl_t acl;
@@ -870,7 +870,7 @@ bail_out:
  * Generic wrapper around acl_set_file call.
  */
 static bacl_exit_code generic_set_acl_on_os(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             bacl_type acltype,
                                             char* content,
                                             uint32_t content_length)
@@ -1005,7 +1005,7 @@ static int os_access_acl_streams[1] = {STREAM_ACL_DARWIN_ACCESS_ACL};
 static int os_default_acl_streams[1] = {-1};
 
 static bacl_exit_code darwin_build_acl_streams(JobControlRecord* jcr,
-                                               acl_data_t* acl_data,
+                                               AclData* acl_data,
                                                FindFilesPacket* ff_pkt)
 {
 #if defined(HAVE_ACL_TYPE_EXTENDED)
@@ -1037,7 +1037,7 @@ static bacl_exit_code darwin_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code darwin_parse_acl_streams(JobControlRecord* jcr,
-                                               acl_data_t* acl_data,
+                                               AclData* acl_data,
                                                int stream,
                                                char* content,
                                                uint32_t content_length)
@@ -1056,11 +1056,11 @@ static bacl_exit_code darwin_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     darwin_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -1075,7 +1075,7 @@ static int os_access_acl_streams[2] = {STREAM_ACL_FREEBSD_ACCESS_ACL,
 static int os_default_acl_streams[1] = {STREAM_ACL_FREEBSD_DEFAULT_ACL};
 
 static bacl_exit_code freebsd_build_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 FindFilesPacket* ff_pkt)
 {
   int acl_enabled = 0;
@@ -1204,7 +1204,7 @@ static bacl_exit_code freebsd_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code freebsd_parse_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length)
@@ -1292,11 +1292,11 @@ static bacl_exit_code freebsd_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     freebsd_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -1318,7 +1318,7 @@ static int os_default_acl_streams[1] = {STREAM_ACL_HURD_DEFAULT_ACL};
 #endif
 
 static bacl_exit_code generic_build_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 FindFilesPacket* ff_pkt)
 {
   /*
@@ -1351,7 +1351,7 @@ static bacl_exit_code generic_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code generic_parse_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length)
@@ -1391,11 +1391,11 @@ static bacl_exit_code generic_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     generic_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -1411,7 +1411,7 @@ static int os_default_acl_streams[2] = {STREAM_ACL_TRU64_DEFAULT_ACL,
                                         STREAM_ACL_TRU64_DEFAULT_DIR_ACL};
 
 static bacl_exit_code tru64_build_acl_streams(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt)
 {
   /*
@@ -1451,8 +1451,8 @@ static bacl_exit_code tru64_build_acl_streams(JobControlRecord* jcr,
       }
 
       static bacl_exit_code tru64_parse_acl_streams(
-          JobControlRecord * jcr, acl_data_t * acl_data, int stream,
-          char* content, uint32_t content_length)
+          JobControlRecord * jcr, AclData * acl_data, int stream, char* content,
+          uint32_t content_length)
       {
         switch (stream) {
           case STREAM_UNIX_ACCESS_ACL:
@@ -1473,10 +1473,10 @@ static bacl_exit_code tru64_build_acl_streams(JobControlRecord* jcr,
          * specific functions.
          */
         static bacl_exit_code (*os_build_acl_streams)(
-            JobControlRecord * jcr, acl_data_t * acl_data,
+            JobControlRecord * jcr, AclData * acl_data,
             FindFilesPacket * ff_pkt) = tru64_build_acl_streams;
         static bacl_exit_code (*os_parse_acl_streams)(
-            JobControlRecord * jcr, acl_data_t * acl_data, int stream,
+            JobControlRecord * jcr, AclData * acl_data, int stream,
             char* content, uint32_t content_length) = tru64_parse_acl_streams;
 
 #endif
@@ -1523,7 +1523,7 @@ static bool AclIsTrivial(int count, struct acl_entry* entries, struct stat sb)
  * OS specific functions for handling different types of acl streams.
  */
 static bacl_exit_code hpux_build_acl_streams(JobControlRecord* jcr,
-                                             acl_data_t* acl_data
+                                             AclData* acl_data
                                                  FindFilesPacket* ff_pkt)
 {
   int n;
@@ -1598,7 +1598,7 @@ static bacl_exit_code hpux_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code hpux_parse_acl_streams(JobControlRecord* jcr,
-                                             acl_data_t* acl_data,
+                                             AclData* acl_data,
                                              int stream,
                                              char* content,
                                              uint32_t content_length)
@@ -1674,11 +1674,11 @@ static bacl_exit_code hpux_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     hpux_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -1736,7 +1736,7 @@ static int os_default_acl_streams[1] = {-1};
  * code)
  */
 static bacl_exit_code solaris_build_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 FindFilesPacket* ff_pkt)
 {
   int acl_enabled, flags;
@@ -1837,7 +1837,7 @@ static bacl_exit_code solaris_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code solaris_parse_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length)
@@ -2022,7 +2022,7 @@ static bool AclIsTrivial(int count, aclent_t* entries)
  * OS specific functions for handling different types of acl streams.
  */
 static bacl_exit_code solaris_build_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 FindFilesPacket* ff_pkt)
 {
   int n;
@@ -2065,7 +2065,7 @@ static bacl_exit_code solaris_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code solaris_parse_acl_streams(JobControlRecord* jcr,
-                                                acl_data_t* acl_data,
+                                                AclData* acl_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length)
@@ -2115,11 +2115,11 @@ static bacl_exit_code solaris_parse_acl_streams(JobControlRecord* jcr,
  * functions.
  */
 static bacl_exit_code (*os_build_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               FindFilesPacket* ff_pkt) =
     solaris_build_acl_streams;
 static bacl_exit_code (*os_parse_acl_streams)(JobControlRecord* jcr,
-                                              acl_data_t* acl_data,
+                                              AclData* acl_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length) =
@@ -2147,7 +2147,7 @@ long pioctl(char* pathp, long opcode, struct ViceIoctl* blobp, int follow);
 }
 
 static bacl_exit_code afs_build_acl_streams(JobControlRecord* jcr,
-                                            acl_data_t* acl_data,
+                                            AclData* acl_data,
                                             FindFilesPacket* ff_pkt)
 {
   int error;
@@ -2181,7 +2181,7 @@ static bacl_exit_code afs_build_acl_streams(JobControlRecord* jcr,
 }
 
 static bacl_exit_code afs_parse_acl_stream(JobControlRecord* jcr,
-                                           acl_data_t* acl_data,
+                                           AclData* acl_data,
                                            int stream,
                                            char* content,
                                            uint32_t content_length)
@@ -2216,7 +2216,7 @@ static bacl_exit_code afs_parse_acl_stream(JobControlRecord* jcr,
  * Read and send an ACL for the last encountered file.
  */
 bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
-                               acl_data_t* acl_data,
+                               AclData* acl_data,
                                FindFilesPacket* ff_pkt)
 {
   /*
@@ -2225,11 +2225,9 @@ bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
    * it with the current st_dev in the last stat performed on
    * the file we are currently storing.
    */
-  if (acl_data->current_dev != ff_pkt->statp.st_dev) {
-    /*
-     * Reset the acl save flags.
-     */
+  if (acl_data->first_dev || acl_data->current_dev != ff_pkt->statp.st_dev) {
     acl_data->flags = 0;
+    acl_data->first_dev = false;
 
 #if defined(HAVE_AFS_ACL)
     /*
@@ -2281,7 +2279,7 @@ bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
 }
 
 bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
-                                 acl_data_t* acl_data,
+                                 AclData* acl_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length)
@@ -2316,11 +2314,9 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
     case 0:
       break;
   }
-  if (acl_data->current_dev != st.st_dev) {
-    /*
-     * Reset the acl save flags.
-     */
+  if (acl_data->first_dev || acl_data->current_dev != st.st_dev) {
     acl_data->flags = 0;
+    acl_data->first_dev = false;
 
 #if defined(HAVE_AFS_ACL)
     /*

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -95,11 +95,12 @@ struct acl_parse_data_t {
 /**
  * Internal tracking data.
  */
-struct acl_data_t {
+struct AclData {
   int filetype;
   POOLMEM* last_fname;
-  uint32_t flags; /* See BACL_FLAG_* */
-  uint32_t current_dev;
+  uint32_t flags{}; /* See BACL_FLAG_* */
+  uint32_t current_dev{0};
+  bool first_dev{true};
   union {
     struct acl_build_data_t* build;
     struct acl_parse_data_t* parse;
@@ -107,13 +108,13 @@ struct acl_data_t {
 };
 
 bacl_exit_code SendAclStream(JobControlRecord* jcr,
-                             acl_data_t* acl_data,
+                             AclData* acl_data,
                              int stream);
 bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
-                               acl_data_t* acl_data,
+                               AclData* acl_data,
                                FindFilesPacket* ff_pkt);
 bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
-                                 acl_data_t* acl_data,
+                                 AclData* acl_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length);

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -72,14 +72,14 @@ static std::string error_message_disabling_xattributes{
  * platform.
  */
 BxattrExitCode BuildXattrStreams(JobControlRecord* jcr,
-                                 xattr_data_t* xattr_data,
+                                 XattrData* xattr_data,
                                  FindFilesPacket* ff_pkt)
 {
   return BxattrExitCode::kErrorFatal;
 }
 
 BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
-                                 xattr_data_t* xattr_data,
+                                 XattrData* xattr_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length)
@@ -91,7 +91,7 @@ BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
  * Send a XATTR stream to the SD.
  */
 BxattrExitCode SendXattrStream(JobControlRecord* jcr,
-                               xattr_data_t* xattr_data,
+                               XattrData* xattr_data,
                                int stream)
 {
   BareosSocket* sd = jcr->store_bsock;
@@ -184,7 +184,7 @@ void XattrDropInternalTable(alist* xattr_value_list)
  *
  */
 uint32_t SerializeXattrStream(JobControlRecord* jcr,
-                              xattr_data_t* xattr_data,
+                              XattrData* xattr_data,
                               uint32_t expected_serialize_len,
                               alist* xattr_value_list)
 {
@@ -230,7 +230,7 @@ uint32_t SerializeXattrStream(JobControlRecord* jcr,
 }
 
 BxattrExitCode UnSerializeXattrStream(JobControlRecord* jcr,
-                                      xattr_data_t* xattr_data,
+                                      XattrData* xattr_data,
                                       char* content,
                                       uint32_t content_length,
                                       alist* xattr_value_list)
@@ -351,7 +351,7 @@ static int os_default_xattr_streams[1] = {STREAM_XATTR_AIX};
 #endif
 
 static BxattrExitCode aix_build_xattr_streams(JobControlRecord* jcr,
-                                              xattr_data_t* xattr_data,
+                                              XattrData* xattr_data,
                                               FindFilesPacket* ff_pkt)
 {
   char* bp;
@@ -606,7 +606,7 @@ bail_out:
 }
 
 static BxattrExitCode aix_parse_xattr_streams(JobControlRecord* jcr,
-                                              xattr_data_t* xattr_data,
+                                              XattrData* xattr_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length)
@@ -668,11 +668,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     aix_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -700,7 +700,7 @@ static xattr_naming_space xattr_naming_spaces[] = {
     {NULL, 0}};
 
 static BxattrExitCode irix_build_xattr_streams(JobControlRecord* jcr,
-                                               xattr_data_t* xattr_data,
+                                               XattrData* xattr_data,
                                                FindFilesPacket* ff_pkt)
 {
   char dummy[32];
@@ -921,7 +921,7 @@ bail_out:
 }
 
 static BxattrExitCode irix_parse_xattr_streams(JobControlRecord* jcr,
-                                               xattr_data_t* xattr_data,
+                                               XattrData* xattr_data,
                                                int stream,
                                                char* content,
                                                uint32_t content_length)
@@ -1019,11 +1019,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     irix_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -1055,7 +1055,16 @@ static const char* xattr_skiplist[3] = {"com.apple.system.extendedsecurity",
 static int os_default_xattr_streams[1] = {STREAM_XATTR_LINUX};
 static const char* xattr_acl_skiplist[3] = {"system.posix_acl_access",
                                             "system.posix_acl_default", NULL};
-static const char* xattr_skiplist[1] = {NULL};
+static const char* xattr_skiplist[] = {"ceph.dir.entries",
+                                       "ceph.dir.files",
+                                       "ceph.dir.rbytes",
+                                       "ceph.dir.rctime",
+                                       "ceph.dir.rentries",
+                                       "ceph.dir.rfiles",
+                                       "ceph.dir.rsubdirs",
+                                       "ceph.dir.subdirs",
+                                       NULL
+};
 #elif defined(HAVE_HURD_OS)
 static int os_default_xattr_streams[1] = {STREAM_XATTR_HURD};
 static const char* xattr_acl_skiplist[1] = {NULL};
@@ -1091,7 +1100,7 @@ static const char* xattr_skiplist[1] = {NULL};
 #endif
 
 static BxattrExitCode generic_build_xattr_streams(JobControlRecord* jcr,
-                                                  xattr_data_t* xattr_data,
+                                                  XattrData* xattr_data,
                                                   FindFilesPacket* ff_pkt)
 {
   char* bp;
@@ -1366,7 +1375,7 @@ bail_out:
 }
 
 static BxattrExitCode generic_parse_xattr_streams(JobControlRecord* jcr,
-                                                  xattr_data_t* xattr_data,
+                                                  XattrData* xattr_data,
                                                   int stream,
                                                   char* content,
                                                   uint32_t content_length)
@@ -1427,11 +1436,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     generic_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -1491,7 +1500,7 @@ static const char* xattr_skiplist[1] = {NULL};
 #endif
 
 static BxattrExitCode bsd_build_xattr_streams(JobControlRecord* jcr,
-                                              xattr_data_t* xattr_data,
+                                              XattrData* xattr_data,
                                               FindFilesPacket* ff_pkt)
 {
   bool skip_xattr;
@@ -1825,7 +1834,7 @@ bail_out:
 }
 
 static BxattrExitCode bsd_parse_xattr_streams(JobControlRecord* jcr,
-                                              xattr_data_t* xattr_data,
+                                              XattrData* xattr_data,
                                               int stream,
                                               char* content,
                                               uint32_t content_length)
@@ -1911,11 +1920,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     bsd_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -1943,7 +1952,7 @@ static const char* xattr_acl_skiplist[1] = {NULL};
 static const char* xattr_skiplist[1] = {NULL};
 
 static BxattrExitCode tru64_build_xattr_streams(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt)
 {
   int cnt;
@@ -2163,7 +2172,7 @@ bail_out:
 }
 
 static BxattrExitCode tru64_parse_xattr_streams(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length)
@@ -2266,11 +2275,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     tru64_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -2394,7 +2403,7 @@ static int os_default_xattr_streams[1] = {STREAM_XATTR_SOLARIS};
  * counterpart(s))
  */
 static inline xattr_link_cache_entry_t* find_xattr_link_cache_entry(
-    xattr_data_t* xattr_data,
+    XattrData* xattr_data,
     ino_t inum)
 {
   xattr_link_cache_entry_t* ptr;
@@ -2405,7 +2414,7 @@ static inline xattr_link_cache_entry_t* find_xattr_link_cache_entry(
   return NULL;
 }
 
-static inline void add_xattr_link_cache_entry(xattr_data_t* xattr_data,
+static inline void add_xattr_link_cache_entry(XattrData* xattr_data,
                                               ino_t inum,
                                               char* target)
 {
@@ -2422,7 +2431,7 @@ static inline void add_xattr_link_cache_entry(xattr_data_t* xattr_data,
   xattr_data->u.build->link_cache->append(ptr);
 }
 
-static inline void DropXattrLinkCache(xattr_data_t* xattr_data)
+static inline void DropXattrLinkCache(XattrData* xattr_data)
 {
   xattr_link_cache_entry_t* ptr;
 
@@ -2526,7 +2535,7 @@ static bool AclIsTrivial(int count, aclent_t* entries)
 #endif /* HAVE_ACL && !HAVE_EXTENDED_ACL */
 
 static BxattrExitCode solaris_save_xattr_acl(JobControlRecord* jcr,
-                                             xattr_data_t* xattr_data,
+                                             XattrData* xattr_data,
                                              int fd,
                                              const char* attrname,
                                              char** acl_text)
@@ -2655,7 +2664,7 @@ bail_out:
  * Forward declaration for recursive function call.
  */
 static BxattrExitCode solaris_save_xattrs(JobControlRecord* jcr,
-                                          xattr_data_t* xattr_data,
+                                          XattrData* xattr_data,
                                           const char* xattr_namespace,
                                           const char* attr_parent);
 
@@ -2675,7 +2684,7 @@ static BxattrExitCode solaris_save_xattrs(JobControlRecord* jcr,
  * actual_xattr_data is the content of the xattr file.
  */
 static BxattrExitCode solaris_save_xattr(JobControlRecord* jcr,
-                                         xattr_data_t* xattr_data,
+                                         XattrData* xattr_data,
                                          int fd,
                                          const char* xattr_namespace,
                                          const char* attrname,
@@ -2992,7 +3001,7 @@ bail_out:
 }
 
 static BxattrExitCode solaris_save_xattrs(JobControlRecord* jcr,
-                                          xattr_data_t* xattr_data,
+                                          XattrData* xattr_data,
                                           const char* xattr_namespace,
                                           const char* attr_parent)
 {
@@ -3181,7 +3190,7 @@ bail_out:
 
 #ifdef HAVE_ACL
 static BxattrExitCode solaris_restore_xattr_acl(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int fd,
                                                 const char* attrname,
                                                 char* acl_text)
@@ -3237,7 +3246,7 @@ static BxattrExitCode solaris_restore_xattr_acl(JobControlRecord* jcr,
 #endif /* HAVE_ACL */
 
 static BxattrExitCode solaris_restore_xattrs(JobControlRecord* jcr,
-                                             xattr_data_t* xattr_data,
+                                             XattrData* xattr_data,
                                              bool is_extensible,
                                              char* content,
                                              uint32_t content_length)
@@ -3654,7 +3663,7 @@ bail_out:
 }
 
 static BxattrExitCode solaris_build_xattr_streams(JobControlRecord* jcr,
-                                                  xattr_data_t* xattr_data,
+                                                  XattrData* xattr_data,
                                                   FindFilesPacket* ff_pkt)
 {
   char cwd[PATH_MAX];
@@ -3680,7 +3689,7 @@ static BxattrExitCode solaris_build_xattr_streams(JobControlRecord* jcr,
 }
 
 static BxattrExitCode solaris_parse_xattr_streams(JobControlRecord* jcr,
-                                                  xattr_data_t* xattr_data,
+                                                  XattrData* xattr_data,
                                                   int stream,
                                                   char* content,
                                                   uint32_t content_length)
@@ -3743,11 +3752,11 @@ bail_out:
  * Function pointers to the build and parse function to use for these xattrs.
  */
 static BxattrExitCode (*os_build_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 FindFilesPacket* ff_pkt) =
     solaris_build_xattr_streams;
 static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
-                                                xattr_data_t* xattr_data,
+                                                XattrData* xattr_data,
                                                 int stream,
                                                 char* content,
                                                 uint32_t content_length) =
@@ -3759,7 +3768,7 @@ static BxattrExitCode (*os_parse_xattr_streams)(JobControlRecord* jcr,
  * Entry points when compiled with support for XATTRs on a supported platform.
  */
 BxattrExitCode BuildXattrStreams(JobControlRecord* jcr,
-                                 xattr_data_t* xattr_data,
+                                 XattrData* xattr_data,
                                  FindFilesPacket* ff_pkt)
 {
   /*
@@ -3768,16 +3777,11 @@ BxattrExitCode BuildXattrStreams(JobControlRecord* jcr,
    * it with the current st_dev in the last stat performed on
    * the file we are currently storing.
    */
-  if (xattr_data->current_dev != ff_pkt->statp.st_dev) {
-    /*
-     * Reset the acl save flags.
-     */
-    xattr_data->flags = 0;
-    xattr_data->flags |= BXATTR_FLAG_SAVE_NATIVE;
-
-    /*
-     * Save that we started scanning a new filesystem.
-     */
+  Dmsg0(1000, "BuildXattrStreams(): Enter\n");
+  if (xattr_data->first_dev ||
+      xattr_data->current_dev != ff_pkt->statp.st_dev) {
+    xattr_data->flags = BXATTR_FLAG_SAVE_NATIVE;
+    xattr_data->first_dev = false;
     xattr_data->current_dev = ff_pkt->statp.st_dev;
   }
 
@@ -3789,7 +3793,7 @@ BxattrExitCode BuildXattrStreams(JobControlRecord* jcr,
 }
 
 BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
-                                 xattr_data_t* xattr_data,
+                                 XattrData* xattr_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length)
@@ -3799,6 +3803,7 @@ BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
   unsigned int cnt;
   BxattrExitCode retval = BxattrExitCode::kError;
 
+  Dmsg0(1000, "ParseXattrStreams(): Enter\n");
   /*
    * See if we are changing from one device to another.
    * We save the current device we are restoring to and compare
@@ -3826,16 +3831,9 @@ BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
     case 0:
       break;
   }
-  if (xattr_data->current_dev != st.st_dev) {
-    /*
-     * Reset the acl save flags.
-     */
-    xattr_data->flags = 0;
-    xattr_data->flags |= BXATTR_FLAG_RESTORE_NATIVE;
-
-    /*
-     * Save that we started restoring to a new filesystem.
-     */
+  if (xattr_data->first_dev || xattr_data->current_dev != st.st_dev) {
+    xattr_data->flags = BXATTR_FLAG_RESTORE_NATIVE;
+    xattr_data->first_dev = false;
     xattr_data->current_dev = st.st_dev;
   }
 

--- a/core/src/findlib/xattr.h
+++ b/core/src/findlib/xattr.h
@@ -86,10 +86,11 @@ struct xattr_parse_data_t {
 /*
  * Internal tracking data.
  */
-struct xattr_data_t {
+struct XattrData {
   POOLMEM* last_fname;
-  uint32_t flags; /* See BXATTR_FLAG_* */
-  uint32_t current_dev;
+  uint32_t flags{0}; /* See BXATTR_FLAG_* */
+  uint32_t current_dev{0};
+  bool first_dev{true};
   union {
     struct xattr_build_data_t* build;
     struct xattr_parse_data_t* parse;
@@ -108,23 +109,23 @@ struct xattr_data_t {
 class alist;
 
 BxattrExitCode SendXattrStream(JobControlRecord* jcr,
-                               xattr_data_t* xattr_data,
+                               XattrData* xattr_data,
                                int stream);
 void XattrDropInternalTable(alist* xattr_value_list);
 uint32_t SerializeXattrStream(JobControlRecord* jcr,
-                              xattr_data_t* xattr_data,
+                              XattrData* xattr_data,
                               uint32_t expected_serialize_len,
                               alist* xattr_value_list);
 BxattrExitCode UnSerializeXattrStream(JobControlRecord* jcr,
-                                      xattr_data_t* xattr_data,
+                                      XattrData* xattr_data,
                                       char* content,
                                       uint32_t content_length,
                                       alist* xattr_value_list);
 BxattrExitCode BuildXattrStreams(JobControlRecord* jcr,
-                                 struct xattr_data_t* xattr_data,
+                                 struct XattrData* xattr_data,
                                  FindFilesPacket* ff_pkt);
 BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
-                                 struct xattr_data_t* xattr_data,
+                                 struct XattrData* xattr_data,
                                  int stream,
                                  char* content,
                                  uint32_t content_length);

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -79,7 +79,7 @@ static char* DirectorName = NULL;
 static DirectorResource* director = NULL;
 
 static struct acl_data_t acl_data;
-static struct xattr_data_t xattr_data;
+static struct XattrData xattr_data;
 static alist* delayed_streams = NULL;
 
 static char* wbuf;            /* write buffer address */

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -78,8 +78,8 @@ static char* VolumeName = NULL;
 static char* DirectorName = NULL;
 static DirectorResource* director = NULL;
 
-static struct acl_data_t acl_data;
-static struct XattrData xattr_data;
+static AclData acl_data;
+static XattrData xattr_data;
 static alist* delayed_streams = NULL;
 
 static char* wbuf;            /* write buffer address */

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -598,8 +598,18 @@ set(SYSTEM_TESTS
 set(SYSTEM_TESTS_DISABLED # initially empty
 )
 
-if(mysql AND postgresql AND dynamic-cats-backends)
-  list(APPEND SYSTEM_TESTS "dbcopy-mysql-postgresql-test")
+include(BareosCheckXattr)
+if(SETFATTR_WORKS)
+  list(APPEND SYSTEM_TESTS xattr)
+else()
+  list(APPEND SYSTEM_TESTS_DISABLED xattr)
+endif()
+
+if(mysql
+   AND postgresql
+   AND dynamic-cats-backends
+)
+  list(APPEND SYSTEM_TESTS "dbcopy-mysql-postgresql")
 else()
   list(APPEND SYSTEM_TESTS_DISABLED "dbcopy-mysql-postgresql-test")
 endif()

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -605,6 +605,13 @@ else()
   list(APPEND SYSTEM_TESTS_DISABLED xattr)
 endif()
 
+include(BareosCheckAcl)
+if(SETFACL_WORKS)
+  list(APPEND SYSTEM_TESTS acl)
+else()
+  list(APPEND SYSTEM_TESTS_DISABLED acl)
+endif()
+
 if(mysql
    AND postgresql
    AND dynamic-cats-backends

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = @hostname@
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_dir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+    File=@tmpdir@/file-with-acl
+  }
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_fd@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/acl/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/acl/testrunner
+++ b/systemtests/tests/acl/testrunner
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 #
 # Run a simple backup
 #   then restore it.

--- a/systemtests/tests/acl/testrunner
+++ b/systemtests/tests/acl/testrunner
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+# Directory to backup.
+# This directory will be created by setup_data "$@"().
+BackupDirectory="${tmp}/data"
+BackupFile="${tmp}/file-with-acl"
+RestoreFile="${tmp}/bareos-restores/${BackupFile}"
+
+acl_should="${tmp}/acl_should.txt"
+acl_is="${tmp}/acl_is.txt"
+
+mkdir -p "${BackupDirectory}"
+touch "${BackupFile}"
+setfacl -m user:0:r-x "${BackupFile}"
+getfacl "${BackupFile}" | grep -vF file: >"$acl_should"
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+label volume=TestVolume001 storage=File pool=Full
+setdebug level=1000 client=bareos-fd trace=1
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bareos "$@"
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+
+getfacl "${RestoreFile}" | grep -vF file: >"$acl_is"
+
+diff -u "$acl_should" "$acl_is" || estat=1
+
+end_test

--- a/systemtests/tests/volume-pruning-test/testrunner
+++ b/systemtests/tests/volume-pruning-test/testrunner
@@ -46,6 +46,7 @@ run job=$JobName Level=Full yes
 run job=$JobName Level=Full yes
 run job=$JobName Level=Full yes
 run job=$JobName Level=Full yes
+wait
 @sleep 10
 run job=$JobName Level=Full yes
 

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = @hostname@
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,27 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  # Enable the Heartbeat if you experience connection losses
+  # (eg. because of your router or firewall configuration).
+  # Additionally the Heartbeat can be enabled in bareos-sd and bareos-fd.
+  #
+  # Heartbeat Interval = 1 min
+
+  # remove comment in next line to load dynamic backends from specified directory
+  Backend Directory = @backenddir@
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all director plugins (*-dir.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_dir@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+    File=@tmpdir@/file-with-xattr
+  }
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,20 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_fd@"
+  # Plugin Names = ""
+
+  # if compatible is set to yes, we are compatible with bacula
+  # if set to no, new bareos features are enabled which is the default
+  # compatible = yes
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/xattr/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/xattr/testrunner
+++ b/systemtests/tests/xattr/testrunner
@@ -1,5 +1,4 @@
 #!/bin/sh
-set -e
 #
 # Run a simple backup
 #   then restore it.

--- a/systemtests/tests/xattr/testrunner
+++ b/systemtests/tests/xattr/testrunner
@@ -1,0 +1,77 @@
+#!/bin/sh
+set -e
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+# Directory to backup.
+# This directory will be created by setup_data "$@"().
+BackupDirectory="${tmp}/data"
+BackupFile="${tmp}/file-with-xattr"
+RestoreFile="${tmp}/bareos-restores/${BackupFile}"
+
+xattr_should="${tmp}/xattr_should.txt"
+xattr_is="${tmp}/xattr_is.txt"
+
+mkdir -p "${BackupDirectory}"
+touch "${BackupFile}"
+setfattr --name=user.bareosattr1 --value=value1 "${BackupFile}"
+setfattr --name=user.bareosattr2 --value=value2 "${BackupFile}"
+
+getfattr --name=user.bareosattr1 --only-values "${BackupFile}" >"$xattr_should"
+echo '-- SEPERATOR --' >>"$xattr_should"
+getfattr --name=user.bareosattr2 --only-values "${BackupFile}" >>"$xattr_should"
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+label volume=TestVolume001 storage=File pool=Full
+setdebug level=1000 client=bareos-fd trace=1
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bareos "$@"
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+
+getfattr --name=user.bareosattr1 --only-values "${RestoreFile}" >"$xattr_is"
+echo '-- SEPERATOR --' >>"$xattr_is"
+getfattr --name=user.bareosattr2 --only-values "${RestoreFile}" >>"$xattr_is"
+
+diff -u "$xattr_should" "$xattr_is" || estat=1
+
+end_test


### PR DESCRIPTION
See https://github.com/bareos/bareos/pull/554

However, this also backports a fix, so the volume-pruning-test doesn't fail.