### PR TITLE
fix full path globbing bug

### DIFF
--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1078,7 +1078,7 @@ std::string FormatMulticolumnPrompts(const UaContext* ua,
                                      const int window_width,
                                      const int min_lines_threshold)
 {
-  size_t max_prompt_length = 1;
+  unsigned int max_prompt_length = 1;
 
   const int max_prompt_index_length = std::to_string(ua->num_prompts).length();
 

--- a/core/src/tests/globbing_test.cc
+++ b/core/src/tests/globbing_test.cc
@@ -156,8 +156,29 @@ TEST(globbing, globbing_in_markcmd)
 
   PopulateTree(files, &tree);
 
-  FakeCdCmd(&ua, &tree, "/some/weirdfiles/");
+  // testing full paths
+  FakeCdCmd(&ua, &tree, "/");
+  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "*"), files.size());
 
+  EXPECT_EQ(
+      FakeMarkCmd(&ua, &tree, "/testingwildcards/lonesubdirectory/whatever"),
+      1);
+
+  EXPECT_EQ(
+      FakeMarkCmd(&ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 1);
+
+  // Using full path while being in a different folder than root
+  FakeCdCmd(&ua, &tree, "/some/weirdfiles/");
+  EXPECT_EQ(
+      FakeMarkCmd(&ua, &tree, "/testingwildcards/lonesubdirectory/whatever"),
+      1);
+  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "/testingwildcards/sub*"), 6);
+
+  EXPECT_EQ(
+      FakeMarkCmd(&ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 0);
+
+  // Testing patterns in different folders
+  FakeCdCmd(&ua, &tree, "/some/weirdfiles/");
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "nope"), 0);
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "potato"), 1);
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "potato*"), 2);
@@ -170,9 +191,6 @@ TEST(globbing, globbing_in_markcmd)
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "wei*/sub*/*"), 6);
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "wei*/subroza/*"), 0);
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "w*efiles/sub*/*"), 6);
-
-  FakeCdCmd(&ua, &tree, "/");
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "*"), files.size());
 
   FakeCdCmd(&ua, &tree, "/testingwildcards/");
   EXPECT_EQ(FakeMarkCmd(&ua, &tree, "p?tato"), 1);


### PR DESCRIPTION
#### Description:
PR #801 introduced a bug when marking full paths in the restore browser. This PR fixes it.
Also fixed a warning in ua_select.cc along on the way.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted

##### Source code quality


- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing


