### PR TITLE
droplet: rename library to libbareosdroplet.so

### DIFF
--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1314,7 +1314,7 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-chunked*.so
 %{backend_dir}/libbareossd-droplet*.so
-%{library_dir}/libdroplet*.so
+%{library_dir}/libbareosdroplet.so*
 %attr(0640, %{director_daemon_user},%{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/S3_Object.conf.example
 %attr(0640, %{storage_daemon_user},%{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/S3_ObjectStorage.conf.example
 %dir %{_sysconfdir}/%{name}/bareos-sd.d/device/droplet/

--- a/core/src/CMakeLists.txt
+++ b/core/src/CMakeLists.txt
@@ -31,6 +31,13 @@ if(NOT client-only)
       )
     endif()
     add_subdirectory(droplet)
+    if(TARGET droplet)
+      set_target_properties(
+        droplet PROPERTIES VERSION "${BAREOS_NUMERIC_VERSION}"
+                           SOVERSION "${BAREOS_VERSION_MAJOR}"
+                           PREFIX "libbareos"
+      )
+    endif()
   endif()
   add_subdirectory(tools)
   add_subdirectory(cats)


### PR DESCRIPTION
This patch renames the contained libdroplet.so to libbareosdroplet.so,
so packages do not accidentially provide a 3rd party usable libdroplet.
