### PR TITLE
core: improve mtx-changer debug output

### DIFF
--- a/core/scripts/mtx-changer.in
+++ b/core/scripts/mtx-changer.in
@@ -123,10 +123,13 @@ make_err_file() {
 wait_for_drive() {
   i=0
   while [ $i -le 300 ]; do  # Wait max 300 seconds
-    if mt -f $1 status 2>&1 | grep "${ready}" >/dev/null 2>&1; then
+    debug "Doing mt -f $1 status ..."
+    drivestatus=$(mt -f "$1" status 2>&1)
+    if echo "${drivestatus}" | grep "${ready}" >/dev/null 2>&1; then
       break
     fi
-    debug "Device $1 - not ready, retrying..."
+    debug "${drivestatus}"
+    debug "Device $1 - not ready, retrying ..."
     sleep 1
     i=`expr $i + 1`
   done


### PR DESCRIPTION
Log the drive status in wait_for_drive().

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
