### PR TITLE
Update default config fileset for windows

### DIFF
--- a/core/src/defaultconfigs/bareos-dir.d/fileset/Windows All Drives.conf
+++ b/core/src/defaultconfigs/bareos-dir.d/fileset/Windows All Drives.conf
@@ -6,7 +6,9 @@ FileSet {
       Signature = MD5
       Drive Type = fixed
       IgnoreCase = yes
+      WildFile = "[A-Z]:/hiberfil.sys"
       WildFile = "[A-Z]:/pagefile.sys"
+      WildFile = "[A-Z]:/swapfile.sys"
       WildDir = "[A-Z]:/RECYCLER"
       WildDir = "[A-Z]:/$RECYCLE.BIN"
       WildDir = "[A-Z]:/System Volume Information"


### PR DESCRIPTION
Exclude `hyberfile.sys` and `swapfiles.sys` from backups (used on latest windows instead of `pagefile.sys`)