### PR TITLE
debian: no mysql/sqlite3 dbconfig-common install

### DIFF
--- a/core/platforms/debian/CMakeLists.txt
+++ b/core/platforms/debian/CMakeLists.txt
@@ -63,23 +63,26 @@ macro(bareos_install_sql_files_to_dbconfig_common)
     DB_CONFIG_COMMON "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN}
   )
 
-  install(
-    DIRECTORY
-    DESTINATION
-      "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbconfig-common/data/bareos-database-common/install/"
-  )
+  if(DB_CONFIG_COMMON_BAREOS_DB_NAME STREQUAL "postgresql")
+    install(
+      DIRECTORY
+      DESTINATION
+        "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbconfig-common/data/bareos-database-common/install/"
+    )
+
+    install(
+      FILES
+        "${CMAKE_SOURCE_DIR}/core/src/cats/ddl/creates/${DB_CONFIG_COMMON_BAREOS_DB_NAME}.sql"
+      DESTINATION
+        "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbconfig-common/data/bareos-database-common/install/"
+      RENAME "${DB_CONFIG_COMMON_DEBIAN_DB_NAME}"
+    )
+  endif()
+
   install(
     DIRECTORY
     DESTINATION
       "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbconfig-common/data/bareos-database-common/upgrade/${DB_CONFIG_COMMON_DEBIAN_DB_NAME}/"
-  )
-
-  install(
-    FILES
-      "${CMAKE_SOURCE_DIR}/core/src/cats/ddl/creates/${DB_CONFIG_COMMON_BAREOS_DB_NAME}.sql"
-    DESTINATION
-      "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbconfig-common/data/bareos-database-common/install/"
-    RENAME "${DB_CONFIG_COMMON_DEBIAN_DB_NAME}"
   )
   file(
     GLOB

--- a/debian/bareos-database-mysql.install.in
+++ b/debian/bareos-database-mysql.install.in
@@ -1,4 +1,3 @@
 @backenddir@/libbareoscats-mysql.so*
 @scriptdir@/ddl/*/mysql*.sql
-/usr/share/dbconfig-common/data/bareos-database-common/install/mysql
 /usr/share/dbconfig-common/data/bareos-database-common/upgrade/mysql/*

--- a/debian/bareos-database-sqlite3.install.in
+++ b/debian/bareos-database-sqlite3.install.in
@@ -1,4 +1,3 @@
 @backenddir@/libbareoscats-sqlite3.so*
 @scriptdir@/ddl/*/sqlite3*.sql
-/usr/share/dbconfig-common/data/bareos-database-common/install/sqlite3
 /usr/share/dbconfig-common/data/bareos-database-common/upgrade/sqlite3/*


### PR DESCRIPTION
This patch removes the dbconfig-common installation scripts for MySQL
and SQlite3.
Upgrades will still work.