### PR TITLE
docs: fix systemtest PostgreSQL preparation

### DIFF
--- a/docs/manuals/source/DeveloperGuide/BuildAndTestBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/BuildAndTestBareos.rst
@@ -5,3 +5,4 @@ Build And Test Bareos
 
    BuildAndTestBareos/documentation.rst
    BuildAndTestBareos/systemtests.rst
+   BuildAndTestBareos/HintsForBuildingBareos.rst

--- a/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/HintsForBuildingBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/HintsForBuildingBareos.rst
@@ -1,0 +1,47 @@
+Hints for Building Bareos
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Configure (cmake) build settings
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. note::
+
+   To build bareos, at least **cmake version 3.12** is required.
+
+
+Bareos cmake configuration allows a lot of different defines to be set.
+For the test-environment, we use the minimal defines required to run the tests.
+
+When interested in the cmake defines for the Bareos production packages,
+please refer to the corresponding build descriptions:
+
+  * Debian Packages: `debian/rules <https://github.com/bareos/bareos/blob/master/core/debian/rules>`__
+  * RPM Packages: `core/platforms/packaging/bareos.spec <https://github.com/bareos/bareos/blob/master/core/platforms/packaging/bareos.spec>`__
+
+
+Using ccache (compiler cache)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bareos can be built using ccache and using it will improve build times for repeated builds a lot.
+Running cmake will autodetect and use ccache if it is available.
+To get the most out of ccache, you should configure it to work correctly with Bareos.
+
+base_dir
+   Set this to a common directory where your checked out sources and cmake binary-dir live.
+   Your homedirectoy is probably a good starting point.
+   This setting lets ccache ignore the path to files below this ``base_dir``.
+   This makes sure you will get a cache hit even if the path to the source files changes.
+hash_dir
+   By disabling this, the current working directory will be ignored.
+   In case of cmake the working directory does not matter, so ignoring this should be safe and will improve cache hits
+sloppiness = file_macro
+   This makes sure the value that ``__FILE__`` expands to is ignored when caching.
+   You may end up with binaries that contain other paths in ``__FILE__``, but Bareos only uses this to determine a relative path so this should not hurt.
+   If you're using a modern compiler that supports ``-ffile-prefix-map`` this should not be required anymore.
+
+.. code-block:: ini
+  :caption: Example ccache.conf
+
+  base_dir = /path/to/common/topdir
+  hash_dir = false
+  sloppiness = file_macro


### PR DESCRIPTION
Fixes the documentation about how to setup the PostgreSQL for running systemtests.
Also cleanup some minor items.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
