### PR TITLE
python-bareos: fallback to ssl.PROTOCOL_SSLv23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix parallel python plugin jobs [PR #729]
 - fix oVirt plugin problem with config file [PR #729]
 - [Issue #1316]: storage daemon loses a configured device instance [PR #739]
+- fix python-bareos for Python < 2.7.13 [PR #748]
 
 
 ### Added

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -102,7 +102,10 @@ class LowLevel(object):
         self.max_reconnects = 0
         self.tls_psk_enable = True
         self.tls_psk_require = False
-        self.tls_version = ssl.PROTOCOL_TLS
+        try:
+            self.tls_version = ssl.PROTOCOL_TLS
+        except AttributeError:
+            self.tls_version = ssl.PROTOCOL_SSLv23
         self.connection_type = None
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()


### PR DESCRIPTION
By default we set ssl.PROTOCOL_TLS.
However, this requires Python >= 2.7.13, which is not available by default on RHEL/CentOS 7.
Therefore we added a fallback to ssl.PROTOCOL_SSLv23.

This requires backports down to bareos-19.2.

### Please follow these few prerequisites before you hand in a PR

#### Consider the following chapters in the Bareos Developer Documentation

- [x] [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [x] [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [x] [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)

#### Add some information

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'
- [x] Add your name to the AUTHORS file

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
