### PR TITLE
Adapt Percona xtrabackup test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fixed all compiler warnings (on our default warning level) [PR #948]
 - Log LDAP info error (e.g. expired SSL cert error) [PR #956]
 - Fix occassional "NULL volume name" error when non-busy, but blocked drive is unloaded [PR #973]
+- Adapt percona-xtrabackup test to work on updated test environment [PR #982]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/core/cmake/BareosFindPrograms.cmake
+++ b/core/cmake/BareosFindPrograms.cmake
@@ -65,12 +65,15 @@ find_program(S3CMD s3cmd)
 find_program(MINIO minio)
 
 find_program(MYSQL mysql)
-find_program(MYSQLD mysqld)
+find_program(MYSQLD mysqld PATH /opt/mysql/bin)
 find_program(MYSQL_INSTALL_DB mysql_install_db)
 
 if(POLICY CMP0109)
   cmake_policy(SET CMP0109 NEW)
   find_program(SUDO sudo)
 else()
-  set(SUDO "/usr/bin/sudo" PARENT_SCOPE)
+  set(SUDO
+      "/usr/bin/sudo"
+      PARENT_SCOPE
+  )
 endif(POLICY CMP0109)

--- a/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
@@ -43,12 +43,12 @@ mkdir -p ${dbHost}
 # initialize mysql db
 
 if [ "${MYSQL_INSTALL_DB}" = "MYSQL_INSTALL_DB-NOTFOUND" ]; then
-	mysqld --defaults-file=mysqldefaults --initialize-insecure --user="$USER" > mysql/mysql_init.log
+	${MYSQLD} --defaults-file=mysqldefaults --initialize-insecure --user="$USER" > mysql/mysql_init.log
 else
 	mysql_install_db --user="$USER" --defaults-file=mysqldefaults > mysql/mysql_init.log
 fi
 # start mysql server
-mysqld --defaults-file=mysqldefaults >mysql/mysql.log 2>&1 &
+${MYSQLD} --defaults-file=mysqldefaults >mysql/mysql.log 2>&1 &
 
 tries=60
 echo "waiting for mysql server to start"

--- a/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
@@ -23,8 +23,9 @@ JobName=backup-bareos-fd
 "${rscripts}"/setup
 
 shutdown_mysql_server(){
-[ -f "mysql/mysqld.pid" ] && kill "$(cat mysql/mysqld.pid)" || :
-[ -f "mysql/data/${HOSTNAME}.pid" ] && kill "$(cat mysql/data/${HOSTNAME}.pid)" || :
+  [ -f "mysql/data/${HOSTNAME}.pid" ] && kill "$(cat mysql/data/${HOSTNAME}.pid)" || :
+# kill running mysqld instance listening on our port
+sudo fuser "${test_db_port}"/tcp -k || :
 }
 
 
@@ -42,11 +43,7 @@ mkdir -p ${dbHost}
 
 # initialize mysql db
 
-if [ "${MYSQL_INSTALL_DB}" = "MYSQL_INSTALL_DB-NOTFOUND" ]; then
-	${MYSQLD} --defaults-file=mysqldefaults --initialize-insecure --user="$USER" > mysql/mysql_init.log
-else
-	mysql_install_db --user="$USER" --defaults-file=mysqldefaults > mysql/mysql_init.log
-fi
+${MYSQLD} --defaults-file=mysqldefaults --initialize-insecure --user="$USER" > mysql/mysql_init.log
 # start mysql server
 ${MYSQLD} --defaults-file=mysqldefaults >mysql/mysql.log 2>&1 &
 


### PR DESCRIPTION
This PR changes the percona xtrabackup test to work with recent MySQL community edition binaries.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
