### PR TITLE
Don't use ephemeral ports for test servers

### DIFF
--- a/core/src/tests/configs/console-director/tls_disabled/bareos-dir.d/director/bareos-dir.conf.in
+++ b/core/src/tests/configs/console-director/tls_disabled/bareos-dir.d/director/bareos-dir.conf.in
@@ -5,7 +5,7 @@ Director {                            # define myself
   Password = "bareos"         # Console password
   Messages = Daemon
   Auditing = yes
-  DirPort = 58882
+  DirPort = 32663
   TlsEnable = no
 
   # Enable the Heartbeat if you experience connection losses

--- a/core/src/tests/configs/console-director/tls_disabled/bconsole.conf
+++ b/core/src/tests/configs/console-director/tls_disabled/bconsole.conf
@@ -7,6 +7,6 @@ Director {
   address = localhost
   Password = "bareos"
   Description = "Bareos Console credentials for local Director"
-  DirPort = 58882
+  DirPort = 32663
   TlsEnable = no
 }

--- a/core/src/tests/configs/console-director/tls_psk_default_enabled/bareos-dir.d/director/bareos-dir.conf.in
+++ b/core/src/tests/configs/console-director/tls_psk_default_enabled/bareos-dir.d/director/bareos-dir.conf.in
@@ -5,7 +5,7 @@ Director {                            # define myself
   Password = "bareos"         # Console password
   Messages = Daemon
   Auditing = yes
-  DirPort = 58881
+  DirPort = 32661
 
   # Enable the Heartbeat if you experience connection losses
   # (eg. because of your router or firewall configuration).

--- a/core/src/tests/configs/console-director/tls_psk_default_enabled/bconsole.conf
+++ b/core/src/tests/configs/console-director/tls_psk_default_enabled/bconsole.conf
@@ -7,5 +7,5 @@ Director {
   address = localhost
   Password = "bareos"
   Description = "Bareos Console credentials for local Director"
-  DirPort = 58881
+  DirPort = 32661
 }

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -1079,7 +1079,7 @@ else()
   endforeach()
 endif()
 
-set(BASEPORT 42001)
+set(BASEPORT 30001)
 
 set(SYSTEMTEST_PREFIX "system:")
 


### PR DESCRIPTION
This PR changes systemtests and unittests to bind their servers only to ports smaller than 32768, so we cannot run into conflicts with ephemeral (i.e. client application) ports during testing anymore.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing