### PR TITLE
cmake: do not pollute sourcetree with untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ debian/bareos-filedaemon-python-plugin.install
 debian/bareos-filedaemon-python-plugins-common.install
 debian/bareos-filedaemon-python2-plugin.install
 debian/bareos-filedaemon-python3-plugin.install
+debian/bareos-filedaemon-postgresql-python-plugin.install
 debian/bareos-filedaemon.bareos-fd.init
 debian/bareos-filedaemon.install
 debian/bareos-filedaemon.postinst

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - storage daemon: class Device: rename dev_name to archive_device_string (as the value stored here is the value of the "Archive Device" directive) [PR #744]
 - Enable c++17 support [PR #741]
 - webui: Localization updated [PR #776]
+- running cmake for the core-directory only is now forbidden [PR #767]
 
 ### Deprecated
 

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -21,6 +21,13 @@ message("Entering ${CMAKE_CURRENT_SOURCE_DIR}")
 cmake_minimum_required(VERSION 3.12)
 project(bareos C CXX)
 
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
+  message(
+    FATAL_ERROR
+      "Building from bareos/core/ is not supported anymore. Use bareos/ instead"
+  )
+endif()
+
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif(POLICY CMP0054)

--- a/core/cmake/BareosConfigureFile.cmake
+++ b/core/cmake/BareosConfigureFile.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -21,16 +21,13 @@
 # configure file all *.in files
 #
 
-# if we're not the toplevel project, then we want to glob in core and debian
-# subdirectories only
-get_directory_property(have_parent PARENT_DIRECTORY)
-if(have_parent)
-  file(GLOB_RECURSE IN_FILES "${CMAKE_SOURCE_DIR}/core/*.in"
-       "${CMAKE_SOURCE_DIR}/debian/*.in"
-  )
-else()
-  file(GLOB_RECURSE IN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.in")
-endif()
+file(
+  GLOB_RECURSE IN_FILES
+  "${CMAKE_SOURCE_DIR}/debian/*.in"
+  "${CMAKE_SOURCE_DIR}/core/src/*.in"
+  "${CMAKE_SOURCE_DIR}/core/scripts/*.in"
+  "${CMAKE_SOURCE_DIR}/core/platforms/*.in"
+)
 
 foreach(in_file ${IN_FILES})
   string(REGEX REPLACE ".in\$" "" file ${in_file})


### PR DESCRIPTION
previously two files showed up that were generated by cmake. This patch
adds the debian install-file to .gitignore and changes the global
configure_file not to pick up files from  core/ but only from core/src
which will disable creation of CTestScript.cmake in core/ as it is
already generated to ${CMAKE_BINARY_DIR}/CTestScript.cmake

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
