### PR TITLE
make branch compatible to new coverage/warning/ctest features in Jenkins

### DIFF
--- a/.quality-gates.yml
+++ b/.quality-gates.yml
@@ -1,0 +1,91 @@
+---
+# quality gates to configure Jenkins build pipeline
+coverage:
+  lines: 
+    healthy: 24
+    unhealthy: 23
+    unstable: 24
+
+docs:
+  warnings_unhealthy: 72
+  warnings_healthy: 36
+
+default:
+  ctest_unstable: 0
+  warnings_unhealthy: 0
+  warnings_healthy: 0
+
+xUbuntu_16.04:
+  ctest_unstable: 0
+  warnings_unhealthy: 67
+  warnings_healthy: 30
+
+xUbuntu:
+  ctest_unstable: 0
+  warnings_unhealthy: 40
+  warnings_healthy: 20
+
+openSUSE:
+  ctest_unstable: 0
+  warnings_unhealthy: 48
+  warnings_healthy: 24
+
+Univention:
+  ctest_unstable: 0
+  warnings_unhealthy: 40
+  warnings_healthy: 20
+
+Debian:
+  ctest_unstable: 0
+  warnings_unhealthy: 41
+  warnings_healthy: 20
+
+SLE:
+  ctest_unstable: 0
+  warnings_unhealthy: 48
+  warnings_healthy: 24
+
+SLE_12_SP4:
+  ctest_unstable: 0
+  warnings_unhealthy: 64
+  warnings_healthy: 32
+
+RHEL_8:
+  ctest_unstable: 0
+  warnings_unhealthy: 48
+  warnings_healthy: 24
+
+CentOS_8:
+  ctest_unstable: 0
+  warnings_unhealthy: 48
+  warnings_healthy: 24
+
+RHEL_7:
+  ctest_unstable: 0
+  warnings_unhealthy: 39
+  warnings_healthy: 19
+
+CentOS_7:
+  ctest_unstable: 0
+  warnings_unhealthy: 39
+  warnings_healthy: 19
+
+Fedora:
+  ctest_unstable: 0
+  warnings_unhealthy: 56
+  warnings_healthy: 28
+
+Fedora_33:
+  ctest_unstable: 0
+  warnings_unhealthy: 69
+  warnings_healthy: 34
+
+MacOS:
+  ctest_unstable: 0
+  warnings_unhealthy: 13
+  warnings_healthy: 6
+
+win:
+  ctest_unstable: 0
+  warnings_unhealthy: 57
+  warnings_healthy: 27

--- a/debian/rules
+++ b/debian/rules
@@ -133,7 +133,7 @@ override_dh_auto_test:
 # see https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options
 # No tabs allowed before ifeq.
 ifneq (nocheck,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	cd obj-x86_64-linux-gnu && make clean && REGRESS_DEBUG=1 ctest -j 10 -V -D Continuous || echo "ctest failed"
+	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest -j 10 -V -D Continuous || echo "ctest failed"
 else
 	@echo "ctest: skipped"
 endif


### PR DESCRIPTION
- debian: configure tests to run in i386, too
- add .quality-gates.yaml
