### PR TITLE
Include zero-file incremental backups in always-incremental consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+- [Issue #1374] Include zero-file incremental backups in always-incremental consolidation [PR #1000]
+
+### Added
+
+### Changed
+
 ## [20.0.4] - 2021-11-22
 
 ### Fixed

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1387,7 +1387,6 @@ bool BareosDb::AccurateGetJobids(JobControlRecord* jcr,
          "SELECT JobId, StartTime, EndTime, JobTDate, PurgedFiles "
          "FROM Job JOIN FileSet USING (FileSetId) "
          "WHERE ClientId = %s "
-         "AND JobFiles > 0 "
          "AND Level='I' AND JobStatus IN ('T','W') AND Type='B' "
          "AND StartTime > (SELECT EndTime FROM btemp3%s ORDER BY EndTime DESC "
          "LIMIT 1) "


### PR DESCRIPTION
Description:
Consolidation jobs for always incremental do not include zero-files backups jobs, and so these jobs stay in the database unnecessarily.

This PR makes sure zero-file incremental backups do get included in consolidation.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing
