### PR TITLE
Fix PostgreSQL client_min_messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fixed all compiler warnings (on our default warning level) [PR #948]
 - Log LDAP info error (e.g. expired SSL cert error) [PR #956]
 - Fix occassional "NULL volume name" error when non-busy, but blocked drive is unloaded [PR #973]
+- Fix set client_min_messages in PostgreSQL update script [PR #979]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/core/src/cats/ddl/updates/postgresql.11_12.sql
+++ b/core/src/cats/ddl/updates/postgresql.11_12.sql
@@ -48,7 +48,7 @@ COMMIT;
 CREATE INDEX basefiles_jobid_idx ON BaseFiles ( JobId );
 
 -- suppress output for index modification
-SET client_min_messages TO 'fatal';
+SET client_min_messages TO error;
 
 -- Remove bad PostgreSQL index
 DROP INDEX file_fp_idx;

--- a/core/src/cats/ddl/updates/postgresql.12_14.sql
+++ b/core/src/cats/ddl/updates/postgresql.12_14.sql
@@ -21,7 +21,7 @@ ALTER TABLE File ADD COLUMN DeltaSeq smallint default 0;
 UPDATE Version SET VersionId=14;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.14_2001.sql
+++ b/core/src/cats/ddl/updates/postgresql.14_2001.sql
@@ -23,7 +23,7 @@ INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
    ('L', 'Committing data', 15);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
-   ('W', 'Terminated with warnings', 20);
+   ('W', 'Terminated with warning', 20);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
    ('l', 'Doing data despooling', 15);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
@@ -32,7 +32,7 @@ INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
 UPDATE Version SET VersionId = 2001;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2001_2002.sql
+++ b/core/src/cats/ddl/updates/postgresql.2001_2002.sql
@@ -39,6 +39,6 @@ ALTER TABLE Pool ADD COLUMN MaxBlockSize INTEGER DEFAULT 0;
 UPDATE Version SET VersionId = 2002;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2002_2003.sql
+++ b/core/src/cats/ddl/updates/postgresql.2002_2003.sql
@@ -43,6 +43,6 @@ DROP TABLE CDImages;
 UPDATE Version SET VersionId = 2003;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2003_2004.sql
+++ b/core/src/cats/ddl/updates/postgresql.2003_2004.sql
@@ -4,6 +4,6 @@ ALTER TABLE FileSet ADD COLUMN FileSetText TEXT DEFAULT '';
 UPDATE Version SET VersionId = 2004;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2004_2171.sql
+++ b/core/src/cats/ddl/updates/postgresql.2004_2171.sql
@@ -62,6 +62,6 @@ UPDATE Version SET VersionId = 2171;
 
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2171_2192.sql
+++ b/core/src/cats/ddl/updates/postgresql.2171_2192.sql
@@ -12,6 +12,6 @@ UPDATE Version SET VersionId = 2192;
 
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2192_2210.sql
+++ b/core/src/cats/ddl/updates/postgresql.2192_2210.sql
@@ -4,5 +4,5 @@ BEGIN;
 CREATE INDEX job_media_media_id_job_id_idx ON jobmedia (mediaid, jobid);
 UPDATE Version SET VersionId = 2210;
 COMMIT;
-set client_min_messages = fatal;
+set client_min_messages = warning;
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.bee.1017_2004.sql
+++ b/core/src/cats/ddl/updates/postgresql.bee.1017_2004.sql
@@ -31,7 +31,7 @@ ALTER TABLE file RENAME filename to name;
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
    ('L', 'Committing data', 15);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
-   ('W', 'Terminated with warnings', 20);
+   ('W', 'Terminated with warning', 20);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
    ('l', 'Doing data despooling', 15);
 INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
@@ -40,7 +40,7 @@ INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
 UPDATE Version SET VersionId = 2001;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 
@@ -61,7 +61,7 @@ ALTER TABLE Pool ADD COLUMN MaxBlockSize INTEGER DEFAULT 0;
 UPDATE Version SET VersionId = 2002;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 --
@@ -105,14 +105,14 @@ DROP TABLE CDImages;
 UPDATE Version SET VersionId = 2003;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 ALTER TABLE FileSet ADD COLUMN FileSetText TEXT DEFAULT '';
 UPDATE Version SET VersionId = 2004;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 ANALYSE;


### PR DESCRIPTION
This PR will modify all postgresql update script to set client_min_message to warning (or error) level
instead of non existent fatal.

It need a backport to 20
Should be merged before 20.0.4

This is a complementary of [PR#405](https://github.com/bareos/bareos/pull/405)

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
