### PR TITLE
python-plugins: restore thread state properly

### DIFF
--- a/core/src/include/version_hex.h
+++ b/core/src/include/version_hex.h
@@ -1,0 +1,28 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_INCLUDE_VERSION_HEX_H
+#define BAREOS_INCLUDE_VERSION_HEX_H
+
+#define VERSION_HEX(maj, min, pat) \
+  (0x##maj << 24 | 0x##min << 16 | 0x##pat << 8)
+
+#endif  // BAREOS_INCLUDE_VERSION_HEX_H

--- a/core/src/plugins/dird/python/module/bareosdir.cc
+++ b/core/src/plugins/dird/python/module/bareosdir.cc
@@ -33,7 +33,9 @@
 #  include "include/bareos.h"
 #endif
 
-#if PY_VERSION_HEX < 0x03000000
+#include "include/version_hex.h"
+
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define LOGPREFIX "python-dir-mod: "
 #else
 #  define LOGPREFIX "python3-dir-mod: "

--- a/core/src/plugins/dird/python/python-dir.cc
+++ b/core/src/plugins/dird/python/python-dir.cc
@@ -33,10 +33,11 @@
 #  include <Python.h>
 #  include "include/bareos.h"
 #endif
+#include "include/version_hex.h"
 
 #define PLUGIN_DAEMON "dir"
 
-#if PY_VERSION_HEX < 0x03000000
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define PLUGIN_NAME "python"
 #  define PLUGIN_DIR PY2MODDIR
 #else
@@ -247,7 +248,10 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
   *plugin_information = &pluginInfo; /* Return pointer to our info */
   *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
+#if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
   PyEval_InitThreads();
+#endif
+
   mainThreadState = PyEval_SaveThread();
 
   return bRC_OK;
@@ -314,7 +318,12 @@ static bRC freePlugin(PluginContext* plugin_ctx)
   if (plugin_priv_ctx->pModule) { Py_DECREF(plugin_priv_ctx->pModule); }
 
   Py_EndInterpreter(plugin_priv_ctx->interpreter);
+#if PY_VERSION_HEX < VERSION_HEX(3, 2, 0)
   PyEval_ReleaseLock();
+#else
+  PyThreadState_Swap(mainThreadState);
+  PyEval_ReleaseThread(mainThreadState);
+#endif
 
   free(plugin_priv_ctx);
   plugin_ctx->plugin_private_context = NULL;

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -33,7 +33,9 @@
 #  include "include/bareos.h"
 #endif
 
-#if PY_VERSION_HEX < 0x03000000
+#include "include/version_hex.h"
+
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define LOGPREFIX "python-fd-mod: "
 #else
 #  define LOGPREFIX "python3-fd-mod: "

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -33,10 +33,11 @@
 #  include <Python.h>
 #  include "include/bareos.h"
 #endif
+#include "include/version_hex.h"
 
 #define PLUGIN_DAEMON "fd"
 
-#if PY_VERSION_HEX < 0x03000000
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define PLUGIN_NAME "python"
 #  define PLUGIN_DIR PY2MODDIR
 #else
@@ -216,7 +217,10 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
     *plugin_information = &pluginInfo; /* Return pointer to our info */
     *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
+#if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
     PyEval_InitThreads();
+#endif
+
     mainThreadState = PyEval_SaveThread();
   }
   return bRC_OK;
@@ -313,7 +317,12 @@ static bRC freePlugin(PluginContext* plugin_ctx)
   if (plugin_priv_ctx->pModule) { Py_DECREF(plugin_priv_ctx->pModule); }
 
   Py_EndInterpreter(plugin_priv_ctx->interpreter);
+#if PY_VERSION_HEX < VERSION_HEX(3, 2, 0)
   PyEval_ReleaseLock();
+#else
+  PyThreadState_Swap(mainThreadState);
+  PyEval_ReleaseThread(mainThreadState);
+#endif
 
   free(plugin_priv_ctx);
   plugin_ctx->plugin_private_context = NULL;

--- a/core/src/plugins/include/python3compat.h
+++ b/core/src/plugins/include/python3compat.h
@@ -23,7 +23,9 @@
 
 /* redefine python3 calls to python2 pendants */
 
-#if PY_VERSION_HEX < 0x03000000
+#include "include/version_hex.h"
+
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define PyLong_FromLong PyInt_FromLong
 #  define PyLong_AsLong PyInt_AsLong
 

--- a/core/src/plugins/stored/python/module/bareossd.cc
+++ b/core/src/plugins/stored/python/module/bareossd.cc
@@ -33,7 +33,9 @@
 #  include "include/bareos.h"
 #endif
 
-#if PY_VERSION_HEX < 0x03000000
+#include "include/version_hex.h"
+
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
 #  define LOGPREFIX "python-sd-mod: "
 #else
 #  define LOGPREFIX "python3-sd-mod: "


### PR DESCRIPTION
- swap interpreter state back to the global state
- do not use deprecated function calls

- add extra header with preprocessor macro for a better
  readable version presentation
- replace existing hex numbers by preprocessor macro