### PR TITLE
core: avoid nullptr dereference

### DIFF
--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -819,7 +819,6 @@ void OutputFormatter::JsonFinalizeResult(bool result)
   json_t* range_obj = NULL;
   PoolMem ErrorMsg;
   char* string;
-  size_t string_length = 0;
 
   /*
    * We mimic json-rpc result and error messages,
@@ -867,14 +866,14 @@ void OutputFormatter::JsonFinalizeResult(bool result)
   } else {
     string = json_dumps(msg_obj, UA_JSON_FLAGS_NORMAL);
   }
-  string_length = strlen(string);
-  Dmsg1(800, "message length (json): %lld\n", string_length);
   if (string == NULL) {
     /*
      * json_dumps return NULL on failure (this should not happen).
      */
     Emsg0(M_ERROR, 0, "Failed to generate json string.\n");
   } else {
+    size_t string_length = strlen(string);
+    Dmsg1(800, "message length (json): %lld\n", string_length);
     /*
      * send json string, on failure, send json error message
      */


### PR DESCRIPTION
This PR is a backport of commit efa74e9 core: avoid nullptr dereference
Fix reference for support Ticket TT4200815
(cherry picked from commit efa74e9bcc3913fc1d0982e227de139f7abefb86)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted
