### PR TITLE
systemd: switch service from forking to simple (foreground)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - added multicolumn prompt selection for selection of more than 20 items [PR #731]
 
 ### Changed
+- core: systemd service: change daemon type from forking to simple and start daemons in foreground [PR #824]
 - core: cleanup systemd service dependencies: Requires network.target, but start after the network-online.target [PR #700]
 - core: Make the jansson library mandatory when compiling the Bareos Director [PR #793]
 - core: Make the jansson library mandatory when compiling the Bareos Director [PR #793]

--- a/core/.gitignore
+++ b/core/.gitignore
@@ -31,7 +31,6 @@ platforms/suse/bareos-sd
 platforms/systemd/bareos-dir.service
 platforms/systemd/bareos-fd.service
 platforms/systemd/bareos-sd.service
-platforms/systemd/bareos.conf
 platforms/univention/AppCenter/univention-bareos.ini
 platforms/univention/conffiles/etc/apt/sources.list.d/60_bareos.list
 scripts/bareos-config

--- a/core/platforms/systemd/CMakeLists.txt
+++ b/core/platforms/systemd/CMakeLists.txt
@@ -20,7 +20,6 @@ message("Entering ${CMAKE_CURRENT_SOURCE_DIR}")
 
 message(STATUS "CMAKE_CURRENT_LIST_FILE: " ${CMAKE_CURRENT_LIST_FILE})
 message(STATUS "installing systemd files to  ${SYSTEMD_UNITDIR}")
-set(SYSTEMD_TMPFILES ${sysconfdir}/tmpfiles.d)
 
 install(FILES "bareos-sd.service" DESTINATION ${SYSTEMD_UNITDIR})
 install(FILES "bareos-fd.service" DESTINATION ${SYSTEMD_UNITDIR})

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -1,40 +1,25 @@
-# This file is part of package Bareos Director Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos director daemon service (bareos-dir)
-#     will be installed as /lib/systemd/system/bareos-dir.service
-#    enable : systemctl enable bareos-dir.service
-#	 start : systemctl start bareos-dir.service
-#
-# Bareos Director Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist and is a directory
 ConditionPathIsDirectory=@working_dir@
-# Before=
-# Conflicts=
 
 [Service]
-Type=forking
+Type=simple
 User=@dir_user@
 Group=@dir_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-dir.@dir_port@.pid
-# EnvironmentFile=-/etc/sysconfig/bareos-dir
-# StandardOutput=syslog
-ExecStartPre=@sbindir@/bareos-dir -t -f
-ExecStart=@sbindir@/bareos-dir
-SuccessExitStatus=0 1 15
+ExecStart=@sbindir@/bareos-dir -f
+SuccessExitStatus=0 15
 ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
 #Restart=on-failure
@@ -46,8 +31,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 # However, as this also have to work for systems with older version of systemd,
 # we stick to this old setting.
 StartLimitInterval=0
-
-
 
 [Install]
 Alias=bareos-director.service

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -1,33 +1,19 @@
-# This file is part of package Bareos File Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos file daemon service (bareos-fd)
-#    will be installed as /lib/systemd/system/bareos-fd.service
-#    enable : systemctl enable bareos-fd.service
-#	 start : systemctl start bareos-fd.service
-#
-# Bareos File Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target
-# Wants=
-# Before=
-# Conflicts=
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
-Type=forking
+Type=simple
 User=@fd_user@
 Group=@fd_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-fd.@fd_port@.pid
-StandardOutput=syslog
-ExecStart=@sbindir@/bareos-fd
+ExecStart=@sbindir@/bareos-fd -f
 SuccessExitStatus=0 15
 Restart=on-failure
 # IOSchedulingClass=idle

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -1,34 +1,19 @@
-# This file is part of package Bareos Storage Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# for Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos storage daemon service (bareos-sd)
-#    will be installed as /lib/systemd/system/bareos-sd.service
-#    enable : systemctl enable bareos-sd.service
-#    start : systemctl start bareos-sd.service
-#
-# Bareos Storage Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target
-# Wants=
-# Before=
-# Conflicts=
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
-Type=forking
+Type=simple
 User=@sd_user@
 Group=@sd_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-sd.@sd_port@.pid
-# EnvironmentFile=-/etc/sysconfig/bareos-sd
-StandardOutput=syslog
-ExecStart=@sbindir@/bareos-sd
+ExecStart=@sbindir@/bareos-sd -f
 # enable this for scsicrypto-sd
 # CapabilityBoundingSet=cap_sys_rawio+ep
 SuccessExitStatus=0 15

--- a/core/platforms/systemd/bareos.conf.in
+++ b/core/platforms/systemd/bareos.conf.in
@@ -1,2 +1,0 @@
-# See tmpfiles.d(5) for details
-d @piddir@ 2775 bareos bareos -

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -1,40 +1,25 @@
-# This file is part of package Bareos Director Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos director daemon service (bareos-dir)
-#     will be installed as /lib/systemd/system/bareos-dir.service
-#    enable : systemctl enable bareos-dir.service
-#	 start : systemctl start bareos-dir.service
-#
-# Bareos Director Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist and is a directory
 ConditionPathIsDirectory=@working_dir@
-# Before=
-# Conflicts=
 
 [Service]
-Type=forking
+Type=simple
 User=@dir_user@
 Group=@dir_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-dir.@dir_port@.pid
-# EnvironmentFile=-/etc/sysconfig/bareos-dir
-# StandardOutput=syslog
-ExecStartPre=@sbindir@/bareos-dir -t -f
-ExecStart=@sbindir@/bareos-dir
-SuccessExitStatus=0 1 15
+ExecStart=@sbindir@/bareos-dir -f
+SuccessExitStatus=0 15
 ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
 #Restart=on-failure
@@ -46,8 +31,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 # However, as this also have to work for systems with older version of systemd,
 # we stick to this old setting.
 StartLimitInterval=0
-
-
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -1,33 +1,19 @@
-# This file is part of package Bareos File Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos file daemon service (bareos-fd)
-#    will be installed as /lib/systemd/system/bareos-fd.service
-#    enable : systemctl enable bareos-fd.service
-#	 start : systemctl start bareos-fd.service
-#
-# Bareos File Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target
-# Wants=
-# Before=
-# Conflicts=
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
-Type=forking
+Type=simple
 User=@fd_user@
 Group=@fd_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-fd.@fd_port@.pid
-StandardOutput=syslog
-ExecStart=@sbindir@/bareos-fd
+ExecStart=@sbindir@/bareos-fd -f
 SuccessExitStatus=0 15
 Restart=on-failure
 # IOSchedulingClass=idle

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -1,34 +1,19 @@
-# This file is part of package Bareos Storage Daemon
 #
-# Copyright (c) 2011 Free Software Foundation Europe e.V.
-# for Bareos Community
-# Author: Bruno Friedmann
-# Description:
-#    Used to start the bareos storage daemon service (bareos-sd)
-#    will be installed as /lib/systemd/system/bareos-sd.service
-#    enable : systemctl enable bareos-sd.service
-#    start : systemctl start bareos-sd.service
-#
-# Bareos Storage Daemon service
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
-Requires=nss-lookup.target network.target time-sync.target
-After=nss-lookup.target network-online.target remote-fs.target time-sync.target
-# Wants=
-# Before=
-# Conflicts=
+Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
-Type=forking
+Type=simple
 User=@sd_user@
 Group=@sd_group@
 WorkingDirectory=@working_dir@
-PIDFile=@piddir@/bareos-sd.@sd_port@.pid
-# EnvironmentFile=-/etc/sysconfig/bareos-sd
-StandardOutput=syslog
-ExecStart=@sbindir@/bareos-sd
+ExecStart=@sbindir@/bareos-sd -f
 # enable this for scsicrypto-sd
 # CapabilityBoundingSet=cap_sys_rawio+ep
 SuccessExitStatus=0 15


### PR DESCRIPTION
The service type forking caused problems on newer systemd versions (Fedora 34).
Using type=simple and starting the daemons without forking
has the advantage,
that daemon messages to stdout and stderr are shown with systemctl status or journalctl.
This includes the daemon debug messages, when set into debug mode.
    
Removed the no longer supported (and never really used)
StandardOutput=syslog
    
Director: Exit code 1 is no longer treated as success.
This has been introduced as a workaround, but is no longer required.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] ~Source code changes are understandable~
- [ ] ~Variable and function names are meaningful~
- [ ] ~Code comments are correct (logically and spelling)~
- [ ] ~Required documentation changes are present and part of the PR~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] ~Decision taken that a system- or unittest is required (if not, then remove this paragraph)~
- [ ] ~The decision towards a systemtest is reasonable compared to a unittest~
- [ ] ~Testname matches exactly what is being tested~
- [ ] ~Output of the test leads quickly to the origin of the fault~
