### PR TITLE
pkglist: remove libdroplet references

### DIFF
--- a/docs/pkglists/CentOS_7.x86_64
+++ b/docs/pkglists/CentOS_7.x86_64
@@ -1,10 +1,8 @@
 debug/x86_64/bareos-debuginfo
-debug/x86_64/libdroplet-debuginfo
 noarch/python3-bareos
 noarch/python-bareos
 src/bareos
 src/bareos-vmware-vix-disklib
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -40,5 +38,3 @@ x86_64/bareos-vmware-plugin
 x86_64/bareos-vmware-plugin-compat
 x86_64/bareos-vmware-vix-disklib
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/Fedora_29.x86_64
+++ b/docs/pkglists/Fedora_29.x86_64
@@ -21,12 +21,9 @@ debug/x86_64/bareos-storage-python-plugin-debuginfo
 debug/x86_64/bareos-storage-tape-debuginfo
 debug/x86_64/bareos-tools-debuginfo
 debug/x86_64/bareos-traymonitor-debuginfo
-debug/x86_64/libdroplet-debuginfo
-debug/x86_64/libdroplet-debugsource
 noarch/python3-bareos
 noarch/python-bareos
 src/bareos
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -58,5 +55,3 @@ x86_64/bareos-storage-tape
 x86_64/bareos-tools
 x86_64/bareos-traymonitor
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/Fedora_30.x86_64
+++ b/docs/pkglists/Fedora_30.x86_64
@@ -21,12 +21,9 @@ debug/x86_64/bareos-storage-python-plugin-debuginfo
 debug/x86_64/bareos-storage-tape-debuginfo
 debug/x86_64/bareos-tools-debuginfo
 debug/x86_64/bareos-traymonitor-debuginfo
-debug/x86_64/libdroplet-debuginfo
-debug/x86_64/libdroplet-debugsource
 noarch/python-bareos
 noarch/python3-bareos
 src/bareos
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -58,5 +55,3 @@ x86_64/bareos-storage-tape
 x86_64/bareos-tools
 x86_64/bareos-traymonitor
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/Fedora_31.x86_64
+++ b/docs/pkglists/Fedora_31.x86_64
@@ -21,12 +21,9 @@ debug/x86_64/bareos-storage-python-plugin-debuginfo
 debug/x86_64/bareos-storage-tape-debuginfo
 debug/x86_64/bareos-tools-debuginfo
 debug/x86_64/bareos-traymonitor-debuginfo
-debug/x86_64/libdroplet-debuginfo
-debug/x86_64/libdroplet-debugsource
 noarch/python-bareos
 noarch/python3-bareos
 src/bareos
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -58,5 +55,3 @@ x86_64/bareos-storage-tape
 x86_64/bareos-tools
 x86_64/bareos-traymonitor
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/Fedora_32.x86_64
+++ b/docs/pkglists/Fedora_32.x86_64
@@ -21,12 +21,9 @@ debug/x86_64/bareos-storage-python-plugin-debuginfo
 debug/x86_64/bareos-storage-tape-debuginfo
 debug/x86_64/bareos-tools-debuginfo
 debug/x86_64/bareos-traymonitor-debuginfo
-debug/x86_64/libdroplet-debuginfo
-debug/x86_64/libdroplet-debugsource
 noarch/python-bareos
 noarch/python3-bareos
 src/bareos
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -58,5 +55,3 @@ x86_64/bareos-storage-tape
 x86_64/bareos-tools
 x86_64/bareos-traymonitor
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/RHEL_7.x86_64
+++ b/docs/pkglists/RHEL_7.x86_64
@@ -1,10 +1,8 @@
 debug/x86_64/bareos-debuginfo
-debug/x86_64/libdroplet-debuginfo
 noarch/python3-bareos
 noarch/python-bareos
 src/bareos
 src/bareos-vmware-vix-disklib
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -42,5 +40,3 @@ x86_64/bareos-vmware-plugin
 x86_64/bareos-vmware-plugin-compat
 x86_64/bareos-vmware-vix-disklib
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel

--- a/docs/pkglists/SLE_12_SP4.x86_64
+++ b/docs/pkglists/SLE_12_SP4.x86_64
@@ -23,7 +23,6 @@ debug/x86_64/bareos-traymonitor-debuginfo
 noarch/python2-bareos
 noarch/python3-bareos
 src/bareos
-src/libdroplet
 src/python-bareos
 x86_64/bareos
 x86_64/bareos-bconsole
@@ -55,5 +54,3 @@ x86_64/bareos-storage-tape
 x86_64/bareos-tools
 x86_64/bareos-traymonitor
 x86_64/bareos-webui
-x86_64/libdroplet
-x86_64/libdroplet-devel


### PR DESCRIPTION
since we now include libdroplet in the bareos-storage-droplet package,
there is no need for separate libdroplet packages anymore.
