### PR TITLE
webui: typo fix in RestoreController.php

### DIFF
--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -837,7 +837,7 @@ class RestoreController extends AbstractActionController
   {
     if(!$this->clientModel) {
       $sm = $this->getServiceLocator();
-      $this->clientModel = $sm->get('CLient\Model\ClientModel');
+      $this->clientModel = $sm->get('Client\Model\ClientModel');
     }
     return $this->clientModel;
   }


### PR DESCRIPTION
Small case-typo-fix in RestoreController.php

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [ ] ~Variable and function names are meaningful~
- [ ] ~Code comments are correct (logically and spelling)~
- [ ] ~Required documentation changes are present and part of the PR~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
