### PR TITLE
vmware: Fix bareos_vadp_dumper VMDK File creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Fixed
+- fix a bug in VMware plugin where VMDK Files were created with wrong size when using the option localvmdk=yes [PR #826]
 - fix a bug where the restore browser would not recognize globbing wildcards in paths [PR #801]
 - fix shutdown of the Storage Daemon backends, especially call UnlockDoor on tape devices [PR #809]
 - fix possible deadlock in storage backend on Solaris and FreeBSD [PR #809]

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
    Copyright (C) 2015-2015 Planets Communications B.V.
 
    This program is Free Software; you can redistribute it and/or
@@ -881,7 +881,7 @@ static inline bool process_disk_info(bool validate_only, json_t* value)
 
   if (create_disk && !validate_only) {
     do_vixdisklib_create(DISK_PARAMS_KEY, vmdk_disk_name, value,
-                         rdie.absolute_disk_length);
+                         rdie.phys_capacity * VIXDISKLIB_SECTOR_SIZE);
     do_vixdisklib_open(DISK_PARAMS_KEY, vmdk_disk_name, value, false, true,
                        &write_diskHandle);
 


### PR DESCRIPTION
Before this change, the value of length attribute of the changed block tracking query
result was used as disk size when bareos_vadp_dumper called the VDDK function
VixDiskLib_Create to create VMDK files on restore with localvmdk=yes. But
this value is not the real disk size in all cases, so the VMDK was too
small.

With this fix, the VMDK files are created with the correct size.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
