### PR TITLE
core: console command show in JSON mode names resource types in plural form

### DIFF
--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -83,11 +83,11 @@ static ResourceItem dir_items[] = {
 };
 
 static ResourceTable resources[] = {
-  { "Console", cons_items, R_CONSOLE, sizeof(ConsoleResource),
+  { "Console", "Consoles", cons_items, R_CONSOLE, sizeof(ConsoleResource),
       [] (){ res_cons = new ConsoleResource(); }, reinterpret_cast<BareosResource**>(&res_cons) },
-  { "Director", dir_items, R_DIRECTOR, sizeof(DirectorResource),
+  { "Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       [] (){ res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir) },
-  {nullptr, nullptr, 0, 0, nullptr, nullptr}
+  {nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr}
 };
 
 /* clang-format on */

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -542,37 +542,37 @@ static ResourceItem counter_items[] = {
  * name handler value code flags default_value
  */
 static ResourceTable resources[] = {
-  { "Director", dir_items, R_DIRECTOR, sizeof(DirectorResource),
+  { "Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       [] (){ res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir) },
-  { "Client", cli_items, R_CLIENT, sizeof(ClientResource),
+  { "Client", "Clients", cli_items, R_CLIENT, sizeof(ClientResource),
       [] (){ res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)  },
-  { "JobDefs", job_items, R_JOBDEFS, sizeof(JobResource),
+  { "JobDefs", "JobDefs", job_items, R_JOBDEFS, sizeof(JobResource),
       [] (){ res_job = new JobResource(); }, reinterpret_cast<BareosResource**>(&res_job) },
-  { "Job", job_items, R_JOB, sizeof(JobResource),
+  { "Job", "Jobs", job_items, R_JOB, sizeof(JobResource),
       [] (){ res_job = new JobResource(); }, reinterpret_cast<BareosResource**>(&res_job) },
-  { "Storage", store_items, R_STORAGE, sizeof(StorageResource),
+  { "Storage", "Storages", store_items, R_STORAGE, sizeof(StorageResource),
       [] (){ res_store = new StorageResource(); }, reinterpret_cast<BareosResource**>(&res_store) },
-  { "Catalog", cat_items, R_CATALOG, sizeof(CatalogResource),
+  { "Catalog", "Catalogs", cat_items, R_CATALOG, sizeof(CatalogResource),
       [] (){ res_cat = new CatalogResource(); }, reinterpret_cast<BareosResource**>(&res_cat) },
-  { "Schedule", sch_items, R_SCHEDULE, sizeof(ScheduleResource),
+  { "Schedule", "Schedules", sch_items, R_SCHEDULE, sizeof(ScheduleResource),
       [] (){ res_sch = new ScheduleResource(); }, reinterpret_cast<BareosResource**>(&res_sch) },
-  { "FileSet", fs_items, R_FILESET, sizeof(FilesetResource),
+  { "FileSet", "FileSets", fs_items, R_FILESET, sizeof(FilesetResource),
       [] (){ res_fs = new FilesetResource(); }, reinterpret_cast<BareosResource**>(&res_fs) },
-  { "Pool", pool_items, R_POOL, sizeof(PoolResource),
+  { "Pool", "Pools", pool_items, R_POOL, sizeof(PoolResource),
       [] (){ res_pool = new PoolResource(); }, reinterpret_cast<BareosResource**>(&res_pool) },
-  { "Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
+  { "Messages", "Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
       [] (){ res_msgs = new MessagesResource(); }, reinterpret_cast<BareosResource**>(&res_msgs) },
-  { "Counter", counter_items, R_COUNTER, sizeof(CounterResource),
+  { "Counter", "Counters", counter_items, R_COUNTER, sizeof(CounterResource),
       [] (){ res_counter = new CounterResource(); }, reinterpret_cast<BareosResource**>(&res_counter) },
-  { "Profile", profile_items, R_PROFILE, sizeof(ProfileResource),
+  { "Profile", "Profiles", profile_items, R_PROFILE, sizeof(ProfileResource),
       [] (){ res_profile = new ProfileResource(); }, reinterpret_cast<BareosResource**>(&res_profile) },
-  { "Console", con_items, R_CONSOLE, sizeof(ConsoleResource),
+  { "Console", "Consoles", con_items, R_CONSOLE, sizeof(ConsoleResource),
       [] (){ res_con = new ConsoleResource(); }, reinterpret_cast<BareosResource**>(&res_con) },
-  { "Device", NULL, R_DEVICE, sizeof(DeviceResource),/* info obtained from SD */
+  { "Device", "Devices", NULL, R_DEVICE, sizeof(DeviceResource),/* info obtained from SD */
       [] (){ res_dev = new DeviceResource(); }, reinterpret_cast<BareosResource**>(&res_dev) },
-  { "User", user_items, R_USER, sizeof(UserResource),
+  { "User", "Users", user_items, R_USER, sizeof(UserResource),
       [] (){ res_user = new UserResource(); }, reinterpret_cast<BareosResource**>(&res_user) },
-  {nullptr, nullptr, 0, 0, nullptr, nullptr}
+  { nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr }
 };
 
 /**
@@ -2134,7 +2134,7 @@ bool FilesetResource::PrintConfig(
 
   Dmsg0(200, "FilesetResource::PrintConfig\n");
 
-  send.ResourceTypeStart("FileSet");
+  send.ResourceTypeStart("FileSets");
   send.ResourceStart(this->resource_name_);
   send.KeyQuotedString("Name", this->resource_name_);
 

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3856,7 +3856,9 @@ static void DumpResource(int type,
       OutputFormatterResource(output_formatter);
 
   if (!res) {
-    sendit(sock, _("No %s resource defined\n"), my_config->ResToStr(type));
+    PoolMem msg;
+    msg.bsprintf(_("No %s resource defined\n"), my_config->ResToStr(type));
+    output_formatter->message(MSG_TYPE_INFO, msg);
     return;
   }
 

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -162,15 +162,15 @@ static ResourceItem dir_items[] = {
 #include "lib/messages_resource_items.h"
 
 static ResourceTable resources[] = {
-  {"Director", dir_items, R_DIRECTOR, sizeof(DirectorResource),
+  {"Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       []() { res_dir = new  DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir)},
-  {"FileDaemon", cli_items, R_CLIENT, sizeof(ClientResource),
+  {"FileDaemon", "FileDaemons", cli_items, R_CLIENT, sizeof(ClientResource),
       []() { res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)},
-  {"Client", cli_items, R_CLIENT, sizeof(ClientResource),
+  {"Client", "Clients", cli_items, R_CLIENT, sizeof(ClientResource),
       []() { res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)}, /* alias for filedaemon */
-  {"Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
+  {"Messages", "Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
       []() { res_msgs = new MessagesResource(); }, reinterpret_cast<BareosResource**>(&res_msgs)},
-  {nullptr, nullptr, 0, 0, nullptr, nullptr}
+  {nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr}
 };
 
 /* clang-format on */

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -55,10 +55,11 @@ class ConfigurationParser;
  * this daemon.
  */
 struct ResourceTable {
-  const char* name;    /* Resource name */
-  ResourceItem* items; /* List of resource keywords */
-  uint32_t rcode;      /* Code if needed */
-  uint32_t size;       /* Size of resource */
+  const char* name;      /* Resource name */
+  const char* groupname; /* Resource name in plural form */
+  ResourceItem* items;   /* List of resource keywords */
+  uint32_t rcode;        /* Code if needed */
+  uint32_t size;         /* Size of resource */
 
   std::function<void()> ResourceSpecificInitializer; /* this allocates memory */
   BareosResource** allocated_resource_;
@@ -299,6 +300,7 @@ class ConfigurationParser {
   void b_LockRes(const char* file, int line) const;
   void b_UnlockRes(const char* file, int line) const;
   const char* ResToStr(int rcode) const;
+  const char* ResGroupToStr(int rcode) const;
   bool StoreResource(int rcode,
                      LEX* lc,
                      ResourceItem* item,

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -140,6 +140,15 @@ const char* ConfigurationParser::ResToStr(int rcode) const
   }
 }
 
+const char* ConfigurationParser::ResGroupToStr(int rcode) const
+{
+  if (rcode < r_first_ || rcode > r_last_) {
+    return _("***UNKNOWN***");
+  } else {
+    return resources_[rcode - r_first_].groupname;
+  }
+}
+
 bool ConfigurationParser::GetTlsPskByFullyQualifiedResourceName(
     ConfigurationParser* config,
     const char* fq_name_in,
@@ -2121,7 +2130,7 @@ bool BareosResource::PrintConfig(OutputFormatterResource& send,
 
   *my_config.resources_[rindex].allocated_resource_ = this;
 
-  send.ResourceTypeStart(my_config.ResToStr(rcode_), internal_);
+  send.ResourceTypeStart(my_config.ResGroupToStr(rcode_), internal_);
   send.ResourceStart(resource_name_);
 
   for (int i = 0; items[i].name; i++) {

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -169,17 +169,17 @@ static ResourceItem con_font_items[] = {
  *  name items rcode res_head
  */
 static ResourceTable resources[] = {
-  {"Monitor", mon_items, R_MONITOR, sizeof(MonitorResource),
+  {"Monitor", "Monitors", mon_items, R_MONITOR, sizeof(MonitorResource),
       []() { res_monitor = new MonitorResource(); }, reinterpret_cast<BareosResource**>(&res_monitor)},
-  {"Director", dir_items, R_DIRECTOR, sizeof(DirectorResource),
+  {"Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       []() { res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir)},
-  {"Client", cli_items, R_CLIENT, sizeof(ClientResource),
+  {"Client", "Clients", cli_items, R_CLIENT, sizeof(ClientResource),
       []() { res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)},
-  {"Storage", store_items, R_STORAGE, sizeof(StorageResource),
+  {"Storage", "Storages", store_items, R_STORAGE, sizeof(StorageResource),
       []() { res_store = new StorageResource(); }, reinterpret_cast<BareosResource**>(&res_store)},
-  {"ConsoleFont", con_font_items, R_CONSOLE_FONT, sizeof(ConsoleFontResource),
+  {"ConsoleFont", "ConsoleFonts", con_font_items, R_CONSOLE_FONT, sizeof(ConsoleFontResource),
       []() { res_font = new ConsoleFontResource(); }, reinterpret_cast<BareosResource**>(&res_font)},
-  {nullptr, nullptr, 0, 0}
+  {nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr}
 };
 
 /* clang-format on */

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -239,19 +239,19 @@ static ResourceItem autochanger_items[] = {
 };
 
 static ResourceTable resources[] = {
-  {"Director", dir_items, R_DIRECTOR, sizeof(DirectorResource),
+  {"Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       []() { res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir)},
-  {"Ndmp", ndmp_items, R_NDMP, sizeof(NdmpResource),
+  {"Ndmp", "Ndmp", ndmp_items, R_NDMP, sizeof(NdmpResource),
       []() { res_ndmp = new NdmpResource(); }, reinterpret_cast<BareosResource**>(&res_ndmp)},
-  {"Storage", store_items, R_STORAGE, sizeof(StorageResource),
+  {"Storage", "Storages", store_items, R_STORAGE, sizeof(StorageResource),
       []() { res_store = new StorageResource(); }, reinterpret_cast<BareosResource**>(&res_store)},
-  {"Device", dev_items, R_DEVICE, sizeof(DeviceResource),
+  {"Device", "Devices", dev_items, R_DEVICE, sizeof(DeviceResource),
       []() { res_dev = new DeviceResource(); }, reinterpret_cast<BareosResource**>(&res_dev)},
-  {"Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
+  {"Messages", "Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
       []() { res_msgs = new MessagesResource(); }, reinterpret_cast<BareosResource**>(&res_msgs)},
-  {"Autochanger", autochanger_items, R_AUTOCHANGER, sizeof(AutochangerResource),
+  {"Autochanger", "Autochangers", autochanger_items, R_AUTOCHANGER, sizeof(AutochangerResource),
       []() { res_changer = new AutochangerResource(); }, reinterpret_cast<BareosResource**>(&res_changer)},
-  {nullptr, nullptr, 0, 0, nullptr, nullptr}};
+  {nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr}};
 
 /* clang-format on */
 


### PR DESCRIPTION
This way, the result of list and show are more similar.
Disadvantage: if only a specific resource if requested, the structure still names the resource in plural.

    *show clients
    {
      "jsonrpc": "2.0",
      "id": null,
      "result": {
        "clients": {
          "bareos1-fd": {
            "name": "bareos1-fd",
            "address": "bareos1.example.com"
          },
          "bareos2-fd": {
            "name": "bareos2-fd",
            "address": "bareos2.example.com"
          }
        }
      }
    }




    *show client=bareos2-fd
    {
      "jsonrpc": "2.0",
      "id": null,
      "result": {
         "clients": {
          "bareos2-fd": {
            "name": "bareos2-fd",
            "address": "bareos2.example.com"
          }
        }
      }
    }