### PR TITLE
director: fix crash in status scheduler when client is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fixed libdroplet xattr.h include issue by using sys/xattr.h [PR #985]
 - Fixed crash on bconsole when using autcomplete with tab [PR #969]
 - [Issue #1374] Include zero-file incremental backups in always-incremental consolidation [PR #995]
+- fix crash in "status scheduler" command when job->client is unset [PR #965]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -662,7 +662,7 @@ start_again:
       // List specific schedule.
       if (job) {
         if (job->schedule && job->schedule->enabled && job->enabled
-            && job->client->enabled) {
+            && job->client && job->client->enabled) {
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -674,7 +674,7 @@ start_again:
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
           if (job->schedule && job->schedule->enabled && job->enabled
-              && job->client == client && job->client->enabled) {
+              && job->client && job->client == client && job->client->enabled) {
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -661,8 +661,10 @@ start_again:
     if (client || job) {
       // List specific schedule.
       if (job) {
-        if (job->schedule && job->schedule->enabled && job->enabled
-            && job->client && job->client->enabled) {
+        if (job->schedule && job->schedule->enabled && job->enabled) {
+          // skip if client is set but not enabled
+          if (job->client && !job->client->enabled) goto start_again;
+
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -673,8 +675,11 @@ start_again:
         foreach_res (job, R_JOB) {
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-          if (job->schedule && job->schedule->enabled && job->enabled
-              && job->client && job->client == client && job->client->enabled) {
+          if (job->schedule && job->schedule->enabled && job->enabled) {
+            // skip if client is set but not enabled
+            if (job->client && job->client == client && !job->client->enabled) {
+              continue;
+            }
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -663,7 +663,7 @@ start_again:
       if (job) {
         if (job->schedule && job->schedule->enabled && job->enabled) {
           // skip if client is set but not enabled
-          if (job->client && !job->client->enabled) goto start_again;
+          if (job->client && !job->client->enabled) { break; }
 
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {

--- a/systemtests/tests/scheduler-backup/etc/bareos/bareos-dir.d/job/copy.conf
+++ b/systemtests/tests/scheduler-backup/etc/bareos/bareos-dir.d/job/copy.conf
@@ -1,0 +1,10 @@
+Job {
+  Name = "copy"
+  Type = Copy
+  Pool = Full
+  Selection Type = Volume
+  Selection Pattern = "."
+  Client = "bareos-fd"
+  Messages = Standard
+  Schedule = TestCycle
+}

--- a/systemtests/tests/scheduler-backup/test-setup
+++ b/systemtests/tests/scheduler-backup/test-setup
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+# Fill ${BackupDirectory} with data.
+setup_data
+
+bin/bareos start
+
+# make sure, director is up and running.
+print_debug "$(bin/bconsole <<< "status dir")"

--- a/systemtests/tests/scheduler-backup/testrunner-scheduler-backup
+++ b/systemtests/tests/scheduler-backup/testrunner-scheduler-backup
@@ -14,12 +14,6 @@ export TestName
 
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
-"${rscripts}"/cleanup
-"${rscripts}"/setup
-
-
-# Fill ${BackupDirectory} with data.
-setup_data
 
 start_test
 
@@ -27,8 +21,9 @@ cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=100 storage=File
-label volume=TestVolume001 storage=File pool=Full
+setdebug level=100 storage=File trace=1
+setdebug level=100 director trace=1
+setdebug level=100 client trace=1
 status director
 status client
 status storage=File
@@ -46,9 +41,8 @@ messages
 quit
 END_OF_DATA
 
-run_bareos "$@"
+run_bconsole
 check_for_zombie_jobs storage=File
-stop_bareos
 
 check_two_logs
 check_restore_diff ${BackupDirectory}

--- a/systemtests/tests/scheduler-backup/testrunner-scheduler-status-copy-job
+++ b/systemtests/tests/scheduler-backup/testrunner-scheduler-status-copy-job
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+#
+# Run test to check correct output of #`status scheduler job=...`
+# of a copy job whose client is disabled
+#
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+messages
+@$out $tmp/log3.out w
+enable client=bareos-fd
+status scheduler job=copy
+
+@$out $tmp/log4.out w
+disable client=bareos-fd
+status scheduler job=copy
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+#check that `status scheduler job=...` returns scheduled copy jobs
+if ! grep "TestCycle               Level=Full" "$tmp"/log3.out; then
+  echo "No scheduled job was found in $tmp/log3.out, which should contain all scheduled jobs" >&2
+  estat=1
+fi
+
+#check that `status scheduler job=...` returns nothing when we disable the client
+if  grep "TestCycle               Level=Full" "$tmp"/log4.out; then
+  echo "a scheduled job was listed in $tmp/log4.out, which shouldn't happen" >&2
+  estat=1
+fi
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!
The `status scheduler` command did not check the `job->client` pointer before dereferencing. This is fixed with this PR.
#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing