### PR TITLE
mssqlvdi: set default for serveraddress+instance on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: unify parsing of bools [PR #2578]
 - core: remove one "unused" layer of abstraction from our tls code [PR #2631]
 - bvfs: fix cache race [PR #2642]
+- mssqlvdi: set default for serveraddress+instance on restore [PR #879]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -1527,6 +1528,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #869]: https://github.com/bareos/bareos/pull/869
 [PR #870]: https://github.com/bareos/bareos/pull/870
 [PR #874]: https://github.com/bareos/bareos/pull/874
+[PR #879]: https://github.com/bareos/bareos/pull/879
 [PR #880]: https://github.com/bareos/bareos/pull/880
 [PR #882]: https://github.com/bareos/bareos/pull/882
 [PR #883]: https://github.com/bareos/bareos/pull/883

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -983,6 +983,14 @@ static void SetAdoConnectString(PluginContext* ctx)
   PoolMem ado_connect_string(PM_NAME);
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
 
+  // If no explicit instance name given usedthe DEFAULT_INSTANCE name.
+  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
+
+  // If no explicit server address given use the DEFAULT_SERVER_ADDRESS.
+  if (!p_ctx->server_address) {
+    p_ctx->server_address = strdup(DEFAULT_SERVER_ADDRESS);
+  }
+
   if (Bstrcasecmp(p_ctx->instance, DEFAULT_INSTANCE)) {
     Mmsg(ado_connect_string,
          "Provider=MSOLEDBSQL.1;Data Source=%s;Initial Catalog=master",
@@ -1019,9 +1027,6 @@ static inline void PerformAdoBackup(PluginContext* ctx)
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
   PoolMem ado_connect_string(PM_NAME), ado_query(PM_NAME);
   POOLMEM* vdsname;
-
-  // If no explicit instance name given usedthe DEFAULT_INSTANCE name.
-  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
 
   SetAdoConnectString(ctx);
 

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -405,6 +405,23 @@ static bRC handlePluginEvent(PluginContext* ctx, bEvent* event, void* value)
   return retval;
 }
 
+const char* instance_name_of(plugin_ctx* p_ctx)
+{
+  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
+
+  return p_ctx->instance;
+}
+
+const char* server_address_of(plugin_ctx* p_ctx)
+{
+  if (!p_ctx->server_address) {
+    p_ctx->server_address = strdup(DEFAULT_SERVER_ADDRESS);
+  }
+
+  return p_ctx->server_address;
+}
+
+
 // Start the backup of a specific file
 static bRC startBackupFile(PluginContext* ctx, save_pkt* sp)
 {
@@ -415,29 +432,22 @@ static bRC startBackupFile(PluginContext* ctx, save_pkt* sp)
 
   if (!p_ctx) { return bRC_Error; }
 
-  // If no explicit instance name given use the DEFAULT_INSTANCE.
-  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
-
-  // If no explicit server address given use the DEFAULT_SERVER_ADDRESS.
-  if (!p_ctx->server_address) {
-    p_ctx->server_address = strdup(DEFAULT_SERVER_ADDRESS);
-  }
+  auto* instance = instance_name_of(p_ctx);
 
   now = time(NULL);
   bstrftime(dt, sizeof(dt), now, "%Y%m%d-%H%M%S");
 
   switch (p_ctx->backup_level) {
     case L_FULL:
-      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-full.bak", p_ctx->instance,
-           p_ctx->database, dt);
+      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-full.bak", instance, p_ctx->database,
+           dt);
       break;
     case L_DIFFERENTIAL:
-      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-diff.bak", p_ctx->instance,
-           p_ctx->database, dt);
+      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-diff.bak", instance, p_ctx->database,
+           dt);
       break;
     case L_INCREMENTAL:
-      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-log.trn", p_ctx->instance,
-           p_ctx->database, dt);
+      Mmsg(fname, "/@MSSQL/%s/%s/db-%s-log.trn", instance, p_ctx->database, dt);
       break;
     default:
       Jmsg(ctx, M_FATAL, "Unsupported backup level (%c).\n",
@@ -983,22 +993,17 @@ static void SetAdoConnectString(PluginContext* ctx)
   PoolMem ado_connect_string(PM_NAME);
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
 
-  // If no explicit instance name given usedthe DEFAULT_INSTANCE name.
-  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
+  auto* server_address = server_address_of(p_ctx);
+  auto* instance = instance_name_of(p_ctx);
 
-  // If no explicit server address given use the DEFAULT_SERVER_ADDRESS.
-  if (!p_ctx->server_address) {
-    p_ctx->server_address = strdup(DEFAULT_SERVER_ADDRESS);
-  }
-
-  if (Bstrcasecmp(p_ctx->instance, DEFAULT_INSTANCE)) {
+  if (Bstrcasecmp(instance, DEFAULT_INSTANCE)) {
     Mmsg(ado_connect_string,
          "Provider=MSOLEDBSQL.1;Data Source=%s;Initial Catalog=master",
-         p_ctx->server_address);
+         server_address);
   } else {
     Mmsg(ado_connect_string,
          "Provider=MSOLEDBSQL.1;Data Source=%s\\%s;Initial Catalog=master",
-         p_ctx->server_address, p_ctx->instance);
+         server_address, instance);
   }
 
   // See if we need to use a username/password or a trusted connection.
@@ -1073,9 +1078,6 @@ static inline void perform_aDoRestore(PluginContext* ctx)
   PoolMem ado_query(PM_NAME), temp(PM_NAME);
   POOLMEM* vdsname;
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
-
-  // If no explicit instance name given use the DEFAULT_INSTANCE name.
-  if (!p_ctx->instance) { p_ctx->instance = strdup(DEFAULT_INSTANCE); }
 
   SetAdoConnectString(ctx);
 
@@ -1268,14 +1270,15 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
     p_ctx->VDIConfig.features |= VDF_RequestComplete;
   }
 
+  auto* instance = instance_name_of(p_ctx);
   // Create the VDI device set.
-  if (Bstrcasecmp(p_ctx->instance, DEFAULT_INSTANCE)) {
+  if (Bstrcasecmp(instance, DEFAULT_INSTANCE)) {
     hr = p_ctx->VDIDeviceSet->CreateEx(NULL, p_ctx->vdsname, &p_ctx->VDIConfig);
   } else {
     POOLMEM* instance_name;
 
     instance_name = GetPoolMemory(PM_NAME);
-    UTF8_2_wchar(instance_name, p_ctx->instance);
+    UTF8_2_wchar(instance_name, instance);
     hr = p_ctx->VDIDeviceSet->CreateEx((LPCWSTR)instance_name, p_ctx->vdsname,
                                        &p_ctx->VDIConfig);
     FreePoolMemory(instance_name);

--- a/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
@@ -158,10 +158,10 @@ mssqlvdi
    This is the reference to the MSSQL plugin.
 
 serveraddress
-   (:sinceVersion:`14.2.2: MSSQL: serveraddress`) Defines the server address to connect to (if empty defaults to localhost).
+   (:sinceVersion:`14.2.2: MSSQL: serveraddress`) Defines the server address to connect to (if empty defaults to ``localhost``).
 
 instance
-   Defines the instance within the database server.
+   Defines the instance within the database server. (if empty defaults to ``default``)
 
 database
    Defines the database that should get backed up.
@@ -283,16 +283,7 @@ Incremental FileSet example:
 Restores
 ^^^^^^^^
 
-If you want to perform a restore of a full backup without differentials or incrementals you have some options which helps you to restore even the corrupted database still exist. But you have to specify the options like plugin, instance and database during every backup.
-
-replace=<yes|no>
-   With this option you can replace the database if it still exist.
-
-instance
-   Defines the server instance within the database is running.
-
-database
-   Defines the database you want to backup.
+There are generally two ways to restore a mssql database.  You can restore it into the filesystem so that you can e.g. use the builtin restore functionality of mssql to do the restore yourself, or you can let bareos restore the database directly.
 
 Restore to local files
 ''''''''''''''''''''''
@@ -305,13 +296,38 @@ If the *where* parameter is set **to a directory** instead of '/', the plugin wi
 restore the backup as files into the given directory.
 
 Example: If *where* is set to  **’c:/temp’**, the plugin will restore the selected backup
-files under a relocated path under c:/temp/@MSSQL@/...
+files under a relocated path under c:/temp/@MSSQL/...
 
 If *where* is set to ’/’ it will restore to the Virtual Device Interface (VDI).
 
 
 Restore to database
 '''''''''''''''''''
+
+To restore the database directly, you can simply run the restore command with *where* set to **/**.
+You can change how the restore is performed by setting some optional plugin options:
+
+replace=<yes|default:no>
+   If this option is set to **yes**, then the database will be replaced if it already exists.
+   Otherwise the restore will fail if the database already exists.
+
+instance
+   Defines the server instance within which the database is running.  If unset,
+   the instance specified during the backup is used.
+
+database
+   Defines the name under which you want to restore the database.  If unset,
+   the name specified during the backup is used.
+
+.. note::
+   Setting the name via *database* does **not** change the name of the files within that database.
+   I.e. if you have a database called **mydb**, then mssql has internal files **mydb.mdf**, **mydb.ldf**, ...
+   for it.  If you now try to restore the database as **newname**, these internal files will still use their
+   old name.  This means that if these files still exist and are used, then the restore under the new name
+   will fail, even if you set ``replace=yes``.
+   If the files exist because an old version of that database still exists, then you can restore the database
+   by restore to the old name with ``replace=yes``.  Otherwise you can restore the db via the local files approach.
+
 
 Example for a full restore:
 
@@ -451,16 +467,17 @@ Example for a full restore:
      SD termination status:  OK
      Termination:            Restore OK
 
+
 Restore a Backup Chain
 ''''''''''''''''''''''
 
-If you like to restore a specific state or a whole chain consists of full, incremental and differential backups you need to use the "norecovery=yes" option. After this the database is in "recovery mode". You can also use a option which put the database right after the restore back into the right mode. If you like to restore certains point with protocols or "LSN" it it not recommend to work with this option.
+If you like to restore a specific state or a whole chain consists of full, incremental and differential backups you need to use the "norecovery=yes" option. Otherwise the database would try to recover the database after the full backup was restored, but before the incremental changes were restored.  As this option turns of the auto recovery mode, you will need to recover the database by either doing it manually after the restore is done, or by setting `recoverafterrestore=yes` so that bareos does it for you. If you like to restore certains point with protocols or "LSN" it it not recommend to work with this option.
 
 norecovery=<yes|no>
-   This option must be set to yes, if the database server should not do a automatic recovery after the backup. Instead, additional manual maintenance operations are possible.
+   This option must be set to yes, if the database server should not do a automatic recovery after the every restore. Instead, additional manual maintenance operations are possible.
 
 recoverafterrestore=<yes|no>
-   With this command the database is right after backup in the correct mode. If you not use this you have to use the followed tsql statement:
+   Automatically issues a recover after bareos is done with all its restores. If you not use this you have to use the followed tsql statement:
 
    ::
 

--- a/systemtests/tests/mssqlvdi-plugin/environment.local
+++ b/systemtests/tests/mssqlvdi-plugin/environment.local
@@ -2,11 +2,6 @@
 
 # Here we set some extra variables that the tests needs.
 #
-# print_delete_trace
-#   This simply prints the fd trace and then deletes it.
-#   This makes sure that only the relevant trace from the
-#   current test is printed.
-#
 # DB_DATA_DIR
 #   This is the directory in which we create the various
 #   databases.  See the note on why this has to include
@@ -21,14 +16,6 @@
 #   This file is used inside the filestream db.  It is added
 #   before the first incremental backup and is later used to
 #   check whether the restore worked correctly.
-
-
-print_delete_trace()
-{
-        local FD_TRACE_NAME="${working_dir}/$(basename "$(pwd)")-fd.trace"
-        cat "${FD_TRACE_NAME}" || echo "Trace does not exist"
-        rm "${FD_TRACE_NAME}" || :
-}
 
 # this looks weird but is required.
 # cygwin is not able to pass double quotes to a windows process if you tell it to

--- a/systemtests/tests/mssqlvdi-plugin/functions.local
+++ b/systemtests/tests/mssqlvdi-plugin/functions.local
@@ -1,7 +1,8 @@
 #!/bin/bash
+
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2025-2026 Bareos GmbH & Co. KG
+#   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -18,28 +19,26 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-set -e
-set -o pipefail
-set -u
-
-TestName="$(basename "$(pwd)")"
-export TestName
-
-myname=$(basename "$0")
-
 #shellcheck source=../../environment.in
 . ./environment
 
-#shellcheck source=../../scripts/functions
-. "${BAREOS_SCRIPTS_DIR}"/functions
+# print_delete_trace
+#   This simply prints the fd trace and then deletes it.
+#   This makes sure that only the relevant trace from the
+#   current test is printed.
+#
+print_delete_trace()
+{
+  local FD_TRACE_NAME="${working_dir}/$(basename "$(pwd)")-fd.trace"
+  cat "${FD_TRACE_NAME}" || echo "Trace does not exist"
+  rm "${FD_TRACE_NAME}" || :
+}
 
-start_test
-
-"${SQLCMD}" -S "${COMPUTERNAME}" -E -b -v myDB=DBNormalTest -i sqlfiles/SQL_drop_db.sql
-
-if db_exists "DBNormalTest"; then
-  echo "Database is not empty"
-  exit 2
-fi
-
-end_test
+db_exists()
+{
+  # Check if the DB still exists: DB_ID() returns a numeric ID if the DB exists,
+  # or NULL if it was dropped. -h -1 suppresses headers, -W strips trailing
+  # whitespace, so grep can match a bare number. A match means the drop failed.
+  "${SQLCMD}" -S "${COMPUTERNAME}" -E -b -h -1 -W \
+    -Q "SET NOCOUNT ON; SELECT DB_ID('$1')" | tr -d '\r' | grep -Eq '^[0-9]+$'
+}

--- a/systemtests/tests/mssqlvdi-plugin/functions.local
+++ b/systemtests/tests/mssqlvdi-plugin/functions.local
@@ -36,9 +36,16 @@ print_delete_trace()
 
 db_exists()
 {
+  local out
+
   # Check if the DB still exists: DB_ID() returns a numeric ID if the DB exists,
   # or NULL if it was dropped. -h -1 suppresses headers, -W strips trailing
-  # whitespace, so grep can match a bare number. A match means the drop failed.
-  "${SQLCMD}" -S "${COMPUTERNAME}" -E -b -h -1 -W \
-    -Q "SET NOCOUNT ON; SELECT DB_ID('$1')" | tr -d '\r' | grep -Eq '^[0-9]+$'
+  # whitespace, so grep can match a bare number. SQLCMD failures return a
+  # dedicated status so drop verification errors do not look like a missing DB.
+  if out="$("${SQLCMD}" -S "${COMPUTERNAME}" -E -b -h -1 -W \
+    -Q "SET NOCOUNT ON; SELECT DB_ID('$1')" | tr -d '\r')"; then
+    grep -Eq '^[0-9]+$' <<<"${out}"
+  else
+    return 2
+  fi
 }

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-04-DBNormal-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-04-DBNormal-DropDB
@@ -37,7 +37,7 @@ start_test
 
 "${SQLCMD}" -S "${COMPUTERNAME}" -E -b -v myDB=DBNormalTest -i sqlfiles/SQL_drop_db.sql
 
-if "${SQLCMD}" -Q "SELECT * FROM DBNormalTest.tests.samples" | grep Bareos; then
+if db_exists "DBNormalTest"; then
   echo "Database is not empty"
   exit 2
 fi

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-04-DBNormal-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-04-DBNormal-DropDB
@@ -38,8 +38,14 @@ start_test
 "${SQLCMD}" -S "${COMPUTERNAME}" -E -b -v myDB=DBNormalTest -i sqlfiles/SQL_drop_db.sql
 
 if db_exists "DBNormalTest"; then
-  echo "Database is not empty"
+  echo "Database still exists after drop"
   exit 2
+else
+  db_exists_rc=$?
+  if [ "${db_exists_rc}" -ne 1 ]; then
+    echo "Failed to verify whether DBNormalTest still exists"
+    exit "${db_exists_rc}"
+  fi
 fi
 
 end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-06-DBNormal-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-06-DBNormal-DropDB
@@ -1,0 +1,45 @@
+#!/bin/bash
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2025-2026 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+myname=$(basename "$0")
+
+#shellcheck source=../../environment.in
+. ./environment
+
+#shellcheck source=../../scripts/functions
+. "${BAREOS_SCRIPTS_DIR}"/functions
+
+start_test
+
+"${SQLCMD}" -S "${COMPUTERNAME}" -E -b -v myDB=DBNormalTest -i sqlfiles/SQL_drop_db.sql
+
+if "${SQLCMD}" -Q "SELECT * FROM DBNormalTest.tests.samples" | grep Bareos; then
+  echo "Database is not empty"
+  exit 2
+fi
+
+end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-06-DBNormal-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-06-DBNormal-DropDB
@@ -38,8 +38,14 @@ start_test
 "${SQLCMD}" -S "${COMPUTERNAME}" -E -b -v myDB=DBNormalTest -i sqlfiles/SQL_drop_db.sql
 
 if db_exists "DBNormalTest"; then
-  echo "Database is not empty"
+  echo "Database still exists after drop"
   exit 2
+else
+  db_exists_rc=$?
+  if [ "${db_exists_rc}" -ne 1 ]; then
+    echo "Failed to verify whether DBNormalTest still exists"
+    exit "${db_exists_rc}"
+  fi
 fi
 
 end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-07-restore-default
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-07-restore-default
@@ -1,0 +1,66 @@
+#!/bin/bash
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2025-2026 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+# this tests the restore with address not being explicitly set
+
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+myname=$(basename "$0")
+
+#shellcheck source=../../environment.in
+. ./environment
+
+#shellcheck source=../../scripts/functions
+. "${BAREOS_SCRIPTS_DIR}"/functions
+
+start_test
+
+mkdir -p "${tmp}/data"
+echo "$0" >"${tmp}/data/${myname}"
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out ${NULL_DEV}
+messages
+setdebug level=300 client trace=1
+@$out "${tmp}/${myname}.log"
+restore client=bareos-fd fileset=DBNormal where=/ pluginoptions=mssqlvdi:database=DBNormalTest:norecovery=yes:replace=yes:recoverafterrestore=yes select all done yes
+wait
+setdebug level=10 client trace=0
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+print_delete_trace
+
+#check_for_zombie_jobs storage=File
+check_log "${tmp}/${myname}.log"
+
+# check that the updated content is there
+"${SQLCMD}" -Q "SELECT * FROM DBNormalTest.tests.samples" >"$tmp/sql-normal-samples-check.out"
+expect_grep "Bareos" "$tmp/sql-normal-samples-check.out" "Bareos not found in samples"
+
+end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-14-DBFileStream-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-14-DBFileStream-DropDB
@@ -37,7 +37,7 @@ start_test
 
 "${SQLCMD}" -S ${COMPUTERNAME} -E -b -v myDB=DBFileStreamTest -i sqlfiles/SQL_drop_db.sql
 
-if "${SQLCMD}" -Q "SELECT * FROM DBFileStreamTest.tests.samples" | grep Bareos; then
+if db_exists "DBFileStreamTest"; then
   echo "Database is not empty"
   exit 2
 fi

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-14-DBFileStream-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-14-DBFileStream-DropDB
@@ -38,8 +38,14 @@ start_test
 "${SQLCMD}" -S ${COMPUTERNAME} -E -b -v myDB=DBFileStreamTest -i sqlfiles/SQL_drop_db.sql
 
 if db_exists "DBFileStreamTest"; then
-  echo "Database is not empty"
+  echo "Database still exists after drop"
   exit 2
+else
+  db_exists_rc=$?
+  if [ "${db_exists_rc}" -ne 1 ]; then
+    echo "Failed to verify whether DBFileStreamTest still exists"
+    exit "${db_exists_rc}"
+  fi
 fi
 
 end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
@@ -37,7 +37,7 @@ start_test
 
 "${SQLCMD}" -S ${COMPUTERNAME} -E -b -v myDB=DBFileStreamTest -i sqlfiles/SQL_drop_db.sql
 
-if "${SQLCMD}" -Q "SELECT * FROM DBFileStreamTest.tests.samples" | grep Bareos; then
+if db_exists "DBFileStreamTest"; then
   echo "Database is not empty"
   exit 2
 fi

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
@@ -1,0 +1,45 @@
+#!/bin/bash
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2025-2026 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+myname=$(basename "$0")
+
+#shellcheck source=../../environment.in
+. ./environment
+
+#shellcheck source=../../scripts/functions
+. "${BAREOS_SCRIPTS_DIR}"/functions
+
+start_test
+
+"${SQLCMD}" -S ${COMPUTERNAME} -E -b -v myDB=DBFileStreamTest -i sqlfiles/SQL_drop_db.sql
+
+if "${SQLCMD}" -Q "SELECT * FROM DBFileStreamTest.tests.samples" | grep Bareos; then
+  echo "Database is not empty"
+  exit 2
+fi
+
+end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-16-DBFileStream-DropDB
@@ -38,8 +38,14 @@ start_test
 "${SQLCMD}" -S ${COMPUTERNAME} -E -b -v myDB=DBFileStreamTest -i sqlfiles/SQL_drop_db.sql
 
 if db_exists "DBFileStreamTest"; then
-  echo "Database is not empty"
+  echo "Database still exists after drop"
   exit 2
+else
+  db_exists_rc=$?
+  if [ "${db_exists_rc}" -ne 1 ]; then
+    echo "Failed to verify whether DBFileStreamTest still exists"
+    exit "${db_exists_rc}"
+  fi
 fi
 
 end_test

--- a/systemtests/tests/mssqlvdi-plugin/testrunner-17-DBFileStream-Restore
+++ b/systemtests/tests/mssqlvdi-plugin/testrunner-17-DBFileStream-Restore
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2025-2026 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+# do the restore again, but this time without setting serveraddress/instance
+
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+myname=$(basename "$0")
+
+#shellcheck source=../../environment.in
+. ./environment
+
+#shellcheck source=../../scripts/functions
+. "${BAREOS_SCRIPTS_DIR}"/functions
+
+start_test
+
+mkdir -p "${tmp}/data"
+echo "$0" >"${tmp}/data/${myname}"
+
+# if the first restore test already ran, then the original files
+# do not exist anymore, so in that case we skip this step
+if ! [ -e "${tmp}/backed-up-data.out" ]; then
+  # this looks weird but im not sure how to output the files in a better way
+  (
+    echo -n "sample_one "
+    cat "${DB_FILE}"
+    echo -e "\r"
+    echo -n "Bareos "
+    cat "${DB_FILE2}"
+    echo -e "\r"
+  ) >"${tmp}/backed-up-data.out"
+
+  # we want to make sure that the original files dont need to exist anymore
+  # for the restore
+  rm "${DB_FILE}"
+  rm "${DB_FILE2}"
+fi
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out ${NULL_DEV}
+messages
+@$out "${tmp}/${myname}.log"
+setdebug level=300 client trace=1
+restore client=bareos-fd fileset=DBFileStream where=/ pluginoptions=mssqlvdi:database=DBFileStreamTest:norecovery=yes:replace=yes:recoverafterrestore=yes select all done yes
+wait
+setdebug level=10 client trace=0
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+#check_for_zombie_jobs storage=File
+
+print_delete_trace
+
+check_log "${tmp}/${myname}.log"
+# check that the updated content is there
+"${SQLCMD}" -Q "SELECT * FROM DBFileStreamTest.tests.samples" >"$tmp/sql-stream-samples-check.out"
+expect_grep "Bareos" "$tmp/sql-stream-samples-check.out" "Bareos not found in samples"
+
+"${SQLCMD}" -Q "SELECT fstream_id, fstream_name, fstream_binary.PathName() FROM DBFileStreamTest.tests.files" >"$tmp/sql-stream-files-check.out"
+expect_grep "Bareos" "$tmp/sql-stream-files-check.out" "Bareos not found in files"
+
+# there is probably a better way to check this ...
+"${SQLCMD}" -E -Q "set NOCOUNT on; select fstream_name, CONVERT(VARCHAR(50), fstream_binary, 0) as fstream_content from DBFileStreamTest.tests.files" -h -1 -W >"${tmp}/restored-data.out"
+
+diff "${tmp}/restored-data.out" "${tmp}/backed-up-data.out"
+end_test


### PR DESCRIPTION
Previously, mssqlvdi set a default for serveraddress  & instance on backup, but not
on restore. If you did not specify serveraddress on backup, restore
would fail unless you specified it in the plugin options manually.

This patch now sets the default for serveraddress&instance on restore just like
it does on backup.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required Backport has been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
