### PR TITLE
webui: fix job status categories in formatter function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - reorder acquire on migrate/copy to avoid possible deadlock [PR #828]
 - [Issue #1324]: Infinite loop when trying to log in with invalid account [PR #864] (backport of [PR #840])
 - [Issue #579]: Unable to connect to the director from webui via ipv6 [PR #871] (backport of [PR #868])
+- [Issue #1300]: some job status are not categorized properly [PR #878] (backport of [PR #874])
 
 ### Added
 - added choice for the drive number in the truncate command [PR #837]

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -3,7 +3,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2020-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2020-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -294,7 +294,7 @@ function formatJobStatus(data) {
       // Created no yet running
       case 'C':
          jobstatus_C = iJS._("Created but not yet running");
-         output = '<span class="label label-default" title="' + jobstatus_C + '">' + iJS._("Queued") + '</span>';
+         output = '<span class="label label-default" title="' + jobstatus_C + '">' + iJS._("Waiting") + '</span>';
          break;
       // Blocked
       case 'B':
@@ -364,12 +364,12 @@ function formatJobStatus(data) {
       // SD despooling attributes
       case 'a':
          jobstatus_a = iJS._("SD despooling attributes");
-         output = '<span class="label label-info" title="' + jobstatus_a + '">' + iJS._("SD despooling attributes") + '</span>';
+         output = '<span class="label label-info" title="' + jobstatus_a + '">' + iJS._("Running") + '</span>';
          break;
       // Doing batch insert file records
       case 'i':
          jobstatus_i = iJS._("Doing batch insert file records");
-         output = '<span class="label label-info" title="' + jobstatus_i + '">' + iJS._("Doing batch insert file records") + '</span>';
+         output = '<span class="label label-info" title="' + jobstatus_i + '">' + iJS._("Running") + '</span>';
          break;
       // Incomplete
       case 'I':
@@ -379,7 +379,7 @@ function formatJobStatus(data) {
       // Committing data
       case 'L':
          jobstatus_L = iJS._("Committing data (last despool)");
-         output = '<span class="label label-info" title="' + jobstatus_L + '">' + iJS._("Committing data") + '</span>';
+         output = '<span class="label label-info" title="' + jobstatus_L + '">' + iJS._("Running") + '</span>';
          break;
       // Terminated with warnings
       case 'W':
@@ -389,12 +389,12 @@ function formatJobStatus(data) {
       // Doing data despooling
       case 'l':
          jobstatus_l = iJS._("Doing data despooling");
-         output = '<span class="label label-info" title="' + jobstatus_l +'">' + iJS._("Doing data despooling") + '</span>';
+         output = '<span class="label label-info" title="' + jobstatus_l +'">' + iJS._("Running") + '</span>';
          break;
       // Queued waiting for device
       case 'q':
          jobstatus_q = iJS._("Queued waiting for device");
-         output = '<span class="label label-default" title="' + jobstatus_q + '">' + iJS._("Queued waiting for device") + '</span>';
+         output = '<span class="label label-default" title="' + jobstatus_q + '">' + iJS._("Waiting") + '</span>';
          break;
       default:
          output = '<span class="label label-primary">' + data + '</span>';


### PR DESCRIPTION
Some job states are not categorized properly so the column filter on
the job table does not work as expected. This commit fixes the issue.

The categories are Running, Waiting, Success, Warning and Failure.

Fixes #1300: some job status are not categorized properly

(cherry picked from commit 907ddbd8017437db4486f6e88bbede1b19e59d1f)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- ~~[ ] Variable and function names are meaningful~~
- [x] Code comments are correct (logically and spelling)
- ~~[ ] Required documentation changes are present and part of the PR~~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
