### PR TITLE
webui: fix possible issues due to PAM misconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1232]: bareos logrotate errors, reintroduce su directive in logrotate [PR #918]
 - fix scheduler running disabled jobs after executing the disable command [PR #924]
 - [Issue #1334]: After deleting storage from the configuration, it still persists in the catalog db [PR #912]
+- [Issue #1191]: The web interface runs under any login and password [PR #936]
 
 ### Added
 - systemtests: allows multiple subtests per systemtest [PR #857]
@@ -137,6 +138,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [Issue #871]: https://bugs.bareos.org/view.php?id=871
 [Issue #971]: https://bugs.bareos.org/view.php?id=971
 [Issue #1020]: https://bugs.bareos.org/view.php?id=1020
+[Issue #1191]: https://bugs.bareos.org/view.php?id=1191
 [Issue #1194]: https://bugs.bareos.org/view.php?id=1194
 [Issue #1205]: https://bugs.bareos.org/view.php?id=1205
 [Issue #1232]: https://bugs.bareos.org/view.php?id=1232
@@ -220,4 +222,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #920]: https://github.com/bareos/bareos/pull/920
 [PR #924]: https://github.com/bareos/bareos/pull/924
 [PR #927]: https://github.com/bareos/bareos/pull/927
+[PR #936]: https://github.com/bareos/bareos/pull/936
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/webui/config/autoload/global.php.in
+++ b/webui/config/autoload/global.php.in
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (C) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -225,6 +225,7 @@ function read_directors_ini($directors, $directors_ini)
 
          if(array_key_exists('pam_console_name', $instance) && isset($instance['pam_console_name'])) {
             $arr[key($directors)]['console_name'] = $instance['pam_console_name'];
+            $arr[key($directors)]['UsePamAuthentication'] = true;
          }
          else {
             $arr[key($directors)]['console_name'] = null;
@@ -232,10 +233,12 @@ function read_directors_ini($directors, $directors_ini)
 
          if(array_key_exists('pam_console_password', $instance) && isset($instance['pam_console_password'])) {
             $arr[key($directors)]['password'] = $instance['pam_console_password'];
+            $arr[key($directors)]['UsePamAuthentication'] = true;
          }
          else {
             $arr[key($directors)]['password'] = null;
          }
+
       }
 
       next($directors);

--- a/webui/install/directors.ini.in
+++ b/webui/install/directors.ini.in
@@ -22,11 +22,11 @@ dirport	= @dirport@
 ; Set catalog to explicit value if you have multiple catalogs
 ;catalog = "MyCatalog"
 
-; Set the console name and password for a dedicated pam console;
-; the counterpart console-config in the director must have set
-; UsePamAuthentication = yes
-;pam_console_name = "admin"
-;pam_console_password = "admin"
+; Set the console name and password for a dedicated pam console.
+; Make sure, that "UsePamAuthentication = yes" is set in the
+; counterpart Director console configuration.
+;pam_console_name = "username"
+;pam_console_password = "password"
 
 ; TLS verify peer
 ; Possible values: true or false
@@ -71,6 +71,8 @@ enabled = "no"
 diraddress = "192.168.120.1"
 dirport = @dirport@
 ;catalog = "MyCatalog"
+;pam_console_name = "username"
+;pam_console_password = "password"
 ;tls_verify_peer = false
 ;server_can_do_tls = false
 ;server_requires_tls = false


### PR DESCRIPTION
Check if UsePAMAuthentication is enabled on configured console
in DIR, if not do not proceed with authentication.

Fixes #1191: The web interface runs under any login and password

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
