### PR TITLE
core: Fix wrong droplet.profile path in droplet example configuration

### DIFF
--- a/core/src/stored/backends/droplet_device.d/bareos-sd.d/device/S3_ObjectStorage.conf.example
+++ b/core/src/stored/backends/droplet_device.d/bareos-sd.d/device/S3_ObjectStorage.conf.example
@@ -18,10 +18,10 @@ Device {
   #
 
   # testing:
-  Device Options = "profile=/etc/bareos/bareos-sd.d/droplet/droplet.profile,bucket=bareos-bucket,chunksize=100M,iothreads=0,retries=1"
+  Device Options = "profile=/etc/bareos/bareos-sd.d/device/droplet/droplet.profile,bucket=bareos-bucket,chunksize=100M,iothreads=0,retries=1"
 
   # performance:
-  #Device Options = "profile=/etc/bareos/bareos-sd.d/droplet/droplet.profile,bucket=bareos-bucket,chunksize=100M"
+  #Device Options = "profile=/etc/bareos/bareos-sd.d/device/droplet/droplet.profile,bucket=bareos-bucket,chunksize=100M"
 
   Device Type = droplet
   Label Media = yes                    # lets Bareos label unlabeled media

--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -199,7 +199,7 @@ A device for CEPH object storage could look like this:
      Media Type = "S3_Object1"
      Archive Device = "Object S3 Storage"
      Device Type = droplet
-     Device Options = "profile=/etc/bareos/bareos-sd.d/droplet/ceph-rados-gateway.profile,bucket=backup-bareos,chunksize=100M"
+     Device Options = "profile=/etc/bareos/bareos-sd.d/device/droplet/ceph-rados-gateway.profile,bucket=backup-bareos,chunksize=100M"
      Label Media = yes                    # Lets Bareos label unlabeled media
      Random Access = yes
      Automatic Mount = yes                # When device opened, read it


### PR DESCRIPTION
This commit fixes a wrong path setting to the droplet.profile in the
device options directive of the example configuration.