### PR TITLE
libcloud-plugin: replace treat_download_errors_as_warnings

### DIFF
--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -298,8 +298,6 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                 if self.options["fail_on_download_error"]:
                     self.active = False
                     error = True
-                else:
-                    pass
             elif worker_result == ABORT:
                 self.active = False
                 error = True

--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -93,7 +93,7 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
 
         super(BareosFdPluginLibcloud, self).__init__(plugindef)
         super(BareosFdPluginLibcloud, self).parse_plugin_definition(plugindef)
-        self.options["treat_download_errors_as_warnings"] = False
+        self.options["fail_on_download_error"] = False
         self.__parse_options()
 
         self.last_run = datetime.datetime.fromtimestamp(self.since)
@@ -165,7 +165,7 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             "temporary_download_directory",
         ]
         optional_options = {}
-        optional_options["misc"] = ["treat_download_errors_as_warnings"]
+        optional_options["misc"] = ["fail_on_download_error"]
 
         # this maps config file options to libcloud options
         option_map = {
@@ -221,7 +221,7 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             if self.config.has_option(section, option):
                 try:
                     value = self.config.get(section, option)
-                    self.options["treat_download_errors_as_warnings"] = strtobool(value)
+                    self.options["fail_on_download_error"] = strtobool(value)
                 except:
                     debugmessage(
                         100,
@@ -295,11 +295,11 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         while self.active:
             worker_result = self.api.check_worker_messages()
             if worker_result == ERROR:
-                if self.options["treat_download_errors_as_warnings"]:
-                    pass
-                else:
+                if self.options["fail_on_download_error"]:
                     self.active = False
                     error = True
+                else:
+                    pass
             elif worker_result == ABORT:
                 self.active = False
                 error = True
@@ -350,20 +350,20 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             try:
                 self.FILE = IterStringIO(self.current_backup_task["data"].as_stream())
             except ObjectDoesNotExistError:
-                if self.options["treat_download_errors_as_warnings"]:
-                    jobmessage(
-                        M_WARNING,
-                        "Skipped file %s because it does not exist anymore"
-                        % (self.current_backup_task["name"]),
-                    )
-                    return bRC_Skip
-                else:
+                if self.options["fail_on_download_error"]:
                     jobmessage(
                         M_ERROR,
                         "File %s does not exist anymore"
                         % (self.current_backup_task["name"]),
                     )
                     return bRC_Error
+                else:
+                    jobmessage(
+                        M_WARNING,
+                        "Skipped file %s because it does not exist anymore"
+                        % (self.current_backup_task["name"]),
+                    )
+                    return bRC_Skip
 
         else:
             raise Exception(value='Wrong argument for current_backup_task["type"]')
@@ -418,10 +418,10 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                     ),
                 )
                 IOP.status = 0
-                if self.options["treat_download_errors_as_warnings"]:
-                    return bRC_Skip
-                else:
+                if self.options["fail_on_download_error"]:
                     return bRC_Error
+                else:
+                    return bRC_Skip
 
         elif IOP.func == IO_WRITE:
             try:

--- a/docs/manuals/source/TasksAndConcepts/Plugins.rst
+++ b/docs/manuals/source/TasksAndConcepts/Plugins.rst
@@ -1636,10 +1636,11 @@ Optional Plugin Options:
 
 This option in the config file is optional:
 
-treat_download_errors_as_warnings
-   This parameter can be set to True to keep a job running if for some reason a file cannot
+fail_on_download_error
+   This parameter is by default False to keep a job running if for some reason a file cannot
    be downloaded from a bucket because it is either deleted or moved to another space during
-   download. The default for this value is False.
+   download. In this case a Job will be marked with warnings as this is the default of Bareos.
+   It is recommended not to change this option.
 
 
 .. _PerconaXtrabackupPlugin:

--- a/docs/manuals/source/TasksAndConcepts/Plugins.rst
+++ b/docs/manuals/source/TasksAndConcepts/Plugins.rst
@@ -1637,10 +1637,8 @@ Optional Plugin Options:
 This option in the config file is optional:
 
 fail_on_download_error
-   This parameter is by default False to keep a job running if for some reason a file cannot
-   be downloaded from a bucket because it is either deleted or moved to another space during
-   download. In this case a Job will be marked with warnings as this is the default of Bareos.
-   It is recommended not to change this option.
+   When this option is enabled, any error during a file download will fail the backup job.
+   By default a warning will be issued and the next file will be backed up.
 
 
 .. _PerconaXtrabackupPlugin:


### PR DESCRIPTION
- replace treat_download_errors_as_warnings by fail_on_download_error
- set fail_on_download_error to False by default because this is
  the default behaviour of bareos backups
- as a matter of fact by default download errors will be flagged
  as warnings and jobs will be marked "with warnings"