### PR TITLE
docs: document the default value of fileset accurate option

### DIFF
--- a/docs/manuals/source/Configuration/Director.rst
+++ b/docs/manuals/source/Configuration/Director.rst
@@ -759,6 +759,8 @@ The directives within an Options resource may be one of the following:
    The options letters specified are used when
    running a :strong:`Backup Level=Incremental/Differential` in Accurate mode. The
    options letters are the same than in the :strong:`verify=` option below.
+   The default setting is **mcs** which means that *modification time*, *change time*
+   and *size* are compared.
 
 .. config:option:: dir/fileset/include/options/Verify
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!
The default value for the accurate fileset option is now documented.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
