### PR TITLE
use correct type for drive-parameter in stored/dir_cmd.cc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - docs: declare shell scripts code blocks as "sh" instead of "shell-session" [PR #802]
 - [Issue #1205]: PHP 7.3 issue with compact() in HeadLink.php [PR #829]
 - reorder acquire on migrate/copy to avoid possible deadlock [PR #828]
+- fix drive parameter handling on big endian architectures [PR #850]
 
 ### Added
 - systemtests for NDMP functionalities [PR #822]

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -609,7 +609,7 @@ bail_out:
   return true;
 }
 
-static drive_number_t IntToDriveNumber(int drive_input)
+static drive_number_t IntToDriveNumber(short int drive_input)
 {
   return (drive_input == -1) ? kInvalidDriveNumber
                              : static_cast<drive_number_t>(drive_input);
@@ -643,7 +643,7 @@ static bool DoLabel(JobControlRecord* jcr, bool relabel)
   poolname = GetMemory(len);
   mediatype = GetMemory(len);
 
-  int drive_input = -1;
+  short int drive_input = -1;
 
   if (relabel) {
     if (sscanf(dir->msg, relabelcmd, dev_name.c_str(), oldname, newname,
@@ -965,7 +965,7 @@ static bool MountCmd(JobControlRecord* jcr)
   DeviceControlRecord* dcr;
   slot_number_t slot = 0;
 
-  int drive_input = -1;
+  short int drive_input = -1;
   bool ok = sscanf(dir->msg, mountslotcmd, devname.c_str(), &drive_input, &slot)
             == 3;
 
@@ -1137,7 +1137,7 @@ static bool UnmountCmd(JobControlRecord* jcr)
   Device* dev;
   DeviceControlRecord* dcr;
 
-  int drive_input = -1;
+  short int drive_input = -1;
   if (sscanf(dir->msg, unmountcmd, devname.c_str(), &drive_input) == 2) {
     drive_number_t drive = IntToDriveNumber(drive_input);
     dcr = FindDevice(jcr, devname, drive, NULL);
@@ -1230,7 +1230,7 @@ static bool ReleaseCmd(JobControlRecord* jcr)
   BareosSocket* dir = jcr->dir_bsock;
   Device* dev;
   DeviceControlRecord* dcr;
-  int drive_input = -1;
+  short int drive_input = -1;
 
   if (sscanf(dir->msg, releasecmd, devname.c_str(), &drive_input) == 2) {
     drive_number_t drive = IntToDriveNumber(drive_input);
@@ -1436,7 +1436,7 @@ static bool ReadlabelCmd(JobControlRecord* jcr)
   Device* dev;
   DeviceControlRecord* dcr;
   slot_number_t slot;
-  int drive_input = -1;
+  short int drive_input = -1;
 
   if (sscanf(dir->msg, readlabelcmd, devname.c_str(), &slot, &drive_input)
       == 3) {

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -651,7 +651,7 @@ set(SYSTEM_TESTS_BROKEN
                              # surrogates not allowed
 )
 
-set(SYSTEMTEST_TIMEOUT 300 CACHE STRING "Timeout for systemtests (in seconds)")
+set(SYSTEMTEST_TIMEOUT "300" CACHE STRING "Timeout for systemtests (in seconds)")
 
 set(glusterfs_uri
     ""
@@ -1142,7 +1142,7 @@ foreach(TEST_NAME ${SYSTEM_TESTS})
   endif()
 
   set_tests_properties(
-    ${SYSTEMTEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT SYSTEMTEST_TIMEOUT
+    ${SYSTEMTEST_PREFIX}${TEST_NAME} PROPERTIES TIMEOUT "${SYSTEMTEST_TIMEOUT}"
                                                 COST 1.0 SKIP_RETURN_CODE 77
   )
   math(EXPR BASEPORT "${BASEPORT} + 10")


### PR DESCRIPTION
This PR fixes an issue with the drive-parameter in SD's director command parsing. This issue is only visible on big endian machines.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] The problem this PR fixes broke a test on big endian machines.