### PR TITLE
python-bareos: fixes support for sslpsk with Python >= 3

### DIFF
--- a/python-bareos/bareos/bsock/__init__.py
+++ b/python-bareos/bareos/bsock/__init__.py
@@ -22,9 +22,12 @@
 from bareos.exceptions import *
 from bareos.util.password import Password
 from bareos.bsock.connectiontype import ConnectionType
+from bareos.bsock.constants import Constants
+from bareos.bsock.filedaemon import FileDaemon
 from bareos.bsock.directorconsole import DirectorConsole
 from bareos.bsock.directorconsolejson import DirectorConsoleJson
-from bareos.bsock.filedaemon import FileDaemon
+from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.tlsversionparser import TlsVersionParser
 
 # compat
 from bareos.bsock.bsock import BSock

--- a/python-bareos/bareos/bsock/directorconsole.py
+++ b/python-bareos/bareos/bsock/directorconsole.py
@@ -27,15 +27,8 @@ from bareos.bsock.lowlevel import LowLevel
 from bareos.bsock.protocolmessageids import ProtocolMessageIds
 from bareos.bsock.protocolmessages import ProtocolMessages
 from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.tlsversionparser import TlsVersionParser
 import bareos.exceptions
-import argparse
-from collections import OrderedDict
-import ssl
-
-
-class ArgParserTlsVersionAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, getattr(ssl, self.choices.get(values)))
 
 
 class DirectorConsole(LowLevel):
@@ -122,34 +115,7 @@ class DirectorConsole(LowLevel):
             dest="BAREOS_tls_psk_require",
         )
 
-        # Add the possibility to specify the TLS protocol version.
-        # This is required,
-        # as sslpsk (1.0.0), depending on the Python and openssl version
-        # is known to fail on various protocol versions,
-        # especially with the default (PROTOCOL_TLS).
-        # Anyhow, if possible, use the default (PROTOCOL_TLS),
-        # as this covers different protocol versions,
-        # including all versions >= v1.3.
-        # There will be no specific constant TLS >= 1.3.
-        tls_version_options = {
-            # "default": "PROTOCOL_TLS",
-            "v1": "PROTOCOL_TLSv1",
-            "v1.1": "PROTOCOL_TLSv1_1",
-            "v1.2": "PROTOCOL_TLSv1_2",
-        }
-
-        # remove invalid options
-        for key, value in tls_version_options.items():
-            if not hasattr(ssl, value):
-                del tls_version_options[key]
-
-        argparser.add_argument(
-            "--tls-version",
-            help="Use a specific TLS protocol version.",
-            action=ArgParserTlsVersionAction,
-            choices=OrderedDict(sorted(tls_version_options.items())),
-            dest="BAREOS_tls_version",
-        )
+        TlsVersionParser().add_argument(argparser)
 
     def __init__(
         self,

--- a/python-bareos/bareos/bsock/filedaemon.py
+++ b/python-bareos/bareos/bsock/filedaemon.py
@@ -24,6 +24,7 @@ Communicates with the bareos-fd
 from bareos.bsock.connectiontype import ConnectionType
 from bareos.bsock.lowlevel import LowLevel
 from bareos.bsock.protocolmessageids import ProtocolMessageIds
+from bareos.bsock.tlsversionparser import TlsVersionParser
 import bareos.exceptions
 import shlex
 
@@ -89,6 +90,8 @@ class FileDaemon(LowLevel):
             dest="BAREOS_tls_psk_require",
         )
 
+        TlsVersionParser().add_argument(argparser)
+
     def __init__(
         self,
         address="localhost",
@@ -98,10 +101,13 @@ class FileDaemon(LowLevel):
         password=None,
         tls_psk_enable=True,
         tls_psk_require=False,
+        tls_version=None,
     ):
         super(FileDaemon, self).__init__()
         self.tls_psk_enable = tls_psk_enable
         self.tls_psk_require = tls_psk_require
+        if tls_version is not None:
+            self.tls_version = tls_version
         # Well, we are not really a Director,
         # but using the interface provided for Directors.
         self.identity_prefix = u"R_DIRECTOR"

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -98,6 +98,7 @@ class LowLevel(object):
         self.max_reconnects = 0
         self.tls_psk_enable = True
         self.tls_psk_require = False
+        self.tls_version = ssl.PROTOCOL_TLS
         self.connection_type = None
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()
@@ -119,6 +120,8 @@ class LowLevel(object):
             self.dirname = address
         self.connection_type = connection_type
         self.name = name
+        if password is None:
+            raise bareos.exceptions.ConnectionError(u"Parameter 'password' is required.")
         if isinstance(password, Password):
             self.password = password
         else:
@@ -220,8 +223,9 @@ class LowLevel(object):
         try:
             self.socket = sslpsk.wrap_socket(
                 client_socket,
-                psk=(password, identity),
+                ssl_version=self.tls_version,
                 ciphers="ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
+                psk=(password, identity),
                 server_side=False,
             )
         except ssl.SSLError as e:
@@ -233,9 +237,12 @@ class LowLevel(object):
 
     def get_tls_psk_identity(self):
         """Bareos TLS-PSK excepts the identiy is a specific format."""
-        return u"{0}{1}{2}".format(
-            self.identity_prefix, Constants.record_separator, str(self.name)
-        )
+        name = str(self.name)
+        if isinstance(self.name, bytes):
+            name = self.name.decode("utf-8")
+        result = u"{0}{1}{2}".format(self.identity_prefix, Constants.record_separator, name)
+        return bytes(bytearray(result, "utf-8"))
+
 
     @staticmethod
     def is_tls_psk_available():
@@ -580,7 +587,7 @@ class LowLevel(object):
         self.logger.debug("received: " + str(msg))
 
         # hash with password
-        hmac_md5 = hmac.new(bytes(bytearray(password, "utf-8")), None, hashlib.md5)
+        hmac_md5 = hmac.new(password, None, hashlib.md5)
         hmac_md5.update(bytes(bytearray(chal, "utf-8")))
         bbase64compatible = BareosBase64().string_to_base64(
             bytearray(hmac_md5.digest()), True
@@ -637,7 +644,7 @@ class LowLevel(object):
         ssl = int(msg_list[3][4])
         compatible = True
         # hmac chal and the password
-        hmac_md5 = hmac.new(bytes(bytearray(password, "utf-8")), None, hashlib.md5)
+        hmac_md5 = hmac.new((password), None, hashlib.md5)
         hmac_md5.update(bytes(chal))
 
         # base64 encoding

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -314,7 +314,7 @@ class LowLevel(object):
 
     def close(self):
         """disconnect"""
-        if self.socket:
+        if self.socket is not None:
             self.socket.close()
         self.socket = None
 

--- a/python-bareos/bareos/bsock/tlsversionparser.py
+++ b/python-bareos/bareos/bsock/tlsversionparser.py
@@ -1,0 +1,73 @@
+#   BAREOS - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+import argparse
+from collections import OrderedDict
+import ssl
+
+
+class ArgParserTlsVersionAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, getattr(ssl, self.choices.get(values)))
+
+
+class TlsVersionParser:
+    def __init__(self):
+        # Add the possibility to specify the TLS protocol version.
+        # This is required,
+        # as sslpsk (1.0.0), depending on the Python and openssl version
+        # is known to fail on various protocol versions,
+        # especially with the default (PROTOCOL_TLS).
+        # Anyhow, if possible, use the default (PROTOCOL_TLS),
+        # as this covers different protocol versions,
+        # including all versions >= v1.3.
+        # There will be no specific constant TLS >= 1.3.
+        self.tls_version_options = {
+            # "default": "PROTOCOL_TLS",
+            "v1": "PROTOCOL_TLSv1",
+            "v1.1": "PROTOCOL_TLSv1_1",
+            "v1.2": "PROTOCOL_TLSv1_2",
+        }
+
+        # remove invalid options
+        for key, value in self.tls_version_options.items():
+            if not hasattr(ssl, value):
+                del self.tls_version_options[key]
+
+    def add_argument(self, argparser):
+        argparser.add_argument(
+            "--tls-version",
+            help="Use a specific TLS protocol version.",
+            action=ArgParserTlsVersionAction,
+            choices=OrderedDict(sorted(self.tls_version_options.items())),
+            dest="BAREOS_tls_version",
+        )
+
+    def get_protocol_version_from_string(self, tls_version):
+        if tls_version is None:
+            return None
+        result = None
+        try:
+            result = getattr(ssl, self.tls_version_options[tls_version.lower()])
+        except (KeyError, AttributeError) as exc:
+            pass
+        return result
+
+    def get_protocol_versions(self):
+        return self.tls_version_options.keys()

--- a/python-bareos/bareos/util/password.py
+++ b/python-bareos/bareos/util/password.py
@@ -49,4 +49,4 @@ class Password(object):
         """
         md5 = hashlib.md5()
         md5.update(bytes(bytearray(password, "utf-8")))
-        return md5.hexdigest()
+        return bytes(bytearray(md5.hexdigest(), "utf-8"))

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -958,6 +958,7 @@ foreach(TEST_NAME ${SYSTEM_TESTS})
   string(
     CONCAT
       pythonpath
+      "${CMAKE_SOURCE_DIR}/python-bareos:"
       "${CMAKE_SOURCE_DIR}/core/src/plugins/filed/python/ldap:"
       "${CMAKE_SOURCE_DIR}/core/src/plugins/filed/python/libcloud:"
       "${CMAKE_SOURCE_DIR}/core/src/plugins/filed/python/percona-xtrabackup:"

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -78,6 +78,11 @@ export db_name=@db_name@
 export db_user=@db_user@
 export db_password=@db_password@
 
+# TLS_VERSION = v1.2 is a workaround,
+# By default, sslpsk should negotiate the highest
+# TLS protocol version.
+# This fails with the current version (1.0.0) of sslpsk.
+export PYTHON_BAREOS_TLS_VERSION="v1.2"
 
 export PAM_WRAPPER_LIBRARIES=@PAM_WRAPPER_LIBRARIES@
 

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -471,20 +471,10 @@ stop_bareos()
 run_python_unittests()
 {
     PYTHON_UNITTEST_SCRIPT=${1:-python-bareos-unittest.py}
-    if [ "${PROJECT_SOURCE_DIR}" ] && [ -e "${PROJECT_SOURCE_DIR}/../python-bareos/" ]; then
-        PYTHONPATH=${PYTHONPATH:-}
-        if [ "$PYTHONPATH" ]; then
-            export PYTHONPATH=${PROJECT_SOURCE_DIR}/../python-bareos/:$PYTHONPATH
-        else
-            export PYTHONPATH=${PROJECT_SOURCE_DIR}/../python-bareos/
-        fi
-        PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE:-python}
-        print_debug "PYTHONPATH=$PYTHONPATH"
-        if  PYTHONRESULT=$($PYTHON_EXECUTABLE "${cwd}/${PYTHON_UNITTEST_SCRIPT}" -v); then
-            print_debug "$PYTHONRESULT"
-        else
-            set_error "$PYTHONRESULT"
-        fi
+    if  PYTHONRESULT=$($PYTHON_EXECUTABLE "${cwd}/${PYTHON_UNITTEST_SCRIPT}" -v); then
+        print_debug "$PYTHONRESULT"
+    else
+        set_error "$PYTHONRESULT"
     fi
 }
 

--- a/systemtests/tests/python-bareos/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos/python-bareos-unittest.py
@@ -28,6 +28,7 @@ import os
 import re
 from time import sleep
 import unittest
+import warnings
 
 import bareos.bsock
 from bareos.bsock.constants import Constants
@@ -67,6 +68,14 @@ class PythonBareosBase(unittest.TestCase):
         logger = logging.getLogger()
         if self.debug:
             logger.setLevel(logging.DEBUG)
+
+        # assertRegexpMatches has been renamed
+        # to assertRegex in Python 3.2
+        # and is deprecated now.
+        # This prevents a deprecation warning.
+        if hasattr(self, "assertRegexpMatches") and not hasattr(self, "assertRegex"):
+            self.assertRegex = self.assertRegexpMatches
+
         logger.debug("setUp")
 
     def tearDown(self):
@@ -135,8 +144,7 @@ class PythonBareosModuleTest(PythonBareosBase):
         hello_message = ProtocolMessages().hello(name)
         logger.debug(hello_message)
 
-        # with Python 3.2 assertRegexpMatches is renamed to assertRegex.
-        self.assertRegexpMatches(hello_message, expected_regex)
+        self.assertRegex(hello_message, expected_regex)
 
         version = re.search(expected_regex, hello_message).group(1).decode("utf-8")
         logger.debug(u"version: {} ({})".format(version, type(version)))
@@ -208,13 +216,15 @@ class PythonBareosPlainTest(PythonBareosBase):
 
         bareos_password = bareos.bsock.Password(password)
         with self.assertRaises(bareos.exceptions.AuthenticationError):
-            director = bareos.bsock.DirectorConsole(
-                address=self.director_address,
-                port=self.director_port,
-                name=username,
-                password=bareos_password,
-                **self.director_extra_options
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                director = bareos.bsock.DirectorConsole(
+                    address=self.director_address,
+                    port=self.director_port,
+                    name=username,
+                    password=bareos_password,
+                    **self.director_extra_options
+                )
 
     def test_login_with_wrong_password(self):
         """
@@ -227,13 +237,15 @@ class PythonBareosPlainTest(PythonBareosBase):
 
         bareos_password = bareos.bsock.Password(password)
         with self.assertRaises(bareos.exceptions.AuthenticationError):
-            director = bareos.bsock.DirectorConsole(
-                address=self.director_address,
-                port=self.director_port,
-                name=username,
-                password=bareos_password,
-                **self.director_extra_options
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                director = bareos.bsock.DirectorConsole(
+                    address=self.director_address,
+                    port=self.director_port,
+                    name=username,
+                    password=bareos_password,
+                    **self.director_extra_options
+                )
 
     def test_no_autodisplay_command(self):
         """
@@ -528,15 +540,17 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         password = self.get_operator_password(username)
 
         with self.assertRaises(bareos.exceptions.AuthenticationError):
-            director = bareos.bsock.DirectorConsole(
-                address=self.director_address,
-                port=self.director_port,
-                tls_psk_enable=False,
-                protocolversion=ProtocolVersions.last,
-                name=username,
-                password=password,
-                **self.director_extra_options
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                director = bareos.bsock.DirectorConsole(
+                    address=self.director_address,
+                    port=self.director_port,
+                    tls_psk_enable=False,
+                    protocolversion=ProtocolVersions.last,
+                    name=username,
+                    password=password,
+                    **self.director_extra_options
+                )
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -742,6 +756,7 @@ class PythonBareosJsonBase(PythonBareosBase):
             port=self.director_port,
             name=console,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         result = console_poolbotfull.call("llist media all")
@@ -1207,8 +1222,10 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             ),
         )
 
-        # TODO: IMHO this is a bug. This console should not see volumes in the Full pool.
-        #       It needs to be fixed in the server side code.
+        # TODO:
+        # IMHO this is a bug.
+        # This console should not see volumes in the Full pool.
+        # It needs to be fixed in the server side code.
         with self.assertRaises(AssertionError):
             self._test_no_volume_in_pool(console_overwrite, console_password, "Full")
 
@@ -1533,9 +1550,6 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
 
     def test_delete_jobids(self):
         """
-        Note:
-        If delete is called on a non existing jobid,
-        this jobid will neithertheless be returned as deleted.
         """
         logger = logging.getLogger()
 
@@ -1550,6 +1564,9 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             **self.director_extra_options
         )
 
+        # Note:
+        # If delete is called on a non existing jobid,
+        # this jobid will neithertheless be returned as deleted.
         jobids = ["1001", "1002", "1003"]
         result = director.call("delete jobid={}".format(",".join(jobids)))
         logger.debug(str(result))
@@ -1560,9 +1577,6 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
 
     def test_delete_jobid_paramter(self):
         """
-        Note:
-        If delete is called on a non existing jobid,
-        this jobid will neithertheless be returned as deleted.
         """
         logger = logging.getLogger()
 
@@ -1577,6 +1591,9 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             **self.director_extra_options
         )
 
+        # Note:
+        # If delete is called on a non existing jobid,
+        # this jobid will neithertheless be returned as deleted.
         jobids = "jobid=1001,1002,1101-1110,1201 jobid=2001,2002,2101-2110,2201"
         #                 1 +  1 +      10  + 1       +  1 +  1 +      10 +  1
         number = 26
@@ -1667,7 +1684,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
 
         # logger.debug(re.search(expected_regex, result).group(1).decode('utf-8'))
 
-        self.assertRegexpMatches(result, expected_regex)
+        self.assertRegex(result, expected_regex)
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -1714,7 +1731,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
             )
         )
 
-        self.assertRegexpMatches(result, expected_regex)
+        self.assertRegex(result, expected_regex)
 
 
 class PythonBareosShowTest(PythonBareosJsonBase):

--- a/systemtests/tests/python-bareos/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos/python-bareos-unittest.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
 #   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
@@ -17,7 +18,6 @@
 #   along with this program; if not, write to the Free Software
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
-
 
 # -*- coding: utf-8 -*-
 
@@ -44,6 +44,7 @@ class PythonBareosBase(unittest.TestCase):
     director_address = "localhost"
     director_port = 9101
     director_root_password = "secret"
+    director_extra_options = {}
     client = "bareos-fd"
 
     filedaemon_address = "localhost"
@@ -161,7 +162,10 @@ class PythonBareosPlainTest(PythonBareosBase):
         bareos_password = bareos.bsock.Password(self.director_root_password)
         with self.assertRaises(bareos.exceptions.ConnectionError):
             director = bareos.bsock.DirectorConsole(
-                address=self.director_address, port=port, password=bareos_password
+                address=self.director_address,
+                port=port,
+                password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_login_as_root(self):
@@ -172,6 +176,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             address=self.director_address,
             port=self.director_port,
             password=bareos_password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual("root", whoami.rstrip())
@@ -187,6 +192,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual(username, whoami.rstrip())
@@ -207,6 +213,7 @@ class PythonBareosPlainTest(PythonBareosBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_login_with_wrong_password(self):
@@ -225,6 +232,7 @@ class PythonBareosPlainTest(PythonBareosBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_no_autodisplay_command(self):
@@ -244,6 +252,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         # get the list of all command
@@ -272,6 +281,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call(".api json").decode("utf-8")
         result = director.call("whoami").decode("utf-8")
@@ -307,6 +317,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -340,6 +351,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual(username, whoami.rstrip())
@@ -374,6 +386,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -405,6 +418,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             protocolversion=ProtocolVersions.bareos_12_4,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -461,6 +475,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -489,6 +504,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -519,6 +535,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
                 protocolversion=ProtocolVersions.last,
                 name=username,
                 password=password,
+                **self.director_extra_options
             )
 
     @unittest.skipUnless(
@@ -543,6 +560,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -570,6 +588,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -578,7 +597,6 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         self.assertTrue(hasattr(director.socket, "cipher"))
         cipher = director.socket.cipher()
         logger.debug(str(cipher))
-
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -599,6 +617,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_require=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -607,7 +626,6 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         self.assertTrue(hasattr(director.socket, "cipher"))
         cipher = director.socket.cipher()
         logger.debug(str(cipher))
-
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -629,6 +647,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_require=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -642,6 +661,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
 #
 # Test with JSON backend
 #
+
 
 class PythonBareosJsonBase(PythonBareosBase):
 
@@ -808,6 +828,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call("list clients")
         logger.debug(str(result))
@@ -829,6 +850,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         with self.assertRaises(bareos.exceptions.JsonRpcErrorReceivedException):
@@ -845,6 +867,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call("whoami")
         logger.debug(str(result))
@@ -871,6 +894,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         result = director_plain.call(bcmd)
@@ -881,6 +905,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # The JsonRpcInvalidJsonReceivedException
@@ -914,6 +939,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
 
@@ -940,6 +966,7 @@ class PythonBareosAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         result = director_root.call("run job=backup-bareos-fd level=Full yes")
@@ -965,6 +992,7 @@ class PythonBareosAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=console_bareos_fd_username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         result = console_bareos_fd.call("restore")
@@ -1077,6 +1105,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # result = director_root.call('run job=backup-bareos-fd level=Full yes')
@@ -1141,6 +1170,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name="poolfull",
             password=bareos_password,
+            **self.director_extra_options
         )
 
         # 'list media all' returns an error,
@@ -1209,6 +1239,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobid1 = self.run_job(
@@ -1241,6 +1272,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=console_username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         #
@@ -1270,6 +1302,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1301,6 +1334,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1335,6 +1369,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1370,6 +1405,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1402,6 +1438,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1431,6 +1468,7 @@ class PythonBareosJsonConfigTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         resourcesname = "clients"
@@ -1482,6 +1520,7 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobid = self.run_job(director, jobname, wait=True)
@@ -1508,6 +1547,7 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobids = ["1001", "1002", "1003"]
@@ -1534,6 +1574,7 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobids = "jobid=1001,1002,1101-1110,1201 jobid=2001,2002,2101-2110,2201"
@@ -1562,6 +1603,7 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         with self.assertRaises(bareos.exceptions.JsonRpcErrorReceivedException):
@@ -1581,6 +1623,7 @@ class PythonBareosDeleteTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobid = self.run_job(director, jobname, level="Full", wait=True)
@@ -1611,6 +1654,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
             port=self.filedaemon_port,
             name=name,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         result = fd.call(u"status")
@@ -1646,6 +1690,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
             port=self.filedaemon_port,
             name=name,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         fd.call(
@@ -1693,6 +1738,7 @@ class PythonBareosShowTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobid = self.run_job(director, jobname, wait=True)
@@ -1712,7 +1758,6 @@ def get_env():
     Get attributes as environment variables,
     if not available or set use defaults.
     """
-
     director_root_password = os.environ.get("dir_password")
     if director_root_password:
         PythonBareosBase.director_root_password = director_root_password
@@ -1733,14 +1778,26 @@ def get_env():
     if backup_directory:
         PythonBareosBase.backup_directory = backup_directory
 
+    tls_version_str = os.environ.get("PYTHON_BAREOS_TLS_VERSION")
+    if tls_version_str is not None:
+        tls_version_parser = bareos.bsock.TlsVersionParser()
+        tls_version = tls_version_parser.get_protocol_version_from_string(
+            tls_version_str
+        )
+        if tls_version is not None:
+            PythonBareosBase.director_extra_options["tls_version"] = tls_version
+        else:
+            print(
+                "Environment variable PYTHON_BAREOS_TLS_VERSION has invalid value ({}). Valid values: {}".format(
+                    tls_version_str,
+                    ", ".join(tls_version_parser.get_protocol_versions()),
+                )
+            )
+
     if os.environ.get("REGRESS_DEBUG"):
         PythonBareosBase.debug = True
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)s %(module)s.%(funcName)s: %(message)s",
-        level=logging.ERROR,
-    )
     get_env()
     unittest.main()

--- a/systemtests/tests/python-pam/python-bareos-unittest.py
+++ b/systemtests/tests/python-pam/python-bareos-unittest.py
@@ -34,6 +34,7 @@ import bareos.exceptions
 class PythonBareosBase(unittest.TestCase):
     director_address = "localhost"
     director_port = 9101
+    director_extra_options = {}
     director_root_password = "secret"
     director_operator_username = "admin"
     director_operator_password = "secret"
@@ -87,6 +88,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
             password=bareos_password,
             pam_username=pam_username,
             pam_password=pam_password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -114,6 +116,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
             password=bareos_password,
             pam_username=pam_username,
             pam_password=pam_password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -135,6 +138,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
                 password=bareos_password,
                 pam_username=pam_username,
                 pam_password=pam_password,
+                **self.director_extra_options
             )
 
     def test_login_with_not_wrong_password(self):
@@ -153,6 +157,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
                 password=bareos_password,
                 pam_username=pam_username,
                 pam_password=pam_password,
+                **self.director_extra_options
             )
 
     def test_login_with_director_requires_pam_but_credentials_not_given(self):
@@ -169,6 +174,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
                 port=self.director_port,
                 name=self.console_pam_username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_login_without_director_pam_console_but_with_pam_credentials(self):
@@ -190,6 +196,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
                 password=bareos_password,
                 pam_username=pam_username,
                 pam_password=pam_password,
+                **self.director_extra_options
             )
 
     def test_login_with_director_requires_pam_but_protocol_124(self):
@@ -211,6 +218,7 @@ class PythonBareosPamLoginTest(PythonBareosBase):
                 protocolversion=ProtocolVersions.bareos_12_4,
                 name=self.console_pam_username,
                 password=bareos_password,
+                **self.director_extra_options
             )
             result = director.call("whoami").decode("utf-8")
 
@@ -233,13 +241,26 @@ def get_env():
     if backup_directory:
         PythonBareosBase.backup_directory = backup_directory
 
+    tls_version_str = os.environ.get("PYTHON_BAREOS_TLS_VERSION")
+    if tls_version_str is not None:
+        tls_version_parser = bareos.bsock.TlsVersionParser()
+        tls_version = tls_version_parser.get_protocol_version_from_string(
+            tls_version_str
+        )
+        if tls_version is not None:
+            PythonBareosBase.director_extra_options["tls_version"] = tls_version
+        else:
+            print(
+                "Environment variable PYTHON_BAREOS_TLS_VERSION has invalid value ({}). Valid values: {}".format(
+                    tls_version_str,
+                    ", ".join(tls_version_parser.get_protocol_versions()),
+                )
+            )
+
     if os.environ.get("REGRESS_DEBUG"):
         PythonBareosBase.debug = True
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        format="%(levelname)s %(module)s.%(funcName)s: %(message)s", level=logging.ERROR
-    )
     get_env()
     unittest.main()


### PR DESCRIPTION
Current sslpsk version require identity and passwort as bytes. Strings are no longer supported.
The python-bareos os now adapted to this.
    
Unfortenatly, depending on the Python and OpenSSL versions
sslpsk (1.0.0) does not work with all TLS protocol versions.
Normally, the best matching protocol version is selected automatically,
but this fails in many environments using sslpsk.
As a workaround it is now possible to specify the TLS protocol version (v1, v1.1, v1.2)
python-bareos should use.
Note: newer newer protocols (TLS v1.3) can not be specified in this may.

See also: https://github.com/drbild/sslpsk/pull/22
