### PR TITLE
Add configuration warnings to SD

### DIFF
--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -21,6 +21,7 @@
    02110-1301, USA.
 */
 
+#include "lib/parse_conf.h"
 #include "stored/autoxflate.h"
 #include "stored/device_resource.h"
 #include "stored/stored_globals.h"
@@ -284,5 +285,13 @@ void DeviceResource::CreateAndAssignSerialNumber(uint16_t number)
   resource_name_ = strdup(tmp_name.c_str());
 }
 
+bool DeviceResource::Validate()
+{
+  if (max_block_size > 0 && dev_type != DeviceType::B_TAPE_DEV) {
+    my_config->AddWarning(
+        "Setting 'Maximum Block Size' on a non-tape device is unsupported");
+  }
+  return true;
+}
 
 } /* namespace storagedaemon  */

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -101,6 +101,7 @@ class DeviceResource : public BareosResource {
   void CreateAndAssignSerialNumber(uint16_t number);
   void MultipliedDeviceRestoreBaseName();
   void MultipliedDeviceRestoreNumberedName();
+  bool Validate() override;
 
  private:
   std::string multiplied_device_resource_base_name; /** < base name without

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -253,6 +253,12 @@ int main(int argc, char* argv[])
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);
 
+  if (forge_on) {
+    my_config->AddWarning(
+        "Running with '-p' is for testing and emergency recovery purposes "
+        "only");
+  }
+
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);
     goto bail_out;

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -736,6 +736,11 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
   int i;
   int error = 0;
 
+  BareosResource* allocated_resource = *resources[rindex].allocated_resource_;
+  if (pass == 2 && !allocated_resource->Validate()) {
+    return false;
+  }
+
   // Ensure that all required items are present
   for (i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {


### PR DESCRIPTION
This PR adds configuration warnings to the SD when
* `Maximum Block Size` is configured on a device that is not a tape
* The SD is invoked with `-p` to ignore i/o errors