### PR TITLE
automatically select modern C++17 compiler in SPECfiles

### DIFF
--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -125,10 +125,15 @@ BuildRequires: libtirpc-devel
 %define ceph 1
 %endif
 
-# use Developer Toolset 7 compiler as standard is too old
-%if 0%{?centos_version} == 600 || 0%{?rhel_version} == 600
-BuildRequires: devtoolset-7-gcc
-BuildRequires: devtoolset-7-gcc-c++
+# use Developer Toolset 8 compiler as standard is too old
+%if 0%{?centos_version} == 700 || 0%{?rhel_version} == 700
+BuildRequires: devtoolset-8-gcc
+BuildRequires: devtoolset-8-gcc-c++
+%endif
+
+%if 0%{?suse_version}
+BuildRequires: gcc9
+BuildRequires: gcc9-c++
 %endif
 
 %if 0%{?systemd_support}
@@ -928,9 +933,15 @@ export MTX=/usr/sbin/mtx
 mkdir %{CMAKE_BUILDDIR}
 pushd %{CMAKE_BUILDDIR}
 
-# use Developer Toolset 7 compiler as standard is too old
-%if 0%{?centos_version} == 600 || 0%{?rhel_version} == 600
-export PATH=/opt/rh/devtoolset-7/root/usr/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin
+# use Developer Toolset 8 compiler as standard is too old
+%if 0%{?centos_version} == 700 || 0%{?rhel_version} == 700
+source /opt/rh/devtoolset-8/enable
+%endif
+
+# use gcc9 on SuSE
+%if 0%{?suse_version}
+CC=gcc-9  ; export CC
+CXX=g++-9 ; export CXX
 %endif
 
 CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ;


### PR DESCRIPTION
We now expect a C++17 compiler to build. Thus the specfile now
BuildRequires and enables the compilers we want if special handling is
needed.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
