### PR TITLE
[Early review] Continuous spooling/de-spooling

### DIFF
--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -627,7 +627,7 @@ void WriteStateFile(const char* dir, const char* progname, int port)
   } catch (const std::system_error& e) {
     BErrNo be;
     Dmsg3(100, "Could not seek filepointer. ERR=%s - %s\n",
-          sizeof(StateFileHeader), be.bstrerror(), e.code().message().c_str());
+          be.bstrerror(), e.code().message().c_str());
     return;
   } catch (const std::exception& e) {
     Dmsg0(100, "Could not seek filepointer. Some error occurred: %s\n",

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -55,8 +55,6 @@ DeviceControlRecord::DeviceControlRecord()
   int errstat;
 
   tid = pthread_self();
-  spool_fd_a = -1;
-  spool_fd_b = -1;
   if ((errstat = pthread_mutex_init(&mutex_, NULL)) != 0) {
     BErrNo be;
 
@@ -69,6 +67,18 @@ DeviceControlRecord::DeviceControlRecord()
 
     Mmsg(errmsg, _("Unable to init r_mutex: ERR=%s\n"), be.bstrerror(errstat));
     Jmsg0(NULL, M_ERROR_TERM, 0, errmsg.c_str());
+  }
+
+  // TODO: Make configurable
+  active_spool_files = SPOOL_FILE_COUNT;
+  for (int i = 0; i < active_spool_files; i++) {
+    if ((errstat = pthread_mutex_init(&spool_fd_mutex[i], NULL)) != 0) {
+      BErrNo be;
+
+      Mmsg(errmsg, _("Unable to init spool file mutex %d: ERR=%s\n"),
+          i, be.bstrerror(errstat));
+      Jmsg0(NULL, M_ERROR_TERM, 0, errmsg.c_str());
+    }
   }
 }
 

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -55,7 +55,8 @@ DeviceControlRecord::DeviceControlRecord()
   int errstat;
 
   tid = pthread_self();
-  spool_fd = -1;
+  spool_fd_a = -1;
+  spool_fd_b = -1;
   if ((errstat = pthread_mutex_init(&mutex_, NULL)) != 0) {
     BErrNo be;
 

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -560,7 +560,7 @@ static const bool no_tape_write_test = false;
  * Returns: true  on success or EOT
  *          false on hard error
  */
-bool DeviceControlRecord::WriteBlockToDev()
+bool DeviceControlRecord::WriteBlockToDev(DeviceBlock* block)
 {
   ssize_t status = 0;
   uint32_t wlen; /* length to write */
@@ -851,12 +851,12 @@ bool DeviceControlRecord::WriteBlockToDev()
  *        : false on failure
  *
  */
-bool DeviceControlRecord::WriteBlockToDevice()
+bool DeviceControlRecord::WriteBlockToDevice(DeviceBlock* block, bool bypass_spool)
 {
   bool status = true;
   DeviceControlRecord* dcr = this;
 
-  if (dcr->spooling) {
+  if (dcr->spooling && !bypass_spool) {
     status = WriteBlockToSpoolFile(dcr);
     return status;
   }
@@ -898,7 +898,7 @@ bool DeviceControlRecord::WriteBlockToDevice()
     }
   }
 
-  if (!dcr->WriteBlockToDev()) {
+  if (!dcr->WriteBlockToDev(block)) {
     if (JobCanceled(jcr) || jcr->is_JobType(JT_SYSTEM)) {
       status = false;
     } else {

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -58,6 +58,14 @@ class DeviceResource;
 struct DeviceBlock;
 struct DeviceRecord;
 
+enum spool_file
+{
+  SPOOL_FILE_A,
+  SPOOL_FILE_B,
+  SPOOL_FILE_COUNT,
+  SPOOL_FILE_INVALID = -1,
+};
+
 /* clang-format off */
 
 class DeviceControlRecord {
@@ -79,21 +87,21 @@ class DeviceControlRecord {
   DeviceRecord* before_rec{};      /**< Pointer to record before translation */
   DeviceRecord* after_rec{};       /**< Pointer to record after translation */
   pthread_t tid{};                 /**< Thread running this dcr */
-  bool spool_data{};         /**< Set to spool data */
-  int spool_fd_a{};          /**< Fd part A if spooling */
-  int spool_fd_b{};          /**< Fd part B if spooling */
-  bool spooling{};           /**< Set when actually spooling */
-  bool spooling_a{};         /**< Set when spooling to part A */
-  bool spooling_b{};         /**< Set when spooling to part B */
-  bool despooling{};         /**< Set when despooling */
-  bool despool_wait{};       /**< Waiting for despooling */
-  bool NewVol{};             /**< Set if new Volume mounted */
-  bool WroteVol{};           /**< Set if Volume written */
-  bool NewFile{};            /**< Set when EOF written */
-  bool reserved_volume{};    /**< Set if we reserved a volume */
-  bool any_volume{};         /**< Any OK for dir_find_next... */
-  bool attached_to_dev{};    /**< Set when attached to dev */
-  bool keep_dcr{};           /**< Do not free dcr in release_dcr */
+  bool spool_data{};               /**< Set to spool data */
+  int spool_fd[SPOOL_FILE_COUNT]{};/**< Fd part A/B if spooling */
+  int active_spool_files{};        /**< Set to the configured maximum spool files to use */
+  pthread_mutex_t spool_fd_mutex[SPOOL_FILE_COUNT]{};  /**< Spool FD access control */
+  bool spooling{};                 /**< Set when actually spooling */
+  spool_file current_spool_file{}; /**< Set when spooling to part A */
+  bool despooling{};               /**< Set when despooling */
+  bool despool_wait{};             /**< Waiting for despooling */
+  bool NewVol{};                   /**< Set if new Volume mounted */
+  bool WroteVol{};                 /**< Set if Volume written */
+  bool NewFile{};                  /**< Set when EOF written */
+  bool reserved_volume{};          /**< Set if we reserved a volume */
+  bool any_volume{};               /**< Any OK for dir_find_next... */
+  bool attached_to_dev{};          /**< Set when attached to dev */
+  bool keep_dcr{};                 /**< Do not free dcr in release_dcr */
   AutoXflateMode autodeflate{AutoXflateMode::IO_DIRECTION_NONE};
   AutoXflateMode autoinflate{AutoXflateMode::IO_DIRECTION_NONE};
   uint32_t VolFirstIndex{};        /**< First file index this Volume */

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -113,6 +113,7 @@ class DeviceControlRecord {
   uint32_t EndBlock{};             /**< Ending block written */
   int64_t VolMediaId{};            /**< MediaId */
   int64_t job_spool_size{};        /**< Current job spool size */
+  int64_t job_despool_size{};      /**< Current job despool size */
   int64_t max_job_spool_size{};    /**< Max job spool size */
   uint32_t VolMinBlocksize{};      /**< Minimum Blocksize */
   uint32_t VolMaxBlocksize{};      /**< Maximum Blocksize */
@@ -199,8 +200,10 @@ class DeviceControlRecord {
   bool IsTapePositionOk();
 
   // Methods in block.c
-  bool WriteBlockToDevice();
-  bool WriteBlockToDev();
+  bool WriteBlockToDevice() { return WriteBlockToDevice(block, false); }
+  bool WriteBlockToDevice(DeviceBlock* block, bool bypass_spool);
+  bool WriteBlockToDev() { return WriteBlockToDev(block); }
+  bool WriteBlockToDev(DeviceBlock* block);
 
   enum ReadStatus
   {

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -80,8 +80,11 @@ class DeviceControlRecord {
   DeviceRecord* after_rec{};       /**< Pointer to record after translation */
   pthread_t tid{};                 /**< Thread running this dcr */
   bool spool_data{};         /**< Set to spool data */
-  int spool_fd{};            /**< Fd if spooling */
+  int spool_fd_a{};          /**< Fd part A if spooling */
+  int spool_fd_b{};          /**< Fd part B if spooling */
   bool spooling{};           /**< Set when actually spooling */
+  bool spooling_a{};         /**< Set when spooling to part A */
+  bool spooling_b{};         /**< Set when spooling to part B */
   bool despooling{};         /**< Set when despooling */
   bool despool_wait{};       /**< Waiting for despooling */
   bool NewVol{};             /**< Set if new Volume mounted */


### PR DESCRIPTION
This is a work-in-progress PR to introduce continuous spooling/de-spooling as discussed [here](https://groups.google.com/g/bareos-users/c/OBghFNWtjls).

Right now it (non-configurably) creates 2 spool files and when the first spool file is filled up, it starts a despooling background thread that flushes that file to the device, while spooling to the next file.

**Notes to testers:** You only need to run a custom `bareos-sd` - you can run the other daemons from `master` if you want. 


By setting `active_spool_files = 1` the idea is that the behavior will be exactly the same as current Bareos behavior.

TODO:
- [ ] The message `Writing spooled data to Volume. Despooling x bytes ...` is wrong as it is using the spooling counters, not how much data is available to despool.
- [ ] It seems that `bareos-sd` can potentially ignore the maxium size and sometimes end up spooling too much in the spool file (e.g. 25G when configured to max 15G). Need to debug why and if it causes bad writes. Probably due to concurrent modification of `dcr->job_spool_size`.
- [ ] If despool fails with error, the job hangs (e.g. 	`bareos-sd JobId 428: Fatal error: Fatal despooling error.`). This is due to that the exit of the despool thread is not tracked right now.
- [ ] SIGABRT when stress-testing this a bit, [log here](https://gist.github.com/bluecmd/9ee4f5a3810a4bb5dd32f6cbcde77d34). Related to spooling at the same time as a tape change is happening maybe?

Example job log:
```
2021-07-11 15:20:40 bareos-dir JobId 24: Start Backup JobId 24, Job=backup-bareos-fd.2021-07-11_15.20.38_16
 2021-07-11 15:20:40 bareos-dir JobId 24: Connected Storage daemon at localhost:9103, encryption: TLS_CHACHA20_POLY1305_SHA256 TLSv1.3
 2021-07-11 15:20:40 bareos-dir JobId 24: Recycled current volume "P0028SL4"
 2021-07-11 15:20:40 bareos-dir JobId 24: Using Device "Tape" to write.
 2021-07-11 15:20:40 bareos-dir JobId 24: Connected Client: bareos-fd at localhost:9102, encryption: TLS_CHACHA20_POLY1305_SHA256 TLSv1.3
 2021-07-11 15:20:40 bareos-dir JobId 24:  Handshake: Immediate TLS  2021-07-11 15:20:40 bareos-dir JobId 24:  Encryption: TLS_CHACHA20_POLY1305_SHA256 TLSv1.3
 2021-07-11 15:20:40 localhost-fd JobId 24: Connected Storage daemon at localhost:9103, encryption: TLS_CHACHA20_POLY1305_SHA256 TLSv1.3
 2021-07-11 15:20:40 localhost-fd JobId 24: Extended attribute support is enabled
 2021-07-11 15:20:40 localhost-fd JobId 24: ACL support is enabled
 2021-07-11 15:20:40 bareos-sd JobId 24: Recycled volume "P0028SL4" on device "Tape" (/dev/nst0), all previous data lost.
 2021-07-11 15:20:40 bareos-sd JobId 24: Spooling data ...
 2021-07-11 15:20:53 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,560 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:20:53 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:20:53 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 1,048,588 bytes ...
 2021-07-11 15:21:07 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,492 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:21:07 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:21:07 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,492 bytes ...
 2021-07-11 15:22:00 bareos-sd JobId 24: Despooling elapsed time = 00:01:07, Transfer rate = 80.13 M Bytes/second
 2021-07-11 15:22:13 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,488 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:22:13 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:22:13 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,488 bytes ...
 2021-07-11 15:23:06 bareos-sd JobId 24: Despooling elapsed time = 00:01:05, Transfer rate = 82.59 M Bytes/second
 2021-07-11 15:23:20 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,560 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:23:20 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:23:20 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,560 bytes ...
 2021-07-11 15:24:17 bareos-sd JobId 24: Despooling elapsed time = 00:01:10, Transfer rate = 76.69 M Bytes/second
 2021-07-11 15:24:30 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,560 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:24:30 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:24:30 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,560 bytes ...
 2021-07-11 15:25:23 bareos-sd JobId 24: Despooling elapsed time = 00:01:06, Transfer rate = 81.34 M Bytes/second
 2021-07-11 15:25:37 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,560 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:25:37 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:25:37 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,560 bytes ...
 2021-07-11 15:26:35 bareos-sd JobId 24: Despooling elapsed time = 00:01:12, Transfer rate = 74.56 M Bytes/second
 2021-07-11 15:26:48 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,550 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:26:48 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:26:48 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,550 bytes ...
 2021-07-11 15:27:46 bareos-sd JobId 24: Despooling elapsed time = 00:01:11, Transfer rate = 75.61 M Bytes/second
 2021-07-11 15:27:59 bareos-sd JobId 24: User specified Device spool size reached: DevSpoolSize=5,368,770,488 MaxDevSpoolSize=5,368,709,120
 2021-07-11 15:27:59 bareos-sd JobId 24: Doing background despooling...
 2021-07-11 15:27:59 bareos-sd JobId 24: Writing spooled data to Volume. Despooling 5,368,770,488 bytes ...
 2021-07-11 15:28:52 bareos-sd JobId 24: Despooling elapsed time = 00:01:06, Transfer rate = 81.34 M Bytes/second
 2021-07-11 15:28:53 bareos-sd JobId 24: Committing spooled data to Volume "P0028SL4". Despooling 17,729,090 bytes ...
 2021-07-11 15:29:58 bareos-sd JobId 24: Despooling elapsed time = 00:01:06, Transfer rate = 268.6 K Bytes/second
 2021-07-11 15:29:59 bareos-sd JobId 24: Despooling elapsed time = 00:00:01, Transfer rate = 0  Bytes/second
 2021-07-11 15:29:59 bareos-sd JobId 24: Releasing device "Tape" (/dev/nst0).
 2021-07-11 15:30:05 bareos-sd JobId 24: Elapsed time=00:09:25, Transfer rate=76.01 M Bytes/second
 2021-07-11 15:30:05 bareos-sd JobId 24: Sending spooled attrs to the Director. Despooling 1,674 bytes ...
 2021-07-11 15:30:05 bareos-dir JobId 24: Insert of attributes batch table with 6 entries start
 2021-07-11 15:30:05 bareos-dir JobId 24: Insert of attributes batch table done
 2021-07-11 15:30:05 bareos-dir JobId 24: Bareos bareos-dir 21.0.0~pre653.570d9cb10 (06Jul21):
  Build OS:               Ubuntu 21.04
  JobId:                  24
  Job:                    backup-bareos-fd.2021-07-11_15.20.38_16
  Backup Level:           Full
  Client:                 "bareos-fd" 21.0.0~pre653.570d9cb10 (06Jul21) Ubuntu 21.04,ubuntu
  FileSet:                "Dummy" 2021-07-09 13:43:28
  Pool:                   "Tapes" (From Job resource)
  Catalog:                "MyCatalog" (From Client resource)
  Storage:                "Tape" (From Job resource)
  Scheduled time:         11-Jul-2021 15:20:37
  Start time:             11-Jul-2021 15:20:40
  End time:               11-Jul-2021 15:30:05
  Elapsed time:           9 mins 25 secs
  Priority:               10
  FD Files Written:       6
  SD Files Written:       6
  FD Bytes Written:       42,949,672,960 (42.94 GB)
  SD Bytes Written:       42,949,673,644 (42.94 GB)
  Rate:                   76017.1 KB/s
  Software Compression:   None
  VSS:                    no
  Encryption:             no
  Accurate:               no
  Volume name(s):         P0028SL4
  Volume Session Id:      1
  Volume Session Time:    1626009633
  Last Volume Bytes:      42,959,078,400 (42.95 GB)
  Non-fatal FD errors:    0
  SD Errors:              0
  FD termination status:  OK
  SD termination status:  OK
  Bareos binary info:     self-compiled: Get official binaries and vendor support on bareos.com
  Job triggered by:       User
  Termination:            Backup OK
```

I have tested by running a backup job that requires 5-6 passes of spool file swapping followed by a restore job and manual `sha256sum` checking of the backup files to ensure data was written correctly.

I am opening the PR for early feedback and visibility.

Example device configuration for `bareos-sd`:
```
Device {
 Name = Tape
 Media Type = LTO-4
 Archive Device = /dev/nst0
 Automatic Mount = yes
 Always Open = yes
 Removable Media = yes
 Random Access = no
 Auto Changer = no
 Drive Crypto Enabled = yes
 Spool Directory = "/tmp"
 Maximum Spool Size = 5G
 Maximum File Size = 20G
}
```

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)
### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
