### PR TITLE
scripts: Fix logrotate by adding su instruction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1369]: webui tries to load a nonexistent file [PR #900]
 - fix lost byte in ChunkedDevice [PR #910]
 - fix director crash on "update slots" when there is a parsing issue with the autochanger or tape devices [PR #919]
+- [Issue #1232]: bareos logrotate errors, reintroduce su directive in logrotate [PR #918]
 
 ### Added
 - Add systemtests fileset-multiple-include-blocks, fileset-multiple-options-blocks, quota-softquota, sparse-file, truncate-command and block-size, (migrated from ``regress/``) [PR #780]
@@ -119,6 +120,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [Issue #1020]: https://bugs.bareos.org/view.php?id=1020
 [Issue #1194]: https://bugs.bareos.org/view.php?id=1194
 [Issue #1205]: https://bugs.bareos.org/view.php?id=1205
+[Issue #1232]: https://bugs.bareos.org/view.php?id=1232
 [Issue #1251]: https://bugs.bareos.org/view.php?id=1251
 [Issue #1300]: https://bugs.bareos.org/view.php?id=1300
 [Issue #1316]: https://bugs.bareos.org/view.php?id=1316
@@ -181,11 +183,16 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #861]: https://github.com/bareos/bareos/pull/861
 [PR #868]: https://github.com/bareos/bareos/pull/868
 [PR #869]: https://github.com/bareos/bareos/pull/869
+[PR #870]: https://github.com/bareos/bareos/pull/870
 [PR #874]: https://github.com/bareos/bareos/pull/874
 [PR #880]: https://github.com/bareos/bareos/pull/880
 [PR #892]: https://github.com/bareos/bareos/pull/892
 [PR #893]: https://github.com/bareos/bareos/pull/893
 [PR #900]: https://github.com/bareos/bareos/pull/900
 [PR #903]: https://github.com/bareos/bareos/pull/903
+[PR #907]: https://github.com/bareos/bareos/pull/907
 [PR #910]: https://github.com/bareos/bareos/pull/910
+[PR #914]: https://github.com/bareos/bareos/pull/914
+[PR #918]: https://github.com/bareos/bareos/pull/918
+[PR #919]: https://github.com/bareos/bareos/pull/919
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/logrotate.in
+++ b/core/scripts/logrotate.in
@@ -11,5 +11,5 @@
     rotate 6
     notifempty
     missingok
-    @logrotate_su@
+    su @dir_user@ @dir_group@
 }


### PR DESCRIPTION
Fixes #1232 : bareos logrotate errors

Adding back su directive with correct dir user and group (variables from cmake call) 

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>


- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

This PR should superseed PR#917


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [ ] ~Variable and function names are meaningful~
- [ ] ~Code comments are correct (logically and spelling)~
- [ ] ~Required documentation changes are present and part of the PR~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing