### PR TITLE
vmware: Fix bareos_vadp_dumper VMDK File creation (backport of PR 826)

### DIFF
--- a/vmware/vadp_dumper/bareos_vadp_dumper.cpp
+++ b/vmware/vadp_dumper/bareos_vadp_dumper.cpp
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2015 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
    Copyright (C) 2015-2015 Planets Communications B.V.
 
    This program is Free Software; you can redistribute it and/or
@@ -902,7 +902,7 @@ static inline bool process_disk_info(bool validate_only, json_t *value)
    }
 
    if (create_disk && !validate_only) {
-      do_vixdisklib_create(DISK_PARAMS_KEY, vmdk_disk_name, value, rdie.absolute_disk_length);
+      do_vixdisklib_create(DISK_PARAMS_KEY, vmdk_disk_name, value, rdie.phys_capacity * VIXDISKLIB_SECTOR_SIZE);
       do_vixdisklib_open(DISK_PARAMS_KEY, vmdk_disk_name, value, false, true, &write_diskHandle);
 
       if (!write_diskHandle) {


### PR DESCRIPTION
Before, the value of length attribute of the changed block tracking query
result was used as disk size when bareos_vadp_dumper called the VDDK function
VixDiskLib_Create to create VMDK files on restore with localvmdk=yes. But
this value is not the real disk size in all cases, so the VMDK was too
small.

With this fix, the VMDK files are created with the correct size.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing
