### PR TITLE
Python > 3.7 error with libcloud and postgresql fd plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - informative debugmessage when a dynamic backend cannot be loaded [PR #746]
 
 ### Changed
+- When using Python > 3.7 the postgres and libcloud plugins will cancel the job and write an error message [PR #775]
 - Disabled test "statefile" for big endian, use temporary state files for all other architectures [PR #758]
 - Fixed broken link in https://docs.bareos.org/IntroductionAndTutorial/WhatIsBareos.html documentation page
 - Ctest now runs in scripted mode. [PR #751]

--- a/core/cmake/BareosFindAllLibraries.cmake
+++ b/core/cmake/BareosFindAllLibraries.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -39,6 +39,16 @@ elseif(${CMAKE_SYSTEM_NAME} MATCHES "SunOS")
 else()
   find_package(Python2 COMPONENTS Interpreter Development)
   find_package(Python3 COMPONENTS Interpreter Development)
+
+  set(Python3_VERSION_MAJOR
+      ${Python3_VERSION_MAJOR}
+      PARENT_SCOPE
+  )
+
+  set(Python3_VERSION_MINOR
+      ${Python3_VERSION_MINOR}
+      PARENT_SCOPE
+  )
 
   if(${Python2_FOUND} OR ${Python3_FOUND})
     set(HAVE_PYTHON 1)

--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -120,6 +120,17 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             self.options["accurate"] = True
 
     def parse_plugin_definition(self, plugindef):
+        if version_info.major >= 3 and version_info.minor > 7:
+            jobmessage(
+                M_FATAL,
+                "Need Python version < 3.8 for Bareos Libcloud (current version: %d.%d.%d)"
+                % (
+                    version_info.major,
+                    version_info.minor,
+                    version_info.micro,
+                ),
+            )
+            return bRC_Error
         debugmessage(100, "parse_plugin_definition()")
         config_filename = self.options.get("config_file")
         if config_filename:
@@ -344,11 +355,11 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
 
         statp = bareosfd.StatPacket()
 
-        statp.st_size = self.current_backup_task['size']
-        statp.st_mtime = self.current_backup_task['mtime']
+        statp.st_size = self.current_backup_task["size"]
+        statp.st_mtime = self.current_backup_task["mtime"]
         statp.st_atime = 0
         statp.st_ctime = 0
-        
+
         savepkt.statp = statp
         savepkt.fname = StringCodec.encode_for_backup(filename)
         savepkt.type = FT_REG

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -249,8 +249,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             except Exception as e:
                 bareosfd.JobMessage(
                     M_ERROR,
-                    'Could net get stat-info for file %s: %s\n'
-                    % (file_to_backup, e),
+                    "Could net get stat-info for file %s: %s\n" % (file_to_backup, e),
                 )
                 continue
             bareosfd.DebugMessage(
@@ -286,7 +285,9 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             self.parseBackupLabelFile()
             bareosfd.JobMessage(
                 M_FATAL,
-                "Another Postgres Backup Operation is in progress (\"{}\" file exists). You may stop it using SELECT pg_stop_backup()\n".format(self.labelFileName)
+                'Another Postgres Backup Operation is in progress ("{}" file exists). You may stop it using SELECT pg_stop_backup()\n'.format(
+                    self.labelFileName
+                ),
             )
             return bRC_Error
 
@@ -322,7 +323,6 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 M_ERROR,
                 "Could not read Label File %s\n" % (self.labelFileName),
             )
-
 
     def start_backup_file(self, savepkt):
         """
@@ -432,7 +432,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             except Exception as e:
                 bareosfd.JobMessage(
                     M_ERROR,
-                    'Could net get stat-info for file %s: %s\n' % (fullPath, e),
+                    "Could net get stat-info for file %s: %s\n" % (fullPath, e),
                 )
                 continue
             fileMtime = datetime.datetime.fromtimestamp(st.st_mtime)

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -669,7 +669,7 @@ endif()
 
 check_pymodule_available(3 fastapi)
 check_pymodule_available(3 uvicorn)
-find_program (CURL curl)
+find_program(CURL curl)
 
 # python-restapi-test does not work on installed files and needs some modules
 if(PYTHON_EXECUTABLE
@@ -683,7 +683,6 @@ if(PYTHON_EXECUTABLE
 else()
   list(APPEND SYSTEM_TESTS_DISABLED "python-restapi")
 endif()
-
 
 bareosfindlibrary("gtest")
 if(GTEST_FOUND AND NOT RUN_SYSTEMTESTS_ON_INSTALLED_FILES)
@@ -758,11 +757,13 @@ if(TARGET python3-fd)
   if(S3CMD
      AND MINIO
      AND PYMODULE_3_LIBCLOUD_FOUND
+     AND (${Python3_VERSION_MAJOR} EQUAL 3)
+     AND (${Python3_VERSION_MINOR} LESS 8)
   )
     list(APPEND SYSTEM_TESTS "py3plug-fd-libcloud")
   else()
     message(
-      "S3CMD, MINIO or LIBCLOUD MODULE not found, disabling py3plug-fd-libcloud"
+      "S3CMD, MINIO or LIBCLOUD MODULE not found or Python > 3.7, disabling py3plug-fd-libcloud"
     )
     list(APPEND SYSTEM_TESTS_DISABLED "py3plug-fd-libcloud")
   endif()
@@ -797,13 +798,18 @@ else()
 endif()
 
 message("checking for requirements of py3plug-fd-postgres:")
-check_pymodule_available(3 psycopg2)
-check_pymodule_available(3 dateutil)
-if(TARGET python-fd
-   AND PYMODULE_3_PSYCOPG2_FOUND
-   AND PYMODULE_3_DATEUTIL_FOUND
-)
-  list(APPEND SYSTEM_TESTS "py3plug-fd-postgres")
+if(TARGET python3-fd)
+  check_pymodule_available(3 psycopg2)
+  check_pymodule_available(3 dateutil)
+  if(PYMODULE_3_PSYCOPG2_FOUND
+     AND PYMODULE_3_DATEUTIL_FOUND
+     AND (${Python3_VERSION_MAJOR} EQUAL 3)
+     AND (${Python3_VERSION_MINOR} LESS 8)
+  )
+    list(APPEND SYSTEM_TESTS "py3plug-fd-postgres")
+  else()
+    list(APPEND SYSTEM_TESTS_DISABLED "py3plug-fd-postgres")
+  endif()
 else()
   list(APPEND SYSTEM_TESTS_DISABLED "py3plug-fd-postgres")
 endif()

--- a/systemtests/tests/py2plug-fd-postgres/database/setup_local_db.sh
+++ b/systemtests/tests/py2plug-fd-postgres/database/setup_local_db.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -97,7 +97,7 @@ local_db_create_superuser_role() {
 }
 
 setup_local_db() {
-  local_db_stop_server "$1"
+  local_db_stop_server "$1" || true
   local_db_prepare_files "$1"
   if ! local_db_start_server "$1"; then return 1; fi
   local_db_create_superuser_role "$1"


### PR DESCRIPTION
With Python > 3.7 the libcloud and postgresql plugins do not work anymore.

The suggested change in this PR is to write an error message to the joblog and cancel the job.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

Is a Backport of PR 769

