### PR TITLE
python-{dir,fd,sd} plugins: do not load python2 and 3 versions in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - fix invalid file descriptor issue in the libcloud plugin [PR #702]
+- fix crash when loading both python-fd and python3-fd plugins [PR #730]
 
 ### Added
 - added reload commands to systemd service [PR #694]

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1790,11 +1790,11 @@ static bool IsPluginCompatible(Plugin* plugin)
 {
   PluginInformation* info = (PluginInformation*)plugin->plugin_information;
   Dmsg0(debuglevel, "IsPluginCompatible called\n");
-  if (debug_level >= 50) { DumpFdPlugin(plugin, stdin); }
   if (!info) {
     Dmsg0(debuglevel, "IsPluginCompatible: plugin_information is empty\n");
     return false;
   }
+  if (debug_level >= 50) { DumpFdPlugin(plugin, stdin); }
   if (!bstrcmp(info->plugin_magic, FD_PLUGIN_MAGIC)) {
     Jmsg(NULL, M_ERROR, 0,
          _("Plugin magic wrong. Plugin=%s wanted=%s got=%s\n"), plugin->file,

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1711,6 +1711,8 @@ static void DumpFdPlugin(Plugin* plugin, FILE* fp)
   if (!plugin) { return; }
 
   info = (PluginInformation*)plugin->plugin_information;
+  if (!info) { return; }
+
   fprintf(fp, "\tversion=%d\n", info->version);
   fprintf(fp, "\tdate=%s\n", NPRTB(info->plugin_date));
   fprintf(fp, "\tmagic=%s\n", NPRTB(info->plugin_magic));
@@ -1789,6 +1791,10 @@ static bool IsPluginCompatible(Plugin* plugin)
   PluginInformation* info = (PluginInformation*)plugin->plugin_information;
   Dmsg0(debuglevel, "IsPluginCompatible called\n");
   if (debug_level >= 50) { DumpFdPlugin(plugin, stdin); }
+  if (!info) {
+    Dmsg0(debuglevel, "IsPluginCompatible: plugin_information is empty\n");
+    return false;
+  }
   if (!bstrcmp(info->plugin_magic, FD_PLUGIN_MAGIC)) {
     Jmsg(NULL, M_ERROR, 0,
          _("Plugin magic wrong. Plugin=%s wanted=%s got=%s\n"), plugin->file,

--- a/core/src/plugins/dird/python/python-dir.cc
+++ b/core/src/plugins/dird/python/python-dir.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2014 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -196,7 +196,6 @@ static void PyErrorHandler()
   Py_DECREF(type);
   Py_XDECREF(value);
   Py_XDECREF(traceback);
-  // printf("%s", error_string);
 
   free(error_string);
   exit(1);
@@ -215,46 +214,46 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
                PluginInformation** plugin_information,
                PluginFunctions** plugin_functions)
 {
-  /* Setup Python */
-  Py_InitializeEx(0);
+  if (!Py_IsInitialized()) {
+    Py_InitializeEx(0);
+    // add bareos plugin path to python module search path
+    PyObject* sysPath = PySys_GetObject((char*)"path");
+    PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
+    PyList_Append(sysPath, pluginPath);
+    Py_DECREF(pluginPath);
 
-  // add bareos plugin path to python module search path
-  PyObject* sysPath = PySys_GetObject((char*)"path");
-  PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
-  PyList_Append(sysPath, pluginPath);
-  Py_DECREF(pluginPath);
+    /* import the bareosdir module */
+    PyObject* bareosdirModule = PyImport_ImportModule("bareosdir");
+    if (!bareosdirModule) {
+      printf("loading of bareosdir failed\n");
+      if (PyErr_Occurred()) { PyErrorHandler(); }
+    }
 
+    /* import the CAPI from the bareosdir python module
+     * afterwards, Bareosdir_* macros are initialized to
+     * point to the corresponding functions in the bareosdir python
+     * module */
+    import_bareosdir();
 
-  /* import the bareosdir module */
-  PyObject* bareosdirModule = PyImport_ImportModule("bareosdir");
-  if (!bareosdirModule) {
-    printf("loading of bareosdir failed\n");
-    if (PyErr_Occurred()) { PyErrorHandler(); }
-  }
+    /* set bareos_core_functions inside of barosdir module */
+    Bareosdir_set_bareos_core_functions(lbareos_core_functions);
 
-  /* import the CAPI from the bareosdir python module
-   * afterwards, Bareosdir_* macros are initialized to
-   * point to the corresponding functions in the bareosdir python
-   * module */
-  import_bareosdir();
+    bareos_core_functions
+        = lbareos_core_functions; /* Set Bareos funct pointers */
+    bareos_plugin_interface_version = lbareos_plugin_interface_version;
 
-  /* set bareos_core_functions inside of barosdir module */
-  Bareosdir_set_bareos_core_functions(lbareos_core_functions);
-
-  bareos_core_functions
-      = lbareos_core_functions; /* Set Bareos funct pointers */
-  bareos_plugin_interface_version = lbareos_plugin_interface_version;
-
-  *plugin_information = &pluginInfo; /* Return pointer to our info */
-  *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
+    *plugin_information = &pluginInfo; /* Return pointer to our info */
+    *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
 #if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
-  PyEval_InitThreads();
+    PyEval_InitThreads();
 #endif
 
-  mainThreadState = PyEval_SaveThread();
-
-  return bRC_OK;
+    mainThreadState = PyEval_SaveThread();
+    return bRC_OK;
+  } else {
+    return bRC_Error;
+  }
 }
 
 /**
@@ -262,12 +261,12 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
  */
 bRC unloadPlugin()
 {
-  /*
-   * Terminate Python
-   */
-  PyEval_RestoreThread(mainThreadState);
-  Py_Finalize();
-
+  /* Terminate Python if it was initialized correctly */
+  if (mainThreadState) {
+    PyEval_RestoreThread(mainThreadState);
+    Py_Finalize();
+    mainThreadState = nullptr;
+  }
   return bRC_OK;
 }
 

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -184,46 +184,44 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
                PluginInformation** plugin_information,
                PluginFunctions** plugin_functions)
 {
-  if (!Py_IsInitialized()) {
-    Py_InitializeEx(0);
-    // add bareos plugin path to python module search path
-    PyObject* sysPath = PySys_GetObject((char*)"path");
-    PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
-    PyList_Append(sysPath, pluginPath);
-    Py_DECREF(pluginPath);
+  if (Py_IsInitialized()) { return bRC_Error; }
 
-    /* import the bareosfd module */
-    PyObject* bareosfdModule = PyImport_ImportModule("bareosfd");
-    if (!bareosfdModule) {
-      printf("loading of bareosfd failed\n");
-      if (PyErr_Occurred()) { PyErrorHandler(); }
-    }
+  Py_InitializeEx(0);
+  // add bareos plugin path to python module search path
+  PyObject* sysPath = PySys_GetObject((char*)"path");
+  PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
+  PyList_Append(sysPath, pluginPath);
+  Py_DECREF(pluginPath);
 
-    /* import the CAPI from the bareosfd python module
-     * afterwards, Bareosfd_* macros are initialized to
-     * point to the corresponding functions in the bareosfd python
-     * module */
-    import_bareosfd();
+  /* import the bareosfd module */
+  PyObject* bareosfdModule = PyImport_ImportModule("bareosfd");
+  if (!bareosfdModule) {
+    printf("loading of bareosfd failed\n");
+    if (PyErr_Occurred()) { PyErrorHandler(); }
+  }
 
-    /* set bareos_core_functions inside of barosfd module */
-    Bareosfd_set_bareos_core_functions(lbareos_core_functions);
+  /* import the CAPI from the bareosfd python module
+   * afterwards, Bareosfd_* macros are initialized to
+   * point to the corresponding functions in the bareosfd python
+   * module */
+  import_bareosfd();
 
-    bareos_core_functions
-        = lbareos_core_functions; /* Set Bareos funct pointers */
-    bareos_plugin_interface_version = lbareos_plugin_interface_version;
+  /* set bareos_core_functions inside of barosfd module */
+  Bareosfd_set_bareos_core_functions(lbareos_core_functions);
 
-    *plugin_information = &pluginInfo; /* Return pointer to our info */
-    *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
+  bareos_core_functions
+      = lbareos_core_functions; /* Set Bareos funct pointers */
+  bareos_plugin_interface_version = lbareos_plugin_interface_version;
+
+  *plugin_information = &pluginInfo; /* Return pointer to our info */
+  *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
 #if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
-    PyEval_InitThreads();
+  PyEval_InitThreads();
 #endif
 
-    mainThreadState = PyEval_SaveThread();
-    return bRC_OK;
-  } else {
-    return bRC_Error;
-  }
+  mainThreadState = PyEval_SaveThread();
+  return bRC_OK;
 }
 
 /**

--- a/core/src/plugins/stored/python/python-sd.cc
+++ b/core/src/plugins/stored/python/python-sd.cc
@@ -115,7 +115,7 @@ static PluginFunctions pluginFuncs
  * final python interpreter on unload of the plugin. Each instance of
  * the plugin get its own interpreter.
  */
-static PyThreadState* mainThreadState;
+static PyThreadState* mainThreadState{nullptr};
 
 /* functions common to all plugins */
 #include "plugins/include/python_plugins_common.inc"
@@ -215,46 +215,44 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
                PluginInformation** plugin_information,
                PluginFunctions** plugin_functions)
 {
-  if (!Py_IsInitialized()) {
-    Py_InitializeEx(0);
-    // add bareos plugin path to python module search path
-    PyObject* sysPath = PySys_GetObject((char*)"path");
-    PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
-    PyList_Append(sysPath, pluginPath);
-    Py_DECREF(pluginPath);
+  if (Py_IsInitialized()) { return bRC_Error; }
 
-    /* import the bareossd module */
-    PyObject* bareossdModule = PyImport_ImportModule("bareossd");
-    if (!bareossdModule) {
-      printf("loading of bareossd failed\n");
-      if (PyErr_Occurred()) { PyErrorHandler(); }
-    }
+  Py_InitializeEx(0);
+  // add bareos plugin path to python module search path
+  PyObject* sysPath = PySys_GetObject((char*)"path");
+  PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
+  PyList_Append(sysPath, pluginPath);
+  Py_DECREF(pluginPath);
 
-    /* import the CAPI from the bareossd python module
-     * afterwards, Bareossd_* macros are initialized to
-     * point to the corresponding functions in the bareossd python
-     * module */
-    import_bareossd();
+  /* import the bareossd module */
+  PyObject* bareossdModule = PyImport_ImportModule("bareossd");
+  if (!bareossdModule) {
+    printf("loading of bareossd failed\n");
+    if (PyErr_Occurred()) { PyErrorHandler(); }
+  }
 
-    /* set bareos_core_functions inside of barossd module */
-    Bareossd_set_bareos_core_functions(lbareos_core_functions);
+  /* import the CAPI from the bareossd python module
+   * afterwards, Bareossd_* macros are initialized to
+   * point to the corresponding functions in the bareossd python
+   * module */
+  import_bareossd();
 
-    bareos_core_functions
-        = lbareos_core_functions; /* Set Bareos funct pointers */
-    bareos_plugin_interface_version = lbareos_plugin_interface_version;
+  /* set bareos_core_functions inside of barossd module */
+  Bareossd_set_bareos_core_functions(lbareos_core_functions);
 
-    *plugin_information = &pluginInfo; /* Return pointer to our info */
-    *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
+  bareos_core_functions
+      = lbareos_core_functions; /* Set Bareos funct pointers */
+  bareos_plugin_interface_version = lbareos_plugin_interface_version;
+
+  *plugin_information = &pluginInfo; /* Return pointer to our info */
+  *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
 #if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
-    PyEval_InitThreads();
+  PyEval_InitThreads();
 #endif
 
-    mainThreadState = PyEval_SaveThread();
-    return bRC_OK;
-  } else {
-    return bRC_Error;
-  }
+  mainThreadState = PyEval_SaveThread();
+  return bRC_OK;
 }
 
 /**

--- a/core/src/plugins/stored/python/python-sd.cc
+++ b/core/src/plugins/stored/python/python-sd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2014 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -215,56 +215,60 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
                PluginInformation** plugin_information,
                PluginFunctions** plugin_functions)
 {
-  Py_InitializeEx(0);
+  if (!Py_IsInitialized()) {
+    Py_InitializeEx(0);
+    // add bareos plugin path to python module search path
+    PyObject* sysPath = PySys_GetObject((char*)"path");
+    PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
+    PyList_Append(sysPath, pluginPath);
+    Py_DECREF(pluginPath);
 
-  // add bareos plugin path to python module search path
-  PyObject* sysPath = PySys_GetObject((char*)"path");
-  PyObject* pluginPath = PyUnicode_FromString(PLUGIN_DIR);
-  PyList_Append(sysPath, pluginPath);
-  Py_DECREF(pluginPath);
+    /* import the bareossd module */
+    PyObject* bareossdModule = PyImport_ImportModule("bareossd");
+    if (!bareossdModule) {
+      printf("loading of bareossd failed\n");
+      if (PyErr_Occurred()) { PyErrorHandler(); }
+    }
 
-  /* import the bareossd module */
-  PyObject* bareossdModule = PyImport_ImportModule("bareossd");
-  if (!bareossdModule) {
-    printf("loading of bareossd failed\n");
-    if (PyErr_Occurred()) { PyErrorHandler(); }
-  }
+    /* import the CAPI from the bareossd python module
+     * afterwards, Bareossd_* macros are initialized to
+     * point to the corresponding functions in the bareossd python
+     * module */
+    import_bareossd();
 
-  /* import the CAPI from the bareossd python module
-   * afterwards, Bareossd_* macros are initialized to
-   * point to the corresponding functions in the bareossd python
-   * module */
-  import_bareossd();
+    /* set bareos_core_functions inside of barossd module */
+    Bareossd_set_bareos_core_functions(lbareos_core_functions);
 
-  /* set bareos_core_functions inside of barossd module */
-  Bareossd_set_bareos_core_functions(lbareos_core_functions);
+    bareos_core_functions
+        = lbareos_core_functions; /* Set Bareos funct pointers */
+    bareos_plugin_interface_version = lbareos_plugin_interface_version;
 
-  bareos_core_functions
-      = lbareos_core_functions; /* Set Bareos funct pointers */
-  bareos_plugin_interface_version = lbareos_plugin_interface_version;
-
-  *plugin_information = &pluginInfo; /* Return pointer to our info */
-  *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
+    *plugin_information = &pluginInfo; /* Return pointer to our info */
+    *plugin_functions = &pluginFuncs;  /* Return pointer to our functions */
 
 #if PY_VERSION_HEX < VERSION_HEX(3, 7, 0)
-  PyEval_InitThreads();
+    PyEval_InitThreads();
 #endif
 
-  mainThreadState = PyEval_SaveThread();
-  return bRC_OK;
+    mainThreadState = PyEval_SaveThread();
+    return bRC_OK;
+  } else {
+    return bRC_Error;
+  }
 }
 
 /**
- * External entry point to unload the plugin
+ * Plugin called here when it is unloaded, normally when Bareos is going to
+ * exit.
  */
 bRC unloadPlugin()
 {
-  /*
-   * Terminate Python
-   */
-  PyEval_RestoreThread(mainThreadState);
-  Py_Finalize();
-
+  /* Terminate Python if it was initialized correctly */
+  if (mainThreadState) {
+    PyEval_RestoreThread(mainThreadState);
+    Py_Finalize();
+    mainThreadState = nullptr;
+  }
   return bRC_OK;
 }
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins.rst
+++ b/docs/manuals/source/TasksAndConcepts/Plugins.rst
@@ -290,6 +290,10 @@ Switching to use the Python 3 plugin, the following needs to be changed:
   * Set `Plugin Names = "python3"` to make sure the Python3 plugin is loaded.
   * Adapt the Plugin setting in the fileset to use Python3: `Plugin = "python3:module_path ...`
 
+.. warning::
+
+   It is not possible to load the python2 and python3 plugins at the same time.
+
 
 Recovering old backups
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-PluginNames.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-PluginNames.rst.inc
@@ -1,3 +1,10 @@
 If a :config:option:`fd/client/PluginDirectory`\  is specified :strong:`Plugin Names`\  defines, which :ref:`fdPlugins` get loaded.
 
 If :strong:`Plugin Names`\  is not defined, all plugins get loaded, otherwise the defined ones.
+
+
+.. warning::
+
+   It is highly recommended to always specify the :strong:`Plugin Names` directive
+   to keep control about what plugins will be loaded by the filedaemon.
+   Some plugins cannot be loaded at the same time, like the python2 and python3 plugins.


### PR DESCRIPTION
- Check if Py_IsInitialized() before initializing the plugin and skip
  double initialization.
- unloadPlugin(): skip the Python shutdown so that a crash is avoided

### Please follow these few prerequisites before you hand in a PR

#### Consider the following chapters in the Bareos Developer Documentation

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
