### PR TITLE
Fix memory access violations in mem_pool.cc and ua_acl.cc (backport from master)

### DIFF
--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -33,6 +33,8 @@
 #include "dird/dird_globals.h"
 #include "lib/edit.h"
 
+#include <string>
+
 namespace directordaemon {
 
 /**
@@ -44,38 +46,13 @@ bool UaContext::AclAccessOk(int acl, const char *item, bool audit_event)
 }
 
 /**
- * Check if this is a regular expresion.
+ * Check if this is a regular expression.
  * A regexp uses the following chars:
  * ., (, ), [, ], |, ^, $, +, ?, *
  */
-static inline bool is_regex(const char *regexp)
+static bool is_regex(std::string string_to_check)
 {
-   const char *p;
-   bool retval = false;
-
-   p = regexp;
-   while (p) {
-      switch (*p++) {
-      case '.':
-      case '(':
-      case ')':
-      case '[':
-      case ']':
-      case '|':
-      case '^':
-      case '$':
-      case '+':
-      case '?':
-      case '*':
-         retval = true;
-         goto bail_out;
-      default:
-         break;
-      }
-   }
-
-bail_out:
-   return retval;
+   return std::string::npos != string_to_check.find_first_of(".()[]|^$+?*");
 }
 
 /**

--- a/core/src/lib/mem_pool.cc
+++ b/core/src/lib/mem_pool.cc
@@ -433,19 +433,13 @@ void GarbageCollectMemoryPool()
 /* Release all freed pooled memory */
 void CloseMemoryPool()
 {
-   struct abufhead *buf, *next;
-   int count = 0;
-   uint64_t bytes = 0;
-
    sm_check(__FILE__, __LINE__, false);
    P(mutex);
    for (int i=1; i<=PM_MAX; i++) {
-      buf = pool_ctl[i].free_buf;
+      abufhead* buf = pool_ctl[i].free_buf;
       while (buf) {
-         next = buf->next;
-         count++;
-         bytes += SizeofPoolMemory((char *)buf);
-         free((char *)buf);
+         abufhead* next = buf->next;
+         free(buf);
          buf = next;
       }
       pool_ctl[i].free_buf = NULL;


### PR DESCRIPTION
Fixes #1281: Director crashes on memory access violation
             in CloseMemoryPool() and is_regex()

mem_pool: Remove calculation of the variables "count"
and "bytes" which caused the crash while the results are
not used at all. Also reduces variable scope and removes
a pointless cast.

ua_acl: fix is_regex() function, replace error-prone and
buggy function with simpler c++-based string-handling.