### PR TITLE
python-bareos: fixes support for sslpsk with Python >= 3 (bareos-19.2)

### DIFF
--- a/python-bareos/bareos/bsock/__init__.py
+++ b/python-bareos/bareos/bsock/__init__.py
@@ -3,9 +3,12 @@
 from bareos.exceptions import *
 from bareos.util.password import Password
 from bareos.bsock.connectiontype import ConnectionType
+from bareos.bsock.constants import Constants
+from bareos.bsock.filedaemon import FileDaemon
 from bareos.bsock.directorconsole import DirectorConsole
 from bareos.bsock.directorconsolejson import DirectorConsoleJson
-from bareos.bsock.filedaemon import FileDaemon
+from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.tlsversionparser import TlsVersionParser
 
 # compat
 from bareos.bsock.bsock import BSock

--- a/python-bareos/bareos/bsock/directorconsole.py
+++ b/python-bareos/bareos/bsock/directorconsole.py
@@ -8,15 +8,8 @@ from bareos.bsock.lowlevel import LowLevel
 from bareos.bsock.protocolmessageids import ProtocolMessageIds
 from bareos.bsock.protocolmessages import ProtocolMessages
 from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.tlsversionparser import TlsVersionParser
 import bareos.exceptions
-import argparse
-from collections import OrderedDict
-import ssl
-
-
-class ArgParserTlsVersionAction(argparse.Action):
-    def __call__(self, parser, namespace, values, option_string=None):
-        setattr(namespace, self.dest, getattr(ssl, self.choices.get(values)))
 
 
 class DirectorConsole(LowLevel):
@@ -103,34 +96,7 @@ class DirectorConsole(LowLevel):
             dest="BAREOS_tls_psk_require",
         )
 
-        # Add the possibility to specify the TLS protocol version.
-        # This is required,
-        # as sslpsk (1.0.0), depending on the Python and openssl version
-        # is known to fail on various protocol versions,
-        # especially with the default (PROTOCOL_TLS).
-        # Anyhow, if possible, use the default (PROTOCOL_TLS),
-        # as this covers different protocol versions,
-        # including all versions >= v1.3.
-        # There will be no specific constant TLS >= 1.3.
-        tls_version_options = {
-            # "default": "PROTOCOL_TLS",
-            "v1": "PROTOCOL_TLSv1",
-            "v1.1": "PROTOCOL_TLSv1_1",
-            "v1.2": "PROTOCOL_TLSv1_2",
-        }
-
-        # remove invalid options
-        for key, value in tls_version_options.items():
-            if not hasattr(ssl, value):
-                del tls_version_options[key]
-
-        argparser.add_argument(
-            "--tls-version",
-            help="Use a specific TLS protocol version.",
-            action=ArgParserTlsVersionAction,
-            choices=OrderedDict(sorted(tls_version_options.items())),
-            dest="BAREOS_tls_version",
-        )
+        TlsVersionParser().add_argument(argparser)
 
     def __init__(
         self,

--- a/python-bareos/bareos/bsock/directorconsole.py
+++ b/python-bareos/bareos/bsock/directorconsole.py
@@ -9,6 +9,14 @@ from bareos.bsock.protocolmessageids import ProtocolMessageIds
 from bareos.bsock.protocolmessages import ProtocolMessages
 from bareos.bsock.protocolversions import ProtocolVersions
 import bareos.exceptions
+import argparse
+from collections import OrderedDict
+import ssl
+
+
+class ArgParserTlsVersionAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, getattr(ssl, self.choices.get(values)))
 
 
 class DirectorConsole(LowLevel):
@@ -70,7 +78,7 @@ class DirectorConsole(LowLevel):
             "--protocolversion",
             default=ProtocolVersions.last,
             type=int,
-            help=u"Specify the protocol version to use. Default: {0} (current).".format(
+            help=u"Specify the Bareos console protocol version. Default: {0} (current).".format(
                 ProtocolVersions.last
             ),
             dest="BAREOS_protocolversion",
@@ -95,6 +103,35 @@ class DirectorConsole(LowLevel):
             dest="BAREOS_tls_psk_require",
         )
 
+        # Add the possibility to specify the TLS protocol version.
+        # This is required,
+        # as sslpsk (1.0.0), depending on the Python and openssl version
+        # is known to fail on various protocol versions,
+        # especially with the default (PROTOCOL_TLS).
+        # Anyhow, if possible, use the default (PROTOCOL_TLS),
+        # as this covers different protocol versions,
+        # including all versions >= v1.3.
+        # There will be no specific constant TLS >= 1.3.
+        tls_version_options = {
+            # "default": "PROTOCOL_TLS",
+            "v1": "PROTOCOL_TLSv1",
+            "v1.1": "PROTOCOL_TLSv1_1",
+            "v1.2": "PROTOCOL_TLSv1_2",
+        }
+
+        # remove invalid options
+        for key, value in tls_version_options.items():
+            if not hasattr(ssl, value):
+                del tls_version_options[key]
+
+        argparser.add_argument(
+            "--tls-version",
+            help="Use a specific TLS protocol version.",
+            action=ArgParserTlsVersionAction,
+            choices=OrderedDict(sorted(tls_version_options.items())),
+            dest="BAREOS_tls_version",
+        )
+
     def __init__(
         self,
         address="localhost",
@@ -107,12 +144,15 @@ class DirectorConsole(LowLevel):
         pam_password=None,
         tls_psk_enable=True,
         tls_psk_require=False,
+        tls_version=None,
     ):
         super(DirectorConsole, self).__init__()
         self.pam_username = pam_username
         self.pam_password = pam_password
         self.tls_psk_enable = tls_psk_enable
         self.tls_psk_require = tls_psk_require
+        if tls_version is not None:
+            self.tls_version = tls_version
         self.identity_prefix = u"R_CONSOLE"
         if protocolversion is not None:
             self.requested_protocol_version = int(protocolversion)

--- a/python-bareos/bareos/bsock/filedaemon.py
+++ b/python-bareos/bareos/bsock/filedaemon.py
@@ -5,6 +5,7 @@ Communicates with the bareos-fd
 from bareos.bsock.connectiontype import ConnectionType
 from bareos.bsock.lowlevel import LowLevel
 from bareos.bsock.protocolmessageids import ProtocolMessageIds
+from bareos.bsock.tlsversionparser import TlsVersionParser
 import bareos.exceptions
 import shlex
 
@@ -70,6 +71,8 @@ class FileDaemon(LowLevel):
             dest="BAREOS_tls_psk_require",
         )
 
+        TlsVersionParser().add_argument(argparser)
+
     def __init__(
         self,
         address="localhost",
@@ -79,10 +82,13 @@ class FileDaemon(LowLevel):
         password=None,
         tls_psk_enable=True,
         tls_psk_require=False,
+        tls_version=None,
     ):
         super(FileDaemon, self).__init__()
         self.tls_psk_enable = tls_psk_enable
         self.tls_psk_require = tls_psk_require
+        if tls_version is not None:
+            self.tls_version = tls_version
         # Well, we are not really a Director,
         # but using the interface provided for Directors.
         self.identity_prefix = u"R_DIRECTOR"

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -79,6 +79,7 @@ class LowLevel(object):
         self.max_reconnects = 0
         self.tls_psk_enable = True
         self.tls_psk_require = False
+        self.tls_version = ssl.PROTOCOL_TLS
         self.connection_type = None
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()
@@ -100,6 +101,8 @@ class LowLevel(object):
             self.dirname = address
         self.connection_type = connection_type
         self.name = name
+        if password is None:
+            raise bareos.exceptions.ConnectionError(u"Parameter 'password' is required.")
         if isinstance(password, Password):
             self.password = password
         else:
@@ -201,8 +204,9 @@ class LowLevel(object):
         try:
             self.socket = sslpsk.wrap_socket(
                 client_socket,
-                psk=(password, identity),
+                ssl_version=self.tls_version,
                 ciphers="ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH",
+                psk=(password, identity),
                 server_side=False,
             )
         except ssl.SSLError as e:
@@ -214,9 +218,12 @@ class LowLevel(object):
 
     def get_tls_psk_identity(self):
         """Bareos TLS-PSK excepts the identiy is a specific format."""
-        return u"{0}{1}{2}".format(
-            self.identity_prefix, Constants.record_separator, str(self.name)
-        )
+        name = str(self.name)
+        if isinstance(self.name, bytes):
+            name = self.name.decode("utf-8")
+        result = u"{0}{1}{2}".format(self.identity_prefix, Constants.record_separator, name)
+        return bytes(bytearray(result, "utf-8"))
+
 
     @staticmethod
     def is_tls_psk_available():
@@ -559,7 +566,7 @@ class LowLevel(object):
         self.logger.debug("received: " + str(msg))
 
         # hash with password
-        hmac_md5 = hmac.new(bytes(bytearray(password, "utf-8")), None, hashlib.md5)
+        hmac_md5 = hmac.new(password, None, hashlib.md5)
         hmac_md5.update(bytes(bytearray(chal, "utf-8")))
         bbase64compatible = BareosBase64().string_to_base64(
             bytearray(hmac_md5.digest()), True
@@ -616,7 +623,7 @@ class LowLevel(object):
         ssl = int(msg_list[3][4])
         compatible = True
         # hmac chal and the password
-        hmac_md5 = hmac.new(bytes(bytearray(password, "utf-8")), None, hashlib.md5)
+        hmac_md5 = hmac.new((password), None, hashlib.md5)
         hmac_md5.update(bytes(chal))
 
         # base64 encoding

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -295,7 +295,7 @@ class LowLevel(object):
 
     def close(self):
         """disconnect"""
-        if self.socket:
+        if self.socket is not None:
             self.socket.close()
         self.socket = None
 

--- a/python-bareos/bareos/bsock/tlsversionparser.py
+++ b/python-bareos/bareos/bsock/tlsversionparser.py
@@ -1,0 +1,73 @@
+#   BAREOS - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+import argparse
+from collections import OrderedDict
+import ssl
+
+
+class ArgParserTlsVersionAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, getattr(ssl, self.choices.get(values)))
+
+
+class TlsVersionParser:
+    def __init__(self):
+        # Add the possibility to specify the TLS protocol version.
+        # This is required,
+        # as sslpsk (1.0.0), depending on the Python and openssl version
+        # is known to fail on various protocol versions,
+        # especially with the default (PROTOCOL_TLS).
+        # Anyhow, if possible, use the default (PROTOCOL_TLS),
+        # as this covers different protocol versions,
+        # including all versions >= v1.3.
+        # There will be no specific constant TLS >= 1.3.
+        self.tls_version_options = {
+            # "default": "PROTOCOL_TLS",
+            "v1": "PROTOCOL_TLSv1",
+            "v1.1": "PROTOCOL_TLSv1_1",
+            "v1.2": "PROTOCOL_TLSv1_2",
+        }
+
+        # remove invalid options
+        for key, value in self.tls_version_options.items():
+            if not hasattr(ssl, value):
+                del self.tls_version_options[key]
+
+    def add_argument(self, argparser):
+        argparser.add_argument(
+            "--tls-version",
+            help="Use a specific TLS protocol version.",
+            action=ArgParserTlsVersionAction,
+            choices=OrderedDict(sorted(self.tls_version_options.items())),
+            dest="BAREOS_tls_version",
+        )
+
+    def get_protocol_version_from_string(self, tls_version):
+        if tls_version is None:
+            return None
+        result = None
+        try:
+            result = getattr(ssl, self.tls_version_options[tls_version.lower()])
+        except (KeyError, AttributeError) as exc:
+            pass
+        return result
+
+    def get_protocol_versions(self):
+        return self.tls_version_options.keys()

--- a/python-bareos/bareos/util/password.py
+++ b/python-bareos/bareos/util/password.py
@@ -30,4 +30,4 @@ class Password(object):
         """
         md5 = hashlib.md5()
         md5.update(bytes(bytearray(password, "utf-8")))
-        return md5.hexdigest()
+        return bytes(bytearray(md5.hexdigest(), "utf-8"))

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -76,6 +76,11 @@ export db_name=@db_name@
 export db_user=@db_user@
 export db_password=@db_password@
 
+# TLS_VERSION = v1.2 is a workaround,
+# By default, sslpsk should negotiate the highest
+# TLS protocol version.
+# This fails with the current version (1.0.0) of sslpsk.
+export PYTHON_BAREOS_TLS_VERSION="v1.2"
 
 export PAM_WRAPPER_LIBRARIES=@PAM_WRAPPER_LIBRARIES@
 

--- a/systemtests/tests/python-bareos-test/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos-test/python-bareos-unittest.py
@@ -14,6 +14,7 @@ import bareos.bsock
 from bareos.bsock.constants import Constants
 from bareos.bsock.protocolmessages import ProtocolMessages
 from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.lowlevel import LowLevel
 import bareos.exceptions
 
 
@@ -114,6 +115,7 @@ class PythonBareosModuleTest(PythonBareosBase):
         hello_message = ProtocolMessages().hello(name)
         logger.debug(hello_message)
 
+        # with Python 3.2 assertRegexpMatches is renamed to assertRegex.
         self.assertRegexpMatches(hello_message, expected_regex)
 
         version = re.search(expected_regex, hello_message).group(1).decode("utf-8")
@@ -122,6 +124,12 @@ class PythonBareosModuleTest(PythonBareosBase):
         self.assertGreaterEqual(
             self.versiontuple(version), self.versiontuple(u"18.2.5")
         )
+
+    def test_password(self):
+        password = bareos.bsock.Password("secret")
+        md5 = password.md5()
+        self.assertTrue(isinstance(md5, bytes))
+        self.assertEqual(md5, b"5ebe2294ecd0e0f08eab7690d2a6ee69")
 
 
 class PythonBareosPlainTest(PythonBareosBase):
@@ -406,6 +414,18 @@ class PythonBareosTlsPskTest(PythonBareosBase):
     # console: tls, director: tls     => login  (tls)
     """
 
+    def test_tls_psk_identity(self):
+        """
+        Check if tls_psk_identity is in the expected format
+        and is of type "bytes".
+        """
+        core = LowLevel()
+        core.identity_prefix = "R_TEST"
+        core.name = "Test"
+        identity = core.get_tls_psk_identity()
+        self.assertTrue(isinstance(identity, bytes))
+        self.assertEqual(identity, b"R_TEST\x1eTest")
+
     def test_login_notls_notls(self):
         """
         console: notls, director: notls => login
@@ -540,6 +560,36 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         cipher = director.socket.cipher()
         logger.debug(str(cipher))
 
+
+    @unittest.skipUnless(
+        bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
+    )
+    def test_login_tls_tls_require(self):
+        """
+        console: tls, director: tls     => login
+        """
+
+        logger = logging.getLogger()
+
+        username = self.get_operator_username(tls=True)
+        password = self.get_operator_password(username)
+
+        director = bareos.bsock.DirectorConsole(
+            address=self.director_address,
+            port=self.director_port,
+            tls_psk_require=True,
+            name=username,
+            password=password,
+        )
+
+        whoami = director.call("whoami").decode("utf-8")
+        self.assertEqual(username, whoami.rstrip())
+
+        self.assertTrue(hasattr(director.socket, "cipher"))
+        cipher = director.socket.cipher()
+        logger.debug(str(cipher))
+
+
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
     )
@@ -573,7 +623,6 @@ class PythonBareosTlsPskTest(PythonBareosBase):
 #
 # Test with JSON backend
 #
-
 
 class PythonBareosJsonBase(PythonBareosBase):
 

--- a/systemtests/tests/python-bareos-test/python-bareos-unittest.py
+++ b/systemtests/tests/python-bareos-test/python-bareos-unittest.py
@@ -1,4 +1,23 @@
 #!/usr/bin/env python
+#
+#   BAREOS - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
 
 # -*- coding: utf-8 -*-
 
@@ -25,6 +44,7 @@ class PythonBareosBase(unittest.TestCase):
     director_address = "localhost"
     director_port = 9101
     director_root_password = "secret"
+    director_extra_options = {}
     client = "bareos-fd"
 
     filedaemon_address = "localhost"
@@ -142,7 +162,10 @@ class PythonBareosPlainTest(PythonBareosBase):
         bareos_password = bareos.bsock.Password(self.director_root_password)
         with self.assertRaises(bareos.exceptions.ConnectionError):
             director = bareos.bsock.DirectorConsole(
-                address=self.director_address, port=port, password=bareos_password
+                address=self.director_address,
+                port=port,
+                password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_login_as_root(self):
@@ -153,6 +176,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             address=self.director_address,
             port=self.director_port,
             password=bareos_password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual("root", whoami.rstrip())
@@ -168,6 +192,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual(username, whoami.rstrip())
@@ -188,6 +213,7 @@ class PythonBareosPlainTest(PythonBareosBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_login_with_wrong_password(self):
@@ -206,6 +232,7 @@ class PythonBareosPlainTest(PythonBareosBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
     def test_no_autodisplay_command(self):
@@ -225,6 +252,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         # get the list of all command
@@ -253,6 +281,7 @@ class PythonBareosPlainTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call(".api json").decode("utf-8")
         result = director.call("whoami").decode("utf-8")
@@ -288,6 +317,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -321,6 +351,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         whoami = director.call("whoami").decode("utf-8")
         self.assertEqual(username, whoami.rstrip())
@@ -355,6 +386,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             tls_psk_enable=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -386,6 +418,7 @@ class PythonBareosProtocol124Test(PythonBareosBase):
             protocolversion=ProtocolVersions.bareos_12_4,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -442,6 +475,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -470,6 +504,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=False,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -500,6 +535,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
                 protocolversion=ProtocolVersions.last,
                 name=username,
                 password=password,
+                **self.director_extra_options
             )
 
     @unittest.skipUnless(
@@ -524,6 +560,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_enable=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -551,6 +588,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -559,7 +597,6 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         self.assertTrue(hasattr(director.socket, "cipher"))
         cipher = director.socket.cipher()
         logger.debug(str(cipher))
-
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -580,6 +617,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_require=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -588,7 +626,6 @@ class PythonBareosTlsPskTest(PythonBareosBase):
         self.assertTrue(hasattr(director.socket, "cipher"))
         cipher = director.socket.cipher()
         logger.debug(str(cipher))
-
 
     @unittest.skipUnless(
         bareos.bsock.DirectorConsole.is_tls_psk_available(), "TLS-PSK is not available."
@@ -610,6 +647,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
             tls_psk_require=True,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         whoami = director.call("whoami").decode("utf-8")
@@ -623,6 +661,7 @@ class PythonBareosTlsPskTest(PythonBareosBase):
 #
 # Test with JSON backend
 #
+
 
 class PythonBareosJsonBase(PythonBareosBase):
 
@@ -782,6 +821,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call("list clients")
         logger.debug(str(result))
@@ -803,6 +843,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         with self.assertRaises(bareos.exceptions.JsonRpcErrorReceivedException):
@@ -819,6 +860,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
         result = director.call("whoami")
         logger.debug(str(result))
@@ -835,6 +877,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         result = director_plain.call("show clients")
@@ -845,6 +888,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # The 'show' command does not deliver JSON output.
@@ -880,6 +924,7 @@ class PythonBareosJsonBackendTest(PythonBareosJsonBase):
                 port=self.director_port,
                 name=username,
                 password=bareos_password,
+                **self.director_extra_options
             )
 
 
@@ -906,6 +951,7 @@ class PythonBareosAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         result = director_root.call("run job=backup-bareos-fd level=Full yes")
@@ -931,6 +977,7 @@ class PythonBareosAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=console_bareos_fd_username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         result = console_bareos_fd.call("restore")
@@ -1043,6 +1090,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # result = director_root.call('run job=backup-bareos-fd level=Full yes')
@@ -1107,6 +1155,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name="poolfull",
             password=bareos_password,
+            **self.director_extra_options
         )
 
         # 'list media all' returns an error,
@@ -1175,6 +1224,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         jobid1 = self.run_job(
@@ -1207,6 +1257,7 @@ class PythonBareosJsonAclTest(PythonBareosJsonBase):
             port=self.director_port,
             name=console_username,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         #
@@ -1236,6 +1287,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1267,6 +1319,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1301,6 +1354,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1336,6 +1390,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1368,6 +1423,7 @@ class PythonBareosJsonRunScriptTest(PythonBareosJsonBase):
             port=self.director_port,
             name=username,
             password=password,
+            **self.director_extra_options
         )
 
         # Example log entry:
@@ -1397,6 +1453,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
             port=self.filedaemon_port,
             name=name,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         result = fd.call(u"status")
@@ -1432,6 +1489,7 @@ class PythonBareosFiledaemonTest(PythonBareosBase):
             port=self.filedaemon_port,
             name=name,
             password=bareos_password,
+            **self.director_extra_options
         )
 
         fd.call(
@@ -1463,7 +1521,6 @@ def get_env():
     Get attributes as environment variables,
     if not available or set use defaults.
     """
-
     director_root_password = os.environ.get("dir_password")
     if director_root_password:
         PythonBareosBase.director_root_password = director_root_password
@@ -1484,14 +1541,26 @@ def get_env():
     if backup_directory:
         PythonBareosBase.backup_directory = backup_directory
 
+    tls_version_str = os.environ.get("PYTHON_BAREOS_TLS_VERSION")
+    if tls_version_str is not None:
+        tls_version_parser = bareos.bsock.TlsVersionParser()
+        tls_version = tls_version_parser.get_protocol_version_from_string(
+            tls_version_str
+        )
+        if tls_version is not None:
+            PythonBareosBase.director_extra_options["tls_version"] = tls_version
+        else:
+            print(
+                "Environment variable PYTHON_BAREOS_TLS_VERSION has invalid value ({}). Valid values: {}".format(
+                    tls_version_str,
+                    ", ".join(tls_version_parser.get_protocol_versions()),
+                )
+            )
+
     if os.environ.get("REGRESS_DEBUG"):
         PythonBareosBase.debug = True
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        format="%(asctime)s %(levelname)s %(module)s.%(funcName)s: %(message)s",
-        level=logging.ERROR,
-    )
     get_env()
     unittest.main()


### PR DESCRIPTION
Current sslpsk version require identity and passwort as bytes. Strings are no longer supported.
The python-bareos os now adapted to this.

Unfortenatly, depending on the Python and OpenSSL versions
sslpsk (1.0.0) does not work with all TLS protocol versions.
Normally, the best matching protocol version is selected automatically,
but this fails in many environments using sslpsk.
As a workaround it is now possible to specify the TLS protocol version (v1, v1.1, v1.2)
python-bareos should use.
Note: newer newer protocols (TLS v1.3) can not be specified in this may.

See also: drbild/sslpsk#22

Downstream PR for https://github.com/bareos/bareos/pull/651