### PR TITLE
drive selection in truncate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Added
 - systemtests for NDMP functionalities [PR #822]
+- added choice for the drive number in the truncate command [PR #823]
 - systemtests for S3 functionalities (droplet, libcloud) now use https [PR #765]
 - added reload commands to systemd service [PR #694]
 - Build the package **bareos-filedaemon-postgresql-python-plugin** also for Debian, Ubuntu and UCS (deb packages) [PR #723].

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -933,6 +933,13 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
           }
           Dmsg3(100, "Device %s drive wrong: want=%hd got=%hd skipping\n",
                 devname.c_str(), drive, device_resource->dev->drive);
+
+          if (changer->device_resources->current()
+              == changer->device_resources->size()) {
+            Jmsg(jcr, M_ERROR, 0,
+                 _("Drive number \"%d\" for device \"%s\" not found.\n"), drive,
+                 devname.c_str());
+          }
         }
         break; /* we found it but could not open a device */
       }

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1398,7 +1398,7 @@ truncate
                [volume=<volume>] [drive=<drivenum>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
-   By default the first drive of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
+   By default the first drive (number 0) of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
 
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1394,7 +1394,8 @@ truncate
    .. code-block:: bconsole
       :caption: truncate
 
-      truncate volstatus=Purged [storage=<storage>] [pool=<pool>] [volume=<volume>] [yes]
+      truncate volstatus=Purged [storage=<storage>] [pool=<pool>]
+               [volume=<volume>] [drive=<drivenum>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
 

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1398,10 +1398,12 @@ truncate
                [volume=<volume>] [drive=<drivenum>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
+   By default the first drive of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
 
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 
    This command is available since Bareos :sinceVersion:`16.2.5: truncate command`.
+   The *drive=<drivenum>* selection was added in  :sinceVersion:`21.0.0: truncate command drive selection`.
 
 umount
    :index:`\ <single: Console; Command; umount>`\  Alias for :bcommand:`unmount`.

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1403,7 +1403,7 @@ truncate
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 
    This command is available since Bareos :sinceVersion:`16.2.5: truncate command`.
-   The *drive=<drivenum>* selection was added in  :sinceVersion:`21.0.0: truncate command drive selection`.
+   The *drive=<drivenum>* selection was added in  :sinceVersion:`20.0.2: truncate command drive selection`.
 
 umount
    :index:`\ <single: Console; Command; umount>`\  Alias for :bcommand:`unmount`.

--- a/systemtests/tests/multiplied-device/testrunner
+++ b/systemtests/tests/multiplied-device/testrunner
@@ -54,6 +54,17 @@ restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all 
 yes
 wait
 messages
+@#
+@# now purge and truncate
+@#
+@$out $tmp/log3.out
+purge volume=Full-0001
+truncate volstatus=Purged drive=0 yes
+purge volume=Full-0002
+truncate volstatus=Purged drive=1 yes
+purge volume=Full-0003
+truncate volstatus=Purged drive=2 yes
+messages
 quit
 END_OF_DATA
 
@@ -82,6 +93,28 @@ if test $estat -ne 1 ; then
     echo "Not all MultiFileStorage devices are used."
     estat=1;
   fi
+fi
+
+#make sure all volumes are purged
+grep "There are no more Jobs associated with Volume \"Full-0001\". Marking it purged." "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "There are no more Jobs associated with Volume \"Full-0002\". Marking it purged." "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "There are no more Jobs associated with Volume \"Full-0003\". Marking it purged." "${tmp}"/log3.out >/dev/null 2>&1
+if test $? -ne 0 ; then
+  echo "The Purge command failed for a MultiFileStorage."
+  estat=1;
+fi
+
+
+#make sure all volumes are correctly truncated with the correct drive
+grep "3000 OK label. VolBytes=223 Volume=\"Full-0001\" Device=\"MultiFileStorage0001\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolBytes=223 Volume=\"Full-0002\" Device=\"MultiFileStorage0002\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolBytes=223 Volume=\"Full-0003\" Device=\"MultiFileStorage0003\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "The volume 'Full-0001' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "The volume 'Full-0002' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "The volume 'Full-0003' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1
+if test $? -ne 0 ; then
+  echo "The Truncate command failed for a MultiFileStorage."
+  estat=1;
 fi
 
 end_test

--- a/systemtests/tests/multiplied-device/testrunner
+++ b/systemtests/tests/multiplied-device/testrunner
@@ -106,9 +106,9 @@ fi
 
 
 #make sure all volumes are correctly truncated with the correct drive
-grep "3000 OK label. VolBytes=223 Volume=\"Full-0001\" Device=\"MultiFileStorage0001\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
-grep "3000 OK label. VolBytes=223 Volume=\"Full-0002\" Device=\"MultiFileStorage0002\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
-grep "3000 OK label. VolBytes=223 Volume=\"Full-0003\" Device=\"MultiFileStorage0003\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolBytes=... Volume=\"Full-0001\" Device=\"MultiFileStorage0001\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolBytes=... Volume=\"Full-0002\" Device=\"MultiFileStorage0002\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolBytes=... Volume=\"Full-0003\" Device=\"MultiFileStorage0003\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0001' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0002' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0003' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1
@@ -117,4 +117,12 @@ if test $? -ne 0 ; then
   estat=1;
 fi
 
+# make sure the devices really have been truncated
+for i in 1 2 3; do
+  size=$(wc -c < "storage/Full-000${i}")
+  if [ "$size" -ge 300 ]; then
+    echo "file storage/Full-000$i" was not truncated
+    estat=3
+  fi
+done
 end_test


### PR DESCRIPTION
#### Description:
This PR adds the capability for a user to select which drive to use when truncating a volume.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
