### PR TITLE
webui: check major version compatibility between webui and DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1324]: Infinite loop when trying to log in with invalid account [PR #840]
 - [Issue #579]: Unable to connect to the director from webui via ipv6 [PR #868]
 - [Issue #1300]: some job status are not categorized properly [PR #874]
+- [Issue #871]: UI will not load complete [PR #880]
 
 ### Added
 - Add systemtests fileset-multiple-include-blocks, fileset-multiple-options-blocks, quota-softquota, sparse-file, truncate-command and block-size, (migrated from ``regress/``) [PR #780]

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -142,6 +142,12 @@ class AuthController extends AbstractActionController
          return $this->createNewLoginForm($form, $multi_dird_env, $apicheck, $this->bsock);
       }
 
+      $versioncheck = $this->checkVersionCompatibilityDIRD();
+
+      if($versioncheck !== true) {
+         return $this->createNewLoginForm($form, $multi_dird_env, $versioncheck, $this->bsock);
+      }
+
       $aclcheck = $this->checkACLStatusDIRD();
 
       if(!$aclcheck) {
@@ -206,6 +212,25 @@ class AuthController extends AbstractActionController
             'err_msg' => $err_msg
          )
       );
+   }
+
+   /**
+    * DIRD version compatibility check
+    *
+    * @return mixed
+    */
+   private function checkVersionCompatibilityDIRD() {
+      include 'version.php'; // provides bareos_full_version (installed ui version)
+      $dird_version_array = $this->getDirectorModel()->getDirectorVersion($this->bsock);
+      $dird_version = $dird_version_array['version'];
+      // compare major version
+      $dird_major_version = explode('.', $dird_version)[0];
+      $ui_major_version = explode('.', $bareos_full_version)[0];
+      if($dird_major_version !== $ui_major_version) {
+        $err_msg = 'Error: Bareos WebUI ('.$bareos_full_version.') requires a Director of the same major release ('.$dird_major_version.'). The Director version is '.$dird_version.'.';
+        return $err_msg;
+      }
+      return true;
    }
 
    /**


### PR DESCRIPTION
To ensure the installed WEBUI and DIR have the same version
because of compatibility reasons, this PR introduces a version
check at login time which provides an error message if versions
do not match. In addition the PR fixes an issue within the api check.

Fixes #0000871: UI will not load complete

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
