### PR TITLE
Console automatic reconnect to database without catalog directive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- If you are relying on the fact that Bareos doesn't try to reconnect automatically on a database drop, you now have to specify it explicitly in the Catalog configuration with a `Reconnect = no` directive. [PR #860]
+
 ### Fixed
 - docs: Adapted the documentation of the VMware plugin due to update to VDDK 7 [PR #844]
 - fix a bug in VMware plugin where VMDK Files were created with wrong size when using the option localvmdk=yes [PR #826]
@@ -100,6 +104,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - version information was moved from core/cmake/ and webui/cmake/ directories into the toplevel cmake/ directory [PR #861]
 - add chromedriver options to improve reliability of selenium tests [PR #920]
 - docs: Describe how to get debugging info when using the VMware plugin [PR #921]
+- reconnecting to the database is now automatic per default without the need to specify it in the catalog [PR #860]
 
 ### Deprecated
 
@@ -186,6 +191,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #844]: https://github.com/bareos/bareos/pull/844
 [PR #850]: https://github.com/bareos/bareos/pull/850
 [PR #858]: https://github.com/bareos/bareos/pull/858
+[PR #860]: https://github.com/bareos/bareos/pull/860
 [PR #861]: https://github.com/bareos/bareos/pull/861
 [PR #868]: https://github.com/bareos/bareos/pull/868
 [PR #869]: https://github.com/bareos/bareos/pull/869

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -497,7 +497,7 @@ class BareosDb : public BareosDbQueryEnum {
   uint32_t ref_count_ = 0;                /**< Reference count */
   bool connected_ = false;                /**< Connection made to db */
   bool have_batch_insert_ = false;        /**< Have batch insert support ? */
-  bool try_reconnect_ = false;   /**< Try reconnecting DB connection ? */
+  bool try_reconnect_ = true;    /**< Try reconnecting DB connection ? */
   bool exit_on_fatal_ = false;   /**< Exit on FATAL DB errors ? */
   char* db_driver_ = nullptr;    /**< Database driver */
   char* db_driverdir_ = nullptr; /**< Database driver dir */

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -327,8 +327,8 @@ static ResourceItem cat_items[] = {
    /* Turned off for the moment */
   { "MultipleConnections", CFG_TYPE_BIT, ITEM(res_cat, mult_db_connections), 0, 0, NULL, NULL, NULL },
   { "DisableBatchInsert", CFG_TYPE_BOOL, ITEM(res_cat, disable_batch_insert), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
-  { "Reconnect", CFG_TYPE_BOOL, ITEM(res_cat, try_reconnect), 0, CFG_ITEM_DEFAULT, "false",
-     "15.1.0-", "Try to reconnect a database connection when its dropped" },
+  { "Reconnect", CFG_TYPE_BOOL, ITEM(res_cat, try_reconnect), 0, CFG_ITEM_DEFAULT, "true",
+     "15.1.0-", "Try to reconnect a database connection when it is dropped" },
   { "ExitOnFatal", CFG_TYPE_BOOL, ITEM(res_cat, exit_on_fatal), 0, CFG_ITEM_DEFAULT, "false",
      "15.1.0-", "Make any fatal error in the connection to the database exit the program" },
   { "MinConnections", CFG_TYPE_PINT32, ITEM(res_cat, pooling_min_connections), 0, CFG_ITEM_DEFAULT, "1", NULL,

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -250,8 +250,8 @@ class CatalogResource : public BareosResource {
   uint32_t mult_db_connections = 0; /**< Set if multiple connections wanted */
   bool disable_batch_insert
       = false;                /**< Set if batch inserts should be disabled */
-  bool try_reconnect = false; /**< Try to reconnect a database connection when
-                         its dropped */
+  bool try_reconnect = true;  /**< Try to reconnect a database connection when
+                          it is dropped */
   bool exit_on_fatal = false; /**< Make any fatal error in the connection to the
                          database exit the program */
   uint32_t pooling_min_connections

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -2001,10 +2001,10 @@
         "Reconnect": {
           "datatype": "BOOLEAN",
           "code": 0,
-          "default_value": "false",
+          "default_value": "true",
           "equals": true,
           "versions": "15.1.0-",
-          "description": "Try to reconnect a database connection when its dropped"
+          "description": "Try to reconnect a database connection when it is dropped"
         },
         "ExitOnFatal": {
           "datatype": "BOOLEAN",

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -932,7 +932,7 @@ Catalog {
   # DbSocket =
   # MultipleConnections = No
   # DisableBatchInsert = No
-  # Reconnect = No
+  # Reconnect = Yes
   # ExitOnFatal = No
   # MinConnections = 1
   # MaxConnections = 5


### PR DESCRIPTION
#### Description

When a connection to the database is dropped, the director automatically tries to reconnect without checking for the "Reconnect" directive in the catalog.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
