### PR TITLE
travis: use dist=bionic as default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 os:
   - linux
 # dist: using Ubuntu 20.04 (Focal Fossa)
-dist: focal
-sudo: required
+#dist: focal
+# dist: using Ubuntu 18.04 (Bionic)
+dist: bionic
+# sudo: required
 language: cpp
 compiler:
   - gcc
@@ -10,6 +12,9 @@ git:
   depth: false
 services:
   - postgresql
+addons:
+  hosts:
+    - bareos.example.com
 
 # This project also uses Coverity Scan https://scan.coverity.com/
 # However, the Travis coverity scan addon (as of 19.02.2014) does not fit our needs,
@@ -21,6 +26,7 @@ env:
     global:
         - BAREOS_VERSION="unknown"
         - NOW=$(LANG=C date -R -u)
+        - DB=postgresql
         # -- BEGIN Coverity Scan ENV
         # The build command with all of the arguments that you would apply to a manual `cov-build`
         # Usually this is the same as STANDARD_BUILD_COMMAND, excluding the automated test arguments
@@ -37,18 +43,31 @@ env:
         - COVERITY_SCAN_BUILD="curl -s $COVERITY_SCAN_BUILD_URL | bash"
         # -- END Coverity Scan ENV
 
-matrix:
+jobs:
   include:
-    - env: DB=postgresql
-    - env: DB=postgresql COVERITY_SCAN=true
-    - env: DB=postgresql BUILD_WEBUI=true
+    - os: linux
+      dist: focal
+      addons:
+        # The travis focal dist from 03 Nov 2020 fails
+        # with the default postgresql installation.
+        # However, Postgresql 13 does work.
+        # This entry can be removed, as soon,
+        # as the default postgresql installation works again.
+        postgresql: "13"
+    - os: linux
+      dist: bionic
+    # disabled, because cmake is too old.
+    #- os: linux
+    #  dist: trusty
+    - compiler: clang
+    - env: COVERITY_SCAN=true
+    - env: BUILD_WEBUI=true
       addons:
         sauce_connect: true
-    - env: DB=postgresql
-      compiler: clang
+
   allow_failures:
-    - env: DB=postgresql COVERITY_SCAN=true
-    - env: DB=postgresql BUILD_WEBUI=true
+    - env: COVERITY_SCAN=true
+    - env: BUILD_WEBUI=true
 
 before_install:
     # install build dependencies
@@ -65,7 +84,3 @@ before_script:
 script:
     # run test script
     - if [ -z "${COVERITY_SCAN:-}" ]; then sudo -E $PWD/.travis/all; fi
-
-addons:
-    hosts:
-        - bareos.example.com

--- a/.travis/travis_before_script.sh
+++ b/.travis/travis_before_script.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -53,10 +53,7 @@ printf 'deb file:%s /\n' $PWD > /tmp/bareos.list
 sudo cp /tmp/bareos.list /etc/apt/sources.list.d/bareos.list
 cd -
 
-PKGS="bareos bareos-database-$DB"
-if [ "${BUILD_WEBUI:-}" ]; then
-    PKGS="$PKGS bareos-webui"
-fi
+PKGS="bareos bareos-database-$DB bareos-webui"
 print_header "install Bareos packages: $PKGS"
 sudo apt-get -qq update --allow-insecure-repositories || true
 sudo apt-get install -y --allow-unauthenticated $PKGS


### PR DESCRIPTION
In the current travis image, the default Postgresql database does not work.
Default is Postgresql 12.
However, Postgresql 13 is also included and does work.
This problem exists since 03 Nov 2020.
As it is still not fixed, we switch to the older bionic dist.
We still keep one job running on focal, however with Postgresql 13.