### PR TITLE
BareosCheckFunctions: check for chflags()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - packages: Build also for Debian_11 [PR #915]
 - packages: Build also for SLE_15_SP3 and openSUSE_15.3 [PR #945]
 - packages: Build also for Fedora_35 [PR #976]
+- cmake: check for chflags() function and enable FreeBSD File Flags support [PR #974]
 
 ### Changed
 - add job name in End Job Session output in bls tool [PR #916]

--- a/cmake/BareosCheckChflags.cmake
+++ b/cmake/BareosCheckChflags.cmake
@@ -1,0 +1,35 @@
+# BAREOS® - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or modify it under
+# the terms of version three of the GNU Affero General Public License as
+# published by the Free Software Foundation and included in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more
+# details.
+#
+# You should have received a copy of the GNU Affero General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+
+# Extract version information and commit timestamp if run in a git checkout
+
+find_program(CHFLAGS_PROG chflags)
+
+set(CHFLAGS_WORKS NO)
+if(CHFLAGS_PROG)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/chflags-test-file.txt"
+       "Just a testfile"
+  )
+  exec_program(
+    ${CHFLAGS_PROG} ${CMAKE_CURRENT_BINARY_DIR}
+    ARGS "nosunlink chflags-test-file.txt"
+    RETURN_VALUE CHFLAGS_RETURN
+  )
+  if(CHFLAGS_RETURN EQUAL 0)
+    set(CHFLAGS_WORKS YES)
+  endif()
+endif()

--- a/core/cmake/BareosCheckFunctions.cmake
+++ b/core/cmake/BareosCheckFunctions.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -87,3 +87,5 @@ check_function_exists(unlinkat HAVE_UNLINKAT)
 check_function_exists(utimes HAVE_UTIMES)
 
 check_function_exists(glfs_readdirplus HAVE_GLFS_READDIRPLUS)
+
+check_function_exists(chflags HAVE_CHFLAGS)

--- a/core/cmake/BareosCheckSymbols.cmake
+++ b/core/cmake/BareosCheckSymbols.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -22,9 +22,15 @@ include(CheckSymbolExists)
 check_symbol_exists(__stub_lchmod features.h LCHMOD_IS_A_STUB1)
 check_symbol_exists(__stub___lchmod features_h LCHMOD_IS_A_STUB2)
 
-if("${LCHMOD_IS_A_STUB1}" OR "${LCHMOD_IS_A_STUB2}")
-  message(STATUS " lchmod is a stub, setting HAVE_LCHMOD to 0")
+if(LCHMOD_IS_A_STUB1 OR LCHMOD_IS_A_STUB2)
+  message(STATUS "lchmod is a stub, setting HAVE_LCHMOD to 0")
   set(HAVE_LCHMOD 0)
+endif()
+
+check_symbol_exists(__stub_chflags features.h CHFLAGS_IS_A_STUB)
+if(CHFLAGS_IS_A_STUB)
+  message(STATUS "lchflags is a stub, setting HAVE_CHFLAGS to 0")
+  set(HAVE_CHFLAGS 0)
 endif()
 
 check_symbol_exists(poll poll.h HAVE_POLL)

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -674,6 +674,14 @@ else()
   list(APPEND SYSTEM_TESTS_DISABLED acl)
 endif()
 
+include(BareosCheckChflags)
+get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
+if(CHFLAGS_WORKS)
+  list(APPEND SYSTEM_TESTS chflags)
+else()
+  list(APPEND SYSTEM_TESTS_DISABLED chflags)
+endif()
+
 if(TARGET droplet
    AND S3CMD
    AND MINIO

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,8 @@
+Catalog {
+  Name = MyCatalog
+  #dbdriver = "@DEFAULT_DB_TYPE@"
+  dbdriver = "XXX_REPLACE_WITH_DATABASE_DRIVER_XXX"
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = @hostname@
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/console/bareos-mon.conf.in
@@ -1,0 +1,7 @@
+Console {
+  Name = bareos-mon
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "@mon_dir_password@"
+  CommandACL = status, .status
+  JobACL = *all*
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,13 @@
+Director {                            # define myself
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"         # Console password
+  Messages = Daemon
+  Auditing = yes
+
+  Backend Directory = @backenddir@
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      signature = MD5
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = MD5 # calculate md5 checksum per file
+    }
+    File=@tmpdir@/file-with-chflags
+  }
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -1,0 +1,20 @@
+Job {
+  Name = "BackupCatalog"
+  Description = "Backup the catalog database (after the nightly save)"
+  JobDefs = "DefaultJob"
+  Level = Full
+  FileSet="Catalog"
+
+  # This creates an ASCII copy of the catalog
+  # Arguments to make_catalog_backup.pl are:
+  #  make_catalog_backup.pl <catalog-name>
+  RunBeforeJob = "@scriptdir@/make_catalog_backup.pl MyCatalog"
+
+  # This deletes the copy of the catalog
+  RunAfterJob  = "@scriptdir@/delete_catalog_backup"
+
+  # This sends the bootstrap via mail for disaster recovery.
+  # Should be sent to another system, please change recipient accordingly
+  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
+  Priority = 11                   # run after main backup
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
@@ -1,0 +1,5 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,8 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  FD Port = @fd_port@
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-fd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_fd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this file daemon."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,11 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/director/bareos-mon.conf.in
@@ -1,0 +1,6 @@
+Director {
+  Name = bareos-mon
+  Password = "@mon_sd_password@"
+  Monitor = yes
+  Description = "Restricted Director, used by tray-monitor to get the status of this storage daemon."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  Pid Directory =  "@piddir@"
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/chflags/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/chflags/testrunner
+++ b/systemtests/tests/chflags/testrunner
@@ -1,0 +1,78 @@
+#!/bin/bash
+set -e
+set -o pipefail
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+BackupFile="${tmp}/file-with-chflags"
+RestoreFile="${tmp}/bareos-restores/${BackupFile}"
+
+# allow delition of test files
+[ -f "${BackupFile}" ] && chflags nosunlink "${BackupFile}"
+[ -f "${RestoreFile}" ] && chflags nosunlink "${RestoreFile}"
+
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+chflags_should="${tmp}/chflags_should.txt"
+chflags_is="${tmp}/chflags_is.txt"
+BackupDirectory="${tmp}/data"
+
+mkdir -p "${BackupDirectory}"
+touch "${BackupFile}"
+chflags sunlink "${BackupFile}"
+ls -lo "${BackupFile}" | cut -b -40 > ${chflags_should}
+
+start_test
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+setdebug level=1000 client=bareos-fd trace=1
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+@#
+@# now do a restore
+@#
+@$out $tmp/log2.out
+wait
+restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bareos "$@"
+check_for_zombie_jobs storage=File
+stop_bareos
+
+check_two_logs
+
+ls -lo "${RestoreFile}" | cut -b -40 > "$chflags_is"
+
+diff -u "$chflags_should" "$chflags_is" || estat=1
+
+# allow deletion of files
+chflags nosunlink "${BackupFile}"
+chflags nosunlink "${RestoreFile}"
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!
When porting to cmake, accidentially the check for the chflags() function was overseen.
This check is now added with this PR.

This enables the build of the support of backup and restore of BSD File Flags:

In addition to file permissions, FreeBSD supports the use of "file flags". These flags add an additional level of security and control over files, but not directories. With file flags, even root can be prevented from removing or altering files.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
