### PR TITLE
fix system:bareos test on btrfs filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - added multicolumn prompt selection for selection of more than 20 items [PR #731]
 - add script devtools/dist-tarball.sh to produce the same tarball from a cloned repo everywhere [PR #861]
 - packages: Build also for openSUSE Leap 15.3 [PR #870]
+- systemtest:bareos test now also runs on btrfs filesystem [PR #907]
 
 ### Changed
 - core: systemd service: change daemon type from forking to simple and start daemons in foreground [PR #824]

--- a/systemtests/tests/bareos/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bareos/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -12,6 +12,7 @@ FileSet {
       fstype = ufs
       fstype = xfs
       fstype = zfs
+      fstype = btrfs
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list


### PR DESCRIPTION
#### Description
When compiling on a system that somehow uses `btrfs`, the `systemtest:bareos` fails to backup with the error found in `tmp/log1.out` that says `Top level directory "..../bareos/systemtests/tests/bareos/tmp/data" has unlisted fstype "btrfs"`
This can happen for example on a fresh default install of Fedora 34.

Adding `fstype = btrfs` to the `fileset` config file resolves this issue.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

