### PR TITLE
Fix memory corruptions in SD

### DIFF
--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -49,7 +49,7 @@ void generic_tape_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
   file_size = 0;
   int timeout = max_open_wait;
 #if !defined(HAVE_WIN32)
-  struct mtop mt_com;
+  struct mtop mt_com{};
   utime_t start_time = time(NULL);
 #endif
 
@@ -154,7 +154,7 @@ void generic_tape_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
  */
 bool generic_tape_device::eod(DeviceControlRecord* dcr)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   bool ok = true;
   int32_t os_file;
 
@@ -329,7 +329,7 @@ void generic_tape_device::SetAteot()
  */
 bool generic_tape_device::offline()
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
 
   /*
    * Remove EOF/EOT flags.
@@ -367,7 +367,7 @@ bool generic_tape_device::offline()
  */
 bool generic_tape_device::weof(int num)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   int status;
   Dmsg1(129, "=== weof_dev=%s\n", prt_name);
 
@@ -416,7 +416,7 @@ bool generic_tape_device::weof(int num)
 bool generic_tape_device::fsf(int num)
 {
   int32_t os_file = 0;
-  struct mtop mt_com;
+  struct mtop mt_com{};
   int status = 0;
 
   if (!IsOpen()) {
@@ -599,7 +599,7 @@ bool generic_tape_device::fsf(int num)
  */
 bool generic_tape_device::bsf(int num)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   int status;
 
   if (!IsOpen()) {
@@ -646,7 +646,7 @@ static inline bool DevGetOsPos(Device* dev, struct mtget* mt_stat)
  */
 bool generic_tape_device::fsr(int num)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   int status;
 
   if (!IsOpen()) {
@@ -702,7 +702,7 @@ bool generic_tape_device::fsr(int num)
  */
 bool generic_tape_device::bsr(int num)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   int status;
 
   if (!IsOpen()) {
@@ -745,7 +745,7 @@ bool generic_tape_device::bsr(int num)
 bool generic_tape_device::LoadDev()
 {
 #ifdef MTLOAD
-  struct mtop mt_com;
+  struct mtop mt_com{};
 #endif
 
   if (fd_ < 0) {
@@ -783,7 +783,7 @@ bool generic_tape_device::LoadDev()
 void generic_tape_device::LockDoor()
 {
 #ifdef MTLOCK
-  struct mtop mt_com;
+  struct mtop mt_com{};
 
   mt_com.mt_op = MTLOCK;
   mt_com.mt_count = 1;
@@ -794,7 +794,7 @@ void generic_tape_device::LockDoor()
 void generic_tape_device::UnlockDoor()
 {
 #ifdef MTUNLOCK
-  struct mtop mt_com;
+  struct mtop mt_com{};
 
   mt_com.mt_op = MTUNLOCK;
   mt_com.mt_count = 1;
@@ -835,7 +835,7 @@ static inline void OsClrerror(Device* dev)
  */
 static inline void OsClrerror(Device* dev)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
 
   /*
    * Clear any error condition on the tape
@@ -992,7 +992,7 @@ void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)
   }
 
 #if defined(HAVE_LINUX_OS) || defined(HAVE_WIN32)
-  struct mtop mt_com;
+  struct mtop mt_com{};
 
   Dmsg0(100, "In SetOsDeviceParameters\n");
 #if defined(MTSETBLK)
@@ -1022,7 +1022,7 @@ void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)
 #endif
 
 #ifdef HAVE_NETBSD_OS
-  struct mtop mt_com;
+  struct mtop mt_com{};
   if (dev->min_block_size == dev->max_block_size &&
       dev->min_block_size == 0) { /* variable block mode */
     mt_com.mt_op = MTSETBSIZ;
@@ -1041,7 +1041,7 @@ void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)
 #endif
 
 #if HAVE_FREEBSD_OS || HAVE_OPENBSD_OS
-  struct mtop mt_com;
+  struct mtop mt_com{};
   if (dev->min_block_size == dev->max_block_size &&
       dev->min_block_size == 0) { /* variable block mode */
     mt_com.mt_op = MTSETBSIZ;
@@ -1069,7 +1069,7 @@ void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)
 #endif
 
 #ifdef HAVE_SUN_OS
-  struct mtop mt_com;
+  struct mtop mt_com{};
   if (dev->min_block_size == dev->max_block_size &&
       dev->min_block_size == 0) { /* variable block mode */
     mt_com.mt_op = MTSRSZ;
@@ -1104,7 +1104,7 @@ int32_t generic_tape_device::GetOsTapeFile()
  */
 bool generic_tape_device::rewind(DeviceControlRecord* dcr)
 {
-  struct mtop mt_com;
+  struct mtop mt_com{};
   unsigned int i;
   bool first = true;
 

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -313,18 +313,17 @@ bail_out:
 static bool WriteVolumeLabelToBlock(DeviceControlRecord* dcr)
 {
   Device* dev = dcr->dev;
-  DeviceBlock* block = dcr->block;
   DeviceRecord rec;
   JobControlRecord* jcr = dcr->jcr;
 
   Dmsg0(130, "write Label in WriteVolumeLabelToBlock()\n");
 
   rec.data = GetMemory(SER_LENGTH_Volume_Label);
-  EmptyBlock(block); /* Volume label always at beginning */
+  EmptyBlock(dcr->block); /* Volume label always at beginning */
 
   CreateVolumeLabelRecord(dcr, dev, &rec);
 
-  block->BlockNumber = 0;
+  dcr->block->BlockNumber = 0;
   if (!WriteRecordToBlock(dcr, &rec)) {
     FreePoolMemory(rec.data);
     Jmsg1(jcr, M_FATAL, 0,
@@ -356,7 +355,6 @@ bool WriteNewVolumeLabelToDev(DeviceControlRecord* dcr,
   DeviceRecord* rec;
   JobControlRecord* jcr = dcr->jcr;
   Device* dev = dcr->dev;
-  DeviceBlock* block = dcr->block;
 
   /*
    * Set the default blocksize to read the label
@@ -403,7 +401,7 @@ bool WriteNewVolumeLabelToDev(DeviceControlRecord* dcr,
     goto bail_out;
   }
 
-  EmptyBlock(block);
+  EmptyBlock(dcr->block);
   if (!dev->rewind(dcr)) {
     Dmsg2(130, "Bad status on %s from rewind: ERR=%s\n", dev->print_name(),
           dev->print_errmsg());


### PR DESCRIPTION
When a device in the SD is configured with custom Maximum Block Size, autolabeling may cause a memory corruption. When writing to a volume with a larger blocksize than the label blocksize and then autolabels a new volume, `WriteNewVolumeLabel()` would call `EmptyBlock()` with an invalid pointer leading to heap corruption.
While pinpointing this problem, valgrind also flagged the use of uninitialized `struct mtop` in generic_tape_device. While this was probably not a real issue, the struct mtop is now always initialized, so valgrind does not complain anymore.
