### PR TITLE
Install python3 bin file to the correct diretory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: console: add the ability to rerun multiple commas separated jobids [PR #1170]
 
 ### Fixed
+- python plugins: store architecture specific modules in sitearch (instead of sitelib) [PR #698]
 - debian: fix package dependencies for webui and Ceph [PR #1183]
 - Python plugins: fix handling of additional pluginoptions parameter [PR #1177]
 - NDMP_BAREOS: support autoxflate plugin [PR #1013]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -445,7 +445,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(Python2_CCSHARED -Wno-register)
 
   set(Python2_SITELIB ${plugindir})
-  set(Python3_SITELIB ${plugindir})
+  set(Python3_SITEARCH ${plugindir})
 endif()
 
 # set INSTALL_LIB_DIR automatically to lib or lib64 automatically Taken from

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -58,8 +58,12 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 option(ENABLE_SANITIZERS "Build with ASan/LSan/UBSan enabled" OFF)
 if(ENABLE_SANITIZERS)
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover")
+    set(CMAKE_CXX_FLAGS
+        "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover"
+    )
+    set(CMAKE_C_FLAGS
+        "${CMAKE_C_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover"
+    )
   else()
     message(
       FATAL_ERROR
@@ -444,7 +448,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   # c++17 removed register keyword
   set(Python2_CCSHARED -Wno-register)
 
-  set(Python2_SITELIB ${plugindir})
+  set(Python2_SITEARCH ${plugindir})
   set(Python3_SITEARCH ${plugindir})
 endif()
 

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1564,12 +1564,12 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %files filedaemon-python2-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python-fd.so
-%{python2_sitelib}/bareosfd*.so
+%{python2_sitearch}/bareosfd*.so
 
 %files filedaemon-python3-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python3-fd.so
-%{python3_sitelib}/bareosfd*.so
+%{python3_sitearch}/bareosfd*.so
 
 %files filedaemon-python-plugins-common
 %{plugin_dir}/bareos-fd-local-fileset.py*
@@ -1623,12 +1623,12 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %files director-python2-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python-dir.so
-%{python2_sitelib}/bareosdir*.so
+%{python2_sitearch}/bareosdir*.so
 
 %files director-python3-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python3-dir.so
-%{python3_sitelib}/bareosdir*.so
+%{python3_sitearch}/bareosdir*.so
 
 %files director-python-plugins-common
 %{plugin_dir}/BareosDirPluginBaseclass.py*
@@ -1638,12 +1638,12 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %files storage-python2-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python-sd.so
-%{python2_sitelib}/bareossd*.so
+%{python2_sitearch}/bareossd*.so
 
 %files storage-python3-plugin
 %defattr(-, root, root)
 %{plugin_dir}/python3-sd.so
-%{python3_sitelib}/bareossd*.so
+%{python3_sitearch}/bareossd*.so
 
 %files storage-python-plugins-common
 %{plugin_dir}/BareosSdPluginBaseclass.py*

--- a/core/src/plugins/dird/python/CMakeLists.txt
+++ b/core/src/plugins/dird/python/CMakeLists.txt
@@ -80,7 +80,7 @@ if(Python3_FOUND)
   target_link_libraries(python3-dir ${Python3_LIBRARIES} bareos)
   target_include_directories(python3-dir PUBLIC ${Python3_INCLUDE_DIRS})
   target_compile_definitions(
-    python3-dir PUBLIC PY3MODDIR=\"${Python3_SITELIB}\"
+    python3-dir PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\"
   )
   add_dependencies(python3-dir bareosdir-python3-module)
 
@@ -93,7 +93,7 @@ endif()
 
 if(Python3_FOUND)
   add_library(bareosdir-python3-module MODULE module/bareosdir.cc)
-  install(TARGETS bareosdir-python3-module DESTINATION ${Python3_SITELIB})
+  install(TARGETS bareosdir-python3-module DESTINATION ${Python3_SITEARCH})
   set_target_properties(
     bareosdir-python3-module
     PROPERTIES PREFIX ""

--- a/core/src/plugins/dird/python/CMakeLists.txt
+++ b/core/src/plugins/dird/python/CMakeLists.txt
@@ -26,7 +26,9 @@ if(Python2_FOUND)
   install(TARGETS python-dir DESTINATION ${plugindir})
   target_link_libraries(python-dir ${Python2_LIBRARIES} bareos)
   target_include_directories(python-dir PUBLIC ${Python2_INCLUDE_DIRS})
-  target_compile_definitions(python-dir PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_definitions(
+    python-dir PUBLIC PY2MODDIR=\"${Python2_SITEARCH}\"
+  )
   target_compile_options(python-dir PUBLIC ${Python2_CCSHARED})
   add_dependencies(python-dir bareosdir-python2-module)
 
@@ -39,7 +41,7 @@ endif()
 
 if(Python2_FOUND)
   add_library(bareosdir-python2-module MODULE module/bareosdir.cc)
-  install(TARGETS bareosdir-python2-module DESTINATION ${Python2_SITELIB})
+  install(TARGETS bareosdir-python2-module DESTINATION ${Python2_SITEARCH})
   set_target_properties(
     bareosdir-python2-module
     PROPERTIES PREFIX ""

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -47,7 +47,7 @@ if(Python3_FOUND)
   )
   target_link_libraries(python3-fd ${Python3_LIBRARIES} bareos)
   target_include_directories(python3-fd PUBLIC ${Python3_INCLUDE_DIRS})
-  target_compile_definitions(python3-fd PUBLIC PY3MODDIR=\"${Python3_SITELIB}\")
+  target_compile_definitions(python3-fd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\")
   add_dependencies(bareos-fd python3-fd)
   add_dependencies(python3-fd bareosfd-python3-module)
 endif()
@@ -136,7 +136,7 @@ endif()
 
 if(Python3_FOUND)
   add_library(bareosfd-python3-module MODULE module/bareosfd.cc)
-  install(TARGETS bareosfd-python3-module DESTINATION ${Python3_SITELIB})
+  install(TARGETS bareosfd-python3-module DESTINATION ${Python3_SITEARCH})
   set_target_properties(
     bareosfd-python3-module
     PROPERTIES PREFIX ""

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -29,7 +29,7 @@ if(Python2_FOUND)
   )
   target_link_libraries(python-fd ${Python2_LIBRARIES} bareos)
   target_include_directories(python-fd PUBLIC ${Python2_INCLUDE_DIRS})
-  target_compile_definitions(python-fd PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_definitions(python-fd PUBLIC PY2MODDIR=\"${Python2_SITEARCH}\")
   target_compile_options(python-fd PUBLIC ${Python2_CCSHARED})
   add_dependencies(bareos-fd python-fd)
   add_dependencies(python-fd bareosfd-python2-module)
@@ -47,7 +47,9 @@ if(Python3_FOUND)
   )
   target_link_libraries(python3-fd ${Python3_LIBRARIES} bareos)
   target_include_directories(python3-fd PUBLIC ${Python3_INCLUDE_DIRS})
-  target_compile_definitions(python3-fd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\")
+  target_compile_definitions(
+    python3-fd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\"
+  )
   add_dependencies(bareos-fd python3-fd)
   add_dependencies(python3-fd bareosfd-python3-module)
 endif()
@@ -101,7 +103,7 @@ endif()
 
 if(Python2_FOUND)
   add_library(bareosfd-python2-module MODULE module/bareosfd.cc)
-  install(TARGETS bareosfd-python2-module DESTINATION ${Python2_SITELIB})
+  install(TARGETS bareosfd-python2-module DESTINATION ${Python2_SITEARCH})
   set_target_properties(
     bareosfd-python2-module
     PROPERTIES PREFIX ""

--- a/core/src/plugins/stored/python/CMakeLists.txt
+++ b/core/src/plugins/stored/python/CMakeLists.txt
@@ -75,7 +75,7 @@ if(Python3_FOUND)
   )
   install(TARGETS python3-sd DESTINATION ${plugindir})
   target_link_libraries(python3-sd ${Python3_LIBRARIES} bareos)
-  target_compile_definitions(python3-sd PUBLIC PY3MODDIR=\"${Python3_SITELIB}\")
+  target_compile_definitions(python3-sd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\")
   target_include_directories(python3-sd PUBLIC ${Python3_INCLUDE_DIRS})
   add_dependencies(python3-sd bareossd-python3-module)
 
@@ -88,7 +88,7 @@ endif()
 
 if(Python3_FOUND)
   add_library(bareossd-python3-module MODULE module/bareossd.cc)
-  install(TARGETS bareossd-python3-module DESTINATION ${Python3_SITELIB})
+  install(TARGETS bareossd-python3-module DESTINATION ${Python3_SITEARCH})
   set_target_properties(
     bareossd-python3-module
     PROPERTIES PREFIX ""

--- a/core/src/plugins/stored/python/CMakeLists.txt
+++ b/core/src/plugins/stored/python/CMakeLists.txt
@@ -25,7 +25,7 @@ if(Python2_FOUND)
   install(TARGETS python-sd DESTINATION ${plugindir})
   target_link_libraries(python-sd ${Python2_LIBRARIES} bareos)
   target_include_directories(python-sd PUBLIC ${Python2_INCLUDE_DIRS})
-  target_compile_definitions(python-sd PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_definitions(python-sd PUBLIC PY2MODDIR=\"${Python2_SITEARCH}\")
   target_compile_options(python-sd PUBLIC ${Python2_CCSHARED})
   add_dependencies(python-sd bareossd-python2-module)
 
@@ -38,7 +38,7 @@ endif()
 
 if(Python2_FOUND)
   add_library(bareossd-python2-module MODULE module/bareossd.cc)
-  install(TARGETS bareossd-python2-module DESTINATION ${Python2_SITELIB})
+  install(TARGETS bareossd-python2-module DESTINATION ${Python2_SITEARCH})
   set_target_properties(
     bareossd-python2-module
     PROPERTIES PREFIX ""
@@ -75,7 +75,9 @@ if(Python3_FOUND)
   )
   install(TARGETS python3-sd DESTINATION ${plugindir})
   target_link_libraries(python3-sd ${Python3_LIBRARIES} bareos)
-  target_compile_definitions(python3-sd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\")
+  target_compile_definitions(
+    python3-sd PUBLIC PY3MODDIR=\"${Python3_SITEARCH}\"
+  )
   target_include_directories(python3-sd PUBLIC ${Python3_INCLUDE_DIRS})
   add_dependencies(python3-sd bareossd-python3-module)
 

--- a/debian/bareos-director-python2-plugin.install.in
+++ b/debian/bareos-director-python2-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python-dir.so
-@Python2_SITELIB@/bareosdir.so
+@Python2_SITEARCH@/bareosdir.so

--- a/debian/bareos-director-python3-plugin.install.in
+++ b/debian/bareos-director-python3-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python3-dir.so
-@Python3_SITELIB@/bareosdir.cpython*.so
+@Python3_SITEARCH@/bareosdir.cpython*.so

--- a/debian/bareos-filedaemon-python2-plugin.install.in
+++ b/debian/bareos-filedaemon-python2-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python-fd.so
-@Python2_SITELIB@/bareosfd.so
+@Python2_SITEARCH@/bareosfd.so

--- a/debian/bareos-filedaemon-python3-plugin.install.in
+++ b/debian/bareos-filedaemon-python3-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python3-fd.so
-@Python3_SITELIB@/bareosfd.cpython*.so
+@Python3_SITEARCH@/bareosfd.cpython*.so

--- a/debian/bareos-storage-python2-plugin.install.in
+++ b/debian/bareos-storage-python2-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python-sd.so
-@Python2_SITELIB@/bareossd.so
+@Python2_SITEARCH@/bareossd.so

--- a/debian/bareos-storage-python3-plugin.install.in
+++ b/debian/bareos-storage-python3-plugin.install.in
@@ -1,2 +1,2 @@
 @plugindir@/python3-sd.so
-@Python3_SITELIB@/bareossd.cpython*.so
+@Python3_SITEARCH@/bareossd.cpython*.so


### PR DESCRIPTION
The python binary files are installed to the arch independence place instant of the arch depend.
See:
https://cmake.org/cmake/help/latest/module/FindPython3.html
Python3_SITEARCH will be the correct macro for the .so stuff.