### PR TITLE
Backport: python-bareos: fallback to ssl.PROTOCOL_SSLv23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix oVirt plugin problem with config file [PR #732]
 - fix crash when loading both python-fd and python3-fd plugins [PR #733]
 - [Issue #1316]: storage daemon loses a configured device instance [PR #734]
+- fix python-bareos for Python < 2.7.13 [PR #753]
+
 
 ### Added
 - py2lug-fd-ovirt systemtest: use ovirt-plugin.ini config file [PR #732]

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -98,7 +98,10 @@ class LowLevel(object):
         self.max_reconnects = 0
         self.tls_psk_enable = True
         self.tls_psk_require = False
-        self.tls_version = ssl.PROTOCOL_TLS
+        try:
+            self.tls_version = ssl.PROTOCOL_TLS
+        except AttributeError:
+            self.tls_version = ssl.PROTOCOL_SSLv23
         self.connection_type = None
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()


### PR DESCRIPTION
This is a backport from master:

By default we set ssl.PROTOCOL_TLS.
However, this requires Python >= 2.7.13, which is not available by default on RHEL/CentOS 7.
Therefore we added a fallback to ssl.PROTOCOL_SSLv23.

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
