### PR TITLE
Fix shebang error on rpmbuild

### DIFF
--- a/core/platforms/redhat/bareos-dir.in
+++ b/core/platforms/redhat/bareos-dir.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos       This shell script takes care of starting and stopping
 #	       the bareos Director daemon

--- a/core/platforms/redhat/bareos-fd.in
+++ b/core/platforms/redhat/bareos-fd.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos       This shell script takes care of starting and stopping
 #	       the bareos File daemon.

--- a/core/platforms/redhat/bareos-sd.in
+++ b/core/platforms/redhat/bareos-sd.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos       This shell script takes care of starting and stopping
 #	       the bareos Storage daemon.

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
 #   Copyright (C) 2013-2020 Bareos GmbH & Co. KG

--- a/core/scripts/bareos-config.in
+++ b/core/scripts/bareos-config.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 
 LIB=@scriptdir@/bareos-config-lib.sh
 

--- a/core/scripts/bareos-ctl-dir.in
+++ b/core/scripts/bareos-ctl-dir.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos-ctl-dir This shell script takes care of starting and stopping
 #		 the bareos Director daemon

--- a/core/scripts/bareos-ctl-fd.in
+++ b/core/scripts/bareos-ctl-fd.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos-ctl-fd This shell script takes care of starting and stopping
 #		the bareos File daemon.

--- a/core/scripts/bareos-ctl-funcs
+++ b/core/scripts/bareos-ctl-funcs
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 
 # A function to find the pid of a program.
 pidofproc() {

--- a/core/scripts/bareos-ctl-sd.in
+++ b/core/scripts/bareos-ctl-sd.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos-ctl-sd This shell script takes care of starting and stopping
 #		the bareos Storage daemon

--- a/core/scripts/bareos-explorer.in
+++ b/core/scripts/bareos-explorer.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/scripts/bareos.in
+++ b/core/scripts/bareos.in
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/usr/bin/sh
 #
 # bareos       This shell script takes care of starting and stopping
 #	       the bareos daemons.

--- a/core/scripts/btraceback.in
+++ b/core/scripts/btraceback.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # Script to do a stack trace of a Bareos daemon/program
 # and create a core-file for postmortem debugging.

--- a/core/scripts/disk-changer.in
+++ b/core/scripts/disk-changer.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS interface to virtual autoloader using disk storage
 #

--- a/core/scripts/mtx-changer.in
+++ b/core/scripts/mtx-changer.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # Bareos interface to mtx autoloader
 #

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/delete_catalog_backup.in
+++ b/core/src/cats/delete_catalog_backup.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/bash
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/drop_bareos_database.in
+++ b/core/src/cats/drop_bareos_database.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/drop_bareos_tables.in
+++ b/core/src/cats/drop_bareos_tables.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/grant_bareos_privileges.in
+++ b/core/src/cats/grant_bareos_privileges.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/make_bareos_tables.in
+++ b/core/src/cats/make_bareos_tables.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/make_catalog_backup.in
+++ b/core/src/cats/make_catalog_backup.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #

--- a/core/src/cats/make_catalog_backup.pl.in
+++ b/core/src/cats/make_catalog_backup.pl.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl
 use strict;
 
 =head1 SCRIPT

--- a/core/src/cats/update_bareos_tables.in
+++ b/core/src/cats/update_bareos_tables.in
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #


### PR DESCRIPTION
When building the rpm package, many errors/warnings about an wrong shebang is shown.