### PR TITLE
lib: correct formatting for a debug message

### DIFF
--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -627,7 +627,7 @@ void WriteStateFile(const char* dir, const char* progname, int port)
   } catch (const std::system_error& e) {
     BErrNo be;
     Dmsg3(100, "Could not seek filepointer. ERR=%s - %s\n",
-          sizeof(StateFileHeader), be.bstrerror(), e.code().message().c_str());
+          be.bstrerror(), e.code().message().c_str());
     return;
   } catch (const std::exception& e) {
     Dmsg0(100, "Could not seek filepointer. Some error occurred: %s\n",


### PR DESCRIPTION
This fixes a SIGSEGV if for example an permission error is thrown and the debug logging is enabled.

The relevant stack trace:
```
09-Jul-2021 14:35:44.268086 localhost-fd (110): filed/dir_cmd.cc:1922-8 <stored: 09-Jul-2021 14:35:44.268111 localhost-fd (150): filed/fd_plugins.cc:356-8 No bplugin_list: GeneratePluginEvent ignored.
09-Jul-2021 14:35:44.268130 localhost-fd (100): filed/dir_cmd.cc:452-8 Quit command loop. Canceled=1
09-Jul-2021 14:35:44.268236 localhost-fd (110): filed/dir_cmd.cc:482-8 End FD msg: 2800 End Job TermCode=102 JobFiles=0 ReadBytes=0 JobBytes=0 Errors=1 VSS=0 Encrypt=0

09-Jul-2021 14:35:44.268264 localhost-fd (150): filed/fd_plugins.cc:356-8 No bplugin_list: GeneratePluginEvent ignored.
65      ../sysdeps/x86_64/multiarch/strlen-avx2.S: No such file or directory.
09-Jul-2021 14:35:44.284992 
Thread 3 "bareos-fd" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7ffff6426640 (LWP 103381)]
__strlen_avx2 () at ../sysdeps/x86_64/multiarch/strlen-avx2.S:65
(gdb) 
(gdb) 
(gdb) bt full
#1  0x00007ffff7ed6902 in fmtstr (buffer=0x5555555cf7d8 "Could not seek filepointer. ERR=r: filed/dir_cmd.cc:2508 Comm error with SD. bad response to Append Data. ERR=No data available\n", currlen=32, maxlen=1023,                                                     
    value=0xc0 <error: Cannot access memory at address 0xc0>, flags=0, min=0, max=1023) at ./src/lib/bsnprintf.cc:460
        padlen = 100                                                                                                                                                                                                                                                        
        strln = 0
        cnt = 0                                                                                                                                                                                                                                                             
        ch = 0 '\000'                                                                                                                 
#2  0x00007ffff7ed66df in Bvsnprintf (buffer=0x5555555cf7d8 "Could not seek filepointer. ERR=r: filed/dir_cmd.cc:2508 Comm error with SD. bad response to Append Data. ERR=No data available\n", maxlen=1023, format=0x7ffff7f5a0da " - %s\n", args=0x7ffff64254c8)
    at ./src/lib/bsnprintf.cc:368                                                                                                                                                                                                                                           
        ch = 115 's'
        value = 140737324930160                                                                                                                                                                                                                                             
        strvalue = 0xc0 <error: Cannot access memory at address 0xc0>                                                     
        wstrvalue = 0x400f64255e0 <error: Cannot access memory at address 0x400f64255e0>
        min = 0                                                                                                                                                                                                                                                             
        max = -1                                                                                                                                                                                                                                                                    state = 6                                                                                                                                                                                                                                                                   flags = 0                                                                                                                                                                                                                                                           
        cflags = 0                                                                                                                                                                                                                                                          
        currlen = 32
        base = -163425168                                                                                                                                                                                                                                                           fvalue = 6.9533477335624441e-310                                                                                                                                                                                                                                    #3  0x00007ffff7f0107c in d_msg (file=0x7ffff7f59d66 "./src/lib/bsys.cc", line=629, level=100, fmt=0x7ffff7f5a0b8 "Could not seek filepointer. ERR=%s - %s\n") at ./src/lib/message.cc:978
        ap = {{gp_offset = 40, fp_offset = 48, overflow_arg_area = 0x7ffff64255f0, reg_save_area = 0x7ffff6425520}}                                                                                                                                                         
        ed1 = "09-Jul-2021 14:35:44\000\000\000\000h\377\377\377\377\377\377\377\005\222\256\367\377\177\000\000\263\060\356\367\377\177\000\000\r"
        len = 0                                                                                                                                                                                                                                                                     maxlen = 1023                                                                                                                                                                                                                                                       
        mtime = 1625834144284992     
        usecs = 284992
        details = true                                                                                                                                                                                                                                                              more = {mem = 0x5555555cf7d8 "Could not seek filepointer. ERR=r: filed/dir_cmd.cc:2508 Comm error with SD. bad response to Append Data. ERR=No data available\n"}                       
#4  0x00007ffff7ee456b in WriteStateFile (dir=0x5555555c9980 "/usr/local/bareos/var/lib/bareos", progname=0x5555555a1c51 "bareos-fd", port=9102) at ./src/lib/bsys.cc:629
        be = {buf_ = 0x5555555f7c68 "Permission denied", berrno_ = 13}                                                                                                                                                                                                              e = @0x7ffff00014d0: <incomplete type>                                                                                                                                                                                                                              
        filename = "/usr/local/bareos/var/lib/bareos/bareos-fd.9102.state"
        erase_on_scope_exit = {filename = "/usr/local/bareos/var/lib/bareos/bareos-fd.9102.state", cleanup = true}
        exclusive_write_access_mutex = {<std::__mutex_base> = {_M_mutex = {__data = {__lock = 1, __count = 0, __owner = 103381, __nusers = 1, __kind = 0, __spins = 0, __elision = 0, __list = {__prev = 0x0, __next = 0x0}}, 
              __size = "\001\000\000\000\000\000\000\000Փ\001\000\001", '\000' <repeats 26 times>, __align = 1}}, <No data fields>}
        m = {_M_device = @0x7ffff7fa1180}
        file = <incomplete type>
#5  0x0000555555582ecd in filedaemon::FiledFreeJcr (jcr=0x7ffff0014260) at ./src/filed/dir_cmd.cc:2475
```

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
