### PR TITLE
build: enable c++17 and use some c++14/17 features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - py2lug-fd-ovirt systemtest: use ovirt-plugin.ini config file [PR #729]
 - Ctest now runs in scripted mode. [PR #742]
 - storage daemon: class Device: rename dev_name to archive_device_string (as the value stored here is the value of the "Archive Device" directive) [PR #744]
+- Enable c++17 support [PR #741]
 
 ### Deprecated
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -44,9 +44,9 @@ if(CCACHE_FOUND)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
-# switch on CXX 11 Support
+# switch on CXX 17 Support
 #
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CheckCCompilerFlag)
@@ -328,11 +328,6 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
 
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-register")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register")
-endif()
-
 include(BareosSetVariableDefaults)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "AIX")
@@ -369,6 +364,9 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     -D_WIN32_WINNT=${WINDOWS_VERSION}
   )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m${WINDOWS_BITS} -mwin32 -mthreads")
+
+  # c++17 removed register keyword
+  set(Python2_CCSHARED -Wno-register)
 
   set(Python2_SITELIB ${plugindir})
   set(Python3_SITELIB ${plugindir})

--- a/core/cmake/BareosFindAllLibraries.cmake
+++ b/core/cmake/BareosFindAllLibraries.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -59,6 +59,7 @@ else()
       OUTPUT_FILE ${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake
     )
     include(${CMAKE_CURRENT_BINARY_DIR}/py2settings.cmake)
+    set(Python2_CCSHARED ${Python2_CC_FLAGS} -Wno-register)
   endif()
 
   if(${Python3_FOUND})

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -110,6 +110,10 @@ if(HAVE_WIN32)
   list(APPEND BAREOS_SRCS ../win32/compat/compat.cc ../win32/compat/glob.cc
        ../win32/compat/winapi.cc
   )
+  set_source_files_properties(
+    ../win32/compat/glob.cc PROPERTIES COMPILE_DEFINITIONS register=
+  )
+
 else()
   list(APPEND BAREOS_SRCS scsi_tapealert.cc)
 endif()

--- a/core/src/lib/osinfo.h
+++ b/core/src/lib/osinfo.h
@@ -22,6 +22,9 @@
 #ifndef BAREOS_LIB_OSINFO_H_
 #define BAREOS_LIB_OSINFO_H_
 
+// register keyword removed in c++17
+#define register
+
 const char* GetOsInfoString(void);
 
 #endif  // BAREOS_LIB_OSINFO_H_

--- a/core/src/ndmp/ndmp0.x
+++ b/core/src/ndmp/ndmp0.x
@@ -68,6 +68,9 @@
 %#endif
 %#endif
 
+%/* register storage class specifier was removed in C++17 so we undefine it */
+%#define register
+
 const NDMPPORT = 10000;
 
 enum ndmp0_error

--- a/core/src/ndmp/ndmp2.x
+++ b/core/src/ndmp/ndmp2.x
@@ -57,6 +57,9 @@
 %#endif
 %#endif
 
+%/* register storage class specifier was removed in C++17 so we undefine it */
+%#define register
+
 %#ifndef NDMOS_OPTION_NO_NDMP2
 
 const NDMP2VER = 2;

--- a/core/src/ndmp/ndmp3.x
+++ b/core/src/ndmp/ndmp3.x
@@ -56,6 +56,9 @@
 %#endif
 %#endif
 
+%/* register storage class specifier was removed in C++17 so we undefine it */
+%#define register
+
 %#ifndef NDMOS_OPTION_NO_NDMP3
 
 const NDMP3VER = 3;

--- a/core/src/ndmp/ndmp4.x
+++ b/core/src/ndmp/ndmp4.x
@@ -56,6 +56,9 @@
 %#endif
 %#endif
 
+%/* register storage class specifier was removed in C++17 so we undefine it */
+%#define register
+
 %#ifndef NDMOS_OPTION_NO_NDMP4
 
 const NDMP4VER = 4;

--- a/core/src/ndmp/ndmp9.x
+++ b/core/src/ndmp/ndmp9.x
@@ -98,6 +98,9 @@
 %#endif
 %#endif
 
+%/* register storage class specifier was removed in C++17 so we undefine it */
+%#define register
+
 const NDMP9VER = 9;
 
 

--- a/core/src/plugins/dird/python/CMakeLists.txt
+++ b/core/src/plugins/dird/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -27,6 +27,7 @@ if(Python2_FOUND)
   target_link_libraries(python-dir ${Python2_LIBRARIES} bareos)
   target_include_directories(python-dir PUBLIC SYSTEM ${Python2_INCLUDE_DIRS})
   target_compile_definitions(python-dir PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_options(python-dir PUBLIC ${Python2_CCSHARED})
   add_dependencies(python-dir bareosdir-python2-module)
 
   set(PYFILES pyfiles/bareos-dir-class-plugin.py
@@ -51,10 +52,7 @@ if(Python2_FOUND)
                INCLUDE_DIRECTORIES "${pymod2_include_dirs}"
   )
   if(NOT "${Python2_CCSHARED}" STREQUAL "")
-    set_property(
-      TARGET bareosdir-python2-module PROPERTY COMPILE_OPTIONS
-                                               ${Python2_CCSHARED}
-    )
+    target_compile_options(bareosdir-python2-module PUBLIC ${Python2_CCSHARED})
   endif()
   target_link_libraries(bareosdir-python2-module bareos ${Python2_LIBRARIES})
 

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -30,6 +30,7 @@ if(Python2_FOUND)
   target_link_libraries(python-fd ${Python2_LIBRARIES} bareos)
   target_include_directories(python-fd PUBLIC SYSTEM ${Python2_INCLUDE_DIRS})
   target_compile_definitions(python-fd PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_options(python-fd PUBLIC ${Python2_CCSHARED})
   add_dependencies(bareos-fd python-fd)
   add_dependencies(python-fd bareosfd-python2-module)
 endif()
@@ -58,6 +59,9 @@ if(Python2_FOUND)
   )
   target_include_directories(
     bareosfd-python2-module-tester PUBLIC SYSTEM ${Python2_INCLUDE_DIRS}
+  )
+  target_compile_options(
+    bareosfd-python2-module-tester PUBLIC ${Python2_CCSHARED}
   )
   add_test(NAME bareosfd-python2-module-tester
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bareosfd-python2-module-tester
@@ -108,10 +112,7 @@ if(Python2_FOUND)
                INCLUDE_DIRECTORIES "${pymod2_include_dirs}"
   )
   if(NOT "${Python2_CCSHARED}" STREQUAL "")
-    set_property(
-      TARGET bareosfd-python2-module PROPERTY COMPILE_OPTIONS
-                                              ${Python2_CCSHARED}
-    )
+    target_compile_options(bareosfd-python2-module PUBLIC ${Python2_CCSHARED})
   endif()
   target_link_libraries(bareosfd-python2-module bareos ${Python2_LIBRARIES})
 

--- a/core/src/plugins/stored/python/CMakeLists.txt
+++ b/core/src/plugins/stored/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,7 @@ if(Python2_FOUND)
   target_link_libraries(python-sd ${Python2_LIBRARIES} bareos)
   target_include_directories(python-sd PUBLIC SYSTEM ${Python2_INCLUDE_DIRS})
   target_compile_definitions(python-sd PUBLIC PY2MODDIR=\"${Python2_SITELIB}\")
+  target_compile_options(python-sd PUBLIC ${Python2_CCSHARED})
   add_dependencies(python-sd bareossd-python2-module)
 
   set(PYFILES pyfiles/bareos-sd-class-plugin.py
@@ -49,10 +50,7 @@ if(Python2_FOUND)
                INCLUDE_DIRECTORIES "${pymod2_include_dirs}"
   )
   if(NOT "${Python2_CCSHARED}" STREQUAL "")
-    set_property(
-      TARGET bareossd-python2-module PROPERTY COMPILE_OPTIONS
-                                              ${Python2_CCSHARED}
-    )
+    target_compile_options(bareossd-python2-module PUBLIC ${Python2_CCSHARED})
   endif()
   target_link_libraries(bareossd-python2-module bareos ${Python2_LIBRARIES})
 

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -66,7 +66,7 @@ extern bool ParseSdConfig(const char* configfile, int exit_code);
 using namespace storagedaemon;
 
 static int quit = 0;
-static char buf[100000];
+static char buf[100'000];
 
 /**
  * If you change the format of the state file,
@@ -165,7 +165,7 @@ int main(int margc, char* margv[])
   int ch, i;
   uint32_t x32, y32;
   uint64_t x64, y64;
-  char buf[1000];
+  char buf[1'000];
   char* DirectorName = NULL;
   DirectorResource* director = NULL;
 
@@ -1069,7 +1069,7 @@ static void speed_test()
   }
 }
 
-const uint64_t num_recs = 10000LL;
+const uint64_t num_recs = 10'000LL;
 
 static bool write_two_files()
 {
@@ -1858,7 +1858,7 @@ static void rrcmd()
 
   if (!GetCmd(_("Enter length to read: "))) { return; }
   len = atoi(cmd);
-  if (len < 0 || len > 1000000) {
+  if (len < 0 || len > 1'000'000) {
     Pmsg0(0, _("Bad length entered, using default of 1024 bytes.\n"));
     len = 1024;
   }
@@ -2185,7 +2185,7 @@ static void fillcmd()
   Pmsg0(-1, _("Wrote Start of Session label.\n"));
 
   DeviceRecord rec;
-  rec.data = GetMemory(100000); /* max record size */
+  rec.data = GetMemory(100'000); /* max record size */
   rec.data_len = REC_SIZE;
 
   /*
@@ -2485,8 +2485,8 @@ static bool do_unfill()
   if (!dev->rewind(dcr)) { /* get to a known place on tape */
     goto bail_out;
   }
-  /* Read the first 10000 records */
-  Pmsg2(-1, _("Reading the first 10000 records from %u:%u.\n"), dev->file,
+  /* Read the first 10'000 records */
+  Pmsg2(-1, _("Reading the first 10'000 records from %u:%u.\n"), dev->file,
         dev->block_num);
   quickie_count = 0;
   ReadRecords(dcr, QuickieCb, MyMountNextReadVolume);
@@ -2588,16 +2588,16 @@ bail_out:
   return rc;
 }
 
-/* Read 10000 records then stop */
+/* Read 10'000 records then stop */
 static bool QuickieCb(DeviceControlRecord* dcr, DeviceRecord* rec)
 {
   Device* dev = dcr->dev;
   quickie_count++;
-  if (quickie_count == 10000) {
-    Pmsg2(-1, _("10000 records read now at %d:%d\n"), dev->file,
+  if (quickie_count == 10'000) {
+    Pmsg2(-1, _("10'000 records read now at %d:%d\n"), dev->file,
           dev->block_num);
   }
-  return quickie_count < 10000;
+  return quickie_count < 10'000;
 }
 
 static bool CompareBlocks(DeviceBlock* last_block, DeviceBlock* block)

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -118,7 +118,7 @@ TEST(edit, convert_siunits_to_numbers)
     char str[] = "1 tb";
     uint64_t retvalue = 0;
     size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000000000000);
+    ASSERT_EQ(retvalue, 1'000'000'000'000);
   }
 
   // pebibyte
@@ -126,14 +126,14 @@ TEST(edit, convert_siunits_to_numbers)
     char str[] = "1 p";
     uint64_t retvalue = 0;
     size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1125899906842624);
+    ASSERT_EQ(retvalue, 1'125'899'906'842'624);
   }
   // petabyte
   {
     char str[] = "1 pb";
     uint64_t retvalue = 0;
     size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000000000000000);
+    ASSERT_EQ(retvalue, 1'000'000'000'000'000);
   }
 
   // exbibyte
@@ -141,14 +141,14 @@ TEST(edit, convert_siunits_to_numbers)
     char str[] = "1 e";
     uint64_t retvalue = 0;
     size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1152921504606846976);
+    ASSERT_EQ(retvalue, 1'152'921'504'606'846'976);
   }
   // exabyte
   {
     char str[] = "1 eb";
     uint64_t retvalue = 0;
     size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000000000000000000);
+    ASSERT_EQ(retvalue, 1'000'000'000'000'000'000);
   }
   // size_to_uint64 only checks for first modifier so the following does not
   // work


### PR DESCRIPTION
- Enable c++17 support in cmake
    - Avoid warnings because the "register" keyword was removed in c++17
      - NDMP files generated by rpcgen
      - Python2 header files
      - Windows: glob.cc
    - Use c++14 digit separator (1'000'000)


### Please follow these few prerequisites before you hand in a PR

#### Consider the following chapters in the Bareos Developer Documentation

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
