### PR TITLE
User date time formats

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Adrew J. Millar
 Adrian Brzezinski
 Adrian Close
 Aitor Matilla
+Alaa Eddine Elamri
 Alan Brown
 Aleksandar Milivojevic
 Aleksandr Kozlov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix oVirt plugin problem with config file [PR #729]
 - [Issue #1316]: storage daemon loses a configured device instance [PR #739]
 - fix python-bareos for Python < 2.7.13 [PR #748]
+- fixed bug when user could enter wrong dates such as 2000-66-100 55:55:89 without being denied [PR #707]
 
 
 ### Added
 - added reload commands to systemd service [PR #694]
 - Build the package **bareos-filedaemon-postgresql-python-plugin** also for Debian, Ubuntu and UCS (deb packages) [PR #723].
 - added an informative debugmessage when a dynamic backend cannot be loaded [PR #740]
+- support for shorter date formats, where shorter dates are compensated with lowest value possible to make a full date [PR #707]
 
 ### Changed
 - Fixed broken link in https://docs.bareos.org/IntroductionAndTutorial/WhatIsBareos.html documentation page

--- a/core/src/dird/ua_restore.h
+++ b/core/src/dird/ua_restore.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,6 +23,8 @@
 #define BAREOS_DIRD_UA_RESTORE_H_
 
 namespace directordaemon {
+
+std::string CompensateShortDate(const char* cmd);
 
 void FindStorageResource(UaContext* ua,
                          RestoreContext& rx,

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -484,3 +484,19 @@ if(NOT client-only)
       ${GTEST_MAIN_LIBRARIES}
   )
 endif() # NOT client-only
+
+if(NOT client-only)
+  bareos_add_test(
+    time_format_test
+    LINK_LIBRARIES
+      bareos
+      dird_objects
+      bareosfind
+      bareoscats
+      bareossql
+      $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}>
+      ${LMDB_LIBS}
+      ${GTEST_LIBRARIES}
+      ${GTEST_MAIN_LIBRARIES}
+  )
+endif() # NOT client-only

--- a/core/src/tests/time_format_test.cc
+++ b/core/src/tests/time_format_test.cc
@@ -1,0 +1,80 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
+   Copyright (C) 2011-2012 Planets Communications B.V.
+   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#  include "gtest/gtest.h"
+#else
+#  include "gtest/gtest.h"
+#  include "include/bareos.h"
+#endif
+
+#include "lib/btime.h"
+
+TEST(time_format, correct_time_and_date_format)
+{
+  // Correct dates
+  EXPECT_TRUE(StrToUtime("1999-01-02 22:22:22") != 0);
+  EXPECT_TRUE(StrToUtime("2020-11-22 1:5:7") != 0);
+  EXPECT_TRUE(StrToUtime("1999-01-02 22:22:") != 0);
+
+  // Correct format, but wrong date
+  EXPECT_EQ(StrToUtime("199-01-02 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-13-02 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-01-35 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-01-02 50:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-01-02 22:90:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-31-52 22:22:65"), 0);
+  EXPECT_EQ(StrToUtime("1999-31-52 50:72:22"), 0);
+
+  EXPECT_EQ(StrToUtime("199--1--2 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999-01-02 22:22:22:10"), 0);
+
+
+  // leap years
+  EXPECT_TRUE(StrToUtime("2000-02-29 10:10:10") != 0);
+  EXPECT_TRUE(StrToUtime("2020-02-29 10:10:10") != 0);
+  EXPECT_TRUE(StrToUtime("2001-02-29 10:10:10") == 0);
+  EXPECT_TRUE(StrToUtime("1900-02-29 10:10:10") == 0);
+
+  // Correct format, but missing entries
+  EXPECT_EQ(StrToUtime("1999-01-02 22:"), 0);
+  EXPECT_EQ(StrToUtime("1999-01-02"), 0);
+  EXPECT_EQ(StrToUtime("1999-"), 0);
+
+  // Wrong format but correct date
+  EXPECT_EQ(StrToUtime("1999/01/02 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("01-02-1999 22:22:22"), 0);
+  EXPECT_EQ(StrToUtime("1999/01/02 22:22:22"), 0);
+
+  // Random stuff
+  EXPECT_EQ(StrToUtime("d-at-ea nd:ti:me"), 0);
+  EXPECT_EQ(StrToUtime("-- ::"), 0);
+  EXPECT_EQ(StrToUtime(" - -   : : "), 0);
+  EXPECT_EQ(StrToUtime("1999-5-----"), 0);
+
+  EXPECT_TRUE(
+      StrToUtime("1999-01-02 "
+                 "22:22:22adfddfkjlsdjklf;asfdkslfkjasflsdfdkslfjdsfklds;"
+                 "lfkjdskkjajkvnkashuiadfvmnknkajnsfkljdnafkljdnafklja")
+      == 0);
+}

--- a/docs/manuals/source/TasksAndConcepts/TheRestoreCommand.rst
+++ b/docs/manuals/source/TasksAndConcepts/TheRestoreCommand.rst
@@ -19,6 +19,8 @@ restore job. You must use the restore command.
 Since Bareos is a network backup program, you must be aware that when you restore files, it is up to you to ensure that you or Bareos have selected the correct Client and the correct hard disk location for restoring those files. Bareos will quite willingly backup client A, and restore it by sending the files to a different directory on client B. Normally, you will want to avoid this, but assuming the operating systems are not too different in their file structures, this should work perfectly
 well, if so desired. By default, Bareos will restore data to the same Client that was backed up, and those data will be restored not to the original places but to /tmp/bareos-restores. This is configured in the default restore command resource in bareos-dir.conf. You may modify any of these defaults when the restore command prompts you to run the job by selecting the mod option.
 
+.. _RestoreCommand:
+
 Restore Command
 ---------------
 
@@ -96,6 +98,8 @@ There are a lot of options, and as a point of reference, most people will want t
 -  Item 12 is a full restore to a specified job date.
 
 -  Item 13 allows you to cancel the restore command.
+
+For items 6, 7 and 9, note that you must specify the date/time either exactly as shown YYYY-MM-DD HH-MM-SS or you can enter a shorter version of the same format such as YYYY-MM, and the command will take care of formatting. For example, if you want the system to restore saves done before October 2020, you can write 2020-10, and the console will understand it as 2020-10-01 00:00:00 and restore all saves before it. Empty fields in the format will get assigned the lowest possible value.
 
 As an example, suppose that we select item 5 (restore to most recent state). If you have not specified a client=xxx on the command line, it it will then ask for the desired Client, which on my system, will print all the Clients found in the database as follows:
 
@@ -388,7 +392,7 @@ The full list of possible command line arguments are:
 
 -  jobid=nnn – specify a JobId or comma separated list of JobIds to be restored.
 
--  before=YYYY-MM-DD HH:MM:SS – specify a date and time to which the system should be restored. Only Jobs started before the specified date/time will be selected, and as is the case for current Bareos will automatically find the most recent prior Full save and all Differential and Incremental saves run before the date you specify. Note, this command is not too user friendly in that you must specify the date/time exactly as shown.
+-  before=YYYY-MM-DD HH:MM:SS – specify a date and time to which the system should be restored. Only Jobs started before the specified date/time will be selected, and as is the case for current Bareos will automatically find the most recent prior Full save and all Differential and Incremental saves run before the date you specify. Note, the same formatting rules as items 6, 7 and 9 in :ref:`Restore Command <RestoreCommand>` apply to it.
 
 -  file=filename – specify a filename to be restored. You must specify the full path and filename. Prefixing the entry with a less-than sign (<) will cause Bareos to assume that the filename is on your system and contains a list of files to be restored. Bareos will thus read the list from that file. Multiple file=xxx specifications may be specified on the command line.
 


### PR DESCRIPTION
add support for shorter date formats, where shorter dates are compensated with lowest value possible to make a full date
also fix a bug where Bareos accepted bogus datetime formats.