### PR TITLE
stored: don't unload tapes from blocked devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix lost byte in ChunkedDevice (backport of [PR #910])
 - fix director crash on "update slots" when there is a parsing issue with the autochanger or tape devices [PR #919]
 - [Issue #1232]: bareos logrotate errors, reintroduce su directive in logrotate ([backport of PR #918])
+- Fix occasional "NULL volume name" error when non-busy, but blocked drive is unloaded [PR #975]
 
 ### Added
 - packages: Build also for Debian_11 [PR #915]

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -592,23 +592,21 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
     Dmsg1(100, "Slot=%hd found in another device\n", slot);
   }
 
-  /*
-   * The Volume we want is on another device.
-   */
-  if (dev->IsBusy()) {
+  // The Volume we want is on another device.
+  if (dev->IsBusy() || dev->IsBlocked()) {
     Dmsg4(100, "Vol %s for dev=%s in use dev=%s slot=%hd\n", dcr->VolumeName,
           dcr->dev->print_name(), dev->print_name(), slot);
   }
 
   for (int i = 0; i < 3; i++) {
-    if (dev->IsBusy()) {
+    if (dev->IsBusy() || dev->IsBlocked()) {
       WaitForDevice(dcr->jcr, retries);
       continue;
     }
     break;
   }
 
-  if (dev->IsBusy()) {
+  if (dev->IsBusy() || dev->IsBlocked()) {
     Jmsg(dcr->jcr, M_WARNING, 0,
          _("Volume \"%s\" wanted on %s is in use by device %s\n"),
          dcr->VolumeName, dcr->dev->print_name(), dev->print_name());


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This patch changes UnloadOtherDrive() so it won't unload a device that
is not blocked. Previously we only checked if the device was busy, which
might not be enough.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
