### PR TITLE
droiplet: remove obsolete attr/xattr.h include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fix PostgreSQL create database script [PR #981]
 - Unify level use with set client_min_message instruction in SQL update scripts [PR #981]
 - Fixed issue with error messages not showing up properly on windows systems [PR #959]
+- Fixed libdroplet xattr.h include issue by using sys/xattr.h [PR #985]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/core/src/droplet/libdroplet/src/backend/posix/reqbuilder.c
+++ b/core/src/droplet/libdroplet/src/backend/posix/reqbuilder.c
@@ -39,8 +39,7 @@
 #include <sys/stat.h>
 #include <dirent.h>
 #include <sys/types.h>
-#include <linux/xattr.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <utime.h>
 #include <pwd.h>
 #include <grp.h>

--- a/core/src/droplet/libdroplet/src/utils.c
+++ b/core/src/droplet/libdroplet/src/utils.c
@@ -33,8 +33,7 @@
  * https://github.com/scality/Droplet
  */
 #include <dropletp.h>
-#include <linux/xattr.h>
-#include <attr/xattr.h>
+#include <sys/xattr.h>
 #include <errno.h>
 
 /** @file */


### PR DESCRIPTION
This PR update the way xattr.h is included in libdroplet by removing obsolete attr/xattr.h include.
see 2015 attr upstream commit https://git.savannah.nongnu.org/cgit/attr.git/commit/?id=7921157890d07858d092f4003ca4c6bae9fd2c38 and replace by sys/xattr.h

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
