### PR TITLE
drive selection in truncate command (backport of PR 823)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Adrew J. Millar
 Adrian Brzezinski
 Adrian Close
 Aitor Matilla
+Alaa Eddine Elamri
 Alan Brown
 Aleksandar Milivojevic
 Aleksandr Kozlov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1205]: PHP 7.3 issue with compact() in HeadLink.php [PR #833] (backport of [PR #829])
 
 ### Added
+- added choice for the drive number in the truncate command [PR #837]
 - systemtests for S3 functionalities (droplet, libcloud) now use https [PR #765]
 - add "copy button" to code snippets in documentation for easy copying [PR #802]
 

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -158,7 +158,9 @@ static bool DeleteJobIdRange(UaContext* ua, char* tok);
 static bool DeleteVolume(UaContext* ua);
 static bool DeletePool(UaContext* ua);
 static void DeleteJob(UaContext* ua);
-static bool DoTruncate(UaContext* ua, MediaDbRecord& mr);
+static bool DoTruncate(UaContext* ua,
+                       MediaDbRecord& mr,
+                       drive_number_t drive_number);
 
 bool quit_cmd(UaContext* ua, const char* cmd);
 
@@ -516,6 +518,7 @@ static struct ua_cmdstruct commands[] = {
      true, true},
     {NT_("truncate"), TruncateCmd, _("Truncate purged volumes"),
      NT_("volstatus=Purged [storage=<storage>] [pool=<pool>] [volume=<volume>] "
+         "[drive=<drivenum>] "
          "[yes]"),
      true, true},
     {NT_("unmount"), UnmountCmd, _("Unmount storage"),
@@ -2060,7 +2063,7 @@ static bool time_cmd(UaContext* ua, const char* cmd)
  *
  * usage:
  * truncate volstatus=Purged [storage=<storage>] [pool=<pool>]
- * [volume=<volume>] [yes]
+ * [volume=<volume>] [drive=<drivenum>] [yes]
  */
 static bool TruncateCmd(UaContext* ua, const char* cmd)
 {
@@ -2074,7 +2077,7 @@ static bool TruncateCmd(UaContext* ua, const char* cmd)
   MediaDbRecord mr;
   PoolDbRecord pool_dbr;
   StorageDbRecord storage_dbr;
-
+  drive_number_t drive_number = 0;
   /*
    * Look for volumes that can be recycled,
    * are enabled and have used more than the first block.
@@ -2158,6 +2161,17 @@ static bool TruncateCmd(UaContext* ua, const char* cmd)
     }
   }
 
+  i = FindArgWithValue(ua, "drive");
+  if (i >= 0) {
+    if (!IsAnInteger(ua->argv[i])) {
+      ua->SendCmdUsage(_("Drive number must be integer but was : %s\n"),
+                       ua->argv[i]);
+    } else {
+      drive_number = atoi(ua->argv[i]);
+      parsed_args++;
+    }
+  }
+
   if (FindArg(ua, NT_("yes")) >= 0) {
     /* parameter yes is evaluated at 'GetConfirmation' */
     parsed_args++;
@@ -2224,7 +2238,7 @@ static bool TruncateCmd(UaContext* ua, const char* cmd)
     if (!ua->db->GetMediaRecord(ua->jcr, &mr)) {
       Dmsg1(0, "Can't find MediaId=%lld\n", (uint64_t)mr.MediaId);
     } else {
-      DoTruncate(ua, mr);
+      DoTruncate(ua, mr, drive_number);
     }
   }
 
@@ -2239,12 +2253,13 @@ bail_out:
   return result;
 }
 
-static bool DoTruncate(UaContext* ua, MediaDbRecord& mr)
+static bool DoTruncate(UaContext* ua,
+                       MediaDbRecord& mr,
+                       drive_number_t drive_number)
 {
   bool retval = false;
   StorageDbRecord storage_dbr;
   PoolDbRecord pool_dbr;
-
 
   storage_dbr.StorageId = mr.StorageId;
   if (!ua->db->GetStorageRecord(ua->jcr, &storage_dbr)) {
@@ -2275,7 +2290,7 @@ static bool DoTruncate(UaContext* ua, MediaDbRecord& mr)
                        /* bool relabel */
                        true,
                        /* drive_number_t drive */
-                       0,
+                       drive_number,
                        /* slot_number_t slot */
                        0)) {
     ua->SendMsg(_("The volume '%s' has been truncated.\n"), mr.VolumeName);

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1397,7 +1397,7 @@ truncate
       truncate volstatus=Purged [storage=<storage>] [pool=<pool>] [volume=<volume>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
-   By default the first drive of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
+   By default the first drive (number 0) of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
 
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1394,7 +1394,8 @@ truncate
    .. code-block:: bconsole
       :caption: truncate
 
-      truncate volstatus=Purged [storage=<storage>] [pool=<pool>] [volume=<volume>] [yes]
+      truncate volstatus=Purged [storage=<storage>] [pool=<pool>]
+               [volume=<volume>] [drive=<drivenum>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
    By default the first drive (number 0) of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1397,10 +1397,12 @@ truncate
       truncate volstatus=Purged [storage=<storage>] [pool=<pool>] [volume=<volume>] [yes]
 
    When using a disk volume (and other volume types also) the volume file still resides on the |sd|. If you want to reclaim disk space, you can use the :bcommand:`truncate volstatus=Purged` command. When used on a volume, it rewrites the header and by this frees the rest of the disk space.
+   By default the first drive of an autochanger is used. By specifying `drive=<drivenum>`, a different drive can be selected.
 
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 
    This command is available since Bareos :sinceVersion:`16.2.5: truncate command`.
+   The *drive=<drivenum>* selection was added in  :sinceVersion:`21.0.0: truncate command drive selection`.
 
 umount
    :index:`\ <single: Console; Command; umount>`\  Alias for :bcommand:`unmount`.

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1403,7 +1403,7 @@ truncate
    If the volume you want to get rid of has not the **Purged** status, you first have to use the :bcommand:`prune volume` or even the :bcommand:`purge volume` command to free the volume from all remaining jobs.
 
    This command is available since Bareos :sinceVersion:`16.2.5: truncate command`.
-   The *drive=<drivenum>* selection was added in  :sinceVersion:`21.0.0: truncate command drive selection`.
+   The *drive=<drivenum>* selection was added in  :sinceVersion:`20.0.2: truncate command drive selection`.
 
 umount
    :index:`\ <single: Console; Command; umount>`\  Alias for :bcommand:`unmount`.


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
