### PR TITLE
libcloud plugin invalid filedescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Fixed
+- fix invalid file descriptor issue in the libcloud plugin [PR #702]
 
 ### Added
 


### PR DESCRIPTION
This PR should fix the invalid file descriptor issue in the libcloud plugin. Remark, there could be information about some other issue that will be lost when written to /dev/null. 

Therefore we should decide if /dev/null is right or if we want to redirect to a regular file. The reason I ask is, the invalid filedescriptor error occurs randomly and only if there was a previous write to stdout just before the new process starts. This text could containt more information about any other issue we do not know yet. 