### PR TITLE
webui: quote strings with slashes in dashboards index view

### DIFF
--- a/webui/module/Dashboard/view/dashboard/dashboard/index.phtml
+++ b/webui/module/Dashboard/view/dashboard/dashboard/index.phtml
@@ -264,7 +264,7 @@ $this->headTitle($title);
             }
             else {
                $('.running-jobs-container').empty();
-               $('.running-jobs-container').append('<?php echo $this->translate('There are no jobs running.'); ?>');
+               $('.running-jobs-container').append('<?php echo addslashes($this->translate('There are no jobs running.')); ?>');
             }
          },
          error: function() {


### PR DESCRIPTION
Strings comming from "translate" function can contain apostrophes that need to be escaped.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
