### PR TITLE
fix scheduler running disabled jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix lost byte in ChunkedDevice [PR #910]
 - fix director crash on "update slots" when there is a parsing issue with the autochanger or tape devices [PR #919]
 - [Issue #1232]: bareos logrotate errors, reintroduce su directive in logrotate [PR #918]
+- fix scheduler running disabled jobs after executing the disable command [PR #924]
 
 ### Added
 - Add systemtests fileset-multiple-include-blocks, fileset-multiple-options-blocks, quota-softquota, sparse-file, truncate-command and block-size, (migrated from ``regress/``) [PR #780]
@@ -199,4 +200,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #918]: https://github.com/bareos/bareos/pull/918
 [PR #919]: https://github.com/bareos/bareos/pull/919
 [PR #920]: https://github.com/bareos/bareos/pull/920
+[PR #924]: https://github.com/bareos/bareos/pull/924
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -146,7 +146,7 @@ void SchedulerPrivate::WaitForJobsToRun()
 
     if (now >= next_job.runtime) {
       auto run_job = prioritised_job_item_queue.TakeOutTopItem();
-      if (!run_job.is_valid) {
+      if (!run_job.is_valid || !run_job.job->enabled) {
         continue;  // check queue again
       }
       JobControlRecord* jcr = TryCreateJobControlRecord(run_job);


### PR DESCRIPTION
#### Description:

In certain situations, when using the `disable job ...` command to disable a job, the scheduler would still execute it even though it is disabled. This PR fixes the issue.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
