### PR TITLE
cmake: fix gentoo release detection

### DIFF
--- a/core/cmake/distname.sh
+++ b/core/cmake/distname.sh
@@ -153,7 +153,7 @@ else
       elif test -f /etc/gentoo-release
       then
          PLATFORM=gentoo
-         DISTVER=`awk '/version / { print $5 }' < /etc/gentoo-release`
+         DISTVER=`awk '/release / { print $5 }' < /etc/gentoo-release`
       elif test -f /etc/debian_version
       then
          if `test -f /etc/apt/sources.list && grep -q ubuntu /etc/apt/sources.list`; then


### PR DESCRIPTION
This patch was already in the gentoo portage tree for some time and
is required for proper release detection