### PR TITLE
systemtest python-bareos: adapt for FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fixed bug when user could enter wrong dates such as 2000-66-100 55:55:89 without being denied [PR #707]
 - fix volume-pruning to be reliable on all test platforms [PR #761]
 - fix memory leak in python module constants [PR #778]
-- fix systemtests: reduce the number of broken tests to two [PR #771]
+- fix systemtests: reduce the number of broken tests [PR #771] [PR #791]
 - [Issue #1329]: If CommandACL limits any command, no messages can be read but "you have messages" is displayed. [PR #763]
 
 ### Added

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -600,7 +600,7 @@ class LowLevel(object):
         """
         msg = self.recv_bytes(length)
         if type(msg) is str:
-            msg = bytearray(msg.decode("utf-8"), "utf-8")
+            msg = bytearray(msg.decode("utf-8", 'replace'), "utf-8")
         if type(msg) is bytes:
             msg = bytearray(msg)
         self.logger.debug(str(msg))
@@ -642,7 +642,7 @@ class LowLevel(object):
 
     def _show_result(self, msg):
         # print(msg.decode('utf-8'))
-        sys.stdout.write(msg.decode("utf-8"))
+        sys.stdout.write(msg.decode("utf-8", 'replace'))
         # add a linefeed, if there isn't one already
         if len(msg) >= 2:
             if msg[-2] != ord(b"\n"):

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -631,7 +631,6 @@ set(SYSTEM_TESTS_DISABLED # initially empty
 # add tests also here that are unreliable they are excluded when running tests
 # during build in jenkins
 set(SYSTEM_TESTS_BROKEN
-    python-bareos # Fails on FreeBSD
     py3plug-fd-local-fileset # Fails with UnicodeEncodeError: 'utf-8' codec
                              # can't encode characters in position 133-142:
                              # surrogates not allowed

--- a/systemtests/tests/python-bareos/write.sh
+++ b/systemtests/tests/python-bareos/write.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -22,7 +22,7 @@
 file=$1
 shift
 
-printf "date=%s\n" "$(LANG=C date)" | tee --append $file
+printf "date=%s\n" "$(LANG=C date)" | tee -a $file
 for i in "$@"; do
-    echo "$i" | tee --append $file
+    echo "$i" | tee -a $file
 done


### PR DESCRIPTION
The tee command on FreeBSD does not allow the parameter --append, instead -a must be used.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
