### PR TITLE
Fix bug-0001194: accurate incremental backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - fix shutdown of the Storage Daemon backends, especially call UnlockDoor on tape devices [PR #809]
 - fix possible deadlock in storage backend on Solaris and FreeBSD [PR #809]
+- [bug-0001194]: when doing an accurate incremental backup, if there is a database error, a full backup is done instead of reporting the error [PR #810]
 - fix a bug in a date function that leads to errors on the 31st day of a month [PR #782]
 - fix possible read/write problems when using droplet with https [PR #765]
 - fix "configure add" handling of quoted strings [PR #764]

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -351,9 +351,13 @@ bool SendAccurateCurrentFiles(JobControlRecord* jcr)
       return false; /* Fail */
     }
 
-    jcr->db_batch->GetFileList(
-        jcr, jobids.GetAsString().c_str(), jcr->impl->use_accurate_chksum,
-        false /* no delta */, AccurateListHandler, (void*)jcr);
+    if (!jcr->db_batch->GetFileList(
+            jcr, jobids.GetAsString().c_str(), jcr->impl->use_accurate_chksum,
+            false /* no delta */, AccurateListHandler, (void*)jcr)) {
+      Jmsg(jcr, M_FATAL, 0, "error in jcr->db_batch->GetBaseFileList:%s\n",
+           jcr->db_batch->strerror());
+      return false;
+    }
   }
 
   jcr->file_bsock->signal(BNET_EOD);


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description:

If an error happens while fetching files during an incremental backup job with the accurate option enabled, a full backup is done instead of aborting the job and reporting the error. This PR addresses the issue.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

