### PR TITLE
Fix broken link in the documentation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,6 +104,7 @@ Josip Almasi
 José Carlos
 Juan Luis Frances
 Juergen Lock
+Justin Nibble
 Jyri Palis
 Jörg Steffens
 Karl Cunningham

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - added an informative debugmessage when a dynamic backend cannot be loaded [PR #740]
 
 ### Changed
+- Fixed broken link in https://docs.bareos.org/IntroductionAndTutorial/WhatIsBareos.html documentation page
 - Package **bareos-database-postgresql**: add recommendation for package **dbconfig-pgsql**.
 - Adapt the init scripts for some platform to not refer to a specific (outdated) configuration file, but to use the default config file instead.
 - scripts: cleaned up code for postgresql db creation [PR #709]

--- a/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
@@ -14,7 +14,7 @@ In technical terms, it is a network Client/Server based backup program. Bareos i
 History
 -------
 
-Bareos is a `fork <http://www.bareos.org/en/faq/items/why_fork.html>`_ of the open source project `Bacula <http://www.bacula.org>`_ version 5.2. In 2010 the Bacula community developer Marco van Wieringen started to collect rejected or neglected community contributions in his own branch. This branch was later on the base of Bareos and since then was enriched by a lot of new features.
+Bareos is a `fork <http://www.bareos.org/en/faq/why_fork.html>`_ of the open source project `Bacula <http://www.bacula.org>`_ version 5.2. In 2010 the Bacula community developer Marco van Wieringen started to collect rejected or neglected community contributions in his own branch. This branch was later on the base of Bareos and since then was enriched by a lot of new features.
 
 This documentation also bases on the `original Bacula documentation <http://www.bacula.org/5.2.x-manuals/en/main/main/>`_, it is technically also a fork of the documenation created following the rules of the GNU Free Documentation License.
 


### PR DESCRIPTION
This patch change broken link in the documentation. This came after some
changes on the https://bareos.org backend side
- docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst was changed

