### PR TITLE
dev.cc: do not call virtual functions in destructor (backport to 20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ core/src/plugins/filed/python/ovirt/python-ovirt-conf.d/bareos-dir.d/fileset/plu
 
 # generated test configuration
 core/src/tests/configs/bareos-configparser-tests/bareos-dir-CFG_TYPE_STR_VECTOR_OF_DIRS.conf
+core/src/tests/configs/sd_backend/bareos-sd.d/storage/myself.conf
 
 # etags and cscope db
 tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix memory leak in python module constants [PR #781]
 - fix german localization errors [PR #786]
 - fix gfapi-fd: avoid possible crash on second glfs_close() call [PR #797]
+- fix shutdown of the Storage Daemon backends, especially call UnlockDoor on tape devices [PR #818] (backport of [PR #809])
+- fix possible deadlock in storage backend on Solaris and FreeBSD [PR #818] (backport of [PR #809])
 
 ### Added
 - systemtests for S3 functionalities (droplet, libcloud) now use https [PR #765]

--- a/core/src/stored/acquire.h
+++ b/core/src/stored/acquire.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,6 +23,8 @@
 
 namespace storagedaemon {
 
+class Device;
+class DeviceControlRecord;
 struct BlockSizeBoundaries;
 
 DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr);

--- a/core/src/stored/backends/cephfs_device.cc
+++ b/core/src/stored/backends/cephfs_device.cc
@@ -398,6 +398,7 @@ cephfs_device::~cephfs_device()
   }
 
   FreePoolMemory(virtual_filename_);
+  close(nullptr);
 }
 
 cephfs_device::cephfs_device()

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -1501,6 +1501,7 @@ ChunkedDevice::~ChunkedDevice()
   }
 
   if (current_volname_) { free(current_volname_); }
+  close(nullptr);
 }
 
 } /* namespace storagedaemon */

--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -1160,12 +1160,9 @@ bool generic_tape_device::rewind(DeviceControlRecord* dcr)
   return true;
 }
 
-/**
- * (Un)mount the device (for tape devices)
- */
-static bool do_mount(DeviceControlRecord* dcr, int mount, int dotimeout)
+// (Un)mount the device (for tape devices)
+bool generic_tape_device::do_mount(DeviceControlRecord* dcr, int mount, int dotimeout)
 {
-  DeviceResource* device_resource = dcr->dev->device_resource;
   PoolMem ocmd(PM_FNAME);
   POOLMEM* results;
   char* icmd;
@@ -1178,9 +1175,9 @@ static bool do_mount(DeviceControlRecord* dcr, int mount, int dotimeout)
     icmd = device_resource->unmount_command;
   }
 
-  dcr->dev->EditMountCodes(ocmd, icmd);
+  EditMountCodes(ocmd, icmd);
   Dmsg2(100, "do_mount: cmd=%s mounted=%d\n", ocmd.c_str(),
-        dcr->dev->IsMounted());
+        IsMounted());
 
   if (dotimeout) {
     /* Try at most 10 times to (un)mount the device. This should perhaps be
@@ -1194,15 +1191,15 @@ static bool do_mount(DeviceControlRecord* dcr, int mount, int dotimeout)
   /* If busy retry each second */
   Dmsg1(100, "do_mount run_prog=%s\n", ocmd.c_str());
   while ((status = RunProgramFullOutput(ocmd.c_str(),
-                                        dcr->dev->max_open_wait / 2, results))
+                                        max_open_wait / 2, results))
          != 0) {
     if (tries-- > 0) { continue; }
 
     Dmsg5(100, "Device %s cannot be %smounted. stat=%d result=%s ERR=%s\n",
-          dcr->dev->print_name(), (mount ? "" : "un"), status, results,
+          print_name(), (mount ? "" : "un"), status, results,
           be.bstrerror(status));
-    Mmsg(dcr->dev->errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
-         dcr->dev->print_name(), (mount ? "" : "un"), be.bstrerror(status));
+    Mmsg(errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
+         print_name(), (mount ? "" : "un"), be.bstrerror(status));
 
     FreePoolMemory(results);
     Dmsg0(200, "============ mount=0\n");

--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -39,6 +39,8 @@
 #include "lib/berrno.h"
 #include "lib/util.h"
 
+#include <string>
+
 namespace storagedaemon {
 
 /**
@@ -804,39 +806,25 @@ void generic_tape_device::UnlockDoor()
 #endif
 }
 
+void generic_tape_device::OsClrError()
+{
 #if defined(MTIOCLRERR)
-/**
- * Found on Solaris
- */
-static inline void OsClrerror(Device* dev)
-{
-  if (dev->d_ioctl(dev->fd, MTIOCLRERR) < 0) { dev->clrerror(MTIOCLRERR); }
+  // Found on Solaris
+  if (d_ioctl(fd, MTIOCLRERR) < 0) { HandleError(MTIOCLRERR); }
   Dmsg0(200, "Did MTIOCLRERR\n");
-}
 #elif defined(MTIOCERRSTAT)
-/**
- * Typically on FreeBSD
- */
-static inline void OsClrerror(Device* dev)
-{
+  // Typically on FreeBSD
   BErrNo be;
   union mterrstat mt_errstat;
 
-  /*
-   * Read and clear SCSI error status
-   */
-  Dmsg2(200, "Doing MTIOCERRSTAT errno=%d ERR=%s\n", dev->dev_errno,
-        be.bstrerror(dev->dev_errno));
-  if (dev->d_ioctl(dev->fd, MTIOCERRSTAT, (char*)&mt_errstat) < 0) {
-    dev->clrerror(MTIOCERRSTAT);
+  // Read and clear SCSI error status
+  Dmsg2(200, "Doing MTIOCERRSTAT errno=%d ERR=%s\n", dev_errno,
+        be.bstrerror(dev_errno));
+  if (d_ioctl(fd, MTIOCERRSTAT, (char*)&mt_errstat) < 0) {
+    HandleError(MTIOCERRSTAT);
   }
-}
 #elif defined(MTCSE)
-/**
- * Clear Subsystem Exception TRU64
- */
-static inline void OsClrerror(Device* dev)
-{
+  // Clear Subsystem Exception TRU64
   mtop mt_com{};
 
   /*
@@ -844,27 +832,19 @@ static inline void OsClrerror(Device* dev)
    */
   mt_com.mt_op = MTCSE;
   mt_com.mt_count = 1;
-  if (dev->d_ioctl(dev->fd, MTIOCTOP, (char*)&mt_com) < 0) {
-    dev->clrerror(mt_com.mt_op);
-  }
+  if (d_ioctl(fd, MTIOCTOP, (char*)&mt_com) < 0) { HandleError(mt_com.mt_op); }
   Dmsg0(200, "Did MTCSE\n");
-}
-#else
-static inline void OsClrerror(Device* dev) {}
 #endif
+}
 
-/**
- * If implemented in system, clear the tape error status.
- */
-void generic_tape_device::clrerror(int func)
+void generic_tape_device::HandleError(int func)
 {
-  const char* msg = NULL;
-  char buf[100];
-
-  dev_errno = errno; /* save errno */
-  if (errno == EIO) { VolCatInfo.VolCatErrors++; }
-
-  if (errno == ENOTTY || errno == ENOSYS) { /* Function not implemented */
+  dev_errno = errno;
+  if (errno == EIO) {
+    VolCatInfo.VolCatErrors++;
+  } else if (errno == ENOTTY
+             || errno == ENOSYS) { /* Function not implemented */
+    std::string msg;
     switch (func) {
       case -1:
         break; /* ignore message printed later */
@@ -912,7 +892,6 @@ void generic_tape_device::clrerror(int func)
         msg = "MTRESET";
         break;
 #endif
-
 #ifdef MTSETBSIZ
       case MTSETBSIZ:
         msg = "MTSETBSIZ";
@@ -957,17 +936,23 @@ void generic_tape_device::clrerror(int func)
         break;
 #endif
       default:
+        char buf[100];
         Bsnprintf(buf, sizeof(buf), _("unknown func code %d"), func);
         msg = buf;
         break;
     }
-    if (msg != NULL) {
+    if (!msg.empty()) {
       dev_errno = ENOSYS;
       Mmsg1(errmsg, _("I/O function \"%s\" not supported on this device.\n"),
-            msg);
+            msg.c_str());
       Emsg0(M_ERROR, 0, errmsg);
     }
   }
+}
+
+void generic_tape_device::clrerror(int func)
+{
+  HandleError(func);
 
   /*
    * Now we try different methods of clearing the error status on the drive
@@ -979,10 +964,8 @@ void generic_tape_device::clrerror(int func)
    */
   GetOsTapeFile();
 
-  /*
-   * OS specific clear function.
-   */
-  OsClrerror(this);
+  // OS specific clear function.
+  OsClrError();
 }
 
 void generic_tape_device::SetOsDeviceParameters(DeviceControlRecord* dcr)

--- a/core/src/stored/backends/generic_tape_device.h
+++ b/core/src/stored/backends/generic_tape_device.h
@@ -34,8 +34,8 @@ namespace storagedaemon {
 
 class generic_tape_device : public Device {
  public:
-  generic_tape_device(){};
-  virtual ~generic_tape_device(){};
+  generic_tape_device() = default;
+  virtual ~generic_tape_device() { close(nullptr); }
 
   /*
    * Interface from Device

--- a/core/src/stored/backends/generic_tape_device.h
+++ b/core/src/stored/backends/generic_tape_device.h
@@ -73,6 +73,10 @@ class generic_tape_device : public Device {
   virtual ssize_t d_read(int fd, void* buffer, size_t count) override;
   virtual ssize_t d_write(int fd, const void* buffer, size_t count) override;
   virtual bool d_truncate(DeviceControlRecord* dcr) override;
+
+ private:
+  void OsClrError();
+  void HandleError(int func);
 };
 
 } /* namespace storagedaemon */

--- a/core/src/stored/backends/generic_tape_device.h
+++ b/core/src/stored/backends/generic_tape_device.h
@@ -75,6 +75,7 @@ class generic_tape_device : public Device {
   virtual bool d_truncate(DeviceControlRecord* dcr) override;
 
  private:
+  bool do_mount(DeviceControlRecord* dcr, int mount, int dotimeout);
   void OsClrError();
   void HandleError(int func);
 };

--- a/core/src/stored/backends/gfapi_device.cc
+++ b/core/src/stored/backends/gfapi_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2014 Planets Communications B.V.
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -627,6 +627,7 @@ gfapi_device::~gfapi_device()
   }
 
   FreePoolMemory(virtual_filename_);
+  close(nullptr);
 }
 
 gfapi_device::gfapi_device()

--- a/core/src/stored/backends/rados_device.cc
+++ b/core/src/stored/backends/rados_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2016 Planets Communications B.V.
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -664,6 +664,7 @@ rados_device::~rados_device()
   if (rados_configstring_) { free(rados_configstring_); }
 
   FreePoolMemory(virtual_filename_);
+  close(nullptr);
 }
 
 rados_device::rados_device()

--- a/core/src/stored/backends/unix_fifo_device.cc
+++ b/core/src/stored/backends/unix_fifo_device.cc
@@ -143,12 +143,9 @@ bool unix_fifo_device::eod(DeviceControlRecord* dcr)
   return true;
 }
 
-/**
- * (Un)mount the device (For a FILE device)
- */
-static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
+// (Un)mount the device (For a FILE device)
+bool unix_fifo_device::do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
 {
-  DeviceResource* device_resource = dcr->dev->device_resource;
   PoolMem ocmd(PM_FNAME);
   POOLMEM* results;
   DIR* dp;
@@ -163,10 +160,10 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
     icmd = device_resource->unmount_command;
   }
 
-  dcr->dev->EditMountCodes(ocmd, icmd);
+  EditMountCodes(ocmd, icmd);
 
   Dmsg2(100, "do_mount: cmd=%s mounted=%d\n", ocmd.c_str(),
-        dcr->dev->IsMounted());
+        IsMounted());
 
   if (dotimeout) {
     /* Try at most 10 times to (un)mount the device. This should perhaps be
@@ -180,7 +177,7 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
   /* If busy retry each second */
   Dmsg1(100, "do_mount run_prog=%s\n", ocmd.c_str());
   while ((status = RunProgramFullOutput(ocmd.c_str(),
-                                        dcr->dev->max_open_wait / 2, results))
+                                        max_open_wait / 2, results))
          != 0) {
     /* Doesn't work with internationalization (This is not a problem) */
     if (mount && fnmatch("*is already mounted on*", results, 0) == 0) { break; }
@@ -190,17 +187,17 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
        * Try to unmount it, then remount it */
       if (mount) {
         Dmsg1(400, "Trying to unmount the device %s...\n",
-              dcr->dev->print_name());
+              print_name());
         do_mount(dcr, 0, 0);
       }
       Bmicrosleep(1, 0);
       continue;
     }
     Dmsg5(100, "Device %s cannot be %smounted. status=%d result=%s ERR=%s\n",
-          dcr->dev->print_name(), (mount ? "" : "un"), status, results,
+          print_name(), (mount ? "" : "un"), status, results,
           be.bstrerror(status));
-    Mmsg(dcr->dev->errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
-         dcr->dev->print_name(), (mount ? "" : "un"), be.bstrerror(status));
+    Mmsg(errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
+         print_name(), (mount ? "" : "un"), be.bstrerror(status));
 
     /*
      * Now, just to be sure it is not mounted, try to read the filesystem.
@@ -210,9 +207,9 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
 
     if (!(dp = opendir(device_resource->mount_point))) {
       BErrNo be;
-      dcr->dev->dev_errno = errno;
+      dev_errno = errno;
       Dmsg3(100, "do_mount: failed to open dir %s (dev=%s), ERR=%s\n",
-            device_resource->mount_point, dcr->dev->print_name(),
+            device_resource->mount_point, print_name(),
             be.bstrerror());
       goto get_out;
     }
@@ -226,10 +223,10 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
       result = readdir(dp);
       if (result == NULL) {
 #endif
-        dcr->dev->dev_errno = EIO;
+        dev_errno = EIO;
         Dmsg2(129,
               "do_mount: failed to find suitable file in dir %s (dev=%s)\n",
-              device_resource->mount_point, dcr->dev->print_name());
+              device_resource->mount_point, print_name());
         break;
       }
       if (!bstrcmp(result->d_name, ".") && !bstrcmp(result->d_name, "..")

--- a/core/src/stored/backends/unix_fifo_device.h
+++ b/core/src/stored/backends/unix_fifo_device.h
@@ -55,6 +55,9 @@ class unix_fifo_device : public Device {
   ssize_t d_read(int fd, void* buffer, size_t count) override;
   ssize_t d_write(int fd, const void* buffer, size_t count) override;
   bool d_truncate(DeviceControlRecord* dcr) override;
+
+ private:
+  bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout);
 };
 
 } /* namespace storagedaemon */

--- a/core/src/stored/backends/unix_fifo_device.h
+++ b/core/src/stored/backends/unix_fifo_device.h
@@ -37,7 +37,7 @@ class DeviceControlRecord;
 class unix_fifo_device : public Device {
  public:
   unix_fifo_device() = default;
-  ~unix_fifo_device() = default;
+  ~unix_fifo_device() { close(nullptr); }
 
   /*
    * Interface from Device

--- a/core/src/stored/backends/unix_file_device.h
+++ b/core/src/stored/backends/unix_file_device.h
@@ -33,7 +33,7 @@ namespace storagedaemon {
 class unix_file_device : public Device {
  public:
   unix_file_device() = default;
-  ~unix_file_device() = default;
+  ~unix_file_device() { close(nullptr); }
 
   /*
    * Interface from Device

--- a/core/src/stored/backends/unix_tape_device.h
+++ b/core/src/stored/backends/unix_tape_device.h
@@ -33,7 +33,7 @@ namespace storagedaemon {
 class unix_tape_device : public generic_tape_device {
  public:
   unix_tape_device();
-  ~unix_tape_device() = default;
+  ~unix_tape_device() { close(nullptr); };
 
   int d_ioctl(int fd, ioctl_req_t request, char* op) override;
 };

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -58,17 +58,10 @@ static DeviceResource* find_device_res(char* archive_device_string,
                                        bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
 
-/**
- * Setup a "daemon" JobControlRecord for the various standalone tools (e.g. bls,
- * bextract, bscan, ...)
- */
-JobControlRecord* SetupJcr(const char* name,
-                           char* dev_name,
-                           BootStrapRecord* bsr,
-                           DirectorResource* director,
-                           DeviceControlRecord* dcr,
-                           const char* VolumeName,
-                           bool readonly)
+
+JobControlRecord* SetupDummyJcr(const char* name,
+                                BootStrapRecord* bsr,
+                                DirectorResource* director)
 {
   JobControlRecord* jcr = new_jcr(MyFreeJcr);
   jcr->impl = new JobControlRecordPrivate;
@@ -95,6 +88,24 @@ JobControlRecord* SetupJcr(const char* name,
   PmStrcpy(jcr->impl->fileset_md5, "Dummy.fileset.md5");
 
   NewPlugins(jcr); /* instantiate plugins */
+
+  return jcr;
+}
+
+
+/**
+ * Setup a "daemon" JobControlRecord for the various standalone tools (e.g. bls,
+ * bextract, bscan, ...)
+ */
+JobControlRecord* SetupJcr(const char* name,
+                           char* dev_name,
+                           BootStrapRecord* bsr,
+                           DirectorResource* director,
+                           DeviceControlRecord* dcr,
+                           const char* VolumeName,
+                           bool readonly)
+{
+  JobControlRecord* jcr = SetupDummyJcr(name, bsr, director);
 
   InitAutochangers();
   CreateVolumeLists();

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -2,7 +2,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -24,10 +24,18 @@
 
 namespace storagedaemon {
 
+class BootStrapRecord;
+class DeviceControlRecord;
+class Device;
+class DirectorResource;
+
 void PrintLsOutput(const char* fname,
                    const char* link,
                    int type,
                    struct stat* statp);
+JobControlRecord* SetupDummyJcr(const char* name,
+                                BootStrapRecord* bsr,
+                                DirectorResource* director);
 JobControlRecord* SetupJcr(const char* name,
                            char* dev_name,
                            BootStrapRecord* bsr,

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -1005,6 +1005,8 @@ void Device::ClearVolhdr()
  */
 bool Device::close(DeviceControlRecord* dcr)
 {
+  // Called with dcr=nullptr on termination (from destructor) .
+
   bool retval = true;
   int status;
   Dmsg1(100, "close_dev %s\n", print_name());
@@ -1075,6 +1077,7 @@ bool Device::close(DeviceControlRecord* dcr)
 bail_out:
   return retval;
 }
+
 
 /**
  * Mount the device.
@@ -1261,16 +1264,6 @@ const char* Device::name() const { return device_resource->resource_name_; }
 Device::~Device()
 {
   Dmsg1(900, "term dev: %s\n", print_name());
-
-  /*
-   * On termination we don't have any DCRs left
-   * so we call close with a nullptr argument as
-   * the dcr argument is only used in the unmount
-   * method to generate a plugin_event we just check
-   * there if the dcr is not nullptr and otherwise skip
-   * the plugin event generation.
-   */
-  close(nullptr);
 
   if (archive_device_string) {
     FreeMemory(archive_device_string);

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -520,6 +520,8 @@ class Device {
 class SpoolDevice :public Device
 {
  public:
+  SpoolDevice() = default;
+  ~SpoolDevice() {   close(nullptr); }
   int d_ioctl(int fd, ioctl_req_t request, char* mt_com = NULL) override {return -1;}
   int d_open(const char* pathname, int flags, int mode) override {return -1;}
   int d_close(int fd) override {return -1;}

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -379,6 +379,10 @@ if(GMOCK_FOUND AND NOT client-only)
 endif()
 
 if(NOT client-only)
+  bareos_add_test(sd_backend LINK_LIBRARIES ${LINK_LIBRARIES} ${GMOCK_LIBRARIES})
+endif()
+
+if(NOT client-only)
   bareos_add_test(
     lib_tests
     ADDITIONAL_SOURCES

--- a/core/src/tests/configs/sd_backend/bareos-sd.d/device/tape1.conf
+++ b/core/src/tests/configs/sd_backend/bareos-sd.d/device/tape1.conf
@@ -1,0 +1,13 @@
+Device {
+  Name = tape1
+  Media Type = File
+  Device Type = tape
+  Archive Device = /dev/null
+  LabelMedia = yes
+  Random Access = yes
+  Autochanger = yes
+  AlwaysOpen = no
+  RemovableMedia = no
+  Drive Index = 0
+  Autoselect = no
+}

--- a/core/src/tests/configs/sd_backend/bareos-sd.d/storage/myself.conf.in
+++ b/core/src/tests/configs/sd_backend/bareos-sd.d/storage/myself.conf.in
@@ -1,0 +1,4 @@
+Storage {
+  Name = test-sd
+  @UNCOMMENT_SD_BACKEND_DIRECTORY@Backend Directory = @PROJECT_BINARY_DIR@/src/stored/backends
+}

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -1,0 +1,154 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#  include "gtest/gtest.h"
+#else
+#  include "gtest/gtest.h"
+#  include "include/bareos.h"
+#endif
+
+
+#include <chrono>
+#include <future>
+
+#define STORAGE_DAEMON 1
+#include "include/jcr.h"
+#include "lib/crypto_cache.h"
+#include "lib/edit.h"
+#include "lib/parse_conf.h"
+#include "stored/butil.h"
+#include "stored/device_control_record.h"
+#include "stored/jcr_private.h"
+#include "stored/job.h"
+#include "stored/sd_plugins.h"
+#include "stored/sd_stats.h"
+#include "stored/stored.h"
+#include "stored/stored_globals.h"
+#include "stored/wait.h"
+#if defined(HAVE_DYNAMIC_SD_BACKENDS)
+#  include "stored/sd_backends.h"
+#endif
+
+#include "bsock_mock.h"
+#include "include/make_unique.h"
+
+using ::testing::Assign;
+using ::testing::DoAll;
+using ::testing::Return;
+using namespace storagedaemon;
+
+namespace storagedaemon {
+/* import this to parse the config */
+extern bool ParseSdConfig(const char* configfile, int exit_code);
+}  // namespace storagedaemon
+
+class sd : public ::testing::Test {
+ protected:
+  void SetUp() override;
+  void TearDown() override;
+};
+
+void sd::SetUp()
+{
+  OSDependentInit();
+  InitMsg(NULL, NULL);
+
+  debug_level = 1000;
+
+  /* configfile is a global char* from stored_globals.h */
+  configfile = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/sd_backend/");
+  my_config = InitSdConfig(configfile, M_ERROR_TERM);
+  ParseSdConfig(configfile, M_ERROR_TERM);
+  /*
+   * we do not run CheckResources() here, so take care the test configration
+   * is not broken. Also autochangers will not work.
+   */
+}
+void sd::TearDown()
+{
+  Dmsg0(100, "TearDown start\n");
+
+  {
+    DeviceResource* d = nullptr;
+    foreach_res (d, R_DEVICE) {
+      Dmsg1(10, "Term device %s (%s)\n", d->resource_name_,
+            d->archive_device_string);
+      if (d->dev) {
+        d->dev->ClearVolhdr();
+        delete d->dev;
+        d->dev = nullptr;
+      }
+    }
+  }
+#if defined(HAVE_DYNAMIC_SD_BACKENDS)
+  FlushAndCloseBackendDevices();
+#endif
+
+  if (configfile) { free(configfile); }
+  if (my_config) { delete my_config; }
+
+  TermMsg();
+  TermReservationsLock();
+
+  CloseMemoryPool();
+  debug_level = 0;
+  CloseMemoryPool();
+}
+
+// Test that load and unloads a tape device.
+TEST_F(sd, backend_load_unload)
+{
+  const char* name = "sd_backend_test";
+  char dev_name[10] = "tape1";
+
+  JobControlRecord* jcr = SetupDummyJcr(name, nullptr, nullptr);
+  ASSERT_TRUE(jcr);
+
+  DeviceResource* device_resource
+      = (DeviceResource*)my_config->GetResWithName(R_DEVICE, dev_name);
+
+  Device* dev = FactoryCreateDevice(jcr, device_resource);
+  ASSERT_TRUE(dev);
+
+  Dmsg0(100, "open\n");
+  /*
+   * Open device. Calling d_open directly,
+   * because otherwise OpenDevice()/open()
+   * would also try IOCTLs on the tape device,
+   * which will fail on our dummy device.
+   */
+  dev->fd = dev->d_open("/dev/null", 0, 0640);
+  ASSERT_TRUE(dev->fd > 0);
+
+  /*
+   * always true on generic (disk) device.
+   * On /dev/null used as tape it will fail.
+   */
+  ASSERT_FALSE(dev->offline());
+
+  Dmsg0(100, "cleanup dev \n");
+  delete dev;
+
+  Dmsg0(100, "cleanup\n");
+  FreeJcr(jcr);
+}

--- a/core/src/win32/stored/backends/win32_fifo_device.cc
+++ b/core/src/win32/stored/backends/win32_fifo_device.cc
@@ -138,12 +138,9 @@ bool win32_fifo_device::eod(DeviceControlRecord* dcr)
   return true;
 }
 
-/**
- * (Un)mount the device (For a FILE device)
- */
-static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
+// (Un)mount the device (For a FILE device)
+bool win32_fifo_device::do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
 {
-  DeviceResource* device_resource = dcr->dev->device_resource;
   PoolMem ocmd(PM_FNAME);
   POOLMEM* results;
   DIR* dp;
@@ -161,10 +158,10 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
     icmd = device_resource->unmount_command;
   }
 
-  dcr->dev->EditMountCodes(ocmd, icmd);
+  EditMountCodes(ocmd, icmd);
 
   Dmsg2(100, "do_mount: cmd=%s mounted=%d\n", ocmd.c_str(),
-        dcr->dev->IsMounted());
+        IsMounted());
 
   if (dotimeout) {
     /* Try at most 10 times to (un)mount the device. This should perhaps be
@@ -178,7 +175,7 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
   /* If busy retry each second */
   Dmsg1(100, "do_mount run_prog=%s\n", ocmd.c_str());
   while ((status = RunProgramFullOutput(ocmd.c_str(),
-                                        dcr->dev->max_open_wait / 2, results))
+                                        max_open_wait / 2, results))
          != 0) {
     /* Doesn't work with internationalization (This is not a problem) */
     if (mount && fnmatch("*is already mounted on*", results, 0) == 0) { break; }
@@ -188,17 +185,17 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
        * Try to unmount it, then remount it */
       if (mount) {
         Dmsg1(400, "Trying to unmount the device %s...\n",
-              dcr->dev->print_name());
+              print_name());
         do_mount(dcr, 0, 0);
       }
       Bmicrosleep(1, 0);
       continue;
     }
     Dmsg5(100, "Device %s cannot be %smounted. status=%d result=%s ERR=%s\n",
-          dcr->dev->print_name(), (mount ? "" : "un"), status, results,
+          print_name(), (mount ? "" : "un"), status, results,
           be.bstrerror(status));
-    Mmsg(dcr->dev->errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
-         dcr->dev->print_name(), (mount ? "" : "un"), be.bstrerror(status));
+    Mmsg(errmsg, _("Device %s cannot be %smounted. ERR=%s\n"),
+         print_name(), (mount ? "" : "un"), be.bstrerror(status));
 
     /*
      * Now, just to be sure it is not mounted, try to read the filesystem.
@@ -208,9 +205,9 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
 
     if (!(dp = opendir(device_resource->mount_point))) {
       BErrNo be;
-      dcr->dev->dev_errno = errno;
+      dev_errno = errno;
       Dmsg3(100, "do_mount: failed to open dir %s (dev=%s), ERR=%s\n",
-            device_resource->mount_point, dcr->dev->print_name(),
+            device_resource->mount_point, print_name(),
             be.bstrerror());
       goto get_out;
     }
@@ -225,10 +222,10 @@ static bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout)
       result = readdir(dp);
       if (result == NULL) {
 #endif
-        dcr->dev->dev_errno = EIO;
+        dev_errno = EIO;
         Dmsg2(129,
               "do_mount: failed to find suitable file in dir %s (dev=%s)\n",
-              device_resource->mount_point, dcr->dev->print_name());
+              device_resource->mount_point, print_name());
         break;
       }
       if (!bstrcmp(result->d_name, ".") && !bstrcmp(result->d_name, "..")

--- a/core/src/win32/stored/backends/win32_fifo_device.h
+++ b/core/src/win32/stored/backends/win32_fifo_device.h
@@ -57,6 +57,9 @@ class win32_fifo_device : public Device {
   ssize_t d_read(int fd, void* buffer, size_t count) override;
   ssize_t d_write(int fd, const void* buffer, size_t count) override;
   bool d_truncate(DeviceControlRecord* dcr) override;
+
+ private:
+  bool do_mount(DeviceControlRecord* dcr, bool mount, int dotimeout);
 };
 
 } /* namespace storagedaemon */

--- a/core/src/win32/stored/backends/win32_fifo_device.h
+++ b/core/src/win32/stored/backends/win32_fifo_device.h
@@ -39,7 +39,7 @@ class DeviceControlRecord;
 class win32_fifo_device : public Device {
  public:
   win32_fifo_device() = default;
-  ~win32_fifo_device() = default;
+  ~win32_fifo_device() { close(nullptr); }
 
   /*
    * Interface from Device

--- a/core/src/win32/stored/backends/win32_file_device.cc
+++ b/core/src/win32/stored/backends/win32_file_device.cc
@@ -303,8 +303,6 @@ bool win32_file_device::d_truncate(DeviceControlRecord* dcr)
   return true;
 }
 
-win32_file_device::~win32_file_device() {}
-
 win32_file_device::win32_file_device() {}
 
 } /* namespace storagedaemon */

--- a/core/src/win32/stored/backends/win32_file_device.h
+++ b/core/src/win32/stored/backends/win32_file_device.h
@@ -34,7 +34,7 @@ namespace storagedaemon {
 class win32_file_device : public Device {
  public:
   win32_file_device();
-  ~win32_file_device();
+  ~win32_file_device() { close(nullptr); }
 
   /*
    * Interface from Device

--- a/core/src/win32/stored/backends/win32_tape_device.cc
+++ b/core/src/win32/stored/backends/win32_tape_device.cc
@@ -1108,8 +1108,6 @@ int win32_tape_device::TapePos(struct mtpos* mt_pos)
   return -1;
 }
 
-win32_tape_device::~win32_tape_device() {}
-
 win32_tape_device::win32_tape_device()
 {
   SetCap(CAP_ADJWRITESIZE); /* Adjust write size to min/max */

--- a/core/src/win32/stored/backends/win32_tape_device.h
+++ b/core/src/win32/stored/backends/win32_tape_device.h
@@ -33,7 +33,7 @@ namespace storagedaemon {
 class win32_tape_device : public generic_tape_device {
  public:
   win32_tape_device();
-  ~win32_tape_device();
+  ~win32_tape_device() { close(nullptr); }
 
   int d_close(int) override;
   int d_open(const char* pathname, int flags, int mode) override;

--- a/systemtests/tests/config-dump/testrunner
+++ b/systemtests/tests/config-dump/testrunner
@@ -30,7 +30,7 @@ remove_bconsole_commands_from_output()
 {
     FILE="$1"
     # remove first and last line from file
-    sed -i -e '1d' -e '$ d' ${FILE}
+    sed -i'.bak' -e '1d' -e '$ d' ${FILE}
 }
 
 strip_config()
@@ -63,6 +63,9 @@ dump_config()
         set_error "Director config file \"${configfile}\" does not exist."
         exit 1
     fi
+
+    DESC="dump_config ${configfile} ext=${ext}"
+    print_debug "*** start $DESC"
 
     "${BAREOS_DIRECTOR_BINARY}" -c "${configfile}" -xc > $tmp/bareos-dir-xc-${ext}.conf
 
@@ -98,6 +101,8 @@ END_OF_DATA
         set_error "Director is not stopped."
         exit 1
     fi
+
+    print_debug "*** end   $DESC"
 }
 
 diff_files()
@@ -107,7 +112,9 @@ diff_files()
     base1="$(basename "$file1" .conf)"
     base2="$(basename "$file2" .conf)"
     difffile="${tmp}/${base1}_${base2}.diff"
-    DIFF_CMD='diff "${file1}" "${file2}"'
+    # --ignore-space-change could be replaced by --ignore-trailing-space,
+    # however, the FreeBSD version of diff does not support this option.
+    DIFF_CMD='diff --ignore-blank-lines --ignore-space-change "${file1}" "${file2}"'
     if ! eval "$DIFF_CMD" > "${difffile}"; then
         echo "Differences found. Output of:"
         eval "echo $DIFF_CMD"


### PR DESCRIPTION
The destructor of the the Device base class can not call
cannot call close(), as close() itself calls virtual functions
but the destructors of the derived classes already have been called before
so the overridden functions are not available anymore.
Calling virtual functions of a class need to be called in the destructor
of that class and not of the base class.

Add a unittest for testing this (load and unload tape device).

This is a backport of PR #809 plus one additional cherry-pick of a fix for the config-dump systemtest.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
