### PR TITLE
added systemd reload commands

### DIFF
--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -35,8 +35,8 @@ PIDFile=@piddir@/bareos-dir.@dir_port@.pid
 ExecStartPre=@sbindir@/bareos-dir -t -f
 ExecStart=@sbindir@/bareos-dir
 SuccessExitStatus=0 1 15
-# This daemon should be able to reload the conf file
-#ExecReload=/sbin/killproc -p @piddir@/bareos-dir.pid -HUP @sbindir@/bareos-dir
+ExecReload=@sbindir@/bareos-dir -t -f
+ExecReload=/bin/kill -HUP $MAINPID
 #Restart=on-failure
 # Allow unlimited restarts,
 # required for automatic restarting on Univention Corporate Servers (UCS).

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -35,8 +35,8 @@ PIDFile=@piddir@/bareos-dir.@dir_port@.pid
 ExecStartPre=@sbindir@/bareos-dir -t -f
 ExecStart=@sbindir@/bareos-dir
 SuccessExitStatus=0 1 15
-# This daemon should be able to reload the conf file
-#ExecReload=/sbin/killproc -p @piddir@/bareos-dir.pid -HUP @sbindir@/bareos-dir
+ExecReload=@sbindir@/bareos-dir -t -f
+ExecReload=/bin/kill -HUP $MAINPID
 #Restart=on-failure
 # Allow unlimited restarts,
 # required for automatic restarting on Univention Corporate Servers (UCS).


### PR DESCRIPTION
This PR adds reload commands for the Bareos director. It first tests the configuration and then sends a SIGHUP to the main process.
If the config tests fails a log message will be reported, but the SIGHUP is fired anyway.