### PR TITLE
Wael_Youssfi Assignment

### DIFF
--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1394,6 +1394,8 @@ void DoAllSetDebug(UaContext* ua,
 }
 
 // setdebug level=nn all trace=1/0 timestamp=1/0
+//I edited the SetdebugCmd function so it propmts the user for a trace property
+//the funtion is now as following:
 static bool SetdebugCmd(UaContext* ua, const char* cmd)
 {
   int i;
@@ -1416,11 +1418,15 @@ static bool SetdebugCmd(UaContext* ua, const char* cmd)
 
   // Look for trace flag. -1 => not change
   i = FindArgWithValue(ua, NT_("trace"));
+  
   if (i >= 0) {
     trace_flag = atoi(ua->argv[i]);
     if (trace_flag > 0) { trace_flag = 1; }
   } else {
-    trace_flag = -1;
+    // trace_flag = -1;
+    //Here I prompt the user instead of setting the trace_flag value to -1
+    if (!GetPint(ua, _("Enable trace? (1:yes, 0:no, -1: keep previous state): "))) { return true; }
+    trace_flag = ua->pint32_val;
   }
 
   // Look for hangup (debug only) flag. -1 => not change


### PR DESCRIPTION
***First task (the output):** I sent the output as plain text to the email: jobs@bareos.com
***Second task (How  to improve setdebug behavior):** 
When using the full command of setdebug level=100 dir trace=1 for the second time the file is created containing the event or the trace should I say.
However, when using the setdebug interactively it doesn't ask for the trace flag (0 or 1). After testing out a couple of times, it uses the last provided flag in the previous full command whether you provided 0 or 1.
Example: if I use setdebug level=100 dir trace=0 then try to use it interactively the trace file won't be created in case I deleted it after running the first full command because the interactive setdebug would have for a trace flag 0 in this case.
How to fix in my opinion: Quite simply I believe that we need to prompt for the user to ask him whether he wants trace= 0 or 1 in the same way we ask about the level 
***Third task (Identifying the codebase function):** 
1)In the code-base the function that handles this functionality is in the file: bareos/bareos/core/src/dird/ua_cmds.cc specifically line 1397 "static bool SetdebugCmd(UaContext* ua, const char* cmd)" .
2)The function is called in line 205 in the file bareos/core/src/stored/dir_cmd.cc and in line 182 in the file bareos/core/src/filed/dir_cmd.cc line.
3)The SetdebugCmd function calls mainly the following functions: 
DoAllSetDebug
DoDirectorSetdebug
DoClientSetdebug
DoStorageSetdebug
***Fourth task (A way to implement the new behavior):**
One of the ways to implement the behavior I mentionned in the second question is to:
To prompt the user and ask him to input the trace flag value 0 or 1 
This will be by adding some code in the implementation of the SetdebugCmd function 
***Fifth task (View the content of the pull request)**
***Sixth task (Other unexpected behaviors):**
Firstly, when I was testing out the setdebug command in the bconsole, I noticed that the trace file will not be created from the first call of the setdebug command but it will be created after the second call.
Secondly, sometimes when I delete the created trace file and execute the setdebug command the won't be created even if I execute the command for many times (with trace= 0 or 1 no difference).

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
