### PR TITLE
Fix PostgreSQL create database script and client_min_message level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix director crash on "update slots" when there is a parsing issue with the autochanger or tape devices [PR #919]
 - [Issue #1232]: bareos logrotate errors, reintroduce su directive in logrotate ([backport of PR #918])
 - Fix occasional "NULL volume name" error when non-busy, but blocked drive is unloaded [PR #975]
+- Fix PostgreSQL create database script [PR #983]
+- Unify level use with set client_min_message instruction in SQL update scripts [PR #983]
+
 
 ### Added
 - packages: Build also for Debian_11 [PR #915]

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -105,39 +105,15 @@ case ${db_type} in
       #
       # use SQL_ASCII to be able to put any filename into
       # the database even those created with unusual character sets
-      PSQLVERSION=`PGOPTIONS='--client-min-messages=warning' psql -d template1 -c 'SELECT version()' $* 2>/dev/null | \
-                   awk '/PostgreSQL/ { print $2 }' | \
-                   cut -d '.' -f 1,2`
-
-      if [ -z "${PSQLVERSION}" ]; then
-         echo "Unable to determine PostgreSQL version."
-         exit 1
-      fi
-
-      #
-      # Note, LC_COLLATE and LC_TYPE are needed on 8.4 and beyond, but are not implemented in 8.3 or below.
-      # This must be updated for future versions of PostgreSQL
-      #
-      case ${PSQLVERSION} in
-         9.*|10.*|11.*|12.*)
-	    ENCODING="ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C'"
-            ;;
-         8.[456789])
-	    ENCODING="ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C'"
-            ;;
-         *)
-	    ENCODING="ENCODING 'SQL_ASCII'"
-            ;;
-      esac
 
       PGOPTIONS='--client-min-messages=warning' psql -f - -d template1 $* << END-OF-DATA
 \set ON_ERROR_STOP on
-CREATE DATABASE ${db_name} $ENCODING TEMPLATE template0;
+CREATE DATABASE ${db_name} ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 ALTER DATABASE ${db_name} SET datestyle TO 'ISO, YMD';
 END-OF-DATA
       retval=$?
 
-      if PGOPTIONS='--client-min-messages=warning' psql -l ${dbname} $* | grep " ${db_name}.*SQL_ASCII" >/dev/null; then
+      if PGOPTIONS='--client-min-messages=warning' psql --list --tuples-only --no-align $* | grep "^${db_name}|.*|SQL_ASCII|C|C" >/dev/null; then
          echo "Database encoding OK"
       else
          echo " "

--- a/core/src/cats/ddl/updates/postgresql.11_12.sql
+++ b/core/src/cats/ddl/updates/postgresql.11_12.sql
@@ -48,7 +48,7 @@ COMMIT;
 CREATE INDEX basefiles_jobid_idx ON BaseFiles ( JobId );
 
 -- suppress output for index modification
-SET client_min_messages TO 'fatal';
+set client_min_messages = error;
 
 -- Remove bad PostgreSQL index
 DROP INDEX file_fp_idx;

--- a/core/src/cats/ddl/updates/postgresql.12_14.sql
+++ b/core/src/cats/ddl/updates/postgresql.12_14.sql
@@ -21,7 +21,7 @@ ALTER TABLE File ADD COLUMN DeltaSeq smallint default 0;
 UPDATE Version SET VersionId=14;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.14_2001.sql
+++ b/core/src/cats/ddl/updates/postgresql.14_2001.sql
@@ -32,7 +32,7 @@ INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
 UPDATE Version SET VersionId = 2001;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2001_2002.sql
+++ b/core/src/cats/ddl/updates/postgresql.2001_2002.sql
@@ -39,6 +39,6 @@ ALTER TABLE Pool ADD COLUMN MaxBlockSize INTEGER DEFAULT 0;
 UPDATE Version SET VersionId = 2002;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2002_2003.sql
+++ b/core/src/cats/ddl/updates/postgresql.2002_2003.sql
@@ -43,6 +43,6 @@ DROP TABLE CDImages;
 UPDATE Version SET VersionId = 2003;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2003_2004.sql
+++ b/core/src/cats/ddl/updates/postgresql.2003_2004.sql
@@ -4,6 +4,6 @@ ALTER TABLE FileSet ADD COLUMN FileSetText TEXT DEFAULT '';
 UPDATE Version SET VersionId = 2004;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2004_2171.sql
+++ b/core/src/cats/ddl/updates/postgresql.2004_2171.sql
@@ -62,6 +62,6 @@ UPDATE Version SET VersionId = 2171;
 
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.2171_2192.sql
+++ b/core/src/cats/ddl/updates/postgresql.2171_2192.sql
@@ -12,6 +12,6 @@ UPDATE Version SET VersionId = 2192;
 
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 ANALYSE;

--- a/core/src/cats/ddl/updates/postgresql.bee.1017_2004.sql
+++ b/core/src/cats/ddl/updates/postgresql.bee.1017_2004.sql
@@ -40,7 +40,7 @@ INSERT INTO Status (JobStatus,JobStatusLong,Severity) VALUES
 UPDATE Version SET VersionId = 2001;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 CREATE INDEX media_poolid_idx on Media (PoolId);
 
 
@@ -61,7 +61,7 @@ ALTER TABLE Pool ADD COLUMN MaxBlockSize INTEGER DEFAULT 0;
 UPDATE Version SET VersionId = 2002;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 --
@@ -105,14 +105,14 @@ DROP TABLE CDImages;
 UPDATE Version SET VersionId = 2003;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 ALTER TABLE FileSet ADD COLUMN FileSetText TEXT DEFAULT '';
 UPDATE Version SET VersionId = 2004;
 COMMIT;
 
-set client_min_messages = fatal;
+set client_min_messages = warning;
 
 
 ANALYSE;


### PR DESCRIPTION
This PR improve the way we create Bareos database with PostgreSQL and fix the used level for client_min_message to actual valid values.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing