### PR TITLE
docs: updating director manual

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -195,6 +195,7 @@ Ulrich Leodolter
 Victor Hugo dos Santos
 Vitaliy Kosharskiy
 Wanderlei Hüttel
+Wanja Zaeske
 Wolfgang Denk
 Yuri Timofeev
 Yves Orton

--- a/docs/manuals/source/Configuration/Director.rst
+++ b/docs/manuals/source/Configuration/Director.rst
@@ -851,7 +851,7 @@ The directives within an Options resource may be one of the following:
    See the example below for more details.
 
    If you think that Bareos should be backing up a particular directory
-   and it is not, and you have :strong:`onefs=no` set, before you complain,
+   and it is not, and you have :strong:`onefs=yes` set, before you complain,
    please do:
 
    .. code-block:: shell-session


### PR DESCRIPTION
The sentence

> If you think that Bareos should be backing up a particular directory
   and it is not, and you have :strong:`onefs=no` set, before you complain,
   please do:
 
Implies that it will make a difference if some files reside on different file systems when `onefs=no`. However, the `onefs` option is said to only make a difference for multiple filesystems if it's set to `yes`.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
