### PR TITLE
webui:  Fix infinite loop when trying to log in with invalid account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix possible deadlock in storage backend on Solaris and FreeBSD [PR #818] (backport of [PR #809])
 - [Issue #1205]: PHP 7.3 issue with compact() in HeadLink.php [PR #833] (backport of [PR #829])
 - reorder acquire on migrate/copy to avoid possible deadlock [PR #828]
-
+- [Issue #1324]: Infinite loop when trying to log in with invalid account [PR #864] (backport of [PR #840])
 
 ### Added
 - added choice for the drive number in the truncate command [PR #837]

--- a/webui/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
+++ b/webui/vendor/Bareos/library/Bareos/BSock/BareosBSock.php
@@ -217,7 +217,7 @@ class BareosBSock implements BareosBSockInterface
       $str_length += 4;
       while($this->socket && $str_length > 0) {
          $send = fwrite($this->socket, $msg, $str_length);
-         if($send === 0) {
+         if($send === 0 || $send === false) {
             fclose($this->socket);
             $this->socket = null;
             return false;


### PR DESCRIPTION
Close socket on fwrite() error. fwrite() returns the number of bytes
written, or false on error.

Fixes #1324: Infinite loop when trying to log with invalid account

(cherry picked from commit 2f58278669d3adbc0ae167289cc0c34c74ebf7c4)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
