### PR TITLE
Fix acquire deadlock on migrate/copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix gfapi-fd: avoid possible crash on second glfs_close() call [PR #792]
 - docs: declare shell scripts code blocks as "sh" instead of "shell-session" [PR #802]
 - [Issue #1205]: PHP 7.3 issue with compact() in HeadLink.php [PR #829]
+- reorder acquire on migrate/copy to avoid possible deadlock [PR #828]
 
 ### Added
 - systemtests for NDMP functionalities [PR #822]
@@ -86,4 +87,51 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Restore error "could not hard link" documented: what is the cause and how it can be avoided or solved. [PR #759]
 - Developer guide: add small chapter about c++ exceptions. [PR #777]
 
+[Issue #1316]: https://bugs.bareos.org/view.php?id=1316
+[Issue #1329]: https://bugs.bareos.org/view.php?id=1329
+[PR #552]: https://github.com/bareos/bareos/pull/552
+[PR #694]: https://github.com/bareos/bareos/pull/694
+[PR #700]: https://github.com/bareos/bareos/pull/700
+[PR #702]: https://github.com/bareos/bareos/pull/702
+[PR #707]: https://github.com/bareos/bareos/pull/707
+[PR #709]: https://github.com/bareos/bareos/pull/709
+[PR #717]: https://github.com/bareos/bareos/pull/717
+[PR #723]: https://github.com/bareos/bareos/pull/723
+[PR #729]: https://github.com/bareos/bareos/pull/729
+[PR #730]: https://github.com/bareos/bareos/pull/730
+[PR #731]: https://github.com/bareos/bareos/pull/731
+[PR #736]: https://github.com/bareos/bareos/pull/736
+[PR #739]: https://github.com/bareos/bareos/pull/739
+[PR #740]: https://github.com/bareos/bareos/pull/740
+[PR #741]: https://github.com/bareos/bareos/pull/741
+[PR #742]: https://github.com/bareos/bareos/pull/742
+[PR #744]: https://github.com/bareos/bareos/pull/744
+[PR #748]: https://github.com/bareos/bareos/pull/748
+[PR #752]: https://github.com/bareos/bareos/pull/752
+[PR #757]: https://github.com/bareos/bareos/pull/757
+[PR #759]: https://github.com/bareos/bareos/pull/759
+[PR #761]: https://github.com/bareos/bareos/pull/761
+[PR #762]: https://github.com/bareos/bareos/pull/762
+[PR #763]: https://github.com/bareos/bareos/pull/763
+[PR #764]: https://github.com/bareos/bareos/pull/764
+[PR #765]: https://github.com/bareos/bareos/pull/765
+[PR #767]: https://github.com/bareos/bareos/pull/767
+[PR #769]: https://github.com/bareos/bareos/pull/769
+[PR #771]: https://github.com/bareos/bareos/pull/771
+[PR #776]: https://github.com/bareos/bareos/pull/776
+[PR #777]: https://github.com/bareos/bareos/pull/777
+[PR #778]: https://github.com/bareos/bareos/pull/778
+[PR #782]: https://github.com/bareos/bareos/pull/782
+[PR #790]: https://github.com/bareos/bareos/pull/790
+[PR #791]: https://github.com/bareos/bareos/pull/791
+[PR #792]: https://github.com/bareos/bareos/pull/792
+[PR #793]: https://github.com/bareos/bareos/pull/793
+[PR #801]: https://github.com/bareos/bareos/pull/801
+[PR #802]: https://github.com/bareos/bareos/pull/802
+[PR #809]: https://github.com/bareos/bareos/pull/809
+[PR #810]: https://github.com/bareos/bareos/pull/810
+[PR #819]: https://github.com/bareos/bareos/pull/819
+[PR #822]: https://github.com/bareos/bareos/pull/822
+[PR #826]: https://github.com/bareos/bareos/pull/826
+[PR #828]: https://github.com/bareos/bareos/pull/828
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2006-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -597,8 +597,8 @@ bool DoMacRun(JobControlRecord* jcr)
           jcr->impl->NumReadVolumes, Type, jcr->impl->VolList->VolumeName);
 
     // Ready devices for reading and writing.
-    if (!AcquireDeviceForRead(jcr->impl->read_dcr)
-        || !AcquireDeviceForAppend(jcr->impl->dcr)) {
+    if (!AcquireDeviceForAppend(jcr->impl->dcr)
+        || !AcquireDeviceForRead(jcr->impl->read_dcr)) {
       ok = false;
       acquire_fail = true;
       goto bail_out;


### PR DESCRIPTION
Previously migrate/copy would acquire the device for reading before the
device for writing. This could lead to deadlock situation when the
volume that should be read was mounted in the device reserved for
writing.
By acquiring the device for writing first any volume in that device will
be unloaded unless it is the volume we are going to write to. This
should fix the deadlock described above.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
