### PR TITLE
Merge Windows Debug-Build into Release-Build

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -1,0 +1,214 @@
+JENKINS_TESTTYPES:
+  - bareos-client-only
+  - bareos-mysql
+  - bareos-postgresql
+  - univention-bareos
+
+OS:
+  xUbuntu:
+    "20.04":
+      TYPE: deb
+      IMAGE: "ubuntu20.04"
+      ARCH:
+        - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-webui
+           - bareos-vmware
+           - python-bareos
+
+    "18.04":
+      TYPE: deb
+      IMAGE: "ubuntu18.04"
+      ARCH:
+        - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-webui
+           - bareos-vmware
+           - python-bareos
+
+  openSUSE:
+    "Leap_15.2":
+      TYPE: rpm
+      IMAGE: opensuse-leap152
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+       x86_64:
+          - bareos
+          - python-bareos
+
+  Univention:
+    "4.4":
+      TYPE: deb
+      IMAGE: univention4.4
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-webui
+           - python-bareos
+
+
+  SLE:
+    "15_SP2":
+      TYPE: rpm
+      IMAGE: sle152
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - python-bareos
+    "12_SP5":
+      TYPE: rpm
+      IMAGE: sles12sp5
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - python-bareos
+
+  RHEL:
+    "8":
+      TYPE: rpm
+      IMAGE: rhel8
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-vmware
+           - python-bareos
+    "7":
+      TYPE: rpm
+      IMAGE: rhel7
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-vmware
+           - python-bareos
+
+  Fedora:
+    "33":
+      TYPE: rpm
+      IMAGE: fedora33
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - python-bareos
+
+  Debian:
+    "10":
+      TYPE: deb
+      IMAGE: "debian10"
+      ARCH:
+        - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-webui
+           - bareos-vmware
+           - python-bareos
+    "9.0":
+      TYPE: deb
+      IMAGE: "debian9.0"
+      ARCH:
+        - i586
+        - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-webui
+           - bareos-vmware
+           - python-bareos
+        i586:
+           - bareos
+           - bareos-webui
+           - python-bareos
+
+  CentOS:
+    "8":
+      TYPE: rpm
+      IMAGE: centos8
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-vmware
+           - python-bareos
+
+    "7":
+      TYPE: rpm
+      IMAGE: centos7
+      ARCH:
+      - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - bareos
+           - bareos-vmware
+           - python-bareos
+
+  FreeBSD:
+    "12.2":
+      TYPE: freebsd
+      ARCH:
+        - amd64
+      PROJECTPACKAGES:
+        amd64:
+           - bareos-freebsd
+    "13.0":
+      TYPE: freebsd
+      ARCH:
+        - amd64
+      PROJECTPACKAGES:
+        amd64:
+           - bareos-freebsd
+
+  MacOS:
+    "10.13.6":
+      TYPE: macos
+      ARCH:
+        - x64
+      PROJECTPACKAGES:
+        x64:
+  Solaris:
+    "11.4":
+      TYPE: solaris
+      ARCH:
+        - i386
+        - sparc
+      PROJECTPACKAGES:
+        i386:
+           - bareos
+        sparc:
+           - bareos
+
+  win:
+    cross:
+      TYPE: win
+      STAGES:
+        - win-32-release
+        - win-64-release
+      ARCH:
+       - x86_64
+      PROJECTPACKAGES:
+        x86_64:
+           - mingw-debugsrc
+           - mingw32-winbareos
+           - mingw64-winbareos
+           - winbareos-nsi
+           - winbareos-opsi
+      WINVERSIONS:
+         - windows-10-32
+         - windows-10-64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - FreeBSD: adapt pkglists for FreeBSD 13.0 [PR #819]
 - Fedora34: do not build mysql db backend, adapt pkglist [PR #819]
 - bscan and bareos systemtests: also test bextract and bls binaries, use autoxflate plugin and FSType fileset options [PR #790]
+- Windows release package now ships source code as optional component, so there is no need for a debug-package anymore [PR #858]
 
 ### Deprecated
 
@@ -96,6 +97,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Restore error "could not hard link" documented: what is the cause and how it can be avoided or solved. [PR #759]
 - Developer guide: add small chapter about c++ exceptions. [PR #777]
 
+[Issue #1205]: https://bugs.bareos.org/view.php?id=1205
 [Issue #1316]: https://bugs.bareos.org/view.php?id=1316
 [Issue #1329]: https://bugs.bareos.org/view.php?id=1329
 [PR #552]: https://github.com/bareos/bareos/pull/552
@@ -130,6 +132,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #776]: https://github.com/bareos/bareos/pull/776
 [PR #777]: https://github.com/bareos/bareos/pull/777
 [PR #778]: https://github.com/bareos/bareos/pull/778
+[PR #780]: https://github.com/bareos/bareos/pull/780
 [PR #782]: https://github.com/bareos/bareos/pull/782
 [PR #790]: https://github.com/bareos/bareos/pull/790
 [PR #791]: https://github.com/bareos/bareos/pull/791
@@ -141,6 +144,12 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #810]: https://github.com/bareos/bareos/pull/810
 [PR #819]: https://github.com/bareos/bareos/pull/819
 [PR #822]: https://github.com/bareos/bareos/pull/822
+[PR #823]: https://github.com/bareos/bareos/pull/823
+[PR #824]: https://github.com/bareos/bareos/pull/824
 [PR #826]: https://github.com/bareos/bareos/pull/826
 [PR #828]: https://github.com/bareos/bareos/pull/828
+[PR #829]: https://github.com/bareos/bareos/pull/829
+[PR #844]: https://github.com/bareos/bareos/pull/844
+[PR #850]: https://github.com/bareos/bareos/pull/850
+[PR #858]: https://github.com/bareos/bareos/pull/858
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1,7 +1,7 @@
 ;
 ;   BAREOS - Backup Archiving REcovery Open Sourced
 ;
-;   Copyright (C) 2012-2020 Bareos GmbH & Co. KG
+;   Copyright (C) 2012-2021 Bareos GmbH & Co. KG
 ;
 ;   This program is Free Software; you can redistribute it and/or
 ;   modify it under the terms of version three of the GNU Affero General Public
@@ -531,17 +531,6 @@ Section -SetPasswords
 SectionEnd
 
 
-!If ${WIN_DEBUG} == yes
-# install sourcecode if WIN_DEBUG is yes
-Section Sourcecode SEC_SOURCE
-   SectionIn 1 2 3 4
-   SetShellVarContext all
-   SetOutPath "C:\"
-   SetOverwrite ifnewer
-   File /r "bareos-${VERSION}"
-SectionEnd
-!Endif
-
 SubSection "File Daemon (Client)" SUBSEC_FD
 
 Section "File Daemon and base libs" SEC_FD
@@ -1048,6 +1037,12 @@ SectionEnd
 
 SubSectionEnd # Consoles Subsection
 
+Section /o Sourcecode SEC_SOURCE
+   SetShellVarContext all
+   SetOutPath "C:\"
+   SetOverwrite ifnewer
+   File /r "bareos-${VERSION}"
+SectionEnd
 
 
 ; Section descriptions
@@ -1090,9 +1085,7 @@ ${EndIf}
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_TRAYMON} "Installs the Tray Icon to monitor the Bareos File Daemon"
 
   ; Sourcecode
-!If ${WIN_DEBUG} == yes
   !insertmacro MUI_DESCRIPTION_TEXT ${SEC_SOURCE} "Sourcecode for debugging will be installed into C:\bareos-${VERSION}"
-!Endif
 
 !insertmacro MUI_FUNCTION_DESCRIPTION_END
 
@@ -1353,10 +1346,6 @@ Function .onInit
   IfErrors 0 +2         # error is set if NOT found
     StrCpy $WriteLogs "no"
   ClearErrors
-
-!If ${WIN_DEBUG} == yes
-    StrCpy $WriteLogs "yes"
-!EndIf
 
   StrCmp $WriteLogs "yes" 0 +3
      LogSet on # enable nsis-own logging to $INSTDIR\install.log, needs INSTDIR defined

--- a/docs/manuals/source/TasksAndConcepts/TheWindowsVersionOfBareos.rst
+++ b/docs/manuals/source/TasksAndConcepts/TheWindowsVersionOfBareos.rst
@@ -141,7 +141,7 @@ Commandline Switches
    install the Bareos Storage Daemon. :sinceVersion:`14.2.1: Windows Installation: INSTALLSTORAGE`
 
 /WRITELOGS
-   makes also non-debug installer write a log file. :sinceVersion:`14.2.1: Windows Installation: WRITELOGS`
+   makes the installer write a log file. :sinceVersion:`14.2.1: Windows Installation: WRITELOGS`
 
 /D=:file:`C:\specify\installation\directory`
    (Important: It has to be the last option!)


### PR DESCRIPTION
As the difference between debug and release for Windows is the shipping of the sourcecode only, this PR merges both packages into one.
The Sourcecode is now an optional component that can be selected at install-time.

To reconfigure the builds, this PR also adds a .matrix.yml that will tell Jenkins to only do the release-builds in the future.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
