### PR TITLE
webui: fix pool module router constraints

### DIFF
--- a/webui/module/Pool/config/module.config.php
+++ b/webui/module/Pool/config/module.config.php
@@ -43,7 +43,7 @@ return array(
           'route' => '/pool[/][:action][/][:id]',
           'constraints' => array(
             'action' => '[a-zA-Z][a-zA-Z0-9_-]*',
-            'id' => '[a-zA-Z][a-zA-Z0-9_-]*',
+            'id' => '[a-zA-Z0-9][a-zA-Z0-9\._-]*',
           ),
           'defaults' => array(
             'controller' => 'Pool\Controller\Pool',


### PR DESCRIPTION
Fixes #1251: Error when displaying pool detail

(cherry picked from commit 02ccca6ededd6c2fb4f7c123bbbf82209040ec9c)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted