### PR TITLE
Fix build for newer openSUSE releases

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -33,6 +33,7 @@ Bastian Friedrich
 Ben Walton
 Benedikt Braunger
 Bernd Frick
+Bernhard M. Wiedemann
 Bill Moran
 Braian Bressan
 Bruno Friedmann

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -57,7 +57,7 @@ BuildConflicts: libtirpc-devel
 %endif
 
 # fedora 28: rpc was removed from libc
-%if 0%{?fedora} >= 28 || 0%{?rhel} > 7
+%if 0%{?fedora} >= 28 || 0%{?rhel} > 7 || 0%{?suse_version} >= 1550
 BuildRequires: rpcgen
 BuildRequires: libtirpc-devel
 %endif
@@ -72,7 +72,7 @@ BuildRequires: libtirpc-devel
 %define python_plugins 0
 %endif
 
-%if 0%{?suse_version} > 1010
+%if 0%{?suse_version} > 1010 && 0%{?suse_version} < 1500
 %define install_suse_fw 1
 %define _fwdefdir   %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services
 %endif

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -57,7 +57,7 @@ BuildConflicts: libtirpc-devel
 %endif
 
 # fedora 28: rpc was removed from libc
-%if 0%{?fedora} >= 28 || 0%{?rhel} > 7 || 0%{?suse_version} >= 1550
+%if 0%{?fedora} >= 28 || 0%{?rhel} > 7 || 0%{?suse_version} >= 1550 || 0%{?sle_version} >= 150300
 BuildRequires: rpcgen
 BuildRequires: libtirpc-devel
 %endif


### PR DESCRIPTION
Without these patches, [bareos builds](https://build.opensuse.org/package/show/Archiving:Backup/bareos) for newer openSUSE releases failed.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted

