### PR TITLE
Backport: python-bareos: fallback to ssl.PROTOCOL_SSLv23

### DIFF
--- a/docs/manuals/source/Appendix/ReleaseNotes.rst
+++ b/docs/manuals/source/Appendix/ReleaseNotes.rst
@@ -21,6 +21,36 @@ The feature overview for a release are shown at the :ref:`genindex` of this docu
 Bareos-19.2
 -----------
 
+.. _bareos-19210-releasenotes:
+
+.. _bareos-19.2.10:
+
+Bareos-19.2.10
+~~~~~~~~~~~~~
+
+General Information
+^^^^^^^^^^^^^^^^^^^
+.. list-table:: Bareos 19.2.10 Release Information
+   :header-rows: 0
+   :widths: auto
+
+   * - **Release Date**
+     - YYYY-MM-DD
+   * - **Database Version**
+     - 2192
+   * - **URL**
+     - https://download.bareos.com/bareos/release/19.2/
+   * - **Release Ticket**
+     - :mantis:`????`
+
+Bugs Fixed
+^^^^^^^^^^
+* fix python-bareos for Python < 2.7.13 [PR #753]
+
+Other Improvements
+^^^^^^^^^^^^^^^^^^
+
+
 .. _bareos-1929-releasenotes:
 
 .. _bareos-19.2.9:

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -79,7 +79,10 @@ class LowLevel(object):
         self.max_reconnects = 0
         self.tls_psk_enable = True
         self.tls_psk_require = False
-        self.tls_version = ssl.PROTOCOL_TLS
+        try:
+            self.tls_version = ssl.PROTOCOL_TLS
+        except AttributeError:
+            self.tls_version = ssl.PROTOCOL_SSLv23
         self.connection_type = None
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()


### PR DESCRIPTION
This is a backport from master.

By default we set ssl.PROTOCOL_TLS.
However, this requires Python >= 2.7.13, which is not available by default on RHEL/CentOS 7.
Therefore we added a fallback to ssl.PROTOCOL_SSLv23.

(cherry picked from commit a3897f5ec36011153e1b05945819f57ac872c33b)

- [x] Add a small description to the CHANGELOG.md file and refer to your PR using this syntax '[PR #xyz]'

#### Keep spirit!
- [x] Do not be afraid to hand in a PR!
