### PR TITLE
systemtests: fix volume-pruning test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1316]: storage daemon loses a configured device instance [PR #739]
 - fix python-bareos for Python < 2.7.13 [PR #748]
 - fixed bug when user could enter wrong dates such as 2000-66-100 55:55:89 without being denied [PR #707]
-
+- fix volume-pruning to be relyable on all test platforms [PR #761]
 
 ### Added
 - added reload commands to systemd service [PR #694]

--- a/core/src/dird/ua_prune.cc
+++ b/core/src/dird/ua_prune.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -874,6 +874,11 @@ bool PruneVolume(UaContext* ua, MediaDbRecord* mr)
            _("Volume \"%s\" contains no jobs after pruning.\n"),
            mr->VolumeName);
     }
+  } else {
+    Jmsg(ua->jcr, M_INFO, 0,
+         _("Pruning volume %s: cannot prune as Volstatus is %s but needs to be "
+           "Full or Used.\n"),
+         mr->VolumeName, mr->VolStatus);
   }
 
   DbUnlock(ua->db);

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -596,7 +596,6 @@ set(SYSTEM_TESTS_BROKEN
     py3plug-fd-postgres
     python-bareos
     scheduler-backup
-    volume-pruning
     # the next two fail on FreeBSD 11.4
     filesets
     py3plug-fd-local-fileset-restoreobject

--- a/systemtests/tests/volume-pruning/testrunner
+++ b/systemtests/tests/volume-pruning/testrunner
@@ -66,6 +66,7 @@ messages
 @# now prune using the commandline
 @#
 @sleep 6
+update volume=TestVolume001 volstatus=Used
 prune volume=TestVolume001 yes
 messages
 quit
@@ -78,13 +79,14 @@ stop_bareos
 check_two_logs
 
 if ! grep "Purging the following JobIds: 1,2,3,4,5,6" "$tmp"/log1.out; then
-  echo "Pruned jobs don't match expectations." >&2
+  echo "'Purging the following JobIds: 1,2,3,4,5,6' not found in $tmp/log1.out" >&2
+  grep 'Purging the' "$tmp"/log1.out >&2 || :
   estat=1
 fi
 
-if ! grep -F 'Volume "TestVolume001" contains no jobs after pruning.' \
-    $tmp/log2.out; then
-  echo "Pruning message is wrong." >&2
+if ! grep -F 'Volume "TestVolume001" contains no jobs after pruning.' $tmp/log2.out; then
+  echo "'Volume \"TestVolume001\" contains no jobs after pruning.' not found in $tmp/log2.out" >&2
+  grep 'Volume.*contains no jobs after pruning.' $tmp/log2.out >&2 || :
   estat=1
 fi
 


### PR DESCRIPTION
Fix the **volume-pruning** system test that was unrelyable on some test platforms.
Now the test passes on all platforms that we build for.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
