### PR TITLE
libcloud-plugin: fix filenames with non-ascii characters

### DIFF
--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/debug.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/debug.py
@@ -30,4 +30,9 @@ def jobmessage(message_type, message):
 
 def debugmessage(level, message):
     message = "BareosFdPluginLibcloud [%s]: %s\n" % (os.getpid(), message)
-    bareosfd.DebugMessage(level, message)
+    #bareosfd.DebugMessage(level, message)
+    #bareosfd.DebugMessage(level, message.encode("utf-8"))
+    try:
+        bareosfd.DebugMessage(level, message)
+    except UnicodeError:
+        bareosfd.DebugMessage(level, message.encode("utf-8"))

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/process_base.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/process_base.py
@@ -25,7 +25,11 @@ from bareos_libcloud_api.queue_message import ErrorMessage
 from bareos_libcloud_api.queue_message import AbortMessage
 from bareos_libcloud_api.queue_message import DebugMessage
 from bareos_libcloud_api.queue_message import MESSAGE_TYPE
-import Queue as Q
+
+try:
+    import Queue as Q
+except ImportError:
+    import queue as Q
 
 
 class ProcessBase(Process):

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
@@ -23,7 +23,7 @@ from bareos_libcloud_api.get_libcloud_driver import get_driver
 import io
 from libcloud.common.types import LibcloudError
 from libcloud.storage.types import ObjectDoesNotExistError
-from utils import silentremove
+from bareos_libcloud_api.utils import silentremove
 from time import sleep
 import uuid
 

--- a/systemtests/scripts/start_minio.sh
+++ b/systemtests/scripts/start_minio.sh
@@ -32,7 +32,7 @@ while pidof "${MINIO}" > /dev/null; do
 done
 
 export MINIO_DOMAIN=localhost,127.0.0.1
-"${MINIO}" server --address \':$minio_port_number\' "$minio_tmp_data_dir" > "$logdir"/minio.log
+"${MINIO}" server --address :${minio_port_number} "$minio_tmp_data_dir" > "$logdir"/minio.log &
 
 if ! pidof ${MINIO} > /dev/null; then
   echo "$0: could not start minio server"
@@ -40,7 +40,7 @@ if ! pidof ${MINIO} > /dev/null; then
 fi
 
 tries=0
-while ! s3cmd --config=etc/s3cfg-local-minio ls S3:// > /dev/null 2>&1; do
+while ! s3cmd --config=${S3CFG} ls S3:// > /dev/null 2>&1; do
   sleep 0.1
   (( tries++ )) && [ $tries == '20' ] \
     && { echo "$0: could not start minio server"; exit 3; }

--- a/systemtests/tests/py2plug-fd-libcloud/testrunner
+++ b/systemtests/tests/py2plug-fd-libcloud/testrunner
@@ -45,8 +45,17 @@ ${S3} rb --recursive --force s3://$bucket_name || echo "s3://$bucket_name does n
 ${S3} mb s3://$bucket_name
 
 
-# this test does not work with links because of the restore objects
-rm -r "${tmp}"/data/weird-files >/dev/null 2>&1
+# this test does not work with links and some other weird files as they would already
+# have a changed name by syncing to S3 using s3cmd
+find ${tmp}/data/weird-files -type l -exec rm {} \;
+find ${tmp}/data/weird-files -links +1 -type f -exec rm {} \;
+rm ${tmp}/data/weird-files/fifo*
+rm ${tmp}/data/weird-files/newline*
+rm ${tmp}/data/weird-files/tab*
+# s3cmd does not sync empty dirs
+rmdir ${tmp}/data/weird-files/big-X
+rmdir ${tmp}/data/weird-files/subdir
+
 ${S3} sync "$BackupDirectory" s3://$bucket_name
 
 start_test
@@ -56,6 +65,7 @@ cat <<END_OF_DATA >$tmp/bconcmds
 messages
 @$out $tmp/log1.out
 setdebug level=100 storage=File
+setdebug level=100 client=bareos-fd trace=1 timestamp=1
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director
@@ -89,6 +99,6 @@ if ! diff -r tmp/data tmp/bareos-restores/$bucket_name/data; then
   export estat=1
 fi
 
-"${rscripts}"/stop_minio.sh
+"${SYSTEMTESTS_DIR}"/scripts/stop_minio.sh
 
 end_test


### PR DESCRIPTION
Also modified the systemtest to include such filenames.
Additional changes to make the plugin compatible with both
Python 2 and 3, and some minor changes to successfully
run the systemtest.

For enabling the plugin build and systemtest, the following is
required:

- The Python 3 version of the s3cmd tool must be installed, may be
  necessary to use
  pip3 install s3cmd
  instead of OS provided s3cmd package
- Apache Libcloud must be installed, use
  pip2 install apache-libcloud
  or pip3 install apache-libcloud
- minio must be installed, use
  curl -o /usr/local/bin/minio https://dl.min.io/server/minio/release/linux-amd64/minio
  chmod 755 /usr/local/bin/minio