### PR TITLE
systemtest python-pam: fix typos

### DIFF
--- a/core/src/plugins/include/python_plugins_common.h
+++ b/core/src/plugins/include/python_plugins_common.h
@@ -52,7 +52,7 @@
 
 #define RETURN_RUNTIME_ERROR_IF_BAREOS_PLUGIN_CTX_UNSET()            \
   if (!plugin_ctx) {                                                 \
-    PyErr_SetString(PyExc_RuntimeError, AT " :plugin_ctx is unset"); \
+    PyErr_SetString(PyExc_RuntimeError, AT ": plugin_ctx is unset"); \
     return NULL;                                                     \
   }
 

--- a/systemtests/tests/python-pam/pamlogintest.py
+++ b/systemtests/tests/python-pam/pamlogintest.py
@@ -40,7 +40,7 @@ class PamLoginTest(bareos_unittest.Base):
 
     @classmethod
     def setUpClass(cls):
-        super(PythonBareosPamLoginTest, cls).setUpClass()
+        super(PamLoginTest, cls).setUpClass()
         cls.console_pam_username = u"PamConsole-notls"
         cls.console_pam_password = u"secret"
 


### PR DESCRIPTION
Commit 6a92885ff4ca52c7bfffb006ea00f3380a2a8432 contais a typo, which prevents the systemtest python-pam from running successfully. This change fixes this. It also fixes a typo in a Python plugin warning.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
