### PR TITLE
stored: fix spooling sideffect bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix crash when loading both python-fd and python3-fd plugins [PR #730]
 - fix parallel python plugin jobs [PR #729]
 - fix oVirt plugin problem with config file [PR #729]
+- [Issue #1316]: storage daemon loses a configured device instance [PR #739]
+
 
 ### Added
 - added reload commands to systemd service [PR #694]

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1278,7 +1278,10 @@ Device::~Device()
   pthread_mutex_destroy(&spool_mutex);
   // RwlDestroy(&lock);
   attached_dcrs.clear();
-  if (device_resource) { device_resource->dev = nullptr; }
+
+  if (device_resource && device_resource->dev == this) {
+    device_resource->dev = nullptr;
+  }
 }
 
 bool Device::CanStealLock() const

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2013 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -511,6 +511,14 @@ VolumeReservationItem* reserve_volume(DeviceControlRecord* dcr,
       /*
        * Caller wants to switch Volume to another device
        */
+
+      // should be different devices with different names
+      if (bstrcmp(dev->print_name(), vol->dev->print_name())) {
+        // names are same
+        Dmsg1(100, "device pointers are different but have same name %s\n",
+              dev->print_name());
+      }
+
       if (!vol->dev->IsBusy() && !vol->IsSwapping()) {
         slot_number_t slot;
 


### PR DESCRIPTION
Fixes #1316: stored loses a configured device instance

The Device reference in the DeviceResource could become invalid
due to a missing comparison in the Device destructor. This bug
only occurs when spooling is turned on and has side effects on
the volume management and the reservation.

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
