### PR TITLE
stored: use "archive_device_string" variable for archive device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Change Copy Job behaviour regarding Archive Jobs [PR #717]
 - py2lug-fd-ovirt systemtest: use ovirt-plugin.ini config file [PR #729]
 - Ctest now runs in scripted mode. [PR #742]
+- storage daemon: class Device: rename dev_name to archive_device_string (as the value stored here is the value of the "Archive Device" directive) [PR #744]
 
 ### Deprecated
 

--- a/core/src/plugins/stored/scsitapealert/scsitapealert-sd.cc
+++ b/core/src/plugins/stored/scsitapealert/scsitapealert-sd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2013-2013 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -213,26 +213,26 @@ static bRC handle_tapealert_readout(void* value)
   if (!device_resource->drive_tapealert_enabled) {
     Dmsg1(debuglevel,
           "scsitapealert-sd: tapealert is not enabled on device %s\n",
-          dev->dev_name);
+          dev->archive_device_string);
     return bRC_OK;
   }
 
   Dmsg1(debuglevel, "scsitapealert-sd: checking for tapealerts on device %s\n",
-        dev->dev_name);
+        dev->archive_device_string);
   P(tapealert_operation_mutex);
-  GetTapealertFlags(dev->fd(), dev->dev_name, &flags);
+  GetTapealertFlags(dev->fd(), dev->archive_device_string, &flags);
   V(tapealert_operation_mutex);
 
   Dmsg1(debuglevel,
         "scsitapealert-sd: checking for tapealerts on device %s DONE\n",
-        dev->dev_name);
+        dev->archive_device_string);
   Dmsg1(debuglevel, "scsitapealert-sd: flags: %ld \n", flags);
 
   if (flags) {
     Dmsg1(
         debuglevel,
         "scsitapealert-sd: tapealerts on device %s, calling UpdateTapeAlerts\n",
-        dev->dev_name);
+        dev->archive_device_string);
     bareos_core_functions->UpdateTapeAlert(dcr, flags);
   }
 

--- a/core/src/stored/ansi_label.cc
+++ b/core/src/stored/ansi_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2005-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -88,7 +88,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
       dev->clrerror(-1);
       Dmsg1(100, "Read device got: ERR=%s\n", be.bstrerror());
       Mmsg2(jcr->errmsg, _("Read error on device %s in ANSI label. ERR=%s\n"),
-            dev->dev_name, be.bstrerror());
+            dev->archive_device_string, be.bstrerror());
       Jmsg(jcr, M_ERROR, 0, "%s", dev->errmsg);
       dev->VolCatInfo.VolCatErrors++;
       return VOL_IO_ERROR;

--- a/core/src/stored/backends/droplet_device.cc
+++ b/core/src/stored/backends/droplet_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -888,7 +888,7 @@ bool droplet_device::initialize()
       sysmd_.location_constraint = dpl_location_constraint(temp.c_str());
       if (sysmd_.location_constraint == -1) {
         Mmsg2(errmsg, _("Illegal location argument %s for device %s%s\n"),
-              temp.c_str(), dev_name);
+              temp.c_str(), archive_device_string);
         goto bail_out;
       }
     }
@@ -899,7 +899,7 @@ bool droplet_device::initialize()
       sysmd_.canned_acl = dpl_canned_acl(temp.c_str());
       if (sysmd_.canned_acl == -1) {
         Mmsg2(errmsg, _("Illegal canned_acl argument %s for device %s%s\n"),
-              temp.c_str(), dev_name);
+              temp.c_str(), archive_device_string);
         goto bail_out;
       }
     }
@@ -910,7 +910,7 @@ bool droplet_device::initialize()
       sysmd_.storage_class = dpl_storage_class(temp.c_str());
       if (sysmd_.storage_class == -1) {
         Mmsg2(errmsg, _("Illegal storage_class argument %s for device %s%s\n"),
-              temp.c_str(), dev_name);
+              temp.c_str(), archive_device_string);
         goto bail_out;
       }
     }

--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2014-2014 Planets Communications B.V.
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -69,7 +69,9 @@ void generic_tape_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
   /*
    * Windows Code
    */
-  if ((fd_ = d_open(dev_name, oflags, 0)) < 0) { dev_errno = errno; }
+  if ((fd_ = d_open(archive_device_string, oflags, 0)) < 0) {
+    dev_errno = errno;
+  }
 #else
   /*
    * UNIX Code
@@ -80,7 +82,7 @@ void generic_tape_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
     /*
      * Try non-blocking open
      */
-    fd_ = d_open(dev_name, oflags | O_NONBLOCK, 0);
+    fd_ = d_open(archive_device_string, oflags | O_NONBLOCK, 0);
     if (fd_ < 0) {
       BErrNo be;
       dev_errno = errno;
@@ -113,7 +115,7 @@ void generic_tape_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
          * Got fd and rewind worked, so we must have medium in drive
          */
         d_close(fd_);
-        fd_ = d_open(dev_name, oflags, 0); /* open normally */
+        fd_ = d_open(archive_device_string, oflags, 0); /* open normally */
         if (fd_ < 0) {
           BErrNo be;
           dev_errno = errno;
@@ -987,7 +989,7 @@ void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)
 {
   Device* dev = dcr->dev;
 
-  if (bstrcmp(dev->dev_name, "/dev/null")) {
+  if (bstrcmp(dev->archive_device_string, "/dev/null")) {
     return; /* no use trying to set /dev/null */
   }
 

--- a/core/src/stored/backends/unix_fifo_device.cc
+++ b/core/src/stored/backends/unix_fifo_device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2013-2013 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -78,7 +78,7 @@ void unix_fifo_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
     /*
      * Try non-blocking open
      */
-    fd_ = d_open(dev_name, oflags | O_NONBLOCK, 0);
+    fd_ = d_open(archive_device_string, oflags | O_NONBLOCK, 0);
     if (fd_ < 0) {
       BErrNo be;
       dev_errno = errno;
@@ -86,7 +86,7 @@ void unix_fifo_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
             prt_name, omode, oflags, errno, be.bstrerror());
     } else {
       d_close(fd_);
-      fd_ = d_open(dev_name, oflags, 0); /* open normally */
+      fd_ = d_open(archive_device_string, oflags, 0); /* open normally */
       if (fd_ < 0) {
         BErrNo be;
         dev_errno = errno;

--- a/core/src/stored/backends/unix_file_device.cc
+++ b/core/src/stored/backends/unix_file_device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2013-2013 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -288,7 +288,7 @@ bool unix_file_device::d_truncate(DeviceControlRecord* dcr)
    * 3. open new file with same mode
    * 4. change ownership to original
    */
-  PmStrcpy(archive_name, dev_name);
+  PmStrcpy(archive_name, archive_device_string);
   if (!IsPathSeparator(
           archive_name.c_str()[strlen(archive_name.c_str()) - 1])) {
     PmStrcat(archive_name, "/");

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -696,7 +696,7 @@ static void capcmd()
   printf("\n");
 
   printf(_("Device parameters:\n"));
-  printf("Device name: %s\n", dev->dev_name);
+  printf("Device name: %s\n", dev->archive_device_string);
   printf("File=%u block=%u\n", dev->file, dev->block_num);
   printf("Min block=%u Max block=%u\n", dev->min_block_size,
          dev->max_block_size);
@@ -1899,8 +1899,8 @@ static void scancmd()
     if ((status = read(dev->fd(), buf, sizeof(buf))) < 0) {
       BErrNo be;
       dev->clrerror(-1);
-      Mmsg2(dev->errmsg, _("read error on %s. ERR=%s.\n"), dev->dev_name,
-            be.bstrerror());
+      Mmsg2(dev->errmsg, _("read error on %s. ERR=%s.\n"),
+            dev->archive_device_string, be.bstrerror());
       Pmsg2(0, _("Bad status from read %d. ERR=%s\n"), status,
             dev->bstrerror());
       if (blocks > 0) {

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,7 +54,8 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
                                    char* dev_name,
                                    const char* VolumeName,
                                    bool readonly);
-static DeviceResource* find_device_res(char* device_name, bool readonly);
+static DeviceResource* find_device_res(char* archive_device_string,
+                                       bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
 
 /**
@@ -175,7 +176,8 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
   if (VolName[0]) {
     bstrncpy(dcr->VolumeName, VolName, sizeof(dcr->VolumeName));
   }
-  bstrncpy(dcr->dev_name, device_resource->device_name, sizeof(dcr->dev_name));
+  bstrncpy(dcr->dev_name, device_resource->archive_device_string,
+           sizeof(dcr->dev_name));
 
   CreateRestoreVolumeList(jcr);
 
@@ -246,7 +248,8 @@ static void MyFreeJcr(JobControlRecord* jcr)
  * Returns: NULL on failure
  *          Device resource pointer on success
  */
-static DeviceResource* find_device_res(char* device_name, bool readonly)
+static DeviceResource* find_device_res(char* archive_device_string,
+                                       bool readonly)
 {
   bool found = false;
   DeviceResource* device_resource;
@@ -254,9 +257,10 @@ static DeviceResource* find_device_res(char* device_name, bool readonly)
   Dmsg0(900, "Enter find_device_res\n");
   LockRes(my_config);
   foreach_res (device_resource, R_DEVICE) {
-    Dmsg2(900, "Compare %s and %s\n", device_resource->device_name,
-          device_name);
-    if (bstrcmp(device_resource->device_name, device_name)) {
+    Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
+          archive_device_string);
+    if (bstrcmp(device_resource->archive_device_string,
+                archive_device_string)) {
       found = true;
       break;
     }
@@ -264,16 +268,16 @@ static DeviceResource* find_device_res(char* device_name, bool readonly)
 
   if (!found) {
     /* Search for name of Device resource rather than archive name */
-    if (device_name[0] == '"') {
-      int len = strlen(device_name);
-      bstrncpy(device_name, device_name + 1, len + 1);
+    if (archive_device_string[0] == '"') {
+      int len = strlen(archive_device_string);
+      bstrncpy(archive_device_string, archive_device_string + 1, len + 1);
       len--;
-      if (len > 0) { device_name[len - 1] = 0; /* zap trailing " */ }
+      if (len > 0) { archive_device_string[len - 1] = 0; /* zap trailing " */ }
     }
     foreach_res (device_resource, R_DEVICE) {
       Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
-            device_name);
-      if (bstrcmp(device_resource->resource_name_, device_name)) {
+            archive_device_string);
+      if (bstrcmp(device_resource->resource_name_, archive_device_string)) {
         found = true;
         break;
       }
@@ -283,14 +287,14 @@ static DeviceResource* find_device_res(char* device_name, bool readonly)
 
   if (!found) {
     Pmsg2(0, _("Could not find device \"%s\" in config file %s.\n"),
-          device_name, configfile);
+          archive_device_string, configfile);
     return NULL;
   }
 
   if (readonly) {
-    Pmsg1(0, _("Using device: \"%s\" for reading.\n"), device_name);
+    Pmsg1(0, _("Using device: \"%s\" for reading.\n"), archive_device_string);
   } else {
-    Pmsg1(0, _("Using device: \"%s\" for writing.\n"), device_name);
+    Pmsg1(0, _("Using device: \"%s\" for writing.\n"), archive_device_string);
   }
 
   return device_resource;

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -250,7 +250,7 @@ class Device {
   int label_type{};           /**< Bareos/ANSI/IBM label types */
   drive_number_t drive{};     /**< Autochanger logical drive number (base 0) */
   drive_number_t drive_index{}; /**< Autochanger physical drive index (base 0) */
-  POOLMEM* dev_name{};        /**< Physical device name */
+  POOLMEM* archive_device_string{};  /**< Physical device name */
   POOLMEM* dev_options{};     /**< Device specific options */
   POOLMEM* prt_name{};        /**< Name used for display purposes */
   char* errmsg{};             /**< Nicely edited error message */
@@ -541,7 +541,10 @@ class SpoolDevice :public Device
 /* clang-format on */
 
 inline const char* Device::strerror() const { return errmsg; }
-inline const char* Device::archive_name() const { return dev_name; }
+inline const char* Device::archive_name() const
+{
+  return archive_device_string;
+}
 inline const char* Device::print_name() const { return prt_name; }
 
 Device* FactoryCreateDevice(JobControlRecord* jcr, DeviceResource* device);

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,7 +31,7 @@ namespace storagedaemon {
 DeviceResource::DeviceResource()
     : BareosResource()
     , media_type(nullptr)
-    , device_name(nullptr)
+    , archive_device_string(nullptr)
     , device_options(nullptr)
     , diag_device_name(nullptr)
     , changer_name(nullptr)
@@ -91,7 +91,7 @@ DeviceResource::DeviceResource()
 DeviceResource::DeviceResource(const DeviceResource& other)
     : BareosResource(other)
     , media_type(nullptr)
-    , device_name(nullptr)
+    , archive_device_string(nullptr)
     , device_options(nullptr)
     , diag_device_name(nullptr)
     , changer_name(nullptr)
@@ -106,7 +106,9 @@ DeviceResource::DeviceResource(const DeviceResource& other)
     , temporarily_swapped_numbered_name(nullptr) /* should not copy */
 {
   if (other.media_type) { media_type = strdup(other.media_type); }
-  if (other.device_name) { device_name = strdup(other.device_name); }
+  if (other.archive_device_string) {
+    archive_device_string = strdup(other.archive_device_string);
+  }
   if (other.device_options) { device_options = strdup(other.device_options); }
   if (other.diag_device_name) {
     diag_device_name = strdup(other.diag_device_name);
@@ -175,7 +177,7 @@ DeviceResource& DeviceResource::operator=(const DeviceResource& rhs)
 {
   BareosResource::operator=(rhs);
   media_type = rhs.media_type;
-  device_name = rhs.device_name;
+  archive_device_string = rhs.archive_device_string;
   device_options = rhs.device_options;
   diag_device_name = rhs.diag_device_name;
   changer_name = rhs.changer_name;
@@ -295,8 +297,7 @@ bool DeviceResource::Validate()
         "Setting 'Maximum Block Size' on a non-tape device is unsupported");
   }
   if (dev_type == DeviceType::B_RADOS_DEV) {
-    my_config->AddWarning(
-        "The Rados Storage Backend Device is deprecated");
+    my_config->AddWarning("The Rados Storage Backend Device is deprecated");
   }
   return true;
 }

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -36,7 +36,7 @@ class AutochangerResource;
 class DeviceResource : public BareosResource {
  public:
   char* media_type;             /**< User assigned media type */
-  char* device_name;            /**< Archive device name */
+  char* archive_device_string;  /**< Archive device name */
   char* device_options;         /**< Device specific option string */
   char* diag_device_name;       /**< Diagnostic device name */
   char* changer_name;           /**< Changer device name */

--- a/core/src/stored/scan.cc
+++ b/core/src/stored/scan.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -65,7 +65,7 @@ bool Device::ScanDirForVolume(DeviceControlRecord* dcr)
   if (device_resource->mount_point) {
     mount_point = device_resource->mount_point;
   } else {
-    mount_point = device_resource->device_name;
+    mount_point = device_resource->archive_device_string;
   }
 
   if (!(dp = opendir(mount_point))) {

--- a/core/src/stored/spool.cc
+++ b/core/src/stored/spool.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -293,8 +293,9 @@ static bool DespoolData(DeviceControlRecord* dcr, bool commit)
    * in rdev and rdcr.
    */
   auto rdev(std::make_unique<SpoolDevice>());
-  rdev->dev_name = GetMemory(strlen(spool_name) + 1);
-  bstrncpy(rdev->dev_name, spool_name, SizeofPoolMemory(rdev->dev_name));
+  rdev->archive_device_string = GetMemory(strlen(spool_name) + 1);
+  bstrncpy(rdev->archive_device_string, spool_name,
+           SizeofPoolMemory(rdev->archive_device_string));
   rdev->errmsg = GetPoolMemory(PM_EMSG);
   rdev->errmsg[0] = 0;
   rdev->max_block_size = dcr->dev->max_block_size;

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -710,7 +710,7 @@ static void ListRunningJobs(StatusPacket* sp)
                    job_type_to_str(jcr->getJobType()), JobName, jcr->JobId,
                    rdcr->VolumeName, rdcr->pool_name,
                    rdcr->dev ? rdcr->dev->print_name()
-                             : rdcr->device_resource->device_name);
+                             : rdcr->device_resource->archive_device_string);
         sp->send(msg, len);
       }
       if (dcr && dcr->device_resource) {
@@ -721,7 +721,7 @@ static void ListRunningJobs(StatusPacket* sp)
                    job_type_to_str(jcr->getJobType()), JobName, jcr->JobId,
                    dcr->VolumeName, dcr->pool_name,
                    dcr->dev ? dcr->dev->print_name()
-                            : dcr->device_resource->device_name);
+                            : dcr->device_resource->archive_device_string);
         sp->send(msg, len);
         len = Mmsg(msg, _("    spooling=%d despooling=%d despool_wait=%d\n"),
                    dcr->spooling, dcr->despooling, dcr->despool_wait);

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -571,12 +571,13 @@ extern "C" void* device_initialization(void* arg)
   }
 
   foreach_res (device_resource, R_DEVICE) {
-    Dmsg1(90, "calling FactoryCreateDevice %s\n", device_resource->device_name);
+    Dmsg1(90, "calling FactoryCreateDevice %s\n",
+          device_resource->archive_device_string);
     dev = FactoryCreateDevice(NULL, device_resource);
-    Dmsg1(10, "SD init done %s\n", device_resource->device_name);
+    Dmsg1(10, "SD init done %s\n", device_resource->archive_device_string);
     if (!dev) {
       Jmsg1(NULL, M_ERROR, 0, _("Could not initialize %s\n"),
-            device_resource->device_name);
+            device_resource->archive_device_string);
       continue;
     }
 
@@ -704,13 +705,14 @@ static
   FreeVolumeLists();
 
   foreach_res (device_resource, R_DEVICE) {
-    Dmsg1(10, "Term device %s\n", device_resource->device_name);
+    Dmsg1(10, "Term device %s\n", device_resource->archive_device_string);
     if (device_resource->dev) {
       device_resource->dev->ClearVolhdr();
       delete device_resource->dev;
       device_resource->dev = nullptr;
     } else {
-      Dmsg1(10, "No dev structure %s\n", device_resource->device_name);
+      Dmsg1(10, "No dev structure %s\n",
+            device_resource->archive_device_string);
     }
   }
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -155,7 +155,7 @@ static ResourceItem dev_items[] = {
       "The Description directive provides easier human recognition, but is not used by Bareos directly."},
   {"MediaType", CFG_TYPE_STRNAME, ITEM(res_dev, media_type), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL},
   {"DeviceType", CFG_TYPE_DEVTYPE, ITEM(res_dev, dev_type), 0, 0, NULL, NULL, NULL},
-  {"ArchiveDevice", CFG_TYPE_STRNAME, ITEM(res_dev, device_name), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL},
+  {"ArchiveDevice", CFG_TYPE_STRNAME, ITEM(res_dev, archive_device_string), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL},
   {"DeviceOptions", CFG_TYPE_STR, ITEM(res_dev, device_options), 0, 0, NULL, "15.2.0-", NULL},
   {"DiagnosticDevice", CFG_TYPE_STRNAME, ITEM(res_dev, diag_device_name), 0, 0, NULL, NULL, NULL},
   {"HardwareEndOfFile", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_EOF, CFG_ITEM_DEFAULT, "on", NULL, NULL},
@@ -561,13 +561,13 @@ static void CheckDropletDevices(ConfigurationParser& my_config)
         Jmsg1(nullptr, M_WARNING, 0,
               _("device %s is set to the default 'Maximum Concurrent Jobs' = "
                 "1.\n"),
-              d->device_name);
+              d->archive_device_string);
         d->max_concurrent_jobs = 1;
       } else if (d->max_concurrent_jobs > 1) {
         Jmsg2(nullptr, M_ERROR_TERM, 0,
               _("device %s is configured with 'Maximum Concurrent Jobs' = %d, "
                 "however only 1 is supported.\n"),
-              d->device_name, d->max_concurrent_jobs);
+              d->archive_device_string, d->max_concurrent_jobs);
       }
     }
   }
@@ -946,7 +946,7 @@ static void FreeResource(BareosResource* res, int type)
       DeviceResource* p = dynamic_cast<DeviceResource*>(res);
       assert(p);
       if (p->media_type) { free(p->media_type); }
-      if (p->device_name) { free(p->device_name); }
+      if (p->archive_device_string) { free(p->archive_device_string); }
       if (p->device_options) { free(p->device_options); }
       if (p->diag_device_name) { free(p->diag_device_name); }
       if (p->changer_name) { free(p->changer_name); }

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,7 +92,7 @@ void ReservationTest::TearDown()
   {
     DeviceResource* d = nullptr;
     foreach_res (d, R_DEVICE) {
-      Dmsg1(10, "Term device %s\n", d->device_name);
+      Dmsg1(10, "Term device %s\n", d->archive_device_string);
       if (d->dev) {
         d->dev->ClearVolhdr();
         delete d->dev;

--- a/core/src/win32/stored/backends/win32_fifo_device.cc
+++ b/core/src/win32/stored/backends/win32_fifo_device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2013-2013 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -73,7 +73,7 @@ void win32_fifo_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
     /*
      * Try non-blocking open
      */
-    fd_ = d_open(dev_name, oflags | O_NONBLOCK, 0);
+    fd_ = d_open(archive_device_string, oflags | O_NONBLOCK, 0);
     if (fd_ < 0) {
       BErrNo be;
       dev_errno = errno;
@@ -81,7 +81,7 @@ void win32_fifo_device::OpenDevice(DeviceControlRecord* dcr, DeviceMode omode)
             prt_name, omode, oflags, errno, be.bstrerror());
     } else {
       d_close(fd_);
-      fd_ = d_open(dev_name, oflags, 0); /* open normally */
+      fd_ = d_open(archive_device_string, oflags, 0); /* open normally */
       if (fd_ < 0) {
         BErrNo be;
         dev_errno = errno;

--- a/core/src/win32/stored/backends/win32_file_device.cc
+++ b/core/src/win32/stored/backends/win32_file_device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -262,7 +262,7 @@ bool win32_file_device::d_truncate(DeviceControlRecord* dcr)
   if (st.st_size != 0) { /* ftruncate() didn't work */
     PoolMem archive_name(PM_FNAME);
 
-    PmStrcpy(archive_name, dev_name);
+    PmStrcpy(archive_name, archive_device_string);
     if (!IsPathSeparator(
             archive_name.c_str()[strlen(archive_name.c_str()) - 1])) {
       PmStrcat(archive_name, "/");


### PR DESCRIPTION
The "archive device" directive was stored in the variable "device_name"
in the "DeviceResource" Class and in "dev_name" in the "Device" Class.

This is misleading as the device name (i.e. the name of the device
resource) is stored in the "resource_name_" member of the device resource.

### Please follow these few prerequisites before you hand in a PR

#### Consider the following chapters in the Bareos Developer Documentation

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
