### PR TITLE
packaging: set php-fpm as a required dependency on Fedora >= 33 (backport 18.2)

### DIFF
--- a/webui/packaging/obs/bareos-webui.spec
+++ b/webui/packaging/obs/bareos-webui.spec
@@ -76,7 +76,11 @@ BuildRequires: httpd-devel
 %define daemon_user  apache
 %define daemon_group apache
 Requires:   httpd
+%if 0%{?fedora_version} >= 33
+Requires:   php-fpm
+%else
 Requires:   mod_php
+%endif
 %endif
 
 #define serverroot #(/usr/sbin/apxs2 -q datadir 2>/dev/null || /usr/sbin/apxs2 -q PREFIX)/htdocs/


### PR DESCRIPTION
There is no mod_php in default configuration. mod_php is deprecated as
FPM is now used by default with httpd in event mode. mod_php is only
used when explicitly enabled or httpd switch to prefork mode.