### PR TITLE
Enable Tracing to file with set debug command (Update ua_cmds.cc)

### DIFF
--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1397,6 +1397,7 @@ void DoAllSetDebug(UaContext* ua,
 static bool SetdebugCmd(UaContext* ua, const char* cmd)
 {
   int i;
+  int j;
   int level;
   int trace_flag;
   int hangup_flag;
@@ -1414,14 +1415,16 @@ static bool SetdebugCmd(UaContext* ua, const char* cmd)
     level = ua->pint32_val;
   }
 
-  // Look for trace flag. -1 => not change
-  i = FindArgWithValue(ua, NT_("trace"));
-  if (i >= 0) {
-    trace_flag = atoi(ua->argv[i]);
-    if (trace_flag > 0) { trace_flag = 1; }
-  } else {
-    trace_flag = -1;
-  }
+  //The work of the candidate  Alaa Mzoughi to enable trace file
+   j = FindArgWithValue(ua, NT_("trace"));
+
+
+   if (j >= 0) {
+     trace_flag = atoi(ua->argv[j]); }
+   if (trace_flag < 0) {
+     if (!GetPint(ua, _("Enter new debug Trace"))) { return true; }
+     trace_flag = ua->pint32_val;
+   }
 
   // Look for hangup (debug only) flag. -1 => not change
   i = FindArgWithValue(ua, NT_("hangup"));


### PR DESCRIPTION
Enable Tracing to file with set debug command .
This is the work of the candidate alaa mzoughi which is an update for the last pull request which has a problem with the source and number of changed files and it's fixed in that pull request .
The Task's Respones and Screen Shots of the tests are sended to the email :  jobs@bareos.com

****#Proposed Changes :**** 
in order to solve the problem of enable tracing , i modified the  setdebugCmd Function
to ask the user to pass the Trace argument like the other arguments (Debug level and daemons) , so
in case the user dosen’t specify the trace , automatically he will be asked to input it
Also if the user passes a negative number as a trace, the command line will display : Enter new
debug Trace and it will repeat that until the user enters a number ( 0 or positive number )
P.S : The only case that the file would not be created is if the client himself fixes the trace as 0