### PR TITLE
allow terabytes, tebibytes, petabytes,pebibytes, exabytes and exbibytes modifiers when specifying sizes

### DIFF
--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -365,14 +365,22 @@ static bool strunit_to_uint64(char* str, uint64_t* value, const char** mod)
   double val;
   char mod_str[20];
   char num_str[50];
-  static const int64_t mult[] = {
-      1,          /* Byte */
-      1024,       /* kiloByte */
-      1000,       /* KiB KiloByte */
-      1048576,    /* MegaByte */
-      1000000,    /* MiB MegaByte */
-      1073741824, /* GigaByte */
-      1000000000  /* GiB GigaByte */
+  static const uint64_t mult[] = {
+      1,                    // Byte
+      1024,                 // KiB Kibibyte
+      1000,                 // kB Kilobyte
+      1048576,              // MiB Mebibyte
+      1000000,              // MB Megabyte
+      1073741824,           // GiB Gibibyte
+      1000000000,           // GB Gigabyte
+      1099511627776,        // TiB Tebibyte
+      1000000000000,        // TB Terabyte
+      1125899906842624,     // PiB Pebibyte
+      1000000000000000,     // PB Petabyte
+      1152921504606846976,  // EiB Exbibyte
+      1000000000000000000,  // EB Exabyte
+                            // 18446744073709551616 2^64
+
   };
 
   if (!GetModifier(str, num_str, sizeof(num_str), mod_str, sizeof(mod_str))) {
@@ -412,7 +420,8 @@ bool size_to_uint64(char* str, uint64_t* value)
   /*
    * First item * not used
    */
-  static const char* mod[] = {"*", "k", "kb", "m", "mb", "g", "gb", NULL};
+  static const char* mod[] = {"*", "k",  "kb", "m",  "mb", "g",  "gb",
+                              "t", "tb", "p",  "pb", "e",  "eb", NULL};
 
   return strunit_to_uint64(str, value, mod);
 }

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -415,6 +415,44 @@ static bool strunit_to_uint64(char* str, uint64_t* value, const char** mod)
   return true;
 }
 
+// convert uint64 number to size string
+std::string SizeAsSiPrefixFormat(uint64_t value_in)
+{
+  uint64_t value = value_in;
+  int factor;
+  std::string result{};
+  /*
+   * convert default value string to numeric value
+   */
+  static const char* modifier[] = {"e", "p", "t", "g", "m", "k", "", NULL};
+  const uint64_t multiplier[] = {1152921504606846976,  // EiB Exbibyte
+                                 1125899906842624,     // PiB Pebibyte
+                                 1099511627776,        // TiB Tebibyte
+                                 1073741824,           // GiB Gibibyte
+                                 1048576,              // MiB Mebibyte
+                                 1024,                 // KiB Kibibyte
+                                 1};
+
+  if (value == 0) {
+    result += "0";
+  } else {
+    for (int t = 0; modifier[t]; t++) {
+      factor = value / multiplier[t];
+      value = value % multiplier[t];
+      if (factor > 0) {
+        result += std::to_string(factor);
+        result += " ";
+        result += modifier[t];
+        if (!(bstrcmp(modifier[t], ""))) { result += " "; }
+      }
+      if (value == 0) { break; }
+    }
+  }
+  result.pop_back();
+  return result;
+}
+
+
 /*
  * Convert a size in bytes to uint64_t
  * Returns false: if error

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -366,17 +366,22 @@ static bool strunit_to_uint64(char* str, uint64_t* value, const char** mod)
   char mod_str[20];
   char num_str[50];
   static const uint64_t mult[] = {
-      1,                    // Byte
-      1024,                 // KiB Kibibyte
-      1000,                 // kB Kilobyte
-      1048576,              // MiB Mebibyte
-      1000000,              // MB Megabyte
-      1073741824,           // GiB Gibibyte
-      1000000000,           // GB Gigabyte
-      1099511627776,        // TiB Tebibyte
-      1000000000000,        // TB Terabyte
-      1125899906842624,     // PiB Pebibyte
-      1000000000000000,     // PB Petabyte
+      1,     // Byte
+      1024,  // KiB Kibibyte
+      1000,  // kB Kilobyte
+
+      1048576,  // MiB Mebibyte
+      1000000,  // MB Megabyte
+
+      1073741824,  // GiB Gibibyte
+      1000000000,  // GB Gigabyte
+
+      1099511627776,  // TiB Tebibyte
+      1000000000000,  // TB Terabyte
+
+      1125899906842624,  // PiB Pebibyte
+      1000000000000000,  // PB Petabyte
+
       1152921504606846976,  // EiB Exbibyte
       1000000000000000000,  // EB Exabyte
                             // 18446744073709551616 2^64
@@ -420,9 +425,23 @@ bool size_to_uint64(char* str, uint64_t* value)
   /*
    * First item * not used
    */
-  static const char* mod[] = {"*", "k",  "kb", "m",  "mb", "g",  "gb",
-                              "t", "tb", "p",  "pb", "e",  "eb", NULL};
+  // clang-format off
+  static const char* mod[] = {"*",
+                              // kibibyte, kilobyte
+                              "k",  "kb",
+                              // mebibyte, megabyte
+                              "m",  "mb",
+                              // gibibyte, gigabyte
+                              "g",  "gb",
+                              // tebibyte, terabyte
+                              "t",  "tb",
+                              // pebibyte, petabyte
+                              "p",  "pb",
+                              // exbibyte, exabyte
+                              "e",  "eb",
+                              NULL};
 
+  // clang-format on
   return strunit_to_uint64(str, value, mod);
 }
 

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -48,5 +48,6 @@ bool IsNameValid(const char* name);
 bool IsAclEntryValid(const char* acl, std::vector<char>& msg);
 bool IsAclEntryValid(const char* acl);
 bool size_to_uint64(char* str, uint64_t* value);
+std::string SizeAsSiPrefixFormat(uint64_t value_in);
 
 #endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,5 +47,6 @@ bool IsNameValid(const char* name, POOLMEM*& msg);
 bool IsNameValid(const char* name);
 bool IsAclEntryValid(const char* acl, std::vector<char>& msg);
 bool IsAclEntryValid(const char* acl);
+bool size_to_uint64(char* str, uint64_t* value);
 
 #endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -1511,13 +1511,14 @@ std::string PrintNumberSiPrefixFormat(ResourceItem* item, uint64_t value_in)
   /*
    * convert default value string to numeric value
    */
-  static const char* modifier[] = {"g", "m", "k", "", NULL};
-  const uint64_t multiplier[] = {
-      1073741824, /* gibi */
-      1048576,    /* mebi */
-      1024,       /* kibi */
-      1           /* byte */
-  };
+  static const char* modifier[] = {"e", "p", "t", "g", "m", "k", "", NULL};
+  const uint64_t multiplier[] = {1152921504606846976,  // EiB Exbibyte
+                                 1125899906842624,     // PiB Pebibyte
+                                 1099511627776,        // TiB Tebibyte
+                                 1073741824,           // GiB Gibibyte
+                                 1048576,              // MiB Mebibyte
+                                 1024,                 // KiB Kibibyte
+                                 1};
 
   if (value == 0) {
     PmStrcat(volspec, "0");

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -1503,40 +1503,7 @@ void IndentConfigItem(PoolMem& cfg_str,
 
 std::string PrintNumberSiPrefixFormat(ResourceItem* item, uint64_t value_in)
 {
-  PoolMem temp;
-  PoolMem volspec; /* vol specification string*/
-  uint64_t value = value_in;
-  int factor;
-
-  /*
-   * convert default value string to numeric value
-   */
-  static const char* modifier[] = {"e", "p", "t", "g", "m", "k", "", NULL};
-  const uint64_t multiplier[] = {1152921504606846976,  // EiB Exbibyte
-                                 1125899906842624,     // PiB Pebibyte
-                                 1099511627776,        // TiB Tebibyte
-                                 1073741824,           // GiB Gibibyte
-                                 1048576,              // MiB Mebibyte
-                                 1024,                 // KiB Kibibyte
-                                 1};
-
-  if (value == 0) {
-    PmStrcat(volspec, "0");
-  } else {
-    for (int t = 0; modifier[t]; t++) {
-      Dmsg2(200, " %s bytes: %lld\n", item->name, value);
-      factor = value / multiplier[t];
-      value = value % multiplier[t];
-      if (factor > 0) {
-        Mmsg(temp, "%d %s ", factor, modifier[t]);
-        PmStrcat(volspec, temp.c_str());
-        Dmsg1(200, " volspec: %s\n", volspec.c_str());
-      }
-      if (value == 0) { break; }
-    }
-  }
-
-  return std::string(volspec.c_str());
+  return SizeAsSiPrefixFormat(value_in);
 }
 
 std::string Print32BitConfigNumberSiPrefixFormat(ResourceItem* item)

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -417,3 +417,8 @@ if(NOT client-only)
       SKIP_GTEST
   )
 endif() # NOT client-only
+
+bareos_add_test(
+  test_edit LINK_LIBRARIES bareos ${GTEST_LIBRARIES}
+                                    ${GTEST_MAIN_LIBRARIES}
+)

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -28,4 +28,116 @@
 
 #include "lib/edit.h"
 
-TEST(edit, edit) { ASSERT_EQ(str_to_uint64("1 kb"), 1024); }
+// kibibyte
+TEST(edit, k)
+{
+  char str[] = "1 k";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1024);
+}
+
+
+// kilobyte
+TEST(edit, kb)
+{
+  char str[] = "1 kb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000);
+}
+TEST(edit, kB)
+{
+  char str[] = "1 KB";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000);
+}
+
+// mebibyte
+TEST(edit, m)
+{
+  char str[] = "1 m";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1024 * 1024);
+}
+
+// megabyte
+TEST(edit, mb)
+{
+  char str[] = "1 mb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000 * 1000);
+}
+
+
+// gibibyte
+TEST(edit, g)
+{
+  char str[] = "1 g";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1024 * 1024 * 1024);
+}
+// gigabyte
+TEST(edit, gb)
+{
+  char str[] = "1 gb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000 * 1000 * 1000);
+}
+
+
+// tebibyte
+TEST(edit, t)
+{
+  char str[] = "1 t";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1099511627776);
+}
+// terabyte
+TEST(edit, tb)
+{
+  char str[] = "1 tb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000000000000);
+}
+
+// pebibyte
+TEST(edit, p)
+{
+  char str[] = "1 p";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1125899906842624);
+}
+// petabyte
+TEST(edit, pb)
+{
+  char str[] = "1 pb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000000000000000);
+}
+
+// exbibyte
+TEST(edit, e)
+{
+  char str[] = "1 e";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1152921504606846976);
+}
+// exabyte
+TEST(edit, eb)
+{
+  char str[] = "1 eb";
+  uint64_t retvalue = 0;
+  size_to_uint64(str, &retvalue);
+  ASSERT_EQ(retvalue, 1000000000000000000);
+}

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -28,6 +28,23 @@
 
 #include "lib/edit.h"
 
+TEST(edit, format_1k)
+{
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1).c_str(), "1");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1024).c_str(), "1 k");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1048576).c_str(), "1 m");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1073741824).c_str(), "1 g");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1099511627776).c_str(), "1 t");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1125899906842624).c_str(), "1 p");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(1152921504606846976).c_str(), "1 e");
+
+  ASSERT_STREQ(
+      SizeAsSiPrefixFormat(1152921504606846976 + 1125899906842624 +
+                           1099511627776 + 1073741824 + 1048576 + 1024 + 1)
+          .c_str(),
+      "1 e 1 p 1 t 1 g 1 m 1 k 1");
+}
+
 // kibibyte
 TEST(edit, k)
 {

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -28,7 +28,7 @@
 
 #include "lib/edit.h"
 
-TEST(edit, format_1k)
+TEST(edit, convert_number_to_siunits)
 {
   ASSERT_STREQ(SizeAsSiPrefixFormat(1).c_str(), "1");
   ASSERT_STREQ(SizeAsSiPrefixFormat(1024).c_str(), "1 k");
@@ -46,115 +46,116 @@ TEST(edit, format_1k)
 }
 
 // kibibyte
-TEST(edit, k)
+TEST(edit, convert_siunits_to_numbers)
 {
-  char str[] = "1 k";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1024);
-}
+  {
+    char str[] = "1 k";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1024);
+  }
 
 
-// kilobyte
-TEST(edit, kb)
-{
-  char str[] = "1 kb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000);
-}
-TEST(edit, kB)
-{
-  char str[] = "1 KB";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000);
-}
+  // kilobyte
+  {
+    char str[] = "1 kb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000);
+  }
+  {
+    char str[] = "1 KB";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000);
+  }
 
-// mebibyte
-TEST(edit, m)
-{
-  char str[] = "1 m";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1024 * 1024);
-}
+  // mebibyte
+  {
+    char str[] = "1 m";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1024 * 1024);
+  }
 
-// megabyte
-TEST(edit, mb)
-{
-  char str[] = "1 mb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000 * 1000);
-}
+  // megabyte
+  {
+    char str[] = "1 mb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000 * 1000);
+  }
 
 
-// gibibyte
-TEST(edit, g)
-{
-  char str[] = "1 g";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1024 * 1024 * 1024);
-}
-// gigabyte
-TEST(edit, gb)
-{
-  char str[] = "1 gb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000 * 1000 * 1000);
-}
+  // gibibyte
+  {
+    char str[] = "1 g";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1024 * 1024 * 1024);
+  }
+  // gigabyte
+  {
+    char str[] = "1 gb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000 * 1000 * 1000);
+  }
 
 
-// tebibyte
-TEST(edit, t)
-{
-  char str[] = "1 t";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1099511627776);
-}
-// terabyte
-TEST(edit, tb)
-{
-  char str[] = "1 tb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000000000000);
-}
+  // tebibyte
+  {
+    char str[] = "1 t";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1099511627776);
+  }
+  // terabyte
+  {
+    char str[] = "1 tb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000000000000);
+  }
 
-// pebibyte
-TEST(edit, p)
-{
-  char str[] = "1 p";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1125899906842624);
-}
-// petabyte
-TEST(edit, pb)
-{
-  char str[] = "1 pb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000000000000000);
-}
+  // pebibyte
+  {
+    char str[] = "1 p";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1125899906842624);
+  }
+  // petabyte
+  {
+    char str[] = "1 pb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000000000000000);
+  }
 
-// exbibyte
-TEST(edit, e)
-{
-  char str[] = "1 e";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1152921504606846976);
-}
-// exabyte
-TEST(edit, eb)
-{
-  char str[] = "1 eb";
-  uint64_t retvalue = 0;
-  size_to_uint64(str, &retvalue);
-  ASSERT_EQ(retvalue, 1000000000000000000);
+  // exbibyte
+  {
+    char str[] = "1 e";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1152921504606846976);
+  }
+  // exabyte
+  {
+    char str[] = "1 eb";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1000000000000000000);
+  }
+  // size_to_uint64 only checks for first modifier so the following does not
+  // work
+  /*
+    {
+      char str[] = "1 e 1 p 1 t 1 g 1 m 1 k 1";
+      uint64_t retvalue = 0;
+      size_to_uint64(str, &retvalue);
+      ASSERT_EQ(retvalue, 1152921504606846976 + 1125899906842624 + 1099511627776
+    + 1073741824 + 1048576 + 1024 + 1);
+    }
+  */
 }

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -1,0 +1,31 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#if defined(HAVE_MINGW)
+#include "include/bareos.h"
+#include "gtest/gtest.h"
+#else
+#include "gtest/gtest.h"
+#include "include/bareos.h"
+#endif
+
+#include "lib/edit.h"
+
+TEST(edit, edit) { ASSERT_EQ(str_to_uint64("1 kb"), 1024); }

--- a/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
+++ b/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
@@ -713,22 +713,40 @@ size
    A size specified as bytes. Typically, this is a floating point scientific input format followed by an optional modifier. The floating point input is stored as a 64 bit integer value. If a modifier is present, it must immediately follow the value with no intervening spaces. The following modifiers are permitted:
 
    k
-      1,024 (kilobytes)
+      1,024  (kibibytes)
 
    kb
-      1,000 (kilobytes)
+      1,0000 (kilobytes)
 
    m
-      1,048,576 (megabytes)
+      1,048,576 (mebibytes)
 
    mb
       1,000,000 (megabytes)
 
    g
-      1,073,741,824 (gigabytes)
+      1,073,741,824 (gibibytes)
 
    gb
       1,000,000,000 (gigabytes)
+
+   t
+      1,099,511,627,776 (tebibytes)
+
+   tb
+      1,000,000,000,000 (terabytes)
+
+   p
+      1,125,899,906,842,624 (pebibytes)
+
+   pb
+      1,000,000,000,000,000 (petabytes)
+
+   e
+      1,152,921,504,606,846,976 (exbibytes)
+
+   eb
+      1,000,000,000,000,000,000 (exabytes)
 
    Don’t use quotes around the parameter, see :ref:`section-Quotes`.
 


### PR DESCRIPTION
The configuratoin parser now additionally allows the following modifiers:

   **t**   1,099,511,627,776 (tebibytes)

  **tb**  1,000,000,000,000 (terabytes)

   **p**   1,125,899,906,842,624 (pebibytes)

   **pb**   1,000,000,000,000,000 (petabytes)

   **e**   1,152,921,504,606,846,976 (exbibytes)

   **eb**   1,000,000,000,000,000,000 (exabytes)
