### PR TITLE
sd_reservation.cc: add thread header

### DIFF
--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -32,6 +32,7 @@
 
 #include <chrono>
 #include <future>
+#include <thread>
 
 #define STORAGE_DAEMON 1
 #include "include/jcr.h"


### PR DESCRIPTION
Without this header, sd_reservation does not compile on
gcc 11.1.1 on Fedora 34

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~~
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [ ] ~~Variable and function names are meaningful~~
- [ ] ~~Code comments are correct (logically and spelling)~~
- [ ] ~~Required documentation changes are present and part of the PR~~
- [x] `check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
