### PR TITLE
autochanger: remove unused logical drive number and use drive_index e…

### DIFF
--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -258,7 +258,7 @@ typedef uint16_t slot_flags_t;
 
 constexpr slot_number_t kInvalidSlotNumber
     = std::numeric_limits<slot_number_t>::max();
-constexpr slot_number_t kInvalidDriveNumber
+constexpr drive_number_t kInvalidDriveNumber
     = std::numeric_limits<drive_number_t>::max();
 
 inline bool IsSlotNumberValid(slot_number_t slot)

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -60,11 +60,13 @@ bool InitAutochangers()
 {
   bool OK = true;
   AutochangerResource* changer;
+  drive_number_t drive_index;
 
   // Ensure that the media_type for each device is the same
   foreach_res (changer, R_AUTOCHANGER) {
     DeviceResource* device_resource = nullptr;
 
+    drive_index = 0;
     foreach_alist (device_resource, changer->device_resources) {
       /*
        * If the device does not have a changer name or changer command
@@ -91,6 +93,9 @@ bool InitAutochangers()
              device_resource->resource_name_);
         OK = false;
       }
+
+      // Give the drive in the autochanger a drive index.
+      device_resource->drive_index = drive_index++;
     }
   }
 

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -94,8 +94,10 @@ bool InitAutochangers()
         OK = false;
       }
 
-      // Give the drive in the autochanger a drive index.
-      device_resource->drive_index = drive_index++;
+      // set the drive index if it is not already set via configuration
+      if (!(device_resource->drive_index == kInvalidSlotNumber)) {
+        device_resource->drive_index = drive_index++;
+      }
     }
   }
 
@@ -163,10 +165,10 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
   if (!IsSlotNumberValid(wanted_slot)) {
     // Suppress info when polling
     if (!dev->poll) {
-      Jmsg(
-          jcr, M_INFO, 0,
-          _("No slot defined in catalog (slot=%hd) for Volume \"%s\" on %s.\n"),
-          wanted_slot, dcr->getVolCatName(), dev->print_name());
+      Jmsg(jcr, M_INFO, 0,
+           _("No slot defined in catalog (slot=%hd) for Volume \"%s\" on "
+             "%s.\n"),
+           wanted_slot, dcr->getVolCatName(), dev->print_name());
       Jmsg(jcr, M_INFO, 0,
            _("Cartridge change or \"update slots\" may be required.\n"));
     }
@@ -219,10 +221,10 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
       // Load the desired volume.
       Dmsg2(100, "Doing changer load slot %hd %s\n", wanted_slot,
             dev->print_name());
-      Jmsg(
-          jcr, M_INFO, 0,
-          _("3304 Issuing autochanger \"load slot %hd, drive %hd\" command.\n"),
-          wanted_slot, drive);
+      Jmsg(jcr, M_INFO, 0,
+           _("3304 Issuing autochanger \"load slot %hd, drive %hd\" "
+             "command.\n"),
+           wanted_slot, drive);
       dcr->VolCatInfo.Slot = wanted_slot; /* slot to be loaded */
       changer = edit_device_codes(
           dcr, changer, dcr->device_resource->changer_command, "load");
@@ -230,10 +232,10 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
       Dmsg1(200, "Run program=%s\n", changer);
       status = RunProgramFullOutput(changer, timeout, results.addr());
       if (status == 0) {
-        Jmsg(
-            jcr, M_INFO, 0,
-            _("3305 Autochanger \"load slot %hd, drive %hd\", status is OK.\n"),
-            wanted_slot, drive);
+        Jmsg(jcr, M_INFO, 0,
+             _("3305 Autochanger \"load slot %hd, drive %hd\", status is "
+               "OK.\n"),
+             wanted_slot, drive);
         Dmsg2(100, "load slot %hd, drive %hd, status is OK.\n", wanted_slot,
               drive);
         dev->SetSlotNumber(wanted_slot); /* set currently loaded slot */
@@ -338,7 +340,8 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
       // Suppress info when polling
       if (!dev->poll && debug_level >= 1) {
         Jmsg(jcr, M_INFO, 0,
-             _("3302 Autochanger \"loaded? drive %hd\", result is Slot %hd.\n"),
+             _("3302 Autochanger \"loaded? drive %hd\", result is Slot "
+               "%hd.\n"),
              drive_index, loaded_slot);
       }
       dev->SetSlotNumber(loaded_slot);
@@ -462,10 +465,10 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
     PoolMem results(PM_MESSAGE);
     POOLMEM* changer = GetPoolMemory(PM_FNAME);
 
-    Jmsg(
-        jcr, M_INFO, 0,
-        _("3307 Issuing autochanger \"unload slot %hd, drive %hd\" command.\n"),
-        loaded_slot, dev->drive_index);
+    Jmsg(jcr, M_INFO, 0,
+         _("3307 Issuing autochanger \"unload slot %hd, drive %hd\" "
+           "command.\n"),
+         loaded_slot, dev->drive_index);
     slot = dcr->VolCatInfo.Slot;
     dcr->VolCatInfo.Slot = loaded_slot;
     changer = edit_device_codes(
@@ -492,8 +495,8 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
   }
 
   /*
-   * Only unlock the changer if the lock_set is false e.g. changer not locked by
-   * calling function.
+   * Only unlock the changer if the lock_set is false e.g. changer not locked
+   * by calling function.
    */
   if (!lock_set) { UnlockChanger(dcr); }
 
@@ -666,8 +669,8 @@ bool UnloadDev(DeviceControlRecord* dcr, Device* dev, bool lock_set)
   if (retval) { dev->ClearUnload(); }
 
   /*
-   * Only unlock the changer if the lock_set is false e.g. changer not locked by
-   * calling function.
+   * Only unlock the changer if the lock_set is false e.g. changer not locked
+   * by calling function.
    */
   if (!lock_set) { UnlockChanger(dcr); }
 

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -1450,7 +1450,7 @@ try_again:
     /* We are going to load a new tape, so close the device */
     dev->close(dcr);
     Pmsg2(-1, _("3302 Issuing autochanger \"unload %d %d\" command.\n"), loaded,
-          dev->drive);
+          dev->drive_index);
     changer = edit_device_codes(
         dcr, changer, dcr->device_resource->changer_command, "unload");
     status = RunProgram(changer, timeout, results);
@@ -1469,7 +1469,7 @@ try_again:
   slot = 1;
   dcr->VolCatInfo.Slot = slot;
   Pmsg2(-1, _("3303 Issuing autochanger \"load %d %d\" command.\n"), slot,
-        dev->drive);
+        dev->drive_index);
   changer = edit_device_codes(dcr, changer,
                               dcr->device_resource->changer_command, "load");
   Dmsg1(100, "Changer=%s\n", changer);
@@ -1477,7 +1477,7 @@ try_again:
   status = RunProgram(changer, timeout, results);
   if (status == 0) {
     Pmsg2(-1, _("3303 Autochanger \"load %d %d\" status is OK.\n"), slot,
-          dev->drive);
+          dev->drive_index);
   } else {
     BErrNo be;
     Pmsg1(-1, _("3993 Bad autochanger command: %s\n"), changer);

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -285,7 +285,6 @@ Device* FactoryCreateDevice(JobControlRecord* jcr,
   dev->max_open_vols = device_resource->max_open_vols;
   dev->vol_poll_interval = device_resource->vol_poll_interval;
   dev->max_spool_size = device_resource->max_spool_size;
-  dev->drive = device_resource->drive;
   dev->drive_index = device_resource->drive_index;
   dev->autoselect = device_resource->autoselect;
   dev->norewindonclose = device_resource->norewindonclose;

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -225,7 +225,6 @@ class Device {
   bool norewindonclose{};     /**< Don't rewind tape drive on close */
   bool initiated{};           /**< Set when FactoryCreateDevice() called */
   int label_type{};           /**< Bareos/ANSI/IBM label types */
-  drive_number_t drive{};     /**< Autochanger logical drive number (base 0) */
   drive_number_t drive_index{}; /**< Autochanger physical drive index (base 0) */
   POOLMEM* archive_device_string{};  /**< Physical device name */
   POOLMEM* dev_options{};     /**< Device specific options */

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -47,7 +47,6 @@ DeviceResource::DeviceResource()
     , query_crypto_status(false)
     , collectstats(false)
     , eof_on_error_is_eot(false)
-    , drive(0)
     , drive_index(0)
     , cap_bits{0}
     , max_changer_wait(300)
@@ -124,7 +123,6 @@ DeviceResource::DeviceResource(const DeviceResource& other)
   query_crypto_status = other.query_crypto_status;
   collectstats = other.collectstats;
   eof_on_error_is_eot = other.eof_on_error_is_eot;
-  drive = other.drive;
   drive_index = other.drive_index;
   memcpy(cap_bits, other.cap_bits, CAP_BYTES);
   max_changer_wait = other.max_changer_wait;
@@ -179,7 +177,6 @@ DeviceResource& DeviceResource::operator=(const DeviceResource& rhs)
   query_crypto_status = rhs.query_crypto_status;
   collectstats = rhs.collectstats;
   eof_on_error_is_eot = rhs.eof_on_error_is_eot;
-  drive = rhs.drive;
   drive_index = rhs.drive_index;
   memcpy(cap_bits, rhs.cap_bits, CAP_BYTES);
   max_changer_wait = rhs.max_changer_wait;

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -52,7 +52,6 @@ class DeviceResource : public BareosResource {
   bool query_crypto_status;     /**< Query device for crypto status */
   bool collectstats;            /**< Set if statistics should be collected */
   bool eof_on_error_is_eot;     /**< Interpret EOF during read error as EOT */
-  drive_number_t drive;         /**< Autochanger logical drive number */
   drive_number_t drive_index;   /**< Autochanger physical drive index */
   char cap_bits[CAP_BYTES];     /**< Capabilities of this device */
   utime_t max_changer_wait;     /**< Changer timeout */

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -925,14 +925,14 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
             continue; /* device is not available */
           }
           if (drive == kInvalidDriveNumber
-              || drive == device_resource->dev->drive) {
+              || drive == device_resource->dev->drive_index) {
             Dmsg1(20, "Found changer device %s\n",
                   device_resource->resource_name_);
             found = true;
             break;
           }
           Dmsg3(100, "Device %s drive wrong: want=%hd got=%hd skipping\n",
-                devname.c_str(), drive, device_resource->dev->drive);
+                devname.c_str(), drive, device_resource->dev->drive_index);
 
           if (changer->device_resources->current()
               == changer->device_resources->size()) {

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -561,10 +561,11 @@ static void SendBlockedStatus(Device* dev, StatusPacket* sp)
   if (dev->AttachedToAutochanger()) {
     if (dev->GetSlot() > 0) {
       len = Mmsg(msg, _("    Slot %hd %s loaded in drive %hd.\n"),
-                 dev->GetSlot(), dev->IsOpen() ? "is" : "was last", dev->drive);
+                 dev->GetSlot(), dev->IsOpen() ? "is" : "was last",
+                 dev->drive_index);
       sp->send(msg, len);
     } else if (dev->GetSlot() <= 0) {
-      len = Mmsg(msg, _("    Drive %hd is not loaded.\n"), dev->drive);
+      len = Mmsg(msg, _("    Drive %hd is not loaded.\n"), dev->drive_index);
       sp->send(msg, len);
     }
   }

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -198,7 +198,7 @@ static ResourceItem dev_items[] = {
   {"SpoolDirectory", CFG_TYPE_DIR, ITEM(res_dev, spool_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_spool_size), 0, 0, NULL, NULL, NULL},
   {"MaximumJobSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_job_spool_size), 0, 0, NULL, NULL, NULL},
-  {"DriveIndex", CFG_TYPE_PINT16, ITEM(res_dev, drive_index), 0, kInvalidSlotNumber, NULL, NULL, NULL},
+  {"DriveIndex", CFG_TYPE_PINT16, ITEM(res_dev, drive_index), 0, CFG_ITEM_DEFAULT, std::to_string(kInvalidSlotNumber).c_str(), NULL, NULL},
   {"MountPoint", CFG_TYPE_STRNAME, ITEM(res_dev, mount_point), 0, 0, NULL, NULL, NULL},
   {"MountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, mount_command), 0, 0, NULL, NULL, NULL},
   {"UnmountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, unmount_command), 0, 0, NULL, NULL, NULL},

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -198,7 +198,7 @@ static ResourceItem dev_items[] = {
   {"SpoolDirectory", CFG_TYPE_DIR, ITEM(res_dev, spool_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_spool_size), 0, 0, NULL, NULL, NULL},
   {"MaximumJobSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_job_spool_size), 0, 0, NULL, NULL, NULL},
-  {"DriveIndex", CFG_TYPE_PINT16, ITEM(res_dev, drive_index), 0, 0, NULL, NULL, NULL},
+  {"DriveIndex", CFG_TYPE_PINT16, ITEM(res_dev, drive_index), 0, kInvalidSlotNumber, NULL, NULL, NULL},
   {"MountPoint", CFG_TYPE_STRNAME, ITEM(res_dev, mount_point), 0, 0, NULL, NULL, NULL},
   {"MountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, mount_command), 0, 0, NULL, NULL, NULL},
   {"UnmountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, unmount_command), 0, 0, NULL, NULL, NULL},


### PR DESCRIPTION
Before the members drive and drive_index existed.
"drive" contained the useless logical drive number while drive_index
contained the required index information.

Unfortunately, the drive member was used instead of drive_index in many
cases.

The useless member was removed and the drive_index now is the only
remaining member and is used everywhere.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
