### PR TITLE
Support VDDK 7.0.1 in Bareos 19.2

### DIFF
--- a/vmware/packaging/bareos-vmware.spec
+++ b/vmware/packaging/bareos-vmware.spec
@@ -41,7 +41,6 @@ Summary:        Bareos VMware plugin
 Group:          Productivity/Archiving/Backup
 Requires:       bareos-vadp-dumper
 Requires:       bareos-filedaemon-python-plugin >= 15.2
-Requires:       python-pyvmomi
 %if 0%{?suse_version} == 1110 
 Requires:       python-ordereddict
 %endif

--- a/vmware/vadp_dumper/CMakeLists.txt
+++ b/vmware/vadp_dumper/CMakeLists.txt
@@ -2,6 +2,20 @@ include_directories(/usr/lib/vmware-vix-disklib/include)
 link_directories(/usr/lib/vmware-vix-disklib/lib64)
 add_executable(bareos_vadp_dumper bareos_vadp_dumper.cc cbuf.cc copy_thread.cc)
 target_link_libraries(bareos_vadp_dumper vixDiskLib pthread jansson)
+
+include(CheckStructHasMember)
+check_struct_has_member(
+  "VixDiskLibCreateParams" physicalSectorSize
+  /usr/lib/vmware-vix-disklib/include/vixDiskLib.h
+  VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
+)
+
+if(VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE)
+  target_compile_definitions(
+    bareos_vadp_dumper PUBLIC VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
+  )
+endif()
+
 install(TARGETS bareos_vadp_dumper DESTINATION "${CMAKE_INSTALL_SBINDIR}")
 install(
   FILES bareos_vadp_dumper_wrapper.sh

--- a/vmware/vadp_dumper/CMakeLists.txt
+++ b/vmware/vadp_dumper/CMakeLists.txt
@@ -1,5 +1,7 @@
 include_directories(/usr/lib/vmware-vix-disklib/include)
 link_directories(/usr/lib/vmware-vix-disklib/lib64)
+add_link_options("-Wl,--disable-new-dtags")
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH true)
 add_executable(bareos_vadp_dumper bareos_vadp_dumper.cc cbuf.cc copy_thread.cc)
 target_link_libraries(bareos_vadp_dumper vixDiskLib pthread jansson)
 

--- a/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -681,6 +681,14 @@ static inline void do_vixdisklib_open(const char* key,
       VixDiskLib_FreeErrorText(error_txt);
       goto bail_out;
     }
+#ifdef VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
+    if (verbose) {
+      fprintf(stderr, "DiskInfo logicalSectorSize: %u\n",
+              info->logicalSectorSize);
+      fprintf(stderr, "DiskInfo physicalSectorSize: %u\n",
+              info->physicalSectorSize);
+    }
+#endif
   }
 
   if (verbose) {
@@ -737,6 +745,10 @@ static inline void do_vixdisklib_create(const char* key,
   } else {
     createParams.diskType = VIXDISKLIB_DISK_MONOLITHIC_SPARSE;
   }
+#ifdef VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
+  createParams.physicalSectorSize = VIXDISKLIB_SECTOR_SIZE;
+  createParams.logicalSectorSize = VIXDISKLIB_SECTOR_SIZE;
+#endif
   createParams.hwVersion = 7; /* for ESX(i)4 */
   err = VixDiskLib_Create(connection, disk_path, &createParams, NULL, NULL);
   if (VIX_FAILED(err)) {

--- a/vmware/vadp_dumper/bareos_vadp_dumper_wrapper.sh
+++ b/vmware/vadp_dumper/bareos_vadp_dumper_wrapper.sh
@@ -1,3 +1,49 @@
 #!/bin/sh
-export LD_LIBRARY_PATH=/usr/lib/vmware-vix-disklib/lib64
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+cancel=0
+
+if [ ! -d /sys/class/scsi_disk/ ]; then
+  cat <<EOT >&2
+  Your system does not have /sys/class/scsi_disk/ which is required for
+  VADP dumper due to a bug in VMware's VDDK. Please load the sd_mod
+  kernel module and make sure /sys/class/scsi_disk/ exists.
+  You can do this temporarily by running "modprobe sd_mod" as root.
+  Please refer to your OS documentation how to persist this change across reboots.
+EOT
+  cancel=1
+fi
+
+if [ ! -r /etc/mtab ]; then
+  cat <<EOT >&2
+  Your system does not have /etc/mtab which is required for VADP dumper
+  due to a bug in VMware's VDDK. Please create /etc/mtab as a symlink to
+  /proc/self/mounts.
+  This can be done by running "cd /etc; ln -s ../proc/self/mounts mtab"
+  as root.
+EOT
+  cancel=1
+fi
+
+if [ "$cancel" -eq 1 ]; then
+  exit 2
+fi
+
 exec bareos_vadp_dumper "$@"


### PR DESCRIPTION
* always set an rpath instead of a runpath when linking bareos_vadp_dumper
* detect issues that trigger a Bug with VDDK and report them early