### PR TITLE
plugin: use signed conversion for uint64_t

### DIFF
--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -2014,7 +2014,7 @@ static int PyStatPacket_init(PyStatPacket* self, PyObject* args, PyObject* kwds)
   self->blocks = 1;
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwds, "|IKHHIIIKIIIIK", kwlist, &self->dev, &self->ino,
+          args, kwds, "|IKHHIIILIIIIK", kwlist, &self->dev, &self->ino,
           &self->mode, &self->nlink, &self->uid, &self->gid, &self->rdev,
           &self->size, &self->atime, &self->mtime, &self->ctime, &self->blksize,
           &self->blocks)) {


### PR DESCRIPTION
-1 is used as "invalid"-number for the value of the size variable, which is uint64_t. On 32 Bit systems -1 will not be extended to 64 bit if the conversion from Python is unsigned. 

This fix solves the problem of the missing sign extension during Python initialization of a C-Structure. Drawback is that sizes can only have up to 63 Bit positive numbers. 