### PR TITLE
webui: set default extras as empty array to prevent compact() errors

### DIFF
--- a/webui/vendor/zendframework/zend-view/src/Helper/HeadLink.php
+++ b/webui/vendor/zendframework/zend-view/src/Helper/HeadLink.php
@@ -395,6 +395,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
             }
         }
 
+        $extras = [];
+
         if (0 < count($args) && is_array($args[0])) {
             $extras = array_shift($args);
             $extras = (array) $extras;
@@ -442,6 +444,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         $href  = array_shift($args);
         $type  = array_shift($args);
         $title = array_shift($args);
+
+        $extras = [];
 
         if (0 < count($args) && is_array($args[0])) {
             $extras = array_shift($args);


### PR DESCRIPTION
PHP compact() function will create php error when $args is an
empty array.

See: https://github.com/zendframework/zend-view/pull/170

Fixes #1205: HeadLink.php error with PHP 7.3

(cherry picked from commit 0fb913c74d22bd73710d4e7097e1df0f662a990d)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted

