### PR TITLE
cmake: speedup symlink creation on cmake >=3.14

### DIFF
--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -332,7 +332,13 @@ macro(prepare_test)
 endmacro()
 
 macro(create_symlink target link)
-  execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${target} ${link})
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.14")
+    file(CREATE_LINK ${target} ${link} SYMBOLIC)
+  else()
+    execute_process(
+      COMMAND ${CMAKE_COMMAND} -E create_symlink ${target} ${link}
+    )
+  endif()
 endmacro()
 
 # Main starts here...


### PR DESCRIPTION
By using the new file (CREATE_LINK ) available since cmake 3.14, the
configuration time could be reduced by about 33%.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
