### PR TITLE
tests: run systemtests during build and exclude broken tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ debian/bareos-database-sqlite3.install
 debian/bareos-database-tools.install
 debian/bareos-devel.install
 debian/bareos-director-python-plugin.install
+debian/bareos-director-python-plugins-common.install
+debian/bareos-director-python2-plugin.install
+debian/bareos-director-python3-plugin.install
 debian/bareos-director.bareos-dir.init
 debian/bareos-director.install
 debian/bareos-director.postinst
@@ -52,6 +55,9 @@ debian/bareos-filedaemon-ldap-python-plugin.install
 debian/bareos-filedaemon-libcloud-python-plugin.install
 debian/bareos-filedaemon-percona-xtrabackup-python-plugin.install
 debian/bareos-filedaemon-python-plugin.install
+debian/bareos-filedaemon-python-plugins-common.install
+debian/bareos-filedaemon-python2-plugin.install
+debian/bareos-filedaemon-python3-plugin.install
 debian/bareos-filedaemon.bareos-fd.init
 debian/bareos-filedaemon.install
 debian/bareos-filedaemon.postinst
@@ -63,6 +69,9 @@ debian/bareos-storage-ceph.install
 debian/bareos-storage-fifo.install
 debian/bareos-storage-glusterfs.install
 debian/bareos-storage-python-plugin.install
+debian/bareos-storage-python-plugins-common.install
+debian/bareos-storage-python2-plugin.install
+debian/bareos-storage-python3-plugin.install
 debian/bareos-storage-tape.install
 debian/bareos-storage.bareos-sd.init
 debian/bareos-storage.install
@@ -77,6 +86,9 @@ debian/univention-bareos.postinst
 # generated sample-configuration
 core/src/plugins/filed/python/ldap/python-ldap-conf.d/bareos-dir.d/fileset/plugin-ldap.conf.example
 core/src/plugins/filed/python/ovirt/python-ovirt-conf.d/bareos-dir.d/fileset/plugin-ovirt.conf.example
+
+# generated test configuration
+core/src/tests/configs/bareos-configparser-tests/bareos-dir-CFG_TYPE_STR_VECTOR_OF_DIRS.conf
 
 # etags and cscope db
 tags

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -139,6 +139,6 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 post-build:
-	cd ${STAGEDIR} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+	cd ${WRKSRC}/core  && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -139,8 +139,6 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 post-build:
-	find  . -name DartConfiguration.tcl
-	exit 1
-	cd ${WRKSRC}/core  && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+	cd work/.build  && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -80,7 +80,7 @@ LIB_DEPENDS+= libpython3.7m.so:lang/python37
 
 #GNU_CONFIGURE=	yes
 CMAKE_VERBOSE = yes
-CMAKE_SOURCE_PATH=   ${WRKSRC}/core
+CMAKE_SOURCE_PATH=   ${WRKSRC}
 CMAKE_ARGS+= -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
       -DCMAKE_INSTALL_LIBDIR:PATH=/usr/local/lib \
@@ -139,6 +139,6 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 post-build:
-	cd work/.build  && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+	cd ${CONFIGURE_WRKSRC} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -138,7 +138,7 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/log/bareos
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
-post-build:
-	cd ${CONFIGURE_WRKSRC} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+#post-build:
+#	cd ${CONFIGURE_WRKSRC} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -138,7 +138,4 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/log/bareos
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
-#post-build:
-#	cd ${CONFIGURE_WRKSRC} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
-
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -139,6 +139,8 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 post-build:
+	find  . -name DartConfiguration.tcl
+	exit 1
 	cd ${WRKSRC}/core  && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -138,4 +138,7 @@ post-install:
 	@${MKDIR} ${STAGEDIR}/var/log/bareos
 	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
+post-build:
+	cd ${STAGEDIR} && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+
 .include <bsd.port.mk>

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1071,7 +1071,7 @@ pushd %{CMAKE_BUILDDIR}
 make clean
 
 # run the tests and fail build if test fails
-REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output -j 10 --repeat until-pass:2 -D Experimental || echo "ctest result:$?"
+REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continous
 
 %install
 ##if 0#{?suse_version}

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1069,16 +1069,9 @@ cmake  .. \
 # run unit tests
 pushd %{CMAKE_BUILDDIR}
 make clean
-REGRESS_DEBUG=1 ctest -j 10 -V -D Continuous || result=$?
-result=$?
-if [ $result -eq 1 ]; then
-  echo "ctest result $result is expected and OK"
-  exit 0
-else
-  echo "ctest result $result is not 1, ERROR"
-fi
 
-
+# run the tests and fail build if test fails
+REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output -j 10 --repeat until-pass:2 -D Experimental || echo "ctest result:$?"
 
 %install
 ##if 0#{?suse_version}

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1071,7 +1071,7 @@ pushd %{CMAKE_BUILDDIR}
 make clean
 
 # run the tests and fail build if test fails
-REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+REGRESS_DEBUG=1 ctest --label-exclude broken --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 %install
 ##if 0#{?suse_version}

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1071,7 +1071,7 @@ pushd %{CMAKE_BUILDDIR}
 make clean
 
 # run the tests and fail build if test fails
-REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous
+REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
 
 %install
 ##if 0#{?suse_version}

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1071,7 +1071,7 @@ pushd %{CMAKE_BUILDDIR}
 make clean
 
 # run the tests and fail build if test fails
-REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continous
+REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output --parallel 10 --repeat until-pass:2 --dashboard Continuous
 
 %install
 ##if 0#{?suse_version}

--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -513,14 +513,6 @@ int DeletePidFile(char* dir, const char* progname, int port)
   return 1;
 }
 
-struct StateFileHeader {
-  char id[14];
-  int32_t version;
-  uint64_t last_jobs_addr;
-  uint64_t end_of_recent_job_results_list;
-  uint64_t reserved[19];
-};
-
 static struct StateFileHeader state_hdr = {{"Bareos State\n"}, 4, 0, 0, {0}};
 
 static bool CheckHeader(const StateFileHeader& hdr)

--- a/core/src/lib/bsys.h
+++ b/core/src/lib/bsys.h
@@ -65,4 +65,12 @@ bool PathAppend(PoolMem& path, PoolMem& extra);
 bool PathCreate(const char* path, mode_t mode = 0750);
 bool PathCreate(PoolMem& path, mode_t mode = 0750);
 
+struct StateFileHeader {
+  char id[14];
+  int32_t version;
+  uint64_t last_jobs_addr;
+  uint64_t end_of_recent_job_results_list;
+  uint64_t reserved[19];
+};
+
 #endif  // BAREOS_LIB_BSYS_H_

--- a/core/src/lib/bsys.h
+++ b/core/src/lib/bsys.h
@@ -73,4 +73,16 @@ struct StateFileHeader {
   uint64_t reserved[19];
 };
 
+static_assert(offsetof(StateFileHeader, version) == 16,
+              "StateFileHeader.version offset");
+static_assert(offsetof(StateFileHeader, last_jobs_addr) == 20 ||
+                  offsetof(StateFileHeader, last_jobs_addr) == 24,
+              "StageFileHeader.last_jobs_addr offset");
+static_assert(offsetof(StateFileHeader, end_of_recent_job_results_list) == 28 ||
+                  offsetof(StateFileHeader, end_of_recent_job_results_list) ==
+                      32,
+              "StateFileHeader.end_of_recent_job_results_list offset");
+static_assert(offsetof(StateFileHeader, reserved) == 36 ||
+                  offsetof(StateFileHeader, reserved) == 40,
+              "StateFileHeader.reserved offset");
 #endif  // BAREOS_LIB_BSYS_H_

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -124,6 +124,7 @@ if(Python2_FOUND)
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../../lib
   )
+  set_tests_properties(bareosfd-python2-module PROPERTIES LABELS "broken")
 endif()
 
 if(Python3_FOUND)

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ macro(bareos_gtest_add_tests testname)
     TEST_PREFIX gtest:
     TEST_LIST found_tests
   )
+  set_tests_properties(${found_tests} PROPERTIES TIMEOUT 120)
   if(HAVE_WIN32)
     set_tests_properties(
       ${found_tests} PROPERTIES ENVIRONMENT "WINEPATH=${WINEPATH}"
@@ -160,8 +161,8 @@ endif() # NOT client-only
 if(NOT client-only)
   bareos_add_test(
     scheduler_job_item_queue
-    LINK_LIBRARIES dird_objects bareos bareosfind bareoscats bareossql ${GTEST_LIBRARIES}
-                   ${GTEST_MAIN_LIBRARIES}
+    LINK_LIBRARIES dird_objects bareos bareosfind bareoscats bareossql
+                   ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}
   )
 endif() # NOT client-only
 
@@ -172,18 +173,10 @@ bareos_add_test(
 
 if(NOT client-only)
   bareos_add_test(
-    test_db_list_ctx
-    LINK_LIBRARIES
-      #dird_objects
-      bareos
-      #bareosfind
-      bareoscats
-      bareossql
-      ${GTEST_LIBRARIES}
-      ${GTEST_MAIN_LIBRARIES}
+    test_db_list_ctx LINK_LIBRARIES bareos bareoscats bareossql
+                                    ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}
   )
 endif()
-
 
 if(NOT client-only)
   bareos_add_test(
@@ -252,6 +245,14 @@ bareos_add_test(
   LINK_LIBRARIES bareos ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}
   COMPILE_DEFINITIONS TEST_TEMP_DIR=\"${TEST_TEMP_DIR}\"
                       TEST_ORIGINAL_FILE_DIR=\"${TEST_ORIGINAL_FILE_DIR}\"
+)
+set_tests_properties(
+  gtest:recent_job_results_list.read_job_results_from_file PROPERTIES LABELS
+                                                                      "broken"
+)
+set_tests_properties(
+  gtest:recent_job_results_list.write_job_results_to_file PROPERTIES LABELS
+                                                                     "broken"
 )
 
 if(NOT client-only)
@@ -355,7 +356,7 @@ if(NOT client-only)
       ${LMDB_LIBS}
       ${GTEST_LIBRARIES}
       ${GTEST_MAIN_LIBRARIES}
-      SKIP_GTEST
+    SKIP_GTEST
   )
 endif()
 
@@ -429,11 +430,10 @@ if(NOT client-only)
       ${LMDB_LIBS}
       ${GTEST_LIBRARIES}
       ${GTEST_MAIN_LIBRARIES}
-      SKIP_GTEST
+    SKIP_GTEST
   )
 endif() # NOT client-only
 
 bareos_add_test(
-  test_edit LINK_LIBRARIES bareos ${GTEST_LIBRARIES}
-                                    ${GTEST_MAIN_LIBRARIES}
+  test_edit LINK_LIBRARIES bareos ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}
 )

--- a/core/src/tests/recent_job_results_list.cc
+++ b/core/src/tests/recent_job_results_list.cc
@@ -32,7 +32,40 @@
 #include <iostream>
 #include <fstream>
 
-static auto Is32BitWordsize = []() { return sizeof(void*) == 4; };
+static inline bool Is32BitWordsize()
+{
+#if defined HAVE_WIN32 and defined HAVE_MINGW
+  return false;  // wincross always 64Bit
+#else
+  return sizeof(void*) == 4;
+#endif
+};
+
+TEST(recent_job_results_list, check_header_padding_bytes)
+{
+  std::string detected;
+
+  if (Is32BitWordsize()) {
+    detected = "32Bit wordsize";
+    EXPECT_EQ(offsetof(StateFileHeader, version), 16);
+    EXPECT_EQ(offsetof(StateFileHeader, last_jobs_addr), 20);
+    EXPECT_EQ(offsetof(StateFileHeader, end_of_recent_job_results_list), 28);
+    EXPECT_EQ(offsetof(StateFileHeader, reserved), 36);
+  } else {
+    detected = "64Bit wordsize";
+    EXPECT_EQ(offsetof(StateFileHeader, version), 16);
+    EXPECT_EQ(offsetof(StateFileHeader, last_jobs_addr), 24);
+    EXPECT_EQ(offsetof(StateFileHeader, end_of_recent_job_results_list), 32);
+    EXPECT_EQ(offsetof(StateFileHeader, reserved), 40);
+  }
+
+#if HAVE_WIN32
+  detected += ", Windows";
+#endif
+  detected += " detected";
+
+  std::cout << " <<< " << detected << " >>> " << std::endl;
+}
 
 TEST(recent_job_results_list, read_job_results_from_file)
 {
@@ -41,7 +74,7 @@ TEST(recent_job_results_list, read_job_results_from_file)
 
   char orig_path[]{TEST_ORIGINAL_FILE_DIR};
 
-  const char *fname = Is32BitWordsize() ? "bareos-dir-32bit" : "bareos-dir";
+  const char* fname = Is32BitWordsize() ? "bareos-dir-32bit" : "bareos-dir";
 
   ReadStateFile(orig_path, fname, 42001);
 
@@ -62,7 +95,7 @@ TEST(recent_job_results_list, write_job_results_to_file)
   OSDependentInit();
   RecentJobResultsList::Cleanup();
 
-  const char *fname = Is32BitWordsize() ? "bareos-dir-32bit" : "bareos-dir";
+  const char* fname = Is32BitWordsize() ? "bareos-dir-32bit" : "bareos-dir";
 
   char orig_path[]{TEST_ORIGINAL_FILE_DIR};
   ReadStateFile(orig_path, fname, 42001);
@@ -123,9 +156,8 @@ TEST(recent_job_results_list, read_job_results_from_file_truncated_jobs)
 
   char orig_path[]{TEST_ORIGINAL_FILE_DIR};
 
-  const char *fname = Is32BitWordsize()
-                      ? "bareos-dir-truncated-jobs-32bit"
-                      : "bareos-dir-truncated-jobs";
+  const char* fname = Is32BitWordsize() ? "bareos-dir-truncated-jobs-32bit"
+                                        : "bareos-dir-truncated-jobs";
 
   ASSERT_TRUE(create_file(orig_path, std::string(fname) + ".42001.state"));
   ReadStateFile(orig_path, fname, 42001);

--- a/debian/rules
+++ b/debian/rules
@@ -133,7 +133,7 @@ override_dh_auto_test:
 # see https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options
 # No tabs allowed before ifeq.
 ifneq (nocheck,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest -j 10 -V -D Continuous || echo "ctest failed"
+	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output -j 10 --repeat until-pass:2 -D Experimental || echo "ctest result:$?"; cp -av Testing ../../../BUILD_RESULTS/*
 else
 	@echo "ctest: skipped"
 endif

--- a/debian/rules
+++ b/debian/rules
@@ -133,7 +133,7 @@ override_dh_auto_test:
 # see https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options
 # No tabs allowed before ifeq.
 ifneq (nocheck,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest --label-exclude broken --no-compress-output -j 10 --repeat until-pass:2 -D Experimental || echo "ctest result:$?"; cp -av Testing ../../../BUILD_RESULTS/*
+	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest --label-exclude broken --parallel 10 --repeat until-pass:2 -D Continuous || echo "ctest result:$?"
 else
 	@echo "ctest: skipped"
 endif

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -22,6 +22,7 @@ cmake_minimum_required(VERSION 3.3)
 project(bareos-systemtests)
 cmake_policy(SET CMP0057 NEW) # IF(.. IN_LIST ..)
 cmake_policy(SET CMP0053 NEW)
+cmake_policy(SET CMP0064 NEW) # IF(TEST ...)
 
 # create a variable BINARY_NAME_TO_TEST for each binary name bareos-dir ->
 # BAREOS_DIR_TO_TEST bconsole -> BCONSOLE_TO_TEST
@@ -575,6 +576,14 @@ set(SYSTEM_TESTS
 set(SYSTEM_TESTS_DISABLED # initially empty
 )
 
+# add tests also here that fail during build they will be run but failing will
+# not fail the build
+set(SYSTEM_TESTS_BROKEN
+    config-dump dbcopy-mysql-postgresql py2plug-fd-postgres
+    py3plug-fd-local-fileset py3plug-fd-postgres python-bareos scheduler-backup
+    volume-pruning
+)
+
 set(glusterfs_uri
     ""
     CACHE STRING "URI for GlusterFS backend test"
@@ -597,7 +606,8 @@ endif()
 
 if(TARGET droplet
    AND S3CMD
-   AND MINIO)
+   AND MINIO
+)
   list(APPEND SYSTEM_TESTS droplet-s3)
 else()
   list(APPEND SYSTEM_TESTS_DISABLED droplet-s3)
@@ -618,22 +628,12 @@ else()
   list(APPEND SYSTEM_TESTS_DISABLED "dbcopy-mysql-postgresql")
 endif()
 
-# python-bareos fails inside of container
-if(EXISTS /run/.containerenv)
-  message(STATUS "detected container environment, disabling python-bareos")
-  set(in_container TRUE)
-  list(APPEND SYSTEM_TESTS "dbcopy-mysql-postgresql-test")
-else()
-  set(in_container FALSE)
-endif()
-
 find_program(PYTHON NAMES python python3 python2)
 
 # python-bareos-test does not work on installed files
 if(PYTHON_EXECUTABLE
    AND PYTHON
    AND NOT RUN_SYSTEMTESTS_ON_INSTALLED_FILES
-   AND NOT in_container
 )
   list(APPEND SYSTEM_TESTS "python-bareos")
 else()
@@ -935,6 +935,7 @@ else()
 endif()
 
 foreach(TEST_NAME ${SYSTEM_TESTS})
+
   message(STATUS "Configuring test: ${SYSTEMTEST_PREFIX}${TEST_NAME}")
   string(REGEX MATCH "py2plug" py_v2 "${TEST_NAME}")
   string(REGEX MATCH "py3plug" py_v3 "${TEST_NAME}")
@@ -973,8 +974,13 @@ foreach(TEST_NAME ${SYSTEM_TESTS})
     COMMAND ${tests_dir}/${TEST_NAME}/testrunner
     WORKING_DIRECTORY ${tests_dir}/${TEST_NAME}
   )
+  if(${TEST_NAME} IN_LIST SYSTEM_TESTS_BROKEN)
+    set_tests_properties(
+      ${SYSTEMTEST_PREFIX}${TEST_NAME} PROPERTIES LABELS "broken"
+    )
+  endif()
 
-  set_tests_properties(${SYSTEMTEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT 180)
+  set_tests_properties(${SYSTEMTEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT 300)
   math(EXPR BASEPORT "${BASEPORT} + 10")
 
 endforeach()
@@ -1035,7 +1041,7 @@ if(ENABLE_WEBUI_SELENIUM_TEST)
       WORKING_DIRECTORY ${tests_dir}/${TEST_NAME}
     )
     set_tests_properties(
-      ${WEBUI_TEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT 180
+      ${WEBUI_TEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT 300
     )
     math(EXPR BASEPORT "${BASEPORT} + 10")
   endforeach()

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -558,7 +558,6 @@ set(SYSTEM_TESTS
     copy-remote-bscan
     deprecation
     list-backups
-    messages
     multiplied-device
     reload-add-client
     reload-add-duplicate-job
@@ -595,6 +594,12 @@ if(SETFATTR_WORKS)
   list(APPEND SYSTEM_TESTS xattr)
 else()
   list(APPEND SYSTEM_TESTS_DISABLED xattr)
+endif()
+
+if(TARGET (messages_resource))
+  list(APPEND SYSTEM_TESTS messages)
+else()
+  list(APPEND SYSTEM_TESTS_DISABLED messages)
 endif()
 
 include(BareosCheckAcl)

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -588,7 +588,7 @@ set(SYSTEM_TESTS_BROKEN
     volume-pruning
     # the next two fail on FreeBSD 11.4
     filesets
-    py3plug-fd-localfileset-restoreobject
+    py3plug-fd-local-fileset-restoreobject
 )
 
 set(glusterfs_uri

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -575,12 +575,20 @@ set(SYSTEM_TESTS
 set(SYSTEM_TESTS_DISABLED # initially empty
 )
 
-# add tests also here that fail during build they will be run but failing will
-# not fail the build
+# add tests also here that are unreliable they are excluded when running tests
+# during build in jenkins
 set(SYSTEM_TESTS_BROKEN
-    config-dump dbcopy-mysql-postgresql py2plug-fd-postgres
-    py3plug-fd-local-fileset py3plug-fd-postgres python-bareos scheduler-backup
+    config-dump
+    dbcopy-mysql-postgresql
+    py2plug-fd-postgres
+    py3plug-fd-local-fileset
+    py3plug-fd-postgres
+    python-bareos
+    scheduler-backup
     volume-pruning
+    # the next two fail on FreeBSD 11.4
+    filesets
+    py3plug-fd-localfileset-restoreobject
 )
 
 set(glusterfs_uri

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -630,7 +630,14 @@ check_restore_diff()
    if "$rscripts/diff.pl" -s "${dest}" -d "${tmp}/bareos-restores/${dest}"; then
        result=$?
    fi
-   OUT="$(diff --no-dereference -ur --exclude="fifo*" "${dest}" "${tmp}/bareos-restores/${dest}")"
+
+   # gnu diff is required
+   if [ "$(uname -s)" == FreeBSD ]; then
+     DIFFTOOL='gdiff'
+   else
+     DIFFTOOL='diff'
+   fi
+   OUT="$($DIFFTOOL --no-dereference -ur --exclude="fifo*" "${dest}" "${tmp}/bareos-restores/${dest}")"
    result=$(( result + $?))
    if is_debug; then
        printf "%s\n" "$OUT"


### PR DESCRIPTION
    - Tests that are not reliable were marked with the label "broken"
      and are excluded when running tests during build.
    
    - Removed check for container environment to exclude tests.
    
    - Adjusted test timeout to suffice when build system is busy.
    
    - Buildsystem now requires all tests to pass
