### PR TITLE
stored: fix spooling sideffect bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix parallel python plugin jobs [PR #732]
 - fix oVirt plugin problem with config file [PR #732]
 - fix crash when loading both python-fd and python3-fd plugins [PR #733]
+- [Issue #1316]: storage daemon loses a configured device instance [PR #734]
 
 ### Added
 
@@ -21,8 +22,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Removed
 
 ### Security
-
-
 ## [20.0.0] - 2020-12-16
 
 ### Fixed
@@ -291,6 +290,4 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #667]: https://github.com/bareos/bareos/pull/667
 [PR #672]: https://github.com/bareos/bareos/pull/672
 [PR #686]: https://github.com/bareos/bareos/pull/686
-[PR #730]: https://github.com/bareos/bareos/pull/730
-[PR #733]: https://github.com/bareos/bareos/pull/733
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1278,7 +1278,10 @@ Device::~Device()
   pthread_mutex_destroy(&spool_mutex);
   // RwlDestroy(&lock);
   attached_dcrs.clear();
-  if (device_resource) { device_resource->dev = nullptr; }
+
+  if (device_resource && device_resource->dev == this) {
+    device_resource->dev = nullptr;
+  }
 }
 
 bool Device::CanStealLock() const

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2013 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -511,6 +511,14 @@ VolumeReservationItem* reserve_volume(DeviceControlRecord* dcr,
       /*
        * Caller wants to switch Volume to another device
        */
+
+      // should be different devices with different names
+      if (bstrcmp(dev->print_name(), vol->dev->print_name())) {
+        // names are same
+        Dmsg1(100, "device pointers are different but have same name %s\n",
+              dev->print_name());
+      }
+
       if (!vol->dev->IsBusy() && !vol->IsSwapping()) {
         slot_number_t slot;
 


### PR DESCRIPTION
Fixes #1316: stored loses a configured device instance

This is a backport of the PR #739. 

The Device reference in the DeviceResource could become invalid
due to a missing comparison in the Device destructor. This bug
only occurs when spooling is turned on and has side effects on
the volume management and the reservation.

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
