### PR TITLE
stored: don't unload tapes from blocked devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Adapt Python DIR and SD plugin Baseclasses to the modernized Python plugin API [PR #923]
 - Fixed all compiler warnings (on our default warning level) [PR #948]
 - Log LDAP info error (e.g. expired SSL cert error) [PR #956]
+- Fix occassional "NULL volume name" error when non-busy, but blocked drive is unloaded [PR #973]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]
@@ -262,6 +263,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #903]: https://github.com/bareos/bareos/pull/903
 [PR #907]: https://github.com/bareos/bareos/pull/907
 [PR #910]: https://github.com/bareos/bareos/pull/910
+[PR #911]: https://github.com/bareos/bareos/pull/911
 [PR #912]: https://github.com/bareos/bareos/pull/912
 [PR #913]: https://github.com/bareos/bareos/pull/913
 [PR #914]: https://github.com/bareos/bareos/pull/914
@@ -272,6 +274,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #921]: https://github.com/bareos/bareos/pull/921
 [PR #923]: https://github.com/bareos/bareos/pull/923
 [PR #924]: https://github.com/bareos/bareos/pull/924
+[PR #926]: https://github.com/bareos/bareos/pull/926
 [PR #927]: https://github.com/bareos/bareos/pull/927
 [PR #936]: https://github.com/bareos/bareos/pull/936
 [PR #937]: https://github.com/bareos/bareos/pull/937
@@ -279,6 +282,13 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #942]: https://github.com/bareos/bareos/pull/942
 [PR #943]: https://github.com/bareos/bareos/pull/943
 [PR #944]: https://github.com/bareos/bareos/pull/944
+[PR #948]: https://github.com/bareos/bareos/pull/948
+[PR #950]: https://github.com/bareos/bareos/pull/950
 [PR #951]: https://github.com/bareos/bareos/pull/951
+[PR #952]: https://github.com/bareos/bareos/pull/952
+[PR #956]: https://github.com/bareos/bareos/pull/956
+[PR #958]: https://github.com/bareos/bareos/pull/958
 [PR #961]: https://github.com/bareos/bareos/pull/961
+[PR #962]: https://github.com/bareos/bareos/pull/962
+[PR #973]: https://github.com/bareos/bareos/pull/973
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -555,20 +555,20 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
   }
 
   // The Volume we want is on another device.
-  if (dev->IsBusy()) {
+  if (dev->IsBusy() || dev->IsBlocked()) {
     Dmsg4(100, "Vol %s for dev=%s in use dev=%s slot=%hd\n", dcr->VolumeName,
           dcr->dev->print_name(), dev->print_name(), slot);
   }
 
   for (int i = 0; i < 3; i++) {
-    if (dev->IsBusy()) {
+    if (dev->IsBusy() || dev->IsBlocked()) {
       WaitForDevice(dcr->jcr, retries);
       continue;
     }
     break;
   }
 
-  if (dev->IsBusy()) {
+  if (dev->IsBusy() || dev->IsBlocked()) {
     Jmsg(dcr->jcr, M_WARNING, 0,
          _("Volume \"%s\" wanted on %s is in use by device %s\n"),
          dcr->VolumeName, dcr->dev->print_name(), dev->print_name());


### PR DESCRIPTION
This patch changes UnloadOtherDrive() so it won't unload a device that
is not blocked. Previously we only checked if the device was busy, which
might not be enough.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
