### PR TITLE
Fix doc typo in StorageBackends

### DIFF
--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -96,7 +96,7 @@ The name and media type must correspond to those settings in the |dir| :ref:`Dir
 
 .. limitation:: Droplet Backend does not support block interleaving
 
-  The current implementation has a known Bug that may lead to bogus data on your S3 volumes when you set :config:option:`sd/device/MaximumConccurentJobs` to a value other than 1.
+  The current implementation has a known Bug that may lead to bogus data on your S3 volumes when you set :config:option:`sd/device/MaximumConcurrentJobs` to a value other than 1.
   Because of this the default for a backend of type Droplet is set to 1 and the |sd| will refuse to start if you set it to a value greater than 1.
 
 


### PR DESCRIPTION
This PR fix a small typo in the word Concurrent 

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>

### Thank you for contributing to the Bareos Project!

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted

