### PR TITLE
python plugins: do not build for solaris

### DIFF
--- a/core/cmake/BareosFindAllLibraries.cmake
+++ b/core/cmake/BareosFindAllLibraries.cmake
@@ -22,39 +22,53 @@ if(${SYSTEMD_FOUND})
   set(HAVE_SYSTEMD 1)
 endif()
 
-if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(HAVE_PYTHON 1)
+  set(Python2_FOUND 1)
+  set(Python2_EXT_SUFFIX ".dll")
+
+  set(Python3_FOUND 1)
+  set(Python3_EXT_SUFFIX ".pyd")
+
+  # Python Plugins currently cannot be built for Solaris
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
+  set(HAVE_PYTHON 0)
+  set(Python2_FOUND 0)
+  set(Python3_FOUND 0)
+
+else()
   if(${CMAKE_VERSION} VERSION_LESS "3.12.0")
     message(STATUS "CMake too old for FindPython2/3, using FindPythonInterp")
     set(Python2_FOUND FALSE)
     set(Python3_FOUND FALSE)
-    set( Python_ADDITIONAL_VERSIONS 2.6 2.7)
+    set(Python_ADDITIONAL_VERSIONS 2.6 2.7)
     find_package(PythonInterp)
     find_package(PythonLibs)
     message(STATUS "Found PYTHON_VERSION_MAJOR" ${PYTHON_VERSION_MAJOR})
-    if (PYTHON_VERSION_MAJOR EQUAL 2)
+    if(PYTHON_VERSION_MAJOR EQUAL 2)
       set(Python2_FOUND ${PYTHONLIBS_FOUND})
       set(Python2_LIBRARIES ${PYTHON_LIBRARIES})
       set(Python2_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
       set(Python2_EXECUTABLE ${PYTHON_EXECUTABLE})
 
-    elseif (PYTHON_VERSION_MAJOR EQUAL 3)
+    elseif(PYTHON_VERSION_MAJOR EQUAL 3)
       set(Python3_FOUND ${PYTHONLIBS_FOUND})
       set(Python3_LIBRARIES ${PYTHON_LIBRARIES})
       set(Python3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
       set(Python3_EXECUTABLE ${PYTHON_EXECUTABLE})
     endif()
 
-    set( Python_ADDITIONAL_VERSIONS 3.6 3.7 3.8 3.9)
+    set(Python_ADDITIONAL_VERSIONS 3.6 3.7 3.8 3.9)
     find_package(PythonInterp)
     find_package(PythonLibs)
     message(STATUS "Found PYTHON_VERSION_MAJOR" ${PYTHON_VERSION_MAJOR})
 
-    if (PYTHON_VERSION_MAJOR EQUAL 2)
+    if(PYTHON_VERSION_MAJOR EQUAL 2)
       set(Python2_FOUND ${PYTHONLIBS_FOUND})
       set(Python2_LIBRARIES ${PYTHON_LIBRARIES})
       set(Python2_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
       set(Python2_EXECUTABLE ${PYTHON_EXECUTABLE})
-    elseif (PYTHON_VERSION_MAJOR EQUAL 3)
+    elseif(PYTHON_VERSION_MAJOR EQUAL 3)
       set(Python3_FOUND ${PYTHONLIBS_FOUND})
       set(Python3_LIBRARIES ${PYTHON_LIBRARIES})
       set(Python3_INCLUDE_DIRS ${PYTHON_INCLUDE_DIRS})
@@ -62,8 +76,8 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     endif()
 
   else()
-    find_package (Python2 COMPONENTS Interpreter Development)
-    find_package (Python3 COMPONENTS Interpreter Development)
+    find_package(Python2 COMPONENTS Interpreter Development)
+    find_package(Python3 COMPONENTS Interpreter Development)
   endif()
 
   if(${Python2_FOUND} OR ${Python3_FOUND})
@@ -71,36 +85,39 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   endif()
 
   if(${Python2_FOUND})
-    set(PYTHON_EXECUTABLE ${Python2_EXECUTABLE} PARENT_SCOPE)
-    set(Python2_EXECUTABLE ${Python2_EXECUTABLE} PARENT_SCOPE)
-      execute_process(
-        COMMAND ${Python2_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_python_compile_settings.py
-        OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake
-     )
-   include(${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake)
+    set(PYTHON_EXECUTABLE
+        ${Python2_EXECUTABLE}
+        PARENT_SCOPE
+    )
+    set(Python2_EXECUTABLE
+        ${Python2_EXECUTABLE}
+        PARENT_SCOPE
+    )
+    execute_process(
+      COMMAND ${Python2_EXECUTABLE}
+              ${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_python_compile_settings.py
+      OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake
+    )
+    include(${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake)
   endif()
 
   if(${Python3_FOUND})
-    set(PYTHON_EXECUTABLE ${Python3_EXECUTABLE} PARENT_SCOPE)
-    set(Python3_EXECUTABLE ${Python3_EXECUTABLE} PARENT_SCOPE)
-      execute_process(
-        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_python_compile_settings.py
-        OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/py3settings.cmake
-     )
-   include(${CMAKE_CURRENT_BINARY_DIR}/py3settings.cmake)
+    set(PYTHON_EXECUTABLE
+        ${Python3_EXECUTABLE}
+        PARENT_SCOPE
+    )
+    set(Python3_EXECUTABLE
+        ${Python3_EXECUTABLE}
+        PARENT_SCOPE
+    )
+    execute_process(
+      COMMAND ${Python3_EXECUTABLE}
+              ${CMAKE_CURRENT_SOURCE_DIR}/cmake/get_python_compile_settings.py
+      OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/py3settings.cmake
+    )
+    include(${CMAKE_CURRENT_BINARY_DIR}/py3settings.cmake)
   endif()
-
-else() # windows
-    set(HAVE_PYTHON 1)
-    set(Python2_FOUND 1)
-    set(Python2_EXT_SUFFIX ".dll")
-
-    set(Python3_FOUND 1)
-    set(Python3_EXT_SUFFIX ".pyd")
 endif()
-
-
-
 
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   include(FindPostgreSQL)
@@ -123,14 +140,18 @@ endif()
 include(BareosFindLibraryAndHeaders)
 
 bareosfindlibraryandheaders(
-  "vixDiskLib" "vixDiskLib.h" "/usr/lib/vmware-vix-disklib-distrib;/usr/lib/vmware-vix-disklib"
+  "vixDiskLib" "vixDiskLib.h"
+  "/usr/lib/vmware-vix-disklib-distrib;/usr/lib/vmware-vix-disklib"
 )
 
 # check for structmember physicalSectorSize in struct VixDiskLibCreateParams
 if(VIXDISKLIB_FOUND)
   include(CheckStructHasMember)
-  CHECK_STRUCT_HAS_MEMBER("VixDiskLibCreateParams" physicalSectorSize
-    ${VIXDISKLIB_INCLUDE_DIRS}/vixDiskLib.h VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE)
+  check_struct_has_member(
+    "VixDiskLibCreateParams" physicalSectorSize
+    ${VIXDISKLIB_INCLUDE_DIRS}/vixDiskLib.h
+    VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
+  )
 endif()
 
 if(VIXDISKLIB_FOUND)
@@ -141,21 +162,23 @@ if(VIXDISKLIB_FOUND)
      OR (NOT DEFINED vmware_folder)
   )
     string(
-      CONCAT
-        MSG
-        "VMware Vix Disklib was found. To enable the vmware plugin test, "
-        "please provide the required information:"
-        "example:"
-        " -Dvmware_user=Administrator@vsphere.local "
-        " -Dvmware_password=\"@one2threeBareos\" "
-        " -Dvmware_vm_name=testvm1 "
-        " -Dvmware_datacenter=mydc1 "
-        " -Dvmware_folder=\"/webservers\" "
-        " -Dvmware_server=139.178.73.195"
+      CONCAT MSG
+             "VMware Vix Disklib was found. To enable the vmware plugin test, "
+             "please provide the required information:"
+             "example:"
+             " -Dvmware_user=Administrator@vsphere.local "
+             " -Dvmware_password=\"@one2threeBareos\" "
+             " -Dvmware_vm_name=testvm1 "
+             " -Dvmware_datacenter=mydc1 "
+             " -Dvmware_folder=\"/webservers\" "
+             " -Dvmware_server=139.178.73.195"
     )
     message(WARNING ${MSG})
   else()
-    set(enable_vmware_test 1 PARENT_SCOPE)
+    set(enable_vmware_test
+        1
+        PARENT_SCOPE
+    )
   endif()
 elseif(
   (DEFINED vmware_server)
@@ -165,7 +188,8 @@ elseif(
   OR (DEFINED vmware_folder)
 )
   message(
-    FATAL_ERROR "vmware options were set but VMware Vix Disklib was not found. Cannot run vmware tests."
+    FATAL_ERROR
+      "vmware options were set but VMware Vix Disklib was not found. Cannot run vmware tests."
   )
 endif()
 


### PR DESCRIPTION
The current way to detect the python build parameter leads to

CC: error: unrecognized command line option '-KPIC'; did you mean '-fPIC'?

Probably that would be solved when using the sunpro compiler, but that
caused other problems.