### PR TITLE
fix status schedule crash 5005

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,5 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+- fix crash in "status scheduler" command when job->client is unset [PR #1002]
+
+### Added
+
+### Changed
 
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -645,7 +645,8 @@ start_again:
        * List specific schedule.
        */
       if (job) {
-        if (job->schedule) {
+        if (job->schedule && job->schedule->enabled && job->enabled
+            && job->client && job->client->enabled) {
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -656,7 +657,8 @@ start_again:
         foreach_res (job, R_JOB) {
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-          if (job->schedule && job->client == client) {
+          if (job->schedule && job->schedule->enabled && job->enabled
+              && job->client && job->client == client && job->client->enabled) {
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -645,8 +645,10 @@ start_again:
        * List specific schedule.
        */
       if (job) {
-        if (job->schedule && job->schedule->enabled && job->enabled
-            && job->client && job->client->enabled) {
+        if (job->schedule && job->schedule->enabled && job->enabled) {
+          // skip if client is set but not enabled
+          if (job->client && !job->client->enabled) goto start_again;
+
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {
             goto start_again;
@@ -657,8 +659,11 @@ start_again:
         foreach_res (job, R_JOB) {
           if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-          if (job->schedule && job->schedule->enabled && job->enabled
-              && job->client && job->client == client && job->client->enabled) {
+          if (job->schedule && job->schedule->enabled && job->enabled) {
+            // skip if client is set but not enabled
+            if (job->client && job->client == client && !job->client->enabled) {
+              continue;
+            }
             if (!show_scheduled_preview(ua, job->schedule, overview,
                                         &max_date_len, time_to_check)) {
               job = NULL;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -647,7 +647,7 @@ start_again:
       if (job) {
         if (job->schedule && job->schedule->enabled && job->enabled) {
           // skip if client is set but not enabled
-          if (job->client && !job->client->enabled) goto start_again;
+          if (job->client && !job->client->enabled) { break; }
 
           if (!show_scheduled_preview(ua, job->schedule, overview,
                                       &max_date_len, time_to_check)) {


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The status scheduler command did not check the job->client pointer before dereferencing. This is fixed with this PR.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
