### PR TITLE
Adapt Python DIR and SD plugin Baseclasses to the modernized Python plugin API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix scheduler running disabled jobs after executing the disable command [PR #924]
 - [Issue #1334]: After deleting storage from the configuration, it still persists in the catalog db [PR #912]
 - [Issue #1191]: The web interface runs under any login and password [PR #936]
+- Adapt Python DIR and SD plugin Baseclasses to the modernized Python plugin API [PR #923]
 
 ### Added
 - systemtests: allows multiple subtests per systemtest [PR #857]

--- a/core/src/plugins/dird/python/module/bareosdir.h
+++ b/core/src/plugins/dird/python/module/bareosdir.h
@@ -86,7 +86,7 @@ static bRC PyHandlePluginEvent(PluginContext* plugin_ctx,
 using namespace directordaemon;
 
 /* variables storing bareos pointers */
-thread_local PluginContext* plugin_context = NULL;
+PluginContext* plugin_context = NULL;
 
 MOD_INIT(bareosdir)
 {

--- a/core/src/plugins/dird/python/pyfiles/BareosDirPluginBaseclass.py
+++ b/core/src/plugins/dird/python/pyfiles/BareosDirPluginBaseclass.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -25,7 +25,6 @@
 # Functions taken and adapted from bareos-dir.py
 
 import bareosdir
-from bareos_dir_consts import bDirEventType, brDirVariable, bRCs
 import time
 
 
@@ -37,20 +36,20 @@ class BareosDirPluginBaseclass(object):
         bareosdir.DebugMessage(100, "Constructor called in module %s\n" % (__name__))
         events = []
 
-        events.append(bDirEventType["bDirEventJobStart"])
-        events.append(bDirEventType["bDirEventJobEnd"])
-        events.append(bDirEventType["bDirEventJobInit"])
-        events.append(bDirEventType["bDirEventJobRun"])
+        events.append(bareosdir.bDirEventJobStart)
+        events.append(bareosdir.bDirEventJobEnd)
+        events.append(bareosdir.bDirEventJobInit)
+        events.append(bareosdir.bDirEventJobRun)
         bareosdir.RegisterEvents(events)
 
         # get some static Bareos values
-        self.jobName = bareosdir.GetValue(brDirVariable["bDirVarJobName"])
-        self.jobLevel = chr(bareosdir.GetValue(brDirVariable["bDirVarLevel"]))
-        self.jobType = bareosdir.GetValue(brDirVariable["bDirVarType"])
-        self.jobId = int(bareosdir.GetValue(brDirVariable["bDirVarJobId"]))
-        self.jobClient = bareosdir.GetValue(brDirVariable["bDirVarClient"])
-        self.jobStatus = bareosdir.GetValue(brDirVariable["bDirVarJobStatus"])
-        self.Priority = bareosdir.GetValue(brDirVariable["bDirVarPriority"])
+        self.jobName = bareosdir.GetValue(bareosdir.bDirVarJobName)
+        self.jobLevel = chr(bareosdir.GetValue(bareosdir.bDirVarLevel))
+        self.jobType = bareosdir.GetValue(bareosdir.bDirVarType)
+        self.jobId = int(bareosdir.GetValue(bareosdir.bDirVarJobId))
+        self.jobClient = bareosdir.GetValue(bareosdir.bDirVarClient)
+        self.jobStatus = bareosdir.GetValue(bareosdir.bDirVarJobStatus)
+        self.Priority = bareosdir.GetValue(bareosdir.bDirVarPriority)
 
         bareosdir.DebugMessage(
             100,
@@ -68,7 +67,7 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
         )
 
     def __str__(self):
-        return "<$%:jobName=%s jobId=%s client=%s>" % (
+        return "<$%s:jobName=%s jobId=%s client=%s>" % (
             self.__class__,
             self.jobName,
             self.jobId,
@@ -79,7 +78,7 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
         """
         Called with the plugin options from the bareos configfiles
         You should overload this method with your own and do option checking
-        here, return bRCs['bRC_Error'], if options are not ok
+        here, return bareosdir.bRC_Error, if options are not ok
         or better call super.parse_plugin_definition in your own class and
         make sanity check on self.options afterwards
         """
@@ -94,7 +93,7 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
                 continue
             else:
                 self.options[key] = val
-        return bRCs["bRC_OK"]
+        return bareosdir.bRC_OK
 
     def handle_plugin_event(self, event):
         """
@@ -103,25 +102,25 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
         You may first call this method in your derived class to get the
         job attributes read and then only adjust where useful.
         """
-        if event == bDirEventType["bDirEventJobInit"]:
+        if event == bareosdir.bDirEventJobInit:
             self.jobInitTime = time.time()
-            self.jobStatus = chr(bareosdir.GetValue(brDirVariable["bDirVarJobStatus"]))
+            self.jobStatus = chr(bareosdir.GetValue(bareosdir.bDirVarJobStatus))
             bareosdir.DebugMessage(
                 100,
                 "bDirEventJobInit event triggered at Unix time %s\n"
                 % (self.jobInitTime),
             )
 
-        elif event == bDirEventType["bDirEventJobStart"]:
+        elif event == bareosdir.bDirEventJobStart:
             self.jobStartTime = time.time()
-            self.jobStatus = chr(bareosdir.GetValue(brDirVariable["bDirVarJobStatus"]))
+            self.jobStatus = chr(bareosdir.GetValue(bareosdir.bDirVarJobStatus))
             bareosdir.DebugMessage(
                 100,
                 "bDirEventJobStart event triggered at Unix time %s\n"
                 % (self.jobStartTime),
             )
 
-        elif event == bDirEventType["bDirEventJobRun"]:
+        elif event == bareosdir.bDirEventJobRun:
             # Now the jobs starts running, after eventually waiting some time,
             # e.g for other jobs to finish
             self.jobRunTime = time.time()
@@ -130,21 +129,21 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
                 "bDirEventJobRun event triggered at Unix time %s\n" % (self.jobRunTime),
             )
 
-        elif event == bDirEventType["bDirEventJobEnd"]:
+        elif event == bareosdir.bDirEventJobEnd:
             self.jobEndTime = time.time()
             bareosdir.DebugMessage(
                 100,
                 "bDirEventJobEnd event triggered at Unix time %s\n" % (self.jobEndTime),
             )
-            self.jobLevel = chr(bareosdir.GetValue(brDirVariable["bDirVarLevel"]))
-            self.jobStatus = chr(bareosdir.GetValue(brDirVariable["bDirVarJobStatus"]))
-            self.jobErrors = int(bareosdir.GetValue(brDirVariable["bDirVarJobErrors"]))
-            self.jobBytes = int(bareosdir.GetValue(brDirVariable["bDirVarJobBytes"]))
-            self.jobFiles = int(bareosdir.GetValue(brDirVariable["bDirVarJobFiles"]))
-            self.jobNumVols = int(bareosdir.GetValue(brDirVariable["bDirVarNumVols"]))
-            self.jobPool = bareosdir.GetValue(brDirVariable["bDirVarPool"])
-            self.jobStorage = bareosdir.GetValue(brDirVariable["bDirVarStorage"])
-            self.jobMediaType = bareosdir.GetValue(brDirVariable["bDirVarMediaType"])
+            self.jobLevel = chr(bareosdir.GetValue(bareosdir.bDirVarLevel))
+            self.jobStatus = chr(bareosdir.GetValue(bareosdir.bDirVarJobStatus))
+            self.jobErrors = int(bareosdir.GetValue(bareosdir.bDirVarJobErrors))
+            self.jobBytes = int(bareosdir.GetValue(bareosdir.bDirVarJobBytes))
+            self.jobFiles = int(bareosdir.GetValue(bareosdir.bDirVarJobFiles))
+            self.jobNumVols = int(bareosdir.GetValue(bareosdir.bDirVarNumVols))
+            self.jobPool = bareosdir.GetValue(bareosdir.bDirVarPool)
+            self.jobStorage = bareosdir.GetValue(bareosdir.bDirVarStorage)
+            self.jobMediaType = bareosdir.GetValue(bareosdir.bDirVarMediaType)
 
             self.jobTotalTime = self.jobEndTime - self.jobInitTime
             self.jobRunningTime = self.jobEndTime - self.jobRunTime
@@ -152,7 +151,7 @@ Client = %s - jobStatus = %s - Priority = %s - BareosDirPluginBaseclass\n"
             if self.jobRunningTime > 0:
                 self.throughput = self.jobBytes / self.jobRunningTime
 
-        return bRCs["bRC_OK"]
+        return bareosdir.bRC_OK
 
 
 # vim: ts=4 tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/core/src/plugins/dird/python/pyfiles/bareos-dir-class-plugin.py
+++ b/core/src/plugins/dird/python/pyfiles/bareos-dir-class-plugin.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -23,7 +23,7 @@
 #
 
 # Provided by the Bareos Dir Python plugin interface
-import bareos_dir_consts
+import bareosdir
 
 # This module contains the wrapper functions called by the Bareos-Dir, the
 # functions call the corresponding methods from your plugin class
@@ -44,7 +44,7 @@ def load_bareos_plugin(plugindef):
     BareosDirWrapper.bareos_dir_plugin_object = (
         BareosDirPluginBaseclass.BareosDirPluginBaseclass(plugindef)
     )
-    return bareos_dir_consts.bRCs["bRC_OK"]
+    return bareosdir.bRC_OK
 
 
 # the rest is done in the Plugin module

--- a/core/src/plugins/stored/python/pyfiles/BareosSdPluginBaseclass.py
+++ b/core/src/plugins/stored/python/pyfiles/BareosSdPluginBaseclass.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -25,7 +25,6 @@
 # Functions taken and adapted from bareos-sd.py
 
 import bareossd
-from bareossd import bsdEventType, bsdrVariable, bRCs
 import time
 
 
@@ -37,14 +36,14 @@ class BareosSdPluginBaseclass(object):
         bareossd.DebugMessage(100, "Constructor called in module %s\n" % (__name__))
         events = []
 
-        events.append(bsdEventType["bsdEventJobStart"])
-        events.append(bsdEventType["bsdEventJobEnd"])
+        events.append(bareossd.bsdEventJobStart)
+        events.append(bareossd.bsdEventJobEnd)
         bareossd.RegisterEvents(events)
 
         # get some static Bareos values
-        self.jobName = bareossd.GetValue(bsdrVariable["bsdVarJobName"])
-        self.jobLevel = chr(bareossd.GetValue(bsdrVariable["bsdVarLevel"]))
-        self.jobId = int(bareossd.GetValue(bsdrVariable["bsdVarJobId"]))
+        self.jobName = bareossd.GetValue(bareossd.bsdVarJobName)
+        self.jobLevel = chr(bareossd.GetValue(bareossd.bsdVarLevel))
+        self.jobId = int(bareossd.GetValue(bareossd.bsdVarJobId))
 
         bareossd.DebugMessage(
             100,
@@ -53,7 +52,7 @@ class BareosSdPluginBaseclass(object):
         )
 
     def __str__(self):
-        return "<$%:jobName=%s jobId=%s Level=%s>" % (
+        return "<$%s:jobName=%s jobId=%s Level=%s>" % (
             self.__class__,
             self.jobName,
             self.jobId,
@@ -79,7 +78,7 @@ class BareosSdPluginBaseclass(object):
                 continue
             else:
                 self.options[key] = val
-        return bRCs["bRC_OK"]
+        return bareossd.bRC_OK
 
     def handle_plugin_event(self, event):
         """
@@ -88,7 +87,7 @@ class BareosSdPluginBaseclass(object):
         You may first call this method in your derived class to get the
         job attributes read and then only adjust where useful.
         """
-        if event == bsdEventType["bsdEventJobStart"]:
+        if event == bareossd.bsdEventJobStart:
             self.jobStartTime = time.time()
             bareossd.DebugMessage(
                 100,
@@ -96,14 +95,14 @@ class BareosSdPluginBaseclass(object):
                 % (self.jobStartTime),
             )
 
-        elif event == bsdEventType["bsdEventJobEnd"]:
+        elif event == bareossd.bsdEventJobEnd:
             self.jobEndTime = time.time()
             bareossd.DebugMessage(
                 100,
                 "bsdEventJobEnd event triggered at Unix time %s\n" % (self.jobEndTime),
             )
-            self.jobBytes = int(bareossd.GetValue(bsdrVariable["bsdVarJobBytes"]))
-            self.jobFiles = int(bareossd.GetValue(bsdrVariable["bsdVarJobFiles"]))
+            self.jobBytes = int(bareossd.GetValue(bareossd.bsdVarJobBytes))
+            self.jobFiles = int(bareossd.GetValue(bareossd.bsdVarJobFiles))
             self.jobRunningTime = self.jobEndTime - self.jobStartTime
             self.throughput = 0
             if self.jobRunningTime > 0:
@@ -114,7 +113,7 @@ class BareosSdPluginBaseclass(object):
                     % (self.jobRunningTime, self.throughput),
                 )
 
-        return bRCs["bRC_OK"]
+        return bareossd.bRC_OK
 
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/core/src/plugins/stored/python/pyfiles/bareos-sd-class-plugin.py
+++ b/core/src/plugins/stored/python/pyfiles/bareos-sd-class-plugin.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -26,7 +26,7 @@
 #
 
 # Provided by the Bareos SD Python plugin interface
-import bareos_sd_consts
+import bareossd
 
 # This module contains the wrapper functions called by the Bareos-SD, the
 # functions call the corresponding methods from your plugin class
@@ -47,7 +47,7 @@ def load_bareos_plugin(plugindef):
     BareosSdWrapper.bareos_sd_plugin_object = (
         BareosSdPluginBaseclass.BareosSdPluginBaseclass(plugindef)
     )
-    return bareos_sd_consts.bRCs["bRC_OK"]
+    return bareossd.bRC_OK
 
 
 # the rest is done in the Plugin module

--- a/systemtests/tests/py2plug-dir/python-modules/BareosDirTest.py
+++ b/systemtests/tests/py2plug-dir/python-modules/BareosDirTest.py
@@ -1,0 +1,75 @@
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+# Author: Tobias Plum
+#
+import bareosdir
+import BareosDirPluginBaseclass
+
+from sys import version_info
+
+
+class BareosDirTest(BareosDirPluginBaseclass.BareosDirPluginBaseclass):
+    def __init__(self, plugindef):
+        bareosdir.DebugMessage(
+            100,
+            "Constructor called in module %s with plugindef=%s\n"
+            % (__name__, plugindef),
+        )
+        bareosdir.DebugMessage(
+            100,
+            "Python Version: %s.%s.%s\n"
+            % (version_info.major, version_info.minor, version_info.micro),
+        )
+        super(BareosDirTest, self).__init__(plugindef)
+
+        self.outputfile = None
+
+    def parse_plugin_definition(self, plugindef):
+        super(BareosDirTest, self).parse_plugin_definition(plugindef)
+        if "output" in self.options:
+            self.outputfile = self.options["output"]
+        else:
+            self.outputfile = "/tmp/bareos-dir-test-plugin.log"
+
+        return bareosdir.bRC_OK
+
+    def handle_plugin_event(self, event):
+        super(BareosDirTest, self).handle_plugin_event(event)
+        if event == bareosdir.bDirEventJobStart:
+            self.toFile("bDirEventJobStart\n")
+
+        elif event == bareosdir.bDirEventJobEnd:
+            self.toFile("bDirEventJobEnd\n")
+
+        elif event == bareosdir.bDirEventJobInit:
+            self.toFile("bDirEventJobInit\n")
+
+        elif event == bareosdir.bDirEventJobRun:
+            self.toFile("bDirEventJobRun\n")
+
+        return bareosdir.bRC_OK
+
+    def toFile(self, text):
+        doc = open(self.outputfile, "a")
+        doc.write(text)
+        doc.close()
+
+
+# vim: ts=4 tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/systemtests/tests/py2plug-dir/python-modules/bareos-dir-test.py
+++ b/systemtests/tests/py2plug-dir/python-modules/bareos-dir-test.py
@@ -1,6 +1,6 @@
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -19,59 +19,18 @@
 #
 # Author: Tobias Plum
 #
-from bareosdir import *
+import bareosdir
+import BareosDirWrapper
+from BareosDirWrapper import *  # noqa
+import BareosDirTest
 
 
 def load_bareos_plugin(plugindef):
-    events = []
-    events.append(bDirEventJobStart)
-    events.append(bDirEventJobEnd)
-    events.append(bDirEventJobInit)
-    events.append(bDirEventJobRun)
-    RegisterEvents(events)
-    return bRC_OK
-
-
-def parse_plugin_definition(plugindef):
-    plugin_options = plugindef.split(":")
-    for current_option in plugin_options:
-        key, sep, val = current_option.partition("=")
-        if val == "":
-            continue
-        elif key == "output":
-            global outputfile
-            outputfile = val
-            continue
-        elif key == "instance":
-            continue
-        elif key == "module_path":
-            continue
-        elif key == "module_name":
-            continue
-        else:
-            return bRC_Error
-        toFile(outputfile)
-
-    return bRC_OK
-
-
-def handle_plugin_event(event):
-    if event == bDirEventJobStart:
-        toFile("bDirEventJobStart\n")
-
-    elif event == bDirEventJobEnd:
-        toFile("bDirEventJobEnd\n")
-
-    elif event == bDirEventJobInit:
-        toFile("bDirEventJobInit\n")
-
-    elif event == bDirEventJobRun:
-        toFile("bDirEventJobRun\n")
-
-    return bRC_OK
-
-
-def toFile(text):
-    doc = open(outputfile, "a")
-    doc.write(text)
-    doc.close()
+    """
+    This function is called by the Bareos-Dir to load the plugin
+    We use it to instantiate the plugin class
+    """
+    # BareosDirWrapper.bareos_dir_plugin_object is the module attribute that
+    # holds the plugin class object
+    BareosDirWrapper.bareos_dir_plugin_object = BareosDirTest.BareosDirTest(plugindef)
+    return bareosdir.bRC_OK

--- a/systemtests/tests/py2plug-dir/testrunner
+++ b/systemtests/tests/py2plug-dir/testrunner
@@ -39,7 +39,7 @@ cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=100 storage=File
+setdebug level=200 dir
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director

--- a/systemtests/tests/py2plug-sd/python-modules/BareosSdTest.py
+++ b/systemtests/tests/py2plug-sd/python-modules/BareosSdTest.py
@@ -1,0 +1,113 @@
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+# Author: Tobias Plum
+#
+import bareossd
+import BareosSdPluginBaseclass
+
+from sys import version_info
+
+
+class BareosSdTest(BareosSdPluginBaseclass.BareosSdPluginBaseclass):
+    def __init__(self, plugindef):
+        bareossd.DebugMessage(
+            100,
+            "Constructor called in module %s with plugindef=%s\n"
+            % (__name__, plugindef),
+        )
+        bareossd.DebugMessage(
+            100,
+            "Python Version: %s.%s.%s\n"
+            % (version_info.major, version_info.minor, version_info.micro),
+        )
+        super(BareosSdTest, self).__init__(plugindef)
+
+        self.outputfile = None
+
+        events = []
+        events.append(bareossd.bsdEventJobStart)
+        events.append(bareossd.bsdEventDeviceReserve)
+        events.append(bareossd.bsdEventVolumeUnload)
+        events.append(bareossd.bsdEventVolumeLoad)
+        events.append(bareossd.bsdEventDeviceOpen)
+        events.append(bareossd.bsdEventDeviceMount)
+        events.append(bareossd.bsdEventLabelRead)
+        events.append(bareossd.bsdEventLabelVerified)
+        events.append(bareossd.bsdEventLabelWrite)
+        events.append(bareossd.bsdEventSetupRecordTranslation)
+        events.append(bareossd.bsdEventWriteRecordTranslation)
+        events.append(bareossd.bsdEventDeviceUnmount)
+        events.append(bareossd.bsdEventDeviceClose)
+        events.append(bareossd.bsdEventJobEnd)
+        bareossd.RegisterEvents(events)
+
+    def parse_plugin_definition(self, plugindef):
+        super(BareosSdTest, self).parse_plugin_definition(plugindef)
+        if "output" in self.options:
+            self.outputfile = self.options["output"]
+        else:
+            self.outputfile = "/tmp/bareos-dir-test-plugin.log"
+
+        return bareossd.bRC_OK
+
+    def handle_plugin_event(self, event):
+        super(BareosSdTest, self).handle_plugin_event(event)
+        bareossd.DebugMessage(
+            100,
+            "%s: bsdEventJobStart event %d triggered\n" % (__name__, event),
+        )
+        if event == bareossd.bsdEventJobStart:
+            self.toFile("bareossd.bsdEventJobStart\n")
+        elif event == bareossd.bsdEventDeviceReserve:
+            self.toFile("bareossd.bsdEventDeviceReserve\n")
+        elif event == bareossd.bsdEventVolumeUnload:
+            self.toFile("bareossd.bsdEventVolumeUnload\n")
+        elif event == bareossd.bsdEventVolumeLoad:
+            self.toFile("bareossd.bsdEventVolumeLoad\n")
+        elif event == bareossd.bsdEventDeviceOpen:
+            self.toFile("bareossd.bsdEventDeviceOpen\n")
+        elif event == bareossd.bsdEventDeviceMount:
+            self.toFile("bareossd.bsdEventDeviceMount\n")
+        elif event == bareossd.bsdEventLabelRead:
+            self.toFile("bareossd.bsdEventLabelRead\n")
+        elif event == bareossd.bsdEventLabelVerified:
+            self.toFile("bareossd.bsdEventLabelVerified\n")
+        elif event == bareossd.bsdEventLabelWrite:
+            self.toFile("bareossd.bsdEventLabelWrite\n")
+        elif event == bareossd.bsdEventSetupRecordTranslation:
+            self.toFile("bareossd.bsdEventSetupRecordTranslation\n")
+        elif event == bareossd.bsdEventWriteRecordTranslation:
+            self.toFile("bareossd.bsdEventWriteRecordTranslation\n")
+        elif event == bareossd.bsdEventDeviceUnmount:
+            self.toFile("bareossd.bsdEventDeviceUnmount\n")
+        elif event == bareossd.bsdEventDeviceClose:
+            self.toFile("bareossd.bsdEventDeviceClose\n")
+        elif event == bareossd.bsdEventJobEnd:
+            self.toFile("bareossd.bsdEventJobEnd\n")
+
+        return bareossd.bRC_OK
+
+    def toFile(self, text):
+        doc = open(self.outputfile, "a")
+        doc.write(text)
+        doc.close()
+
+
+# vim: ts=4 tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/systemtests/tests/py2plug-sd/python-modules/bareos-sd-test.py
+++ b/systemtests/tests/py2plug-sd/python-modules/bareos-sd-test.py
@@ -1,6 +1,6 @@
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -19,86 +19,18 @@
 #
 # Author: Tobias Plum
 #
-from bareossd import *
+import bareossd
+import BareosSdWrapper
+from BareosSdWrapper import *  # noqa
+import BareosSdTest
 
 
 def load_bareos_plugin(plugindef):
-    events = []
-    events.append(bsdEventJobStart)
-    events.append(bsdEventDeviceReserve)
-    events.append(bsdEventVolumeUnload)
-    events.append(bsdEventVolumeLoad)
-    events.append(bsdEventDeviceOpen)
-    events.append(bsdEventDeviceMount)
-    events.append(bsdEventLabelRead)
-    events.append(bsdEventLabelVerified)
-    events.append(bsdEventLabelWrite)
-    events.append(bsdEventSetupRecordTranslation)
-    events.append(bsdEventWriteRecordTranslation)
-    events.append(bsdEventDeviceUnmount)
-    events.append(bsdEventDeviceClose)
-    events.append(bsdEventJobEnd)
-    RegisterEvents(events)
-    return bRC_OK
-
-
-def parse_plugin_definition(plugindef):
-    plugin_options = plugindef.split(":")
-    for current_option in plugin_options:
-        key, sep, val = current_option.partition("=")
-        if val == "":
-            continue
-        elif key == "output":
-            global outputfile
-            outputfile = val
-            continue
-        elif key == "instance":
-            continue
-        elif key == "module_path":
-            continue
-        elif key == "module_name":
-            continue
-        else:
-            return bRC_Error
-        toFile(outputfile)
-
-    return bRC_OK
-
-
-def handle_plugin_event(event):
-    if event == bsdEventJobStart:
-        toFile("bsdEventJobStart\n")
-    elif event == bsdEventDeviceReserve:
-        toFile("bsdEventDeviceReserve\n")
-    elif event == bsdEventVolumeUnload:
-        toFile("bsdEventVolumeUnload\n")
-    elif event == bsdEventVolumeLoad:
-        toFile("bsdEventVolumeLoad\n")
-    elif event == bsdEventDeviceOpen:
-        toFile("bsdEventDeviceOpen\n")
-    elif event == bsdEventDeviceMount:
-        toFile("bsdEventDeviceMount\n")
-    elif event == bsdEventLabelRead:
-        toFile("bsdEventLabelRead\n")
-    elif event == bsdEventLabelVerified:
-        toFile("bsdEventLabelVerified\n")
-    elif event == bsdEventLabelWrite:
-        toFile("bsdEventLabelWrite\n")
-    elif event == bsdEventSetupRecordTranslation:
-        toFile("bsdEventSetupRecordTranslation\n")
-    elif event == bsdEventWriteRecordTranslation:
-        toFile("bsdEventWriteRecordTranslation\n")
-    elif event == bsdEventDeviceUnmount:
-        toFile("bsdEventDeviceUnmount\n")
-    elif event == bsdEventDeviceClose:
-        toFile("bsdEventDeviceClose\n")
-    elif event == bsdEventJobEnd:
-        toFile("bsdEventJobEnd\n")
-
-    return bRC_OK
-
-
-def toFile(text):
-    doc = open(outputfile, "a")
-    doc.write(text)
-    doc.close()
+    """
+    This function is called by the Bareos-Sd to load the plugin
+    We use it to instantiate the plugin class
+    """
+    # BareosSdWrapper.bareos_sd_plugin_object is the module attribute that
+    # holds the plugin class object
+    BareosSdWrapper.bareos_sd_plugin_object = BareosSdTest.BareosSdTest(plugindef)
+    return bareossd.bRC_OK


### PR DESCRIPTION
This PR adapts the Python DIR and SD plugin Baseclasses to the modernized Python plugin API, see
https://docs.bareos.org/TasksAndConcepts/Plugins.html#modernization-of-the-python-plugin-api

It also contains a fix for the DIR plugin, where DebugMessage after certain events caused
a plugin_ctx is unset runtime error.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
