### PR TITLE
webui: change updateBvfsCache trigger in restore controller

### DIFF
--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -550,10 +550,9 @@ class RestoreController extends AbstractActionController
     $this->setRestoreParams();
     $this->getJobIds();
 
-    if($this->restore_params['id'] == null || $this->restore_params['id'] == "#") {
+    if($this->restore_params['id'] !== null && $this->restore_params['id'] !== "#") {
       $this->updateBvfsCache();
     }
-
     $this->getDirectories();
     $this->getFiles();
 


### PR DESCRIPTION
Hello,
Actually updateBvfsCache is done when the main restoration page is open. As no jobid is given, it's a full bvfs_update....  and it's long before the page can bu used.

By reversing the condition. It's done only when a jobid is selected. As updateBvfsCache() method check the current jobid, and target it, It's very faster!