### PR TITLE
FD Python3 plugin to enable the backup/restoration of CIFS ACLs

### DIFF
--- a/contrib/fd-plugins/cifs-acls/BareosFdPluginCifsAcls.py
+++ b/contrib/fd-plugins/cifs-acls/BareosFdPluginCifsAcls.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+# Author: Olivier Gagnon
+#
+
+import bareosfd
+import xattr as eattr
+
+from BareosFdPluginBaseclass import BareosFdPluginBaseclass
+
+class BareosFdPluginCifsAcls(BareosFdPluginBaseclass):
+    plugin_name = "bareos-fd-cifs-acls"
+    mandatory_options = None
+    
+    def __init__(self, plugindef):
+        bareosfd.DebugMessage(
+            100,
+            "Constructor called in module %s with plugindef=%s\n"
+            % (__name__, plugindef),
+        )
+        super(BareosFdPluginCifsAcls, self).__init__(plugindef, self.mandatory_options)
+    
+    def get_xattr(self, xattr: bareosfd.XattrPacket):
+        bname = str("system.cifs_acl")
+        bvalue = None
+        has_xattr = False
+
+        try:
+            bvalue = eattr.getxattr(xattr.fname, bname)
+            has_xattr = True
+            xattr.name = bytearray(bname, 'ascii')
+            xattr.value = bytearray(bvalue)
+            
+        except OSError as e:
+            bareosfd.JobMessage(
+                bareosfd.M_WARNING,
+                "Unable to retrieve CIFS ACLs for %s: %s\n" % (xattr.fname, e.strerror))
+            pass
+
+        bareosfd.DebugMessage(100, "%s GETXATTR: %s\n" % (self.plugin_name, xattr))
+            
+        return bareosfd.bRC_OK
+
+    def set_xattr(self, xattr: bareosfd.XattrPacket):
+        bname = str("system.cifs_acl")
+
+        if xattr.name.decode() == bname:
+            try:
+                eattr.setxattr(xattr.fname, bname, bytes(xattr.value))
+            except OSError as e:
+                bareosfd.JobMessage(
+                    bareosfd.M_WARNING,
+                    "Unable to restore CIFS ACLs for %s: %s\n" % (xattr.fname, e.strerror))
+                pass
+            bareosfd.DebugMessage(100, "%s SETXATTR: %s\n" % (self.plugin_name, xattr))
+        return bareosfd.bRC_OK

--- a/contrib/fd-plugins/cifs-acls/README.md
+++ b/contrib/fd-plugins/cifs-acls/README.md
@@ -1,0 +1,76 @@
+# Bareos Plugin to backup NT ACLs from mounted CIFS filesystems
+
+## Introduction
+
+At the moment, Bareos only supports backing up NT ACLs (Windows) permissions using the Bareos Windows client.
+However, backing up "shared drives" via SMB (i.e. NAS) doesn't work natively.
+Years ago (<https://groups.google.com/g/bareos-users/c/WI0Ak5fpGcw?pli=1>) I found out that the way Bareos implements its file/folder lookups prohibits it:
+* Bareos uses the`GetFileAttributes` API function to test if the file/folder is present and bails out if it fails. Unfortunately, that function doesn't work on remote drives.
+* Back then, I tweaked the code to bypass that check and succeeded at being able to backup those drives with the ACLs permissions.
+* It was however an ugly fix that could not be integrated into the official code.
+
+Eight years forward and in the process of moving to a new Bareos environment, it looks like it is still not supported. Since then a lot changed and the Linux `cifs` module is much more stable and gives access natively to those ACLs as Extended Attributes. They can be read and parsed using the `getcifsacl` tool or with a simple `getxattr`system call to retrieve the `system.cifs_acl`attribute containing a raw data blob containing the ACLs. 
+
+The `system.cifs_acl` attribute is not listed using the `listxattr` call by design and needs to be specified explicitly for retrieval. It is then not saved by default by Bareos.
+
+After some thoughts, a native C PoC and some code reading, I decided that it would be easier to just implement it using a Python plugin for the `bareos-fd` client. And much more easier it was !
+
+So here it is. 
+
+Olivier Gagnon
+
+## Requirements
+
+* Recent Linux kernel and `cifs-utils`
+* Bareos client compiled with `HAVE_XATTR`and Python3 support
+* Python3 `xattr` module
+* A mounted CIFS remote share to backup
+
+### Test for requirements
+* `cat /proc/fs/cifs/DebugData | grep XATTR` 
+* `python -c 'import xattr'`
+* `getcifsacl </mnt/mountedcifs/existingfile>`
+* `getfattr -n system.cifs_acl </mnt/mountedcifs/existingfile>`
+
+## Installation
+* Copy the **BareosFdPluginCifsAcls.py** and **bareosfd-cifs-acls.py** files in your Bareos plugin directory (usually */usr/lib64/bareos/plugins*)
+
+### Activate the python3 plugin in the fd resource conf on the client
+```
+Client (or FileDaemon) {                          
+  Name = client-fd
+  ...
+  Plugin Directory = /usr/lib64/bareos/plugins
+  Plugin Names = "python3"
+}
+```
+### Include the Plugin in the fileset definition in the Options block
+```
+FileSet {
+  Name = "cifs-files"
+  Include {
+    Options {
+      ...
+      Plugin =  "python3"
+                ":module_path=/usr/lib64/bareos/plugins"
+                ":module_name=bareosfd-cifs-acls"
+    }
+    File = "</mnt/mountedcifstobackup>"
+    ...
+  }
+} 
+```
+* *Note*: A specific Restore Job should be created using that FileSet or manually changed to it when restoring.
+
+## TODOs
+
+* Add Options parameters (ie. white/black listing files/directories)
+* Add more extensive checks depending of the environment (only tested on two Linux system)
+
+## Authors
+
+* Olivier Gagnon
+
+## License
+
+This project is licensed under the GNU Affero General Public License v3.0 License - see the [LICENSE](https://raw.githubusercontent.com/bareos/bareos/master/core/AGPL-3.0.txt) file for details

--- a/contrib/fd-plugins/cifs-acls/bareos-fd-cifs-acls.py
+++ b/contrib/fd-plugins/cifs-acls/bareos-fd-cifs-acls.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+# Author: Olivier Gagnon
+#
+
+import bareosfd
+import BareosFdWrapper
+from BareosFdWrapper import *  # noqa
+
+
+import BareosFdPluginCifsAcls
+
+
+def load_bareos_plugin(plugindef):
+    BareosFdWrapper.bareos_fd_plugin_object = (
+        BareosFdPluginCifsAcls.BareosFdPluginCifsAcls(plugindef)
+    )
+    return bareosfd.bRC_OK


### PR DESCRIPTION
FD Python3 plugin to enable the backup/restoration of CIFS ACLs (aka Windows permissions aka NT ACLs) of remote CIFS shares from Linux client.

See the [README.md](/procule/bareos/blob/plugin/fd-cifs-acls/contrib/fd-plugins/cifs-acls/README.md) for complete description.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
