### PR TITLE
`update slots` command crashes director when device or autochanger disappears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1251]: Error when displaying pool detail [PR #903]
 - [Issue #1369]: webui tries to load a nonexistent file [PR #900]
 - fix lost byte in ChunkedDevice [PR #910]
+- fix director crash on "update slots" when there is a parsing issue with the autochanger or tape devices [PR #919]
 
 ### Added
 - Add systemtests fileset-multiple-include-blocks, fileset-multiple-options-blocks, quota-softquota, sparse-file, truncate-command and block-size, (migrated from ``regress/``) [PR #780]

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -348,16 +348,15 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
       field5 = nullptr;
     }
 
+    vl = (vol_list_t*)malloc(sizeof(vol_list_t));
+    {
+      *vl = vol_list_t{};
+    }
     /*
      * See if this is a parsable string from either list or listall
      * e.g. at least f1:f2
      */
     if (!field1 || !field2) { goto parse_error; }
-
-    vl = (vol_list_t*)malloc(sizeof(vol_list_t));
-    {
-      *vl = vol_list_t{};
-    }
 
     if (scan && !listall) {
       // Scanning -- require only valid slot


### PR DESCRIPTION
#### Description

When there is an issue communicating with an autochanger or tape device, the director could crash when executing an `update slots` command in bconsole. This PR fixes the issue.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
