### PR TITLE
systemtests: fix config-dump test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Fixed
+- fix config-dump systemtest [PR #736]
 - fix systemtests daemon control scripts [PR #762]
 - fix invalid file descriptor issue in the libcloud plugin [PR #702]
 - fix crash when loading both python-fd and python3-fd plugins [PR #730]
@@ -23,6 +24,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - support for shorter date formats, where shorter dates are compensated with lowest value possible to make a full date [PR #707]
 
 ### Changed
+- bstrncpy: workaround when used with overlapping strings [PR #736]
 - Disabled test "statefile" for big endian, use temporary state files for all other architectures [PR #757]
 - Fixed broken link in https://docs.bareos.org/IntroductionAndTutorial/WhatIsBareos.html documentation page
 - Package **bareos-database-postgresql**: add recommendation for package **dbconfig-pgsql**.

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -407,8 +407,8 @@ if(NOT client-only)
   bareos_add_test(
     lib_tests
     ADDITIONAL_SOURCES
-      alist_test.cc bareos_test_sockets.cc dlist_test.cc htable_test.cc
-      qualified_resource_name_type_converter_test.cc
+      alist_test.cc bareos_test_sockets.cc bsys_test.cc dlist_test.cc
+      htable_test.cc qualified_resource_name_type_converter_test.cc
       ${PROJECT_SOURCE_DIR}/src/filed/evaluate_job_command.cc
     LINK_LIBRARIES stored_objects bareossd bareos ${JANSSON_LIBRARIES}
                    ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}

--- a/core/src/tests/bsys_test.cc
+++ b/core/src/tests/bsys_test.cc
@@ -1,0 +1,293 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#  include "gtest/gtest.h"
+#else
+#  include "gtest/gtest.h"
+#  include "include/bareos.h"
+#endif
+
+#include "lib/bsys.h"
+
+TEST(bstrncpy, src_NULL)
+{
+  char dest[] = "DESTDESTDEST";
+  char* src = NULL;
+
+  bstrncpy(dest, src, 10);
+
+  EXPECT_STREQ(dest, "");
+}
+
+TEST(bstrncpy, src_empty)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "";
+
+  bstrncpy(dest, src, 10);
+
+  EXPECT_STREQ(dest, "");
+}
+
+TEST(bstrncpy, negative_maxlen)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, -99);
+
+  EXPECT_STREQ(dest, "");
+}
+
+TEST(bstrncpy, maxlen0)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, 0);
+
+  EXPECT_STREQ(dest, "");
+}
+
+TEST(bstrncpy, maxlen1)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, 1);
+
+  EXPECT_STREQ(dest, "");
+}
+
+TEST(bstrncpy, maxlen2)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, 2);
+
+  EXPECT_STREQ(dest, "S");
+}
+
+TEST(bstrncpy, maxlen3)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, 3);
+
+  EXPECT_STREQ(dest, "SR");
+}
+
+TEST(bstrncpy, maxlen_strlen)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, strlen(src));
+
+  EXPECT_STREQ(dest, "SRCSR");
+}
+
+TEST(bstrncpy, maxlen_strlen1)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, strlen(src) + 1);
+
+  EXPECT_STREQ(dest, src);
+}
+
+TEST(bstrncpy, maxlen_longer_than_src)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+
+  bstrncpy(dest, src, 10);
+
+  EXPECT_STREQ(dest, src);
+}
+
+TEST(bstrncpy, overlap4)
+{
+  char dest[] = "d1d2d3d4d5d6d7d8d9";
+  char* src = &dest[4];
+
+  bstrncpy(dest, src, 5);
+
+  EXPECT_STREQ(dest, "d3d4");
+}
+
+TEST(bstrncpy, overlap_remaining)
+{
+  const int start = 4;
+  char dest[] = "d1d2d3d4d5d6d7d8d9";
+  char* src = &dest[start];
+
+  bstrncpy(dest, src, strlen(dest) + 1 - start);
+
+  EXPECT_STREQ(dest, "d3d4d5d6d7d8d9");
+}
+
+TEST(bstrncpy, overlap_maxlen_longer_than_src)
+{
+  char dest[] = "d1d2d3d4d5d6d7d8d9";
+  char* src = &dest[4];
+
+  bstrncpy(dest, src, strlen(dest));
+
+  EXPECT_STREQ(dest, "d3d4d5d6d7d8d9");
+}
+
+TEST(bstrncpy, src_without_terminating_null_byte)
+{
+  char dest[] = "DESTDESTDEST";
+  char src[] = "SRCSRC";
+  int src_len = strlen(src);
+  src[src_len - 1] = 'X';
+  src[src_len] = 'Y';
+
+  bstrncpy(dest, src, src_len + 2);
+
+  EXPECT_STREQ(dest, "SRCSRXY");
+}
+
+TEST(bstrncat, src_NULL)
+{
+  char dest[100] = "<OLD>";
+  char* src = NULL;
+
+  bstrncat(dest, src, 10);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, src_empty)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "";
+
+  bstrncat(dest, src, 10);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, negative_maxlen)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, -99);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, maxlen0)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, 0);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, maxlen1)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, 1);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, maxlen2)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, 2);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, maxlen3)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, 2);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}
+
+TEST(bstrncat, maxlen_strlen)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, strlen(dest) + strlen(src));
+
+  EXPECT_STREQ(dest, "<OLD><NEW");
+}
+
+TEST(bstrncat, maxlen_strlen1)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, strlen(dest) + strlen(src) + 1);
+
+  EXPECT_STREQ(dest, "<OLD><NEW>");
+}
+
+TEST(bstrncat, maxlen_longer_than_result)
+{
+  char dest[100] = "<OLD>";
+  char src[] = "<NEW>";
+
+  bstrncat(dest, src, 100);
+
+  EXPECT_STREQ(dest, "<OLD><NEW>");
+}
+
+TEST(bstrncat, overlap_maxlen_longer_than_result)
+{
+  char dest[100] = "<OLD>";
+  char* src = &dest[3];
+
+  bstrncat(dest, src, 100);
+
+  EXPECT_STREQ(dest, "<OLD>D>");
+}
+
+TEST(bstrncat, overlap_terminating_null_byte)
+{
+  char dest[100] = "<OLD>";
+  char* src = &dest[5];
+
+  bstrncat(dest, src, 100);
+
+  EXPECT_STREQ(dest, "<OLD>");
+}

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir-CFG_TYPE_TIME.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir-CFG_TYPE_TIME.conf
@@ -1,0 +1,6 @@
+Director {
+  Name = "bareos-dir"
+  Password = "secret"
+
+  Heartbeat Interval = 1 years 2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds
+}

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -230,6 +230,21 @@ void test_CFG_TYPE_FNAME(DirectorResource* me)
 TEST(ConfigParser_Dir, CFG_TYPE_FNAME)
 {
   test_config_directive_type(test_CFG_TYPE_FNAME);
+}
+
+void test_CFG_TYPE_TIME(DirectorResource* me)
+{
+  /* clang-format off */
+  /*
+   * Heartbeat Interval = 1 years 2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds
+   */
+  /* clang-format on */
+  EXPECT_EQ(me->heartbeat_interval, 38898367);
+}
+
+TEST(ConfigParser_Dir, CFG_TYPE_TIME)
+{
+  test_config_directive_type(test_CFG_TYPE_TIME);
 }
 
 

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -589,7 +589,6 @@ set(SYSTEM_TESTS_DISABLED # initially empty
 # add tests also here that are unreliable they are excluded when running tests
 # during build in jenkins
 set(SYSTEM_TESTS_BROKEN
-    config-dump
     dbcopy-mysql-postgresql
     py2plug-fd-postgres
     py3plug-fd-local-fileset

--- a/systemtests/tests/config-dump/testrunner
+++ b/systemtests/tests/config-dump/testrunner
@@ -30,7 +30,7 @@ remove_bconsole_commands_from_output()
 {
     FILE="$1"
     # remove first and last line from file
-    sed -i -e '1d' -e '$ d' ${FILE}
+    sed -i'.bak' -e '1d' -e '$ d' ${FILE}
 }
 
 strip_config()
@@ -63,6 +63,9 @@ dump_config()
         set_error "Director config file \"${configfile}\" does not exist."
         exit 1
     fi
+
+    DESC="dump_config ${configfile} ext=${ext}"
+    print_debug "*** start $DESC"
 
     "${BAREOS_DIRECTOR_BINARY}" -c "${configfile}" -xc > $tmp/bareos-dir-xc-${ext}.conf
 
@@ -98,6 +101,8 @@ END_OF_DATA
         set_error "Director is not stopped."
         exit 1
     fi
+
+    print_debug "*** end   $DESC"
 }
 
 diff_files()
@@ -107,7 +112,9 @@ diff_files()
     base1="$(basename "$file1" .conf)"
     base2="$(basename "$file2" .conf)"
     difffile="${tmp}/${base1}_${base2}.diff"
-    DIFF_CMD='diff "${file1}" "${file2}"'
+    # --ignore-space-change could be replaced by --ignore-trailing-space,
+    # however, the FreeBSD version of diff does not support this option.
+    DIFF_CMD='diff --ignore-blank-lines --ignore-space-change "${file1}" "${file2}"'
     if ! eval "$DIFF_CMD" > "${difffile}"; then
         echo "Differences found. Output of:"
         eval "echo $DIFF_CMD"


### PR DESCRIPTION
Workaround for a problem introduced by 84a44ca6cc4d3bd4fcbe428c6433722cae251d35.
This test have been whitespace sensitive, but that commit removed all trailing whitespaces.
As a workaround for this problem, we use
diff --ignore-blank-lines --ignore-trailing-space
instead of a diff without parameter.

In order to run these tests successfully, #762 must be applied before.


### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
