### PR TITLE
missing job name in `End Job Session` in non-verbose output of bls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - systemtest:bareos test now also runs on btrfs filesystem [PR #907]
 - packages: Build also for Fedora_34 [PR #869]
 - packages: Build also for Debian_11 [PR #914]
+- add job name in End Job Session output in bls tool [PR #916]
 
 ### Changed
 - core: systemd service: change daemon type from forking to simple and start daemons in foreground [PR #824]

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -1038,13 +1038,14 @@ void DumpLabelRecord(Device* dev, DeviceRecord* rec, bool verbose)
               _("%s Record: File:blk=%u:%u SessId=%d SessTime=%d JobId=%d\n"),
               type, dev->file, dev->block_num, rec->VolSessionId,
               rec->VolSessionTime, label.JobId);
-        Pmsg7(-1,
-              _("   Date=%s Level=%c Type=%c Files=%s Bytes=%s Errors=%d "
-                "Status=%c\n"),
-              dt, label.JobLevel, label.JobType,
-              edit_uint64_with_commas(label.JobFiles, ed1),
-              edit_uint64_with_commas(label.JobBytes, ed2), label.JobErrors,
-              (char)label.JobStatus);
+        Pmsg7(
+            -1,
+            _("   Job=%s Date=%s Level=%c Type=%c Files=%s Bytes=%s Errors=%d "
+              "Status=%c\n"),
+            label.Job, dt, label.JobLevel, label.JobType,
+            edit_uint64_with_commas(label.JobFiles, ed1),
+            edit_uint64_with_commas(label.JobBytes, ed2), label.JobErrors,
+            (char)label.JobStatus);
         break;
       case EOM_LABEL:
       case PRE_LABEL:


### PR DESCRIPTION
#### Description:

Added the job name to the `End Job Session` output in the `bls` tool when in non-verbose mode.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
