### PR TITLE
docs: rename Autochanger chapter to include Tape drive support

### DIFF
--- a/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
+++ b/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
@@ -1,7 +1,7 @@
 .. _AutochangersChapter:
 
-Autochanger Support
-===================
+Autochanger & Tape drive Support
+================================
 
 :index:`\ <single: Support; Autochanger>`\  :index:`\ <single: Autochanger; Support>`\
 


### PR DESCRIPTION
"Tapespeed and blocksizes" section is not specific only to autochangers.
Proposed changes: introduce new "Performance Tuning" chapter and move "Tapespeed and blocksizes" section to it.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted

##### Source code quality

- [X] Source code changes are understandable
- [X] Required documentation changes are present and part of the PR
- [X] `bareos-check-sources --since-merge` does not report any problems
- [X] `git status` should not report modifications in the source tree after building and testing
