### PR TITLE
Fixes newly introduced problems with the show command

### DIFF
--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2134,8 +2134,7 @@ bool FilesetResource::PrintConfig(
 
   Dmsg0(200, "FilesetResource::PrintConfig\n");
 
-  send.ResourceTypeStart("FileSets");
-  send.ResourceStart(this->resource_name_);
+  send.ResourceStart("FileSets", "FileSet", this->resource_name_);
   send.KeyQuotedString("Name", this->resource_name_);
 
   if (this->description_ != NULL) {
@@ -2208,8 +2207,7 @@ bool FilesetResource::PrintConfig(
     send.ArrayEnd("Exclude", inherited, "");
   }
 
-  send.ResourceEnd(this->resource_name_);
-  send.ResourceTypeEnd("FileSet");
+  send.ResourceEnd("FileSets", "FileSet", this->resource_name_);
 
   return true;
 }

--- a/core/src/lib/output_formatter_resource.cc
+++ b/core/src/lib/output_formatter_resource.cc
@@ -82,28 +82,32 @@ std::string OutputFormatterResource::GetKeyFormatString(bool inherited,
   return format;
 }
 
-void OutputFormatterResource::ResourceTypeStart(const char* name,
-                                                bool as_comment)
-{
-  send_->ObjectStart(name, GetKeyFormatString(as_comment, "%s {\n").c_str());
-  indent_level_++;
-}
-
-void OutputFormatterResource::ResourceTypeEnd(const char* name, bool as_comment)
-{
-  indent_level_--;
-  send_->ObjectEnd(name, GetKeyFormatString(as_comment, "}\n\n").c_str());
-}
-
-void OutputFormatterResource::ResourceStart(const char* name)
+void OutputFormatterResource::ResourceStart(const char* resource_type_groupname,
+                                            const char* resource_type_name,
+                                            const char* resource_name,
+                                            bool as_comment)
 {
   const bool case_sensitive_name = true;
-  send_->ObjectStart(name, nullptr, case_sensitive_name);
+  /*
+   * Use resource_type_groupname as structure key (JSON),
+   * but use resource_type_name when writing config resources.
+   */
+  std::string format = std::string(resource_type_name) + std::string(" {\n");
+  send_->ObjectStart(resource_type_groupname,
+                     GetKeyFormatString(as_comment, format).c_str());
+  indent_level_++;
+  send_->ObjectStart(resource_name, nullptr, case_sensitive_name);
 }
 
-void OutputFormatterResource::ResourceEnd(const char* name)
+void OutputFormatterResource::ResourceEnd(const char* resource_type_groupname,
+                                          const char* resource_type_name,
+                                          const char* resource_name,
+                                          bool as_comment)
 {
-  send_->ObjectEnd(name);
+  send_->ObjectEnd(resource_name);
+  indent_level_--;
+  send_->ObjectEnd(resource_type_groupname,
+                   GetKeyFormatString(as_comment, "}\n\n").c_str());
 }
 
 void OutputFormatterResource::SubResourceStart(const char* name,

--- a/core/src/lib/output_formatter_resource.h
+++ b/core/src/lib/output_formatter_resource.h
@@ -64,11 +64,14 @@ class OutputFormatterResource {
   std::string GetKeyFormatString(bool inherited,
                                  std::string baseformat = "%s = ");
 
-  void ResourceTypeStart(const char* name, bool as_comment = false);
-  void ResourceTypeEnd(const char* name, bool as_comment = false);
-
-  void ResourceStart(const char* name);
-  void ResourceEnd(const char* name);
+  void ResourceStart(const char* resource_type_groupname,
+                     const char* resource_type_name,
+                     const char* resource_name,
+                     bool as_comment = false);
+  void ResourceEnd(const char* resource_type_groupname,
+                   const char* resource_type_name,
+                   const char* resource_name,
+                   bool as_comment = false);
 
   void SubResourceStart(const char* name,
                         bool as_comment = false,

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -1671,8 +1671,7 @@ bool MessagesResource::PrintConfig(OutputFormatterResource& send,
 
   msgres = this;
 
-  send.ResourceTypeStart("Messages");
-  send.ResourceStart(resource_name_);
+  send.ResourceStart("Messages", "Messages", resource_name_);
 
   send.KeyQuotedString("Name", resource_name_);
 
@@ -1715,8 +1714,7 @@ bool MessagesResource::PrintConfig(OutputFormatterResource& send,
     }
   }
 
-  send.ResourceEnd(resource_name_);
-  send.ResourceTypeEnd("Messages");
+  send.ResourceEnd("Messages", "Messages", resource_name_);
 
   return true;
 }
@@ -2130,8 +2128,8 @@ bool BareosResource::PrintConfig(OutputFormatterResource& send,
 
   *my_config.resources_[rindex].allocated_resource_ = this;
 
-  send.ResourceTypeStart(my_config.ResGroupToStr(rcode_), internal_);
-  send.ResourceStart(resource_name_);
+  send.ResourceStart(my_config.ResGroupToStr(rcode_),
+                     my_config.ResToStr(rcode_), resource_name_, internal_);
 
   for (int i = 0; items[i].name; i++) {
     bool inherited = BitIsSet(i, inherit_content_);
@@ -2140,8 +2138,8 @@ bool BareosResource::PrintConfig(OutputFormatterResource& send,
                       verbose);
   }
 
-  send.ResourceEnd(resource_name_);
-  send.ResourceTypeEnd(my_config.ResToStr(rcode_), internal_);
+  send.ResourceEnd(my_config.ResGroupToStr(rcode_), my_config.ResToStr(rcode_),
+                   resource_name_, internal_);
 
   return true;
 }

--- a/systemtests/tests/python-bareos/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos/python-bareos-unittest.py
@@ -1499,7 +1499,7 @@ class PythonBareosShowTest(PythonBareosJsonBase):
         fileset_content_list = result["filesets"][0]["filesettext"]
 
         result = director.call("show fileset={}".format(fileset))
-        fileset_show_description = result["fileset"][fileset]["description"]
+        fileset_show_description = result["filesets"][fileset]["description"]
 
         self.assertIn(fileset_show_description, fileset_content_list)
 


### PR DESCRIPTION
This PR fixes a problem introduced by 486f5976a9f2ee9b944c398846c46f653f48bfb8.
The show command have to use the plural form of the resource name in JSON mode, but the original form when in plain text mode.
