### PR TITLE
Fix acquire deadlock on migrate/copy

### DIFF
--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -551,8 +551,7 @@ bool DoMacRun(JobControlRecord* jcr)
     }
 
     Dmsg2(200, "===== After acquire pos %u:%u\n",
-          jcr->impl->read_dcr->dev->file,
-          jcr->impl->read_dcr->dev->block_num);
+          jcr->impl->read_dcr->dev->file, jcr->impl->read_dcr->dev->block_num);
 
     jcr->sendJobStatus(JS_Running);
 
@@ -665,8 +664,8 @@ bool DoMacRun(JobControlRecord* jcr)
     /*
      * Ready devices for reading and writing.
      */
-    if (!AcquireDeviceForRead(jcr->impl->read_dcr) ||
-        !AcquireDeviceForAppend(jcr->impl->dcr)) {
+    if (!AcquireDeviceForAppend(jcr->impl->dcr) ||
+        !AcquireDeviceForRead(jcr->impl->read_dcr)) {
       ok = false;
       acquire_fail = true;
       goto bail_out;


### PR DESCRIPTION
Previously migrate/copy would acquire the device for reading before the device for writing. This could lead to deadlock situation when the volume that should be read was mounted in the device reserved for writing. By acquiring the device for writing first any volume in that device will be unloaded unless it is the volume we are going to write to. This should fix the deadlock described above.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [ ] ~Required documentation changes are present and part of the PR~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [ ] ~`git status` should not report modifications in the source tree after building and testing~

