### PR TITLE
director: fix crash in status scheduler when client is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - [Issue #1374] Include zero-file incremental backups in always-incremental consolidation [PR #1000]
+- fix crash in "status scheduler" command when job->client is unset [PR #1001]
 
 ### Added
 

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -686,7 +686,7 @@ start_again:
        */
       if (job) {
         if (job->schedule && job->schedule->enabled && job->enabled
-            && job->client->enabled) {
+            && job->client && job->client->enabled) {
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -698,7 +698,7 @@ start_again:
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
           if (job->schedule && job->schedule->enabled && job->enabled
-              && job->client == client && job->client->enabled) {
+              && job->client && job->client == client && job->client->enabled) {
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -687,7 +687,7 @@ start_again:
       if (job) {
         if (job->schedule && job->schedule->enabled && job->enabled) {
           // skip if client is set but not enabled
-          if (job->client && !job->client->enabled) goto start_again;
+          if (job->client && !job->client->enabled) { break; }
 
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -685,8 +685,10 @@ start_again:
        * List specific schedule.
        */
       if (job) {
-        if (job->schedule && job->schedule->enabled && job->enabled
-            && job->client && job->client->enabled) {
+        if (job->schedule && job->schedule->enabled && job->enabled) {
+          // skip if client is set but not enabled
+          if (job->client && !job->client->enabled) goto start_again;
+
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -697,8 +699,11 @@ start_again:
         foreach_res (job, R_JOB) {
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-          if (job->schedule && job->schedule->enabled && job->enabled
-              && job->client && job->client == client && job->client->enabled) {
+          if (job->schedule && job->schedule->enabled && job->enabled) {
+            // skip if client is set but not enabled
+            if (job->client && job->client == client && !job->client->enabled) {
+              continue;
+            }
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The status scheduler command did not check the job->client pointer before dereferencing. This is fixed with this PR.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
