### PR TITLE
webui: add inchanger column to volume tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - packages: Build also for Fedora_35 [PR #972]
 - cmake: check for chflags() function and enable FreeBSD File Flags support [PR #963]
 - plugin: added mariabackup python plugin, added systemtest for mariabackup and updated systemtest for percona-xtrabackup [PR #967]
+- webui: add inchanger column to volume tables [PR #998]
 
 
 ### Changed

--- a/webui/module/Media/view/media/media/details.phtml
+++ b/webui/module/Media/view/media/media/details.phtml
@@ -369,7 +369,7 @@ $this->headTitle($title);
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("In changer")); ?></th>');
-      html.push('<td>' + row.inchanger + '</td>');
+      html.push('<td>' + formatInchanger(row.inchanger) + '</td>');
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Volume Files")); ?></th>');

--- a/webui/module/Media/view/media/media/index.phtml
+++ b/webui/module/Media/view/media/media/index.phtml
@@ -86,6 +86,12 @@ $this->headTitle($title);
       <?php echo $this->translate("Status"); ?>
    </th>
    <th
+      data-field="inchanger"
+      data-filter-control="input"
+      data-filter-control-placeholder="<?php echo $this->translate("In changer"); ?>">
+      <?php echo $this->translate("In changer"); ?>
+   </th>
+   <th
       data-field="retention"
       data-filter-control="input"
       data-filter-control-placeholder="<?php echo $this->translate("Retention"); ?>">
@@ -194,6 +200,13 @@ $this->headTitle($title);
             {
                field: 'volstatus',
                sortable: true,
+            },
+            {
+               field: 'inchanger',
+               sortable: true,
+               formatter: function(value) {
+                  return formatInchanger(value);
+               }
             },
             {
                field: 'retention',

--- a/webui/module/Pool/view/pool/pool/details.phtml
+++ b/webui/module/Pool/view/pool/pool/details.phtml
@@ -118,6 +118,12 @@ $this->headTitle($title);
       <?php echo $this->translate("Status"); ?>
    </th>
    <th
+      data-field="inchanger"
+      data-filter-control="input"
+      data-filter-control-placeholder="<?php echo $this->translate("In changer"); ?>">
+      <?php echo $this->translate("In changer"); ?>
+   </th>
+   <th
       data-field="retention"
       data-filter-control="input"
       data-filter-control-placeholder="<?php echo $this->translate("Retention"); ?>">
@@ -264,6 +270,13 @@ $this->headTitle($title);
             {
                field: 'volstatus',
                sortable: true,
+            },
+            {
+               field: 'inchanger',
+               sortable: true,
+               formatter: function(value) {
+                  return formatInchanger(value);
+               }
             },
             {
                field: 'retention',

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -208,6 +208,17 @@ function formatRecycle(data) {
    return r;
 }
 
+function formatInchanger(data) {
+   var r;
+   if(data == 1) {
+      r = '<span class="label label-success">' + iJS._("Yes") + '</span>';
+   }
+   else {
+      r = '<span class="label label-default">' + iJS._("No") + '</span>';
+   }
+   return r;
+}
+
 function formatJobStatus(data) {
    var output;
    switch(data) {


### PR DESCRIPTION
In order to quickly identify which volumes are available by your
autochanger an additional column is introduced on volume tables.

Fixes #1151: bareos webui does not show the inchanger flag for volumes

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
