### PR TITLE
python modules: fix memleak in module constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix python-bareos for Python < 2.7.13 [PR #748]
 - fixed bug when user could enter wrong dates such as 2000-66-100 55:55:89 without being denied [PR #707]
 - fix volume-pruning to be relyable on all test platforms [PR #761]
+- fix memory leak in python module constants [PR #778]
 
 
 ### Added

--- a/core/src/plugins/dird/python/python-dir.cc
+++ b/core/src/plugins/dird/python/python-dir.cc
@@ -226,7 +226,7 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
   /* import the bareosdir module */
   PyObject* bareosdirModule = PyImport_ImportModule("bareosdir");
   if (!bareosdirModule) {
-    printf("loading of bareosdir failed\n");
+    printf("loading of bareosdir extension module failed\n");
     if (PyErr_Occurred()) { PyErrorHandler(); }
   }
 

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -196,7 +196,7 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
   /* import the bareosfd module */
   PyObject* bareosfdModule = PyImport_ImportModule("bareosfd");
   if (!bareosfdModule) {
-    printf("loading of bareosfd failed\n");
+    printf("loading of bareosfd extension module failed\n");
     if (PyErr_Occurred()) { PyErrorHandler(); }
   }
 

--- a/core/src/plugins/filed/python/test/python-fd-module-tester.cc
+++ b/core/src/plugins/filed/python/test/python-fd-module-tester.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -19,7 +19,7 @@
    02110-1301, USA.
 */
 
-/* Load the python-fd plugin and test it */
+/* Load the python-fd extension module and test it */
 
 #if defined(HAVE_MINGW)
 #  include "include/bareos.h"
@@ -197,7 +197,7 @@ int main(int argc, char* argv[])
   if (bareosfdModule) {
     printf("loaded bareosfd successfully\n");
   } else {
-    printf("loading of bareosfd failed\n");
+    printf("loading of bareosfd extension module failed\n");
   }
   if (PyErr_Occurred()) { PyErrorHandler(); }
 

--- a/core/src/plugins/include/python_plugins_common.h
+++ b/core/src/plugins/include/python_plugins_common.h
@@ -83,19 +83,28 @@
      IO_WRITE = 3
  */
 
-#define ConstSet_StrLong(dict, string, value)           \
-  if (PyDict_SetItem(dict, PyBytes_FromString(#string), \
-                     PyLong_FromLong(value))) {         \
-    return MOD_ERROR_VAL;                               \
-  }                                                     \
-  if (PyModule_AddIntConstant(m, #string, value)) { return MOD_ERROR_VAL; }
-
-#define ConstSet_StrStr(dict, string, value)            \
-  if (PyDict_SetItem(dict, PyBytes_FromString(#string), \
-                     PyBytes_FromString(value))) {      \
-    return MOD_ERROR_VAL;                               \
-  }                                                     \
-  if (PyModule_AddStringConstant(m, #string, value)) { return MOD_ERROR_VAL; }
+#define ConstSet_StrLong(dict, string, value)                                 \
+  {                                                                           \
+    PyObject* stringKey = PyBytes_FromString(#string);                        \
+    PyObject* longValue = PyLong_FromLong(value);                             \
+    if (PyDict_SetItem(dict, stringKey, longValue)) { return MOD_ERROR_VAL; } \
+    if (PyModule_AddIntConstant(m, #string, value)) { return MOD_ERROR_VAL; } \
+    Py_DECREF(stringKey);                                                     \
+    Py_DECREF(longValue);                                                     \
+  }
+#define ConstSet_StrStr(dict, string, value)             \
+  {                                                      \
+    PyObject* stringKey = PyBytes_FromString(#string);   \
+    PyObject* stringValue = PyBytes_FromString(value);   \
+    if (PyDict_SetItem(dict, stringKey, stringValue)) {  \
+      return MOD_ERROR_VAL;                              \
+    }                                                    \
+    if (PyModule_AddStringConstant(m, #string, value)) { \
+      return MOD_ERROR_VAL;                              \
+    }                                                    \
+    Py_DECREF(stringKey);                                \
+    Py_DECREF(stringValue);                              \
+  }
 
 
 /* commonly used definitions in multiple python modules */

--- a/core/src/plugins/stored/python/python-sd.cc
+++ b/core/src/plugins/stored/python/python-sd.cc
@@ -227,7 +227,7 @@ bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
   /* import the bareossd module */
   PyObject* bareossdModule = PyImport_ImportModule("bareossd");
   if (!bareossdModule) {
-    printf("loading of bareossd failed\n");
+    printf("loading of bareossd extension module failed\n");
     if (PyErr_Occurred()) { PyErrorHandler(); }
   }
 


### PR DESCRIPTION
When creating the module constants in the python modules, the intermediate results were
not Py_DECREF'ed so the new references created memory leaks.

This PR fixes this problem.



#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
