### PR TITLE
Fix LSN reading for incremental backups of MySQL 8.0 servers

### DIFF
--- a/core/src/plugins/filed/python/percona-xtrabackup/BareosFdPluginPerconaXtraBackup.py
+++ b/core/src/plugins/filed/python/percona-xtrabackup/BareosFdPluginPerconaXtraBackup.py
@@ -235,7 +235,7 @@ class BareosFdPercona(BareosFdPluginBaseclass):
             # use old method as fallback, if module MySQLdb not available
             else:
                 get_lsn_command = (
-                    "echo 'SHOW ENGINE INNODB STATUS' | %s | grep 'Log sequence number' | cut -d ' ' -f 4"
+                    "echo 'SHOW ENGINE INNODB STATUS' | %s | grep 'Log sequence number' | awk '{ print $4 }'"
                     % self.mysqlcmd
                 )
                 last_lsn_proc = Popen(


### PR DESCRIPTION
This will fix the following error message, that occurs when trying to start an incremental backup of a MySQL 8.0 server

```
Fatal error: python-fd: Error reading LSN: "
" not an integer
```