### PR TITLE
docs: make bareos-20 the default (backport bareos-20)

### DIFF
--- a/docs/manuals/source/conf.py
+++ b/docs/manuals/source/conf.py
@@ -298,13 +298,13 @@ scv_whitelist_branches = (
     re.compile(r"^master$"),
     re.compile(r"^bareos-18.2$"),
     re.compile(r"^bareos-19.2$"),
-    re.compile(r"^bareos-20.2$"),
+    re.compile(r"^bareos-2.$"),
 )
 scv_whitelist_tags = (re.compile(r"^not-exisiting-tag$"),)
 scv_show_banner = True
 scv_priority = "branches"
-scv_root_ref = "bareos-19.2"
-scv_banner_main_ref = "bareos-19.2"
+scv_root_ref = "bareos-20"
+scv_banner_main_ref = "bareos-20"
 
 
 plantuml_output_format = "svg_img"


### PR DESCRIPTION
While this change is not required for https://docs.bareos.org, it is required for the test documentation in https://download.bareos.com/bareos/testing/CD/bareos-20/BareosMainReference/
