### PR TITLE
webui: provide a better error message on login failure

### DIFF
--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -102,7 +102,7 @@ class AuthController extends AbstractActionController
       $this->bsock->set_user_credentials($username, $password);
 
       if(!$this->bsock->connect_and_authenticate()) {
-         $err_msg = "Sorry, can not authenticate. Wrong username and/or password.";
+         $err_msg = "Sorry, cannot authenticate. Wrong username, password or SSL/TLS handshake failed.";
          return $this->createNewLoginForm($form, $multi_dird_env, $err_msg, $this->bsock);
       }
 


### PR DESCRIPTION
The error message on login failure should give a hint
when you try to login with a console user having the
"TLS Enable = false" parameter not set.

Fixes #1096: misleading error message


OP#4883

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [ ] ~Variable and function names are meaningful~
- [ ] ~Code comments are correct (logically and spelling)~
- [ ] ~Required documentation changes are present and part of the PR~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
