### PR TITLE
webui: handle filenames containing backslashes properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1300]: some job status are not categorized properly [PR #874]
 - [Issue #871]: UI will not load complete [PR #880]
 - [Issue #1020]: Can not restore a client with spaces in its name [PR #893]
+- [Issue #971]: Error building tree for filenames with backslashes [PR #892]
 
 ### Added
 - Add systemtests fileset-multiple-include-blocks, fileset-multiple-options-blocks, quota-softquota, sparse-file, truncate-command and block-size, (migrated from ``regress/``) [PR #780]
@@ -107,6 +108,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 [Issue #579]: https://bugs.bareos.org/view.php?id=579
 [Issue #871]: https://bugs.bareos.org/view.php?id=871
+[Issue #971]: https://bugs.bareos.org/view.php?id=971
 [Issue #1020]: https://bugs.bareos.org/view.php?id=1020
 [Issue #1205]: https://bugs.bareos.org/view.php?id=1205
 [Issue #1300]: https://bugs.bareos.org/view.php?id=1300
@@ -171,5 +173,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #869]: https://github.com/bareos/bareos/pull/869
 [PR #874]: https://github.com/bareos/bareos/pull/874
 [PR #880]: https://github.com/bareos/bareos/pull/880
+[PR #892]: https://github.com/bareos/bareos/pull/892
 [PR #893]: https://github.com/bareos/bareos/pull/893
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2020 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -541,6 +541,15 @@ class RestoreController extends AbstractActionController
     }
   }
 
+  private function escapeNameString($n=null)
+  {
+    $n = preg_replace('/[\x00-\x1F\x7F]/', '', $n);
+    $replace_pairs = array('"' => '\"', '\\' => '\\\\');
+    $n = strtr($n, $replace_pairs);
+
+    return $n;
+  }
+
   /**
    * Builds a subtree as Json for JStree
    */
@@ -588,7 +597,7 @@ class RestoreController extends AbstractActionController
           --$dnum;
           $items .= '{';
           $items .= '"id":"-' . $dir['pathid'] . '"';
-          $items .= ',"text":"' . preg_replace('/[\x00-\x1F\x7F]/', '', str_replace('"', '\"', $dir["name"])) . '"';
+          $items .= ',"text":"' . $this->escapeNameString($dir["name"]) . '"';
           $items .= ',"icon":"glyphicon glyphicon-folder-close"';
           $items .= ',"state":""';
           $items .= ',"data":' . \Zend\Json\Json::encode($dir, \Zend\Json\Json::TYPE_OBJECT);
@@ -608,7 +617,7 @@ class RestoreController extends AbstractActionController
       foreach($this->files as $file) {
         $items .= '{';
         $items .= '"id":"' . $file["fileid"] . '"';
-        $items .= ',"text":"' . preg_replace('/[\x00-\x1F\x7F]/', '', str_replace('"', '\"', $file["name"])) . '"';
+        $items .= ',"text":"' . $this->escapeNameString($file["name"]) . '"';
         $items .= ',"icon":"glyphicon glyphicon-file"';
         $items .= ',"state":""';
         $items .= ',"data":' . \Zend\Json\Json::encode($file, \Zend\Json\Json::TYPE_OBJECT);


### PR DESCRIPTION
Fixes #971: Error building tree for filenames with backslashes

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
