### PR TITLE
gfapi-fd: Fix possible crash on second glfs_close()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix possible read/write problems when using droplet with https [PR #773]
 - fix memory leak in python module constants [PR #781]
 - fix german localization errors [PR #786]
+- fix gfapi-fd: avoid possible crash on second glfs_close() call [PR #797]
 
 ### Added
 - systemtests for S3 functionalities (droplet, libcloud) now use https [PR #773]

--- a/core/src/plugins/filed/gfapi/gfapi-fd.cc
+++ b/core/src/plugins/filed/gfapi/gfapi-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1738,11 +1738,6 @@ static bRC pluginIO(PluginContext* ctx, struct io_pkt* io)
 
   switch (io->func) {
     case IO_OPEN:
-      /*
-       * Close the gfd when it was not closed before.
-       */
-      if (p_ctx->gfd) { glfs_close(p_ctx->gfd); }
-
       if (io->flags & (O_CREAT | O_WRONLY)) {
         p_ctx->gfd = glfs_creat(p_ctx->glfs, io->fname, io->flags, io->mode);
       } else {
@@ -1785,11 +1780,11 @@ static bRC pluginIO(PluginContext* ctx, struct io_pkt* io)
     case IO_CLOSE:
       if (p_ctx->gfd) {
         io->status = glfs_close(p_ctx->gfd);
+        p_ctx->gfd = NULL;
         if (io->status < 0) {
           io->io_errno = errno;
           goto bail_out;
         }
-        p_ctx->gfd = NULL;
       } else {
         io->status = -1;
         io->io_errno = EBADF;


### PR DESCRIPTION
Under rare circumstances, namely when a file was deleted during
backup after the glfs_open() and before the first glfs_close() call,
which then returns an error, the code assumed that the file was
closed and invoked a second glfs_close() call. This second call
could cause a segmentation fault.

The changed code no longer does a second glfs_close() call, the
first call already cleans up the glfs file descriptor properly,
even when an error occurs while trying to close the file.

(cherry picked from commit 874bfec6d5327181d4023c2a44568f23fbb01985)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

