### PR TITLE
ctest: run ctest in scripted mode (Backport of PR 742)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - Fixed broken link in https://docs.bareos.org/IntroductionAndTutorial/WhatIsBareos.html documentation page
+- Ctest now runs in scripted mode. [PR #751]
 
 ### Deprecated
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -975,3 +975,12 @@ if(HAVE_WIN32)
   message("   WINDOWS_BITS:                 ${WINDOWS_BITS}")
   message("   WINEPATH environment:         $ENV{WINEPATH}")
 endif()
+
+# REPEAT_UNTIL requires cmake 3.17+
+if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+  set(REPEAT_UNTIL "REPEAT UNTIL_PASS:2")
+endif()
+
+configure_file(
+  "CTestScript.cmake.in" "${CMAKE_BINARY_DIR}/CTestScript.cmake" @ONLY
+)

--- a/core/CTestScript.cmake.in
+++ b/core/CTestScript.cmake.in
@@ -1,0 +1,28 @@
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+set(CTEST_SOURCE_DIRECTORY @CMAKE_SOURCE_DIR@)
+set(CTEST_BINARY_DIRECTORY @CMAKE_BINARY_DIR@)
+
+ctest_start("Continuous")
+ctest_test(
+  EXCLUDE_LABEL broken
+  PARALLEL_LEVEL 10
+  @REPEAT_UNTIL@
+)
+ctest_coverage()

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/Makefile
@@ -12,5 +12,8 @@ LIB_DEPENDS+= liblzo2.so:archivers/lzo2 \
 post-patch:
 	@${REINPLACE_CMD} -e 's|pg_dump|/usr/local/bin/pg_dump|g' ${WRKSRC}/core/src/cats/make_catalog_backup.pl.in
 
+pre-package:
+	if [ -f work/.build/Testing/TAG ]; then echo "Testing/TAG exists, not running ctest a second time"; else cd work/.build && REGRESS_DEBUG=1  ctest -V -S CTestScript.cmake || echo "ctest result:$?"; fi
+
 
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1066,10 +1066,9 @@ cmake  .. \
 %check
 # run unit tests
 pushd %{CMAKE_BUILDDIR}
-make clean
 
 # run the tests and fail build if test fails
-REGRESS_DEBUG=1 ctest --label-exclude broken --parallel 10 --repeat until-pass:2 --dashboard Continuous || echo "ctest result:$?"
+REGRESS_DEBUG=1 ctest -V -S CTestScript.cmake || echo "ctest result:$?"
 
 %install
 ##if 0#{?suse_version}

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -59,7 +59,6 @@ if(Python2_FOUND)
   target_include_directories(
     bareosfd-python2-module-tester PUBLIC SYSTEM ${Python2_INCLUDE_DIRS}
   )
-
   add_test(NAME bareosfd-python2-module-tester
            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bareosfd-python2-module-tester
   )
@@ -69,6 +68,9 @@ if(Python2_FOUND)
       ENVIRONMENT
       PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test/:${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/pyfiles
   )
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set_property(TEST bareosfd-python2-module-tester PROPERTY DISABLED true)
+  endif()
 endif()
 
 if(Python3_FOUND AND NOT HAVE_WIN32)

--- a/debian/rules
+++ b/debian/rules
@@ -133,7 +133,7 @@ override_dh_auto_test:
 # see https://www.debian.org/doc/debian-policy/ch-source.html#s-debianrules-options
 # No tabs allowed before ifeq.
 ifneq (nocheck,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
-	cd obj-$(DEB_BUILD_GNU_TYPE) && make clean && REGRESS_DEBUG=1 ctest --label-exclude broken --parallel 10 --repeat until-pass:2 -D Continuous || echo "ctest result:$?"
+	cd obj-$(DEB_BUILD_GNU_TYPE) && ls Testing/*/Test.xml || REGRESS_DEBUG=1 ctest -V -S CTestScript.cmake || echo "ctest result:$?"
 else
 	@echo "ctest: skipped"
 endif


### PR DESCRIPTION
    ctest: run ctest in scripted mode
    
    - run "ctest -V -S CTestScript.cmake"
    - run "start", "test" and "coverage" steps
    - skip "configure", "build" and "submit" steps
    - do not "make clean" before ctest
    - skip second run of ctest on debian based os
    - skip "bareosfd-python2-module-tester" test on MacOS(Darwin) as it
      segfaults
    
    (cherry picked from commit 714cfce57050f550ea31da94d51e8fe24e942639)
