### PR TITLE
core: adapt debian/control to new version of debian/control.in

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -352,3 +352,5 @@ Description: Backup Archiving Recovery Open Sourced - common tools
 
 
 
+
+


### PR DESCRIPTION
debian/control is generated from debian/control.in during cmake.
This change (adding 2 blank lines) prevents that this file differs from git after every run of cmake.
This change is required, as the optional package bareos-storage-droplet has been added recently.