### PR TITLE
Fix acquire deadlock on migrate/copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,8 @@ debian/bareos-traymonitor.install
 debian/bareos-traymonitor.postinst
 debian/univention-bareos.postinst
 
+core/CTestScript.cmake
+
 # generated sample-configuration
 core/src/plugins/filed/python/ldap/python-ldap-conf.d/bareos-dir.d/fileset/plugin-ldap.conf.example
 core/src/plugins/filed/python/ovirt/python-ovirt-conf.d/bareos-dir.d/fileset/plugin-ovirt.conf.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix shutdown of the Storage Daemon backends, especially call UnlockDoor on tape devices [PR #818] (backport of [PR #809])
 - fix possible deadlock in storage backend on Solaris and FreeBSD [PR #818] (backport of [PR #809])
 - [Issue #1205]: PHP 7.3 issue with compact() in HeadLink.php [PR #833] (backport of [PR #829])
+- reorder acquire on migrate/copy to avoid possible deadlock [PR #828]
+
 
 ### Added
 - systemtests for S3 functionalities (droplet, libcloud) now use https [PR #765]
@@ -205,6 +207,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [Issue #1184]: https://bugs.bareos.org/view.php?id=1184
 [Issue #1190]: https://bugs.bareos.org/view.php?id=1190
 [Issue #1192]: https://bugs.bareos.org/view.php?id=1192
+[Issue #1205]: https://bugs.bareos.org/view.php?id=1205
 [Issue #1206]: https://bugs.bareos.org/view.php?id=1206
 [Issue #1210]: https://bugs.bareos.org/view.php?id=1210
 [Issue #1211]: https://bugs.bareos.org/view.php?id=1211
@@ -214,6 +217,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [Issue #1257]: https://bugs.bareos.org/view.php?id=1257
 [Issue #1281]: https://bugs.bareos.org/view.php?id=1281
 [Issue #1316]: https://bugs.bareos.org/view.php?id=1316
+[Issue #1329]: https://bugs.bareos.org/view.php?id=1329
 [PR #383]: https://github.com/bareos/bareos/pull/383
 [PR #384]: https://github.com/bareos/bareos/pull/384
 [PR #385]: https://github.com/bareos/bareos/pull/385
@@ -333,4 +337,21 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #746]: https://github.com/bareos/bareos/pull/746
 [PR #751]: https://github.com/bareos/bareos/pull/751
 [PR #753]: https://github.com/bareos/bareos/pull/753
+[PR #758]: https://github.com/bareos/bareos/pull/758
+[PR #759]: https://github.com/bareos/bareos/pull/759
+[PR #763]: https://github.com/bareos/bareos/pull/763
+[PR #765]: https://github.com/bareos/bareos/pull/765
+[PR #773]: https://github.com/bareos/bareos/pull/773
+[PR #775]: https://github.com/bareos/bareos/pull/775
+[PR #781]: https://github.com/bareos/bareos/pull/781
+[PR #786]: https://github.com/bareos/bareos/pull/786
+[PR #795]: https://github.com/bareos/bareos/pull/795
+[PR #797]: https://github.com/bareos/bareos/pull/797
+[PR #802]: https://github.com/bareos/bareos/pull/802
+[PR #809]: https://github.com/bareos/bareos/pull/809
+[PR #818]: https://github.com/bareos/bareos/pull/818
+[PR #828]: https://github.com/bareos/bareos/pull/828
+[PR #829]: https://github.com/bareos/bareos/pull/829
+[PR #830]: https://github.com/bareos/bareos/pull/830
+[PR #833]: https://github.com/bareos/bareos/pull/833
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2006-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -665,8 +665,8 @@ bool DoMacRun(JobControlRecord* jcr)
     /*
      * Ready devices for reading and writing.
      */
-    if (!AcquireDeviceForRead(jcr->impl->read_dcr)
-        || !AcquireDeviceForAppend(jcr->impl->dcr)) {
+    if (!AcquireDeviceForAppend(jcr->impl->dcr)
+        || !AcquireDeviceForRead(jcr->impl->read_dcr)) {
       ok = false;
       acquire_fail = true;
       goto bail_out;


### PR DESCRIPTION
Previously migrate/copy would acquire the device for reading before the device for writing. This could lead to deadlock situation when the volume that should be read was mounted in the device reserved for writing. By acquiring the device for writing first any volume in that device will be unloaded unless it is the volume we are going to write to. This should fix the deadlock described above.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

