### PR TITLE
packaging: set php-fpm as a required dependency on Fedora >= 33

### DIFF
--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -814,8 +814,12 @@ BuildRequires: httpd-devel
 %define _apache_conf_dir /etc/httpd/conf.d/
 %define www_daemon_user  apache
 %define www_daemon_group apache
-Requires:   httpd
+%if 0%{?fedora_version} >= 33
+Requires:   php-fpm
+%else
 Requires:   mod_php
+%endif
+Requires:   httpd
 %endif
 
 


### PR DESCRIPTION
There is no mod_php in default configuration. mod_php is deprecated as
FPM is now used by default with httpd in event mode. mod_php is only
used when explicitly enabled or httpd switch to prefork mode.