### PR TITLE
gfapi-fd: Fix possible crash on second glfs_close()

### DIFF
--- a/core/src/plugins/filed/gfapi-fd.cc
+++ b/core/src/plugins/filed/gfapi-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1768,13 +1768,6 @@ static bRC pluginIO(bpContext *ctx, struct io_pkt *io)
 
    switch(io->func) {
    case IO_OPEN:
-      /*
-       * Close the gfd when it was not closed before.
-       */
-      if (p_ctx->gfd) {
-         glfs_close(p_ctx->gfd);
-      }
-
       if (io->flags & (O_CREAT | O_WRONLY)) {
          p_ctx->gfd = glfs_creat(p_ctx->glfs, io->fname, io->flags, io->mode);
       } else {
@@ -1817,11 +1810,11 @@ static bRC pluginIO(bpContext *ctx, struct io_pkt *io)
    case IO_CLOSE:
       if (p_ctx->gfd) {
          io->status = glfs_close(p_ctx->gfd);
+         p_ctx->gfd = NULL;
          if (io->status < 0) {
             io->io_errno = errno;
             goto bail_out;
          }
-         p_ctx->gfd = NULL;
       } else {
          io->status = -1;
          io->io_errno = EBADF;


### PR DESCRIPTION
Under rare circumstances, namely when a file was deleted during
backup after the glfs_open() and before the first glfs_close() call,
which then returns an error, the code assumed that the file was
closed and invoked a second glfs_close() call. This second call
could cause a segmentation fault.

The changed code no longer does a second glfs_close() call, the
first call already cleans up the glfs file descriptor properly,
even when an error occurs while trying to close the file.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted


