### PR TITLE
LibCloud Populate statp on new file

### DIFF
--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -344,6 +344,11 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
 
         statp = bareosfd.StatPacket()
 
+        statp.st_size = self.current_backup_task['size']
+        statp.st_mtime = self.current_backup_task['mtime']
+        statp.st_atime = 0
+        statp.st_ctime = 0
+        
         savepkt.statp = statp
         savepkt.fname = StringCodec.encode_for_backup(filename)
         savepkt.type = FT_REG


### PR DESCRIPTION
In current implementation statp is only populated with default stats instead of object's actual stats. This causes an accurate incremental backup to backup every file as the modified time does not match the time stored in the catalog.