### PR TITLE
Log LDAP info error (e.g. expired SSL cert error)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1191]: The web interface runs under any login and password [PR #936]
 - Adapt Python DIR and SD plugin Baseclasses to the modernized Python plugin API [PR #923]
 - Fixed all compiler warnings (on our default warning level) [PR #948]
+- Log LDAP info error (e.g. expired SSL cert error) [PR #956]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/core/src/plugins/filed/python/ldap/BareosFdPluginLDAP.py
+++ b/core/src/plugins/filed/python/ldap/BareosFdPluginLDAP.py
@@ -256,7 +256,7 @@ class BareosLDAPWrapper:
         except ldap.INVALID_CREDENTIALS:
             bareosfd.JobMessage(
                 bareosfd.bJobMessageType["M_FATAL"],
-                "Failed to bind to LDAP uri %s\n" % (options["uri"]),
+                "Failed to bind to LDAP uri due to invalid credentials %s\n" % (options["uri"]),
             )
 
             return bareosfd.bRC_Error
@@ -264,8 +264,8 @@ class BareosLDAPWrapper:
             if type(e.message) == dict and "desc" in e.message:
                 bareosfd.JobMessage(
                     bareosfd.bJobMessageType["M_FATAL"],
-                    "Failed to bind to LDAP uri %s: %s\n"
-                    % (options["uri"], e.message["desc"]),
+                    "Failed to bind to LDAP uri %s: %s %s\n"
+                    % (options["uri"], e.message["desc"], e.message["info"]),
                 )
             else:
                 bareosfd.JobMessage(


### PR DESCRIPTION
- Log LDAP error info field as well to get underlying error, e.g. expired SSL cert error:
```
Can't contact LDAP server error:14090086:SSL routines:ssl3_get_server_certificate:certificate verify failed (certificate has expired)
```

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
