### PR TITLE
Disable autotosectionlabel plugin in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - reconnecting to the database is now automatic per default without the need to specify it in the catalog [PR #860]
 - bareos is now set to listen to both IPv6 and IPv4 by default, instead of needing to specify it via a directive [PR #882]
 - bareos is now able to create IPv6 addresses with the `DirAddress` directive [PR #882]
+- Disable autotosectionlabel plugin in documentation and add required labels [PR #942]
 
 ### Deprecated
 
@@ -255,8 +256,10 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #919]: https://github.com/bareos/bareos/pull/919
 [PR #920]: https://github.com/bareos/bareos/pull/920
 [PR #921]: https://github.com/bareos/bareos/pull/921
+[PR #923]: https://github.com/bareos/bareos/pull/923
 [PR #924]: https://github.com/bareos/bareos/pull/924
 [PR #927]: https://github.com/bareos/bareos/pull/927
 [PR #936]: https://github.com/bareos/bareos/pull/936
 [PR #938]: https://github.com/bareos/bareos/pull/938
+[PR #942]: https://github.com/bareos/bareos/pull/942
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/DeveloperGuide/ReleasingBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/ReleasingBareos.rst
@@ -47,7 +47,7 @@ The script will also prepare all git commits that are required to release the ne
 
 .. important::
 
-   All changes are only done to you local git repository. For pushing these changes see :ref:`DeveloperGuide/ReleasingBareos:Publishing the release`.
+   All changes are only done to you local git repository. For pushing these changes see :ref:`publishing-the-release`.
 
 
 Special considerations for major versions
@@ -75,6 +75,7 @@ The commit that contains the above changes should then be tagged as the new WIP-
 For example ``git add CHANGELOG.md docs/manuals/source/conf.py`` followed by ``git commit -m 'Start development of X.Y.Z'``.
 That commit can now be tagged with a new WIP-tag using ``git tag WIP/X.Y.Z-pre``.
 
+.. _publishing-the-release:
 
 Publishing the release
 ----------------------

--- a/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosConfiguration.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosConfiguration.rst
@@ -1,5 +1,9 @@
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:bareos configuration:
+
 Bareos Configuration
 ====================
+
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:bareos configuration resource:
 
 Bareos Configuration Resource
 -----------------------------
@@ -68,6 +72,7 @@ This will get displayed as
 
 :config:option:`dir/job`
 
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:resource name:
 
 Resource Name
 -------------
@@ -84,6 +89,8 @@ This will get displayed as
 
 Resource Directive
 ------------------
+
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:resource directive definition:
 
 Resource Directive Definition
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -114,6 +121,8 @@ the corresponding file in the :file:`manually_added_config_directive_description
       * :file:`manually_added_config_directive_descriptions/fd-client-AllowBandwidthBursting.rst.inc`
 
 
+
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:reference to a resource directive:
 
 Reference to a Resource Directive
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -146,6 +155,7 @@ For example:
 
 
 
+.. _documentationstyleguide/bareosspecificformatting/bareosconfiguration:resource directive with value:
 
 Resource Directive With Value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosHostNames.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosHostNames.rst
@@ -1,3 +1,5 @@
+.. _documentationstyleguide/bareosspecificformatting/bareoshostnames:bareos host names:
+
 Bareos Host Names
 =================
 

--- a/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosLogging.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/BareosLogging.rst
@@ -1,3 +1,5 @@
+.. _documentationstyleguide/bareosspecificformatting/bareoslogging:bareos logging:
+
 Bareos Logging
 ==============
 

--- a/docs/manuals/source/DocumentationStyleGuide/CommonNames.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/CommonNames.rst
@@ -1,3 +1,5 @@
+.. _documentationstyleguide/commonnames:common names:
+
 Common Names
 ============
 

--- a/docs/manuals/source/DocumentationStyleGuide/Gotchas.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/Gotchas.rst
@@ -45,6 +45,8 @@ making it really hard to find typos in this kind of references.
 
   * :config:option:`dir/job/ThisIsaDeadEntry`
 
+.. _documentationstyleguide/gotchas:toctree vs include:
+
 toctree vs include
 ------------------
 

--- a/docs/manuals/source/DocumentationStyleGuide/RestOverview.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/RestOverview.rst
@@ -83,6 +83,8 @@ is significant in reST, so all lines of the same paragraph must be left-aligned
 to the same level of indentation.
 
 
+.. _documentationstyleguide/restoverview:inline markup:
+
 Inline markup
 -------------
 
@@ -264,10 +266,10 @@ Internal links
 ~~~~~~~~~~~~~~
 
 Internal linking is done via a special reST role, see the section on specific
-markup, :ref:`doc-ref-role`.
+markup, :ref:`documentationstyleguide/restoverview:cross-linking markup`.
 
 
-.. _doc-ref-role:
+.. _documentationstyleguide/restoverview:cross-linking markup:
 
 Cross-linking markup
 --------------------
@@ -330,6 +332,7 @@ Example::
 This will link to :ref:`DocumentationStyleGuide/RestOverview:Cross-linking markup`\ .
 
 
+.. _documentationstyleguide/restoverview:sections:
 
 Sections
 --------
@@ -397,6 +400,7 @@ Therefore the specific names part, chapter, section ... might not match the actu
    and possibly renders the result incorrectly.
 
 
+.. _documentationstyleguide/restoverview:explicit markup:
 
 Explicit Markup
 ---------------
@@ -404,6 +408,9 @@ Explicit Markup
 “Explicit markup” is used in reST for most constructs that need special handling, such as footnotes, specially-highlighted paragraphs, comments, and generic directives.
 
 An explicit markup block begins with a line starting with .. followed by whitespace and is terminated by the next paragraph at the same level of indentation. (There needs to be a blank line between explicit markup and normal paragraphs. This may all sound a bit complicated, but it is intuitive enough when you write it.)
+
+
+.. _documentationstyleguide/restoverview:directives:
 
 Directives
 ~~~~~~~~~~

--- a/docs/manuals/source/DocumentationStyleGuide/SpecificFormatting.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/SpecificFormatting.rst
@@ -109,6 +109,7 @@ The output should look like this:
 
 ``HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\BackupRestore\FilesNotToBackup``
 
+.. _documentationstyleguide/specificformatting:environment variable:
 
 Environment Variable
 --------------------
@@ -232,6 +233,8 @@ or
 **Recycle = yes**
 
 
+
+.. _documentationstyleguide/specificformatting:operating system:
 
 Operating System
 ----------------

--- a/docs/manuals/source/conf.py
+++ b/docs/manuals/source/conf.py
@@ -97,7 +97,6 @@ extensions = [
     "limitation",
     "sphinx_issues",
     "sphinx.ext.autodoc",  # Core Sphinx library for auto html doc generation from docstrings
-    "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",  # Create neat summary tables for modules/classes/methods etc
     "sphinx.ext.coverage",
     "sphinx.ext.intersphinx",  # Link to other project's documentation (see mapping below)


### PR DESCRIPTION
This PR disables the autosectionlabel plugin in Sphinx as it produces issues with some of our autogenerated headings (especially in release notes). The headings that has autogenerated labels and were referenced by them now have matching labels added manually.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
