### PR TITLE
docs: fix glusterfs administration guide uri

### DIFF
--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -333,7 +333,7 @@ GFAPI Storage Backend
 
 **GFAPI** (GlusterFS)
 
-A GlusterFS Storage can be used as Storage backend of Bareos. Prerequistes are a working GlusterFS storage system and the package **bareos-storage-glusterfs**. See http://www.gluster.org/ for more information regarding GlusterFS installation and configuration and specifically `https://gluster.readthedocs.org/en/latest/Administrator Guide/Bareos/ <https://gluster.readthedocs.org/en/latest/Administrator Guide/Bareos/>`__ for Bareos integration. You can use following snippet to
+A GlusterFS Storage can be used as Storage backend of Bareos. Prerequistes are a working GlusterFS storage system and the package **bareos-storage-glusterfs**. See http://www.gluster.org/ for more information regarding GlusterFS installation and configuration and specifically `https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/ <https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/>`__ for Bareos integration. You can use following snippet to
 configure it as storage device:
 
 


### PR DESCRIPTION
This PR fix the upstream url of glusterfs administration guide we have as reference in Bareos documentation.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
