### PR TITLE
cats: failed update message when updating all volumes from all pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - core cats: Add IF EXISTS in drop table statements fix for bug #1409 (Allow usage of ExitOnFatal) [PR #1035]
 - sql_get.cc: fix error logging in GetJobRecord() for jobname #1042
 - webui: fix empty job timeline issue if date.timezone is not set in php.ini [PR #1051]
+- Fix for wrong update message when updating all volumes from all pools with no existing volumes [PR #1015]
 
 ### Added
 - tests: simplify test coverage analysis [PR #1010]

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -1007,6 +1007,14 @@ class BareosDb : public BareosDbQueryEnum {
 #define QUERY_DB(jcr, cmd) QueryDB(__FILE__, __LINE__, jcr, cmd)
 #define DELETE_DB(jcr, cmd) DeleteDB(__FILE__, __LINE__, jcr, cmd)
 
+class DbLocker {
+  BareosDb* db_handle_;
+
+ public:
+  DbLocker(BareosDb* db_handle) : db_handle_(db_handle) { DbLock(db_handle_); }
+  ~DbLocker() { DbUnlock(db_handle_); }
+};
+
 // Pooled backend connection.
 struct SqlPoolEntry {
   int id = 0; /**< Unique ID, connection numbering can have holes and the pool

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -596,11 +596,10 @@ class BareosDb : public BareosDbQueryEnum {
                int line,
                JobControlRecord* jcr,
                const char* DeleteCmd);
-  bool UpdateDB(const char* file,
-                int line,
-                JobControlRecord* jcr,
-                const char* UpdateCmd,
-                int expected_minimum_number_affected_rows);
+  int UpdateDB(const char* file,
+               int line,
+               JobControlRecord* jcr,
+               const char* UpdateCmd);
   int GetSqlRecordMax(JobControlRecord* jcr);
   void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
   void ListDashes(OutputFormatter* send);
@@ -1003,9 +1002,7 @@ class BareosDb : public BareosDbQueryEnum {
 #define BATCH_FLUSH 800000
 
 /* Use for better error location printing */
-#define UPDATE_DB(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd, 1)
-#define UPDATE_DB_NO_AFFECTED_ROWS(jcr, cmd) \
-  UpdateDB(__FILE__, __LINE__, jcr, cmd, 0)
+#define UPDATE_DB(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd)
 #define INSERT_DB(jcr, cmd) InsertDB(__FILE__, __LINE__, jcr, cmd)
 #define QUERY_DB(jcr, cmd) QueryDB(__FILE__, __LINE__, jcr, cmd)
 #define DELETE_DB(jcr, cmd) DeleteDB(__FILE__, __LINE__, jcr, cmd)

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -588,10 +588,10 @@ class BareosDb : public BareosDbQueryEnum {
                int line,
                JobControlRecord* jcr,
                const char* select_cmd);
-  bool InsertDB(const char* file,
-                int line,
-                JobControlRecord* jcr,
-                const char* select_cmd);
+  int InsertDB(const char* file,
+               int line,
+               JobControlRecord* jcr,
+               const char* select_cmd);
   int DeleteDB(const char* file,
                int line,
                JobControlRecord* jcr,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -600,7 +600,7 @@ class BareosDb : public BareosDbQueryEnum {
                 int line,
                 JobControlRecord* jcr,
                 const char* UpdateCmd,
-                int nr_afr);
+                int expected_minimum_number_affected_rows);
   int GetSqlRecordMax(JobControlRecord* jcr);
   void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
   void ListDashes(OutputFormatter* send);
@@ -1004,7 +1004,8 @@ class BareosDb : public BareosDbQueryEnum {
 
 /* Use for better error location printing */
 #define UPDATE_DB(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd, 1)
-#define UPDATE_DB_NO_AFR(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd, 0)
+#define UPDATE_DB_NO_AFFECTED_ROWS(jcr, cmd) \
+  UpdateDB(__FILE__, __LINE__, jcr, cmd, 0)
 #define INSERT_DB(jcr, cmd) InsertDB(__FILE__, __LINE__, jcr, cmd)
 #define QUERY_DB(jcr, cmd) QueryDB(__FILE__, __LINE__, jcr, cmd)
 #define DELETE_DB(jcr, cmd) DeleteDB(__FILE__, __LINE__, jcr, cmd)

--- a/core/src/cats/mysql.cc
+++ b/core/src/cats/mysql.cc
@@ -268,7 +268,7 @@ bool BareosDbMysql::ValidateConnection(void)
    * the server. We also catch a changing threadid which means
    * a reconnect has taken place.
    */
-  DbLock(this);
+  DbLocker _{this};
   mysql_threadid = mysql_thread_id(db_handle_);
   if (mysql_ping(db_handle_) == 0) {
     Dmsg2(500,
@@ -291,7 +291,6 @@ bool BareosDbMysql::ValidateConnection(void)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -389,7 +388,7 @@ bool BareosDbMysql::SqlQueryWithHandler(const char* query,
 
   Dmsg1(500, "SqlQueryWithHandler starts with %s\n", query);
 
-  DbLock(this);
+  DbLocker _{this};
 
 retry_query:
   status = mysql_query(db_handle_, query);
@@ -453,7 +452,6 @@ retry_query:
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -542,7 +540,7 @@ retry_query:
 
 void BareosDbMysql::SqlFreeResult(void)
 {
-  DbLock(this);
+    DbLocker _{this};
   if (result_) {
     mysql_free_result(result_);
     result_ = NULL;
@@ -552,7 +550,6 @@ void BareosDbMysql::SqlFreeResult(void)
     fields_ = NULL;
   }
   num_rows_ = num_fields_ = 0;
-  DbUnlock(this);
 }
 
 SQL_ROW BareosDbMysql::SqlFetchRow(void)

--- a/core/src/cats/mysql_batch.cc
+++ b/core/src/cats/mysql_batch.cc
@@ -39,7 +39,7 @@ bool BareosDbMysql::SqlBatchStartFileTable(JobControlRecord* jcr)
 {
   bool retval;
 
-  DbLock(this);
+  DbLocker _{this};
   retval = SqlQuery(
       "CREATE TEMPORARY TABLE batch ("
       "FileIndex integer,"
@@ -51,7 +51,6 @@ bool BareosDbMysql::SqlBatchStartFileTable(JobControlRecord* jcr)
       "DeltaSeq integer,"
       "Fhinfo NUMERIC(20),"
       "Fhnode NUMERIC(20) )");
-  DbUnlock(this);
 
   // Keep track of the number of changes in batch mode.
   changes = 0;

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -303,20 +303,19 @@ bool BareosDbPostgresql::ValidateConnection(void)
   if (!SqlQueryWithoutHandler("SELECT 1", true)) {
     // Try resetting the connection.
     PQreset(db_handle_);
-    if (PQstatus(db_handle_) != CONNECTION_OK) { goto bail_out; }
+    if (PQstatus(db_handle_) != CONNECTION_OK) { return retval; }
 
     SqlQueryWithoutHandler("SET datestyle TO 'ISO, YMD'");
     SqlQueryWithoutHandler("SET cursor_tuple_fraction=1");
     SqlQueryWithoutHandler("SET standard_conforming_strings=on");
 
     // Retry the null query.
-    if (!SqlQueryWithoutHandler("SELECT 1", true)) { goto bail_out; }
+    if (!SqlQueryWithoutHandler("SELECT 1", true)) { return retval; }
   }
 
   SqlFreeResult();
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -559,7 +558,7 @@ bool BareosDbPostgresql::SqlQueryWithHandler(const char* query,
     Mmsg(errmsg, _("Query failed: %s: ERR=%s\n"), query, sql_strerror());
     Dmsg0(500, "SqlQueryWithHandler failed\n");
     retval = false;
-    goto bail_out;
+    return retval;
   }
 
   Dmsg0(500, "SqlQueryWithHandler succeeded. checking handler\n");
@@ -575,7 +574,6 @@ bool BareosDbPostgresql::SqlQueryWithHandler(const char* query,
 
   Dmsg0(500, "SqlQueryWithHandler finished\n");
 
-bail_out:
   return retval;
 }
 

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -236,10 +236,10 @@ bool BareosDb::QueryDB(const char* file,
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::InsertDB(const char* file,
-                        int line,
-                        JobControlRecord* jcr,
-                        const char* select_cmd)
+int BareosDb::InsertDB(const char* file,
+                       int line,
+                       JobControlRecord* jcr,
+                       const char* select_cmd)
 {
   int num_rows;
 
@@ -248,7 +248,7 @@ bool BareosDb::InsertDB(const char* file,
          sql_strerror());
     j_msg(file, line, jcr, M_FATAL, 0, "%s", errmsg);
     if (verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", select_cmd); }
-    return false;
+    return -1;
   }
   num_rows = SqlAffectedRows();
   if (num_rows != 1) {
@@ -256,10 +256,10 @@ bool BareosDb::InsertDB(const char* file,
     msg_(file, line, errmsg, _("Insertion problem: affected_rows=%s\n"),
          edit_uint64(num_rows, ed1));
     if (verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", select_cmd); }
-    return false;
+    return num_rows;
   }
   changes++;
-  return true;
+  return num_rows;
 }
 
 /**

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -271,7 +271,7 @@ bool BareosDb::UpdateDB(const char* file,
                         int line,
                         JobControlRecord* jcr,
                         const char* UpdateCmd,
-                        int nr_afr)
+                        int expected_minimum_number_affected_rows)
 {
   int num_rows;
 
@@ -283,9 +283,9 @@ bool BareosDb::UpdateDB(const char* file,
     return false;
   }
 
-  if (nr_afr > 0) {
+  if (expected_minimum_number_affected_rows > 0) {
     num_rows = SqlAffectedRows();
-    if (num_rows < nr_afr) {
+    if (num_rows < expected_minimum_number_affected_rows) {
       char ed1[30];
       msg_(file, line, errmsg, _("Update failed: affected_rows=%s for %s\n"),
            edit_uint64(num_rows, ed1), UpdateCmd);

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -267,37 +267,21 @@ bool BareosDb::InsertDB(const char* file,
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::UpdateDB(const char* file,
-                        int line,
-                        JobControlRecord* jcr,
-                        const char* UpdateCmd,
-                        int expected_minimum_number_affected_rows)
+int BareosDb::UpdateDB(const char* file,
+                       int line,
+                       JobControlRecord* jcr,
+                       const char* UpdateCmd)
 {
-  int num_rows;
-
   if (!SqlQuery(UpdateCmd)) {
     msg_(file, line, errmsg, _("update %s failed:\n%s\n"), UpdateCmd,
          sql_strerror());
     j_msg(file, line, jcr, M_ERROR, 0, "%s", errmsg);
     if (verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", UpdateCmd); }
-    return false;
-  }
-
-  if (expected_minimum_number_affected_rows > 0) {
-    num_rows = SqlAffectedRows();
-    if (num_rows < expected_minimum_number_affected_rows) {
-      char ed1[30];
-      msg_(file, line, errmsg, _("Update failed: affected_rows=%s for %s\n"),
-           edit_uint64(num_rows, ed1), UpdateCmd);
-      if (verbose) {
-        //          j_msg(file, line, jcr, M_INFO, 0, "%s\n", UpdateCmd);
-      }
-      return false;
-    }
+    return -1;
   }
 
   changes++;
-  return true;
+  return SqlAffectedRows();
 }
 
 /**

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -50,7 +50,6 @@ static const int dbglevel = 100;
  */
 bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
 {
-  bool retval = false;
   PoolMem buf;
   char dt[MAX_TIME_LENGTH];
   time_t stime;
@@ -90,10 +89,10 @@ bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
     Mmsg2(errmsg, _("Create DB Job record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
   } else {
-    retval = true;
+    return true;
   }
 
-  return retval;
+  return false;
 }
 
 /**
@@ -103,7 +102,6 @@ bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
  */
 bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
 {
-  bool retval = false;
   int count;
   char ed1[50], ed2[50], ed3[50];
 
@@ -141,11 +139,11 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
       Mmsg2(errmsg, _("Update Media record %s failed: ERR=%s\n"), cmd,
             sql_strerror());
     } else {
-      retval = true;
+      return true;
     }
   }
-  Dmsg0(300, "Return from JobMedia\n");
-  return retval;
+
+  return false;
 }
 
 /**
@@ -223,7 +221,6 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
  */
 bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[30], ed2[30];
   char esc[MAX_ESCAPE_NAME_LENGTH];
@@ -249,7 +246,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
         Mmsg1(errmsg, _("error fetching Device row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        return retval;
+        return false;
       }
       dr->DeviceId = str_to_int64(row[0]);
       if (row[1]) {
@@ -258,8 +255,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
         dr->Name[0] = 0; /* no name */
       }
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -273,10 +269,10 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
     Mmsg2(errmsg, _("Create db Device record %s failed: ERR=%s\n"), cmd,
           sql_strerror());
   } else {
-    retval = true;
+    return true;
   }
 
-  return retval;
+  return false;
 }
 
 /**
@@ -287,7 +283,6 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
 bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
 {
   SQL_ROW row;
-  bool retval = false;
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
@@ -309,13 +304,12 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
         Mmsg1(errmsg, _("error fetching Storage row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        return retval;
+        return false;
       }
       sr->StorageId = str_to_int64(row[0]);
       sr->AutoChanger = atoi(row[1]); /* bool */
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -332,10 +326,10 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   } else {
     sr->created = true;
-    retval = true;
+    return true;
   }
 
-  return retval;
+  return false;
 }
 
 /**
@@ -346,7 +340,6 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
 bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
                                      MediaTypeDbRecord* mr)
 {
-  bool retval = false;
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
@@ -362,7 +355,7 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
     if (num_rows > 0) {
       Mmsg1(errmsg, _("mediatype record %s already exists\n"), mr->MediaType);
       SqlFreeResult();
-      return retval;
+      return false;
     }
     SqlFreeResult();
   }
@@ -380,12 +373,10 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
   if (mr->MediaTypeId == 0) {
     Mmsg2(errmsg, _("Create db mediatype record %s failed: ERR=%s\n"), cmd,
           sql_strerror());
-    return retval;
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -492,7 +483,6 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
  */
 bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[50], ed2[50];
   int num_rows;
@@ -517,7 +507,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
         Mmsg1(errmsg, _("error fetching Client row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        return retval;
+        return false;
       }
       cr->ClientId = str_to_int64(row[0]);
       if (row[1]) {
@@ -526,8 +516,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
         cr->Uname[0] = 0; /* no name */
       }
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -548,10 +537,10 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   } else {
-    retval = true;
+    return true;
   }
 
-  return retval;
+  return false;
 }
 
 /**
@@ -638,7 +627,6 @@ bail_out:
  */
 bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
 {
-  bool retval = false;
   char esc[MAX_ESCAPE_NAME_LENGTH];
   CounterDbRecord mcr;
 
@@ -646,8 +634,7 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   bstrncpy(mcr.Counter, cr->Counter, sizeof(mcr.Counter));
   if (GetCounterRecord(jcr, &mcr)) {
     memcpy(cr, &mcr, sizeof(CounterDbRecord));
-    retval = true;
-    return retval;
+    return true;
   }
   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
@@ -659,10 +646,10 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   } else {
-    retval = true;
+    return true;
   }
 
-  return retval;
+  return false;
 }
 
 /**
@@ -673,7 +660,6 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
  */
 bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
 {
-  bool retval = false;
   SQL_ROW row;
   int num_rows, len;
   char esc_fs[MAX_ESCAPE_NAME_LENGTH];
@@ -701,7 +687,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
               sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        return retval;
+        return false;
       }
       fsr->FileSetId = str_to_int64(row[0]);
       if (row[1] == NULL) {
@@ -710,8 +696,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
         bstrncpy(fsr->cCreateTime, row[1], sizeof(fsr->cCreateTime));
       }
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -744,13 +729,11 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
     Mmsg2(errmsg, _("Create DB FileSet record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    return retval;
+    return false;
   } else {
     fsr->created = true;
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -893,25 +876,22 @@ bool BareosDb::CreateBatchFileAttributesRecord(JobControlRecord* jcr,
 bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
                                           AttributesDbRecord* ar)
 {
-  bool retval = false;
-
   DbLocker _{this};
   Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
   Dmsg0(dbglevel, "put_file_into_catalog\n");
 
   SplitPathAndFile(jcr, ar->fname);
 
-  if (!CreatePathRecord(jcr, ar)) { return retval; }
+  if (!CreatePathRecord(jcr, ar)) { return false; }
   Dmsg1(dbglevel, "CreatePathRecord: %s\n", esc_name);
 
   /* Now create master File record */
-  if (!CreateFileRecord(jcr, ar)) { return retval; }
+  if (!CreateFileRecord(jcr, ar)) { return false; }
   Dmsg0(dbglevel, "CreateFileRecord OK\n");
 
   Dmsg2(dbglevel, "CreateAttributes Path=%s File=%s\n", path, fname);
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 /**
@@ -1009,7 +989,6 @@ bool BareosDb::CreateAttributesRecord(JobControlRecord* jcr,
 bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
                                               AttributesDbRecord* ar)
 {
-  bool retval;
   Dmsg1(dbglevel, "create_base_file Fname=%s\n", ar->fname);
   Dmsg0(dbglevel, "put_base_file_into_catalog\n");
 
@@ -1025,9 +1004,7 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
   Mmsg(cmd, "INSERT INTO basefile%lld (Path, Name) VALUES ('%s','%s')",
        (uint64_t)jcr->JobId, esc_path, esc_name);
 
-  retval = INSERT_DB(jcr, cmd) == 1;
-
-  return retval;
+  return INSERT_DB(jcr, cmd) == 1;
 }
 
 void BareosDb::CleanupBaseFile(JobControlRecord* jcr)
@@ -1083,26 +1060,23 @@ bool BareosDb::CommitBaseFileAttributesRecord(JobControlRecord* jcr)
  */
 bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, const char* jobids)
 {
-  bool retval = false;
   PoolMem buf(PM_MESSAGE);
 
   DbLocker _{this};
 
   if (!*jobids) {
     Mmsg(errmsg, _("ERR=JobIds are empty\n"));
-    return retval;
+    return false;
   }
 
   FillQuery(SQL_QUERY::create_temp_basefile, (uint64_t)jcr->JobId);
-  if (!SqlQuery(cmd)) { return retval; }
+  if (!SqlQuery(cmd)) { return false; }
 
   FillQuery(buf, SQL_QUERY::select_recent_version, jobids, jobids);
   FillQuery(SQL_QUERY::create_temp_new_basefile, (uint64_t)jcr->JobId,
             buf.c_str());
 
-  retval = SqlQuery(cmd);
-
-  return retval;
+  return SqlQuery(cmd);
 }
 
 /**
@@ -1162,7 +1136,6 @@ bool BareosDb::CreateRestoreObjectRecord(JobControlRecord* jcr,
  */
 bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-  bool retval = false;
   char ed1[50];
   int num_rows;
 
@@ -1174,8 +1147,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -1189,11 +1161,10 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
     Mmsg2(errmsg, _("Create DB Quota record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -1205,7 +1176,6 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
                                       JobDbRecord* jr,
                                       char* filesystem)
 {
-  bool retval = false;
   char ed1[50], ed2[50];
   int num_rows;
 
@@ -1224,8 +1194,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       SqlFreeResult();
-      retval = true;
-      return retval;
+      return true;
     }
     SqlFreeResult();
   }
@@ -1239,11 +1208,10 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
     Mmsg2(errmsg, _("Create DB NDMP Level Map record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -1256,7 +1224,6 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
                                            char* name,
                                            char* value)
 {
-  bool retval = false;
   char ed1[50], ed2[50];
   char esc_envname[MAX_ESCAPE_NAME_LENGTH];
   char esc_envvalue[MAX_ESCAPE_NAME_LENGTH];
@@ -1277,11 +1244,10 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
           _("Create DB NDMP Job Environment record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -1293,7 +1259,6 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
                                    JobStatisticsDbRecord* jsr)
 {
   time_t stime;
-  bool retval = false;
   char dt[MAX_TIME_LENGTH];
   char ed1[50], ed2[50], ed3[50], ed4[50];
 
@@ -1315,12 +1280,10 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
     Mmsg2(errmsg, _("Create DB JobStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    return retval;
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -1332,7 +1295,6 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
                                       DeviceStatisticsDbRecord* dsr)
 {
   time_t stime;
-  bool retval = false;
   char dt[MAX_TIME_LENGTH];
   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50];
   char ed7[50], ed8[50], ed9[50], ed10[50], ed11[50], ed12[50];
@@ -1372,12 +1334,10 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
 
-    return retval;
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 
 /**
@@ -1389,7 +1349,6 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
                                          TapealertStatsDbRecord* tsr)
 {
   time_t stime;
-  bool retval = false;
   char dt[MAX_TIME_LENGTH];
   char ed1[50], ed2[50];
 
@@ -1416,12 +1375,10 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
 
-    return retval;
+    return false;
   } else {
-    retval = true;
+    return true;
   }
-
-  return retval;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
           HAVE_DBI */

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -61,7 +61,7 @@ bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
   char esc_ujobname[MAX_ESCAPE_NAME_LENGTH];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
 
   stime = jr->SchedTime;
   ASSERT(stime != 0);
@@ -93,7 +93,6 @@ bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
   } else {
     retval = true;
   }
-  DbUnlock(this);
 
   return retval;
 }
@@ -109,7 +108,7 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
   int count;
   char ed1[50], ed2[50], ed3[50];
 
-  DbLock(this);
+  DbLocker _{this};
 
   Mmsg(cmd, "SELECT count(*) from JobMedia WHERE JobId=%s",
        edit_int64(jm->JobId, ed1));
@@ -146,7 +145,6 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
       retval = true;
     }
   }
-  DbUnlock(this);
   Dmsg0(300, "Return from JobMedia\n");
   return retval;
 }
@@ -165,7 +163,7 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   int num_rows;
 
   Dmsg0(200, "In create pool\n");
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_poolname, pr->Name, strlen(pr->Name));
   EscapeString(jcr, esc_lf, pr->LabelFormat, strlen(pr->LabelFormat));
   Mmsg(cmd, "SELECT PoolId,Name FROM Pool WHERE Name='%s'", esc_poolname);
@@ -215,7 +213,6 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   }
 
 bail_out:
-  DbUnlock(this);
   Dmsg0(500, "Create Pool: done\n");
   return retval;
 }
@@ -234,7 +231,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
   int num_rows;
 
   Dmsg0(200, "In create Device\n");
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc, dr->Name, strlen(dr->Name));
   Mmsg(cmd,
        "SELECT DeviceId,Name FROM Device WHERE Name='%s' AND StorageId = %s",
@@ -281,7 +278,6 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -297,7 +293,7 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc, sr->Name, strlen(sr->Name));
   Mmsg(cmd, "SELECT StorageId,AutoChanger FROM Storage WHERE Name='%s'", esc);
 
@@ -342,7 +338,6 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -359,7 +354,7 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
   Dmsg0(200, "In create mediatype\n");
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc, mr->MediaType, strlen(mr->MediaType));
   Mmsg(cmd, "SELECT MediaTypeId,MediaType FROM MediaType WHERE MediaType='%s'",
        esc);
@@ -394,7 +389,6 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -413,7 +407,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   char esc_mtype[MAX_ESCAPE_NAME_LENGTH];
   char esc_status[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_medianame, mr->VolumeName, strlen(mr->VolumeName));
   EscapeString(jcr, esc_mtype, mr->MediaType, strlen(mr->MediaType));
   EscapeString(jcr, esc_status, mr->VolStatus, strlen(mr->VolStatus));
@@ -493,7 +487,6 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -511,7 +504,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
   char esc_clientname[MAX_ESCAPE_NAME_LENGTH];
   char esc_uname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_clientname, cr->Name, strlen(cr->Name));
   EscapeString(jcr, esc_uname, cr->Uname, strlen(cr->Uname));
   Mmsg(cmd, "SELECT ClientId,Uname FROM Client WHERE Name='%s'",
@@ -564,7 +557,6 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -656,7 +648,7 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   char esc[MAX_ESCAPE_NAME_LENGTH];
   CounterDbRecord mcr;
 
-  DbLock(this);
+  DbLocker _{this};
   bstrncpy(mcr.Counter, cr->Counter, sizeof(mcr.Counter));
   if (GetCounterRecord(jcr, &mcr)) {
     memcpy(cr, &mcr, sizeof(CounterDbRecord));
@@ -677,7 +669,6 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -695,7 +686,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
   char esc_fs[MAX_ESCAPE_NAME_LENGTH];
   char esc_md5[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   fsr->created = false;
   EscapeString(jcr, esc_fs, fsr->FileSet, strlen(fsr->FileSet));
   EscapeString(jcr, esc_md5, fsr->MD5, strlen(fsr->MD5));
@@ -767,7 +758,6 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -913,7 +903,7 @@ bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
 {
   bool retval = false;
 
-  DbLock(this);
+  DbLocker _{this};
   Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
   Dmsg0(dbglevel, "put_file_into_catalog\n");
 
@@ -930,7 +920,6 @@ bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1033,7 +1022,7 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
   Dmsg1(dbglevel, "create_base_file Fname=%s\n", ar->fname);
   Dmsg0(dbglevel, "put_base_file_into_catalog\n");
 
-  DbLock(this);
+  DbLocker _{this};
   SplitPathAndFile(jcr, ar->fname);
 
   esc_name = CheckPoolMemorySize(esc_name, fnl * 2 + 1);
@@ -1046,7 +1035,6 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
        (uint64_t)jcr->JobId, esc_path, esc_name);
 
   retval = INSERT_DB(jcr, cmd) == 1;
-  DbUnlock(this);
 
   return retval;
 }
@@ -1072,7 +1060,7 @@ bool BareosDb::CommitBaseFileAttributesRecord(JobControlRecord* jcr)
   bool retval;
   char ed1[50];
 
-  DbLock(this);
+  DbLocker _{this};
 
   /* clang-format off */
   Mmsg(cmd,
@@ -1090,7 +1078,6 @@ bool BareosDb::CommitBaseFileAttributesRecord(JobControlRecord* jcr)
   jcr->nb_base_files_used = SqlAffectedRows();
   CleanupBaseFile(jcr);
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -1108,7 +1095,7 @@ bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, const char* jobids)
   bool retval = false;
   PoolMem buf(PM_MESSAGE);
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (!*jobids) {
     Mmsg(errmsg, _("ERR=JobIds are empty\n"));
@@ -1125,7 +1112,6 @@ bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, const char* jobids)
   retval = SqlQuery(cmd);
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1141,7 +1127,7 @@ bool BareosDb::CreateRestoreObjectRecord(JobControlRecord* jcr,
   int plug_name_len;
   POOLMEM* esc_plug_name = GetPoolMemory(PM_MESSAGE);
 
-  DbLock(this);
+  DbLocker _{this};
 
   Dmsg1(dbglevel, "Oname=%s\n", ro->object_name);
   Dmsg0(dbglevel, "put_object_into_catalog\n");
@@ -1175,7 +1161,6 @@ bool BareosDb::CreateRestoreObjectRecord(JobControlRecord* jcr,
   } else {
     retval = true;
   }
-  DbUnlock(this);
   FreePoolMemory(esc_plug_name);
   return retval;
 }
@@ -1191,7 +1176,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
   char ed1[50];
   int num_rows;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd, "SELECT ClientId FROM Quota WHERE ClientId='%s'",
        edit_uint64(cr->ClientId, ed1));
 
@@ -1219,7 +1204,6 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1236,7 +1220,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
   char ed1[50], ed2[50];
   int num_rows;
 
-  DbLock(this);
+  DbLocker _{this};
 
   esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
   EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
@@ -1271,7 +1255,6 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1292,7 +1275,7 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
 
   Jmsg(jcr, M_INFO, 0, "NDMP Environment: %s=%s\n", name, value);
 
-  DbLock(this);
+  DbLocker _{this};
 
   EscapeString(jcr, esc_envname, name, strlen(name));
   EscapeString(jcr, esc_envvalue, value, strlen(value));
@@ -1310,7 +1293,6 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
     retval = true;
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -1327,7 +1309,7 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
   char dt[MAX_TIME_LENGTH];
   char ed1[50], ed2[50], ed3[50], ed4[50];
 
-  DbLock(this);
+  DbLocker _{this};
 
   stime = jsr->SampleTime;
   ASSERT(stime != 0);
@@ -1351,7 +1333,6 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1369,7 +1350,7 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50];
   char ed7[50], ed8[50], ed9[50], ed10[50], ed11[50], ed12[50];
 
-  DbLock(this);
+  DbLocker _{this};
 
   stime = dsr->SampleTime;
   ASSERT(stime != 0);
@@ -1409,7 +1390,6 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1426,7 +1406,7 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
   char dt[MAX_TIME_LENGTH];
   char ed1[50], ed2[50];
 
-  DbLock(this);
+  DbLocker _{this};
 
   stime = tsr->SampleTime;
   ASSERT(stime != 0);
@@ -1454,7 +1434,6 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -132,7 +132,7 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
   /* clang-format on */
 
   Dmsg0(300, cmd);
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create JobMedia record %s failed: ERR=%s\n"), cmd,
           sql_strerror());
   } else {
@@ -668,7 +668,7 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   FillQuery(SQL_QUERY::insert_counter_values, esc, cr->MinValue, cr->MaxValue,
             cr->CurrentValue, cr->WrapCounter);
 
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB Counters record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1045,7 +1045,7 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
   Mmsg(cmd, "INSERT INTO basefile%lld (Path, Name) VALUES ('%s','%s')",
        (uint64_t)jcr->JobId, esc_path, esc_name);
 
-  retval = INSERT_DB(jcr, cmd);
+  retval = INSERT_DB(jcr, cmd) == 1;
   DbUnlock(this);
 
   return retval;
@@ -1210,7 +1210,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        " VALUES ('%s', '%s', %s)",
        edit_uint64(cr->ClientId, ed1), "0", "0");
 
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB Quota record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1262,7 +1262,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
        " VALUES ('%s', '%s', '%s', %s)",
        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
        esc_name, "0");
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB NDMP Level Map record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1301,7 +1301,7 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
        " VALUES ('%s', '%s', '%s', '%s')",
        edit_int64(jr->JobId, ed1), edit_uint64(jr->FileIndex, ed2), esc_envname,
        esc_envvalue);
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg,
           _("Create DB NDMP Job Environment record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
@@ -1341,7 +1341,7 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
        edit_uint64(jsr->JobBytes, ed3), edit_int64(jsr->DeviceId, ed4));
   Dmsg1(200, "Create job stats: %s\n", cmd);
 
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB JobStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1399,7 +1399,7 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
 
   Dmsg1(200, "Create device stats: %s\n", cmd);
 
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB DeviceStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1444,7 +1444,7 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
 
   Dmsg1(200, "Create tapealert: %s\n", cmd);
 
-  if (!INSERT_DB(jcr, cmd)) {
+  if (INSERT_DB(jcr, cmd) != 1) {
     Mmsg2(errmsg, _("Create DB TapeAlerts record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -51,7 +51,6 @@ static const int dbglevel = 100;
 bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
 {
   bool retval = false;
-  ;
   PoolMem buf;
   char dt[MAX_TIME_LENGTH];
   time_t stime;
@@ -174,7 +173,8 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
     if (num_rows > 0) {
       Mmsg1(errmsg, _("pool record %s already exists\n"), pr->Name);
       SqlFreeResult();
-      goto bail_out;
+      Dmsg0(500, "Create Pool: done\n");
+      return retval;
     }
     SqlFreeResult();
   }
@@ -212,7 +212,6 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
     retval = true;
   }
 
-bail_out:
   Dmsg0(500, "Create Pool: done\n");
   return retval;
 }
@@ -250,7 +249,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
         Mmsg1(errmsg, _("error fetching Device row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return retval;
       }
       dr->DeviceId = str_to_int64(row[0]);
       if (row[1]) {
@@ -260,7 +259,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
       }
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -277,7 +276,6 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -311,13 +309,13 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
         Mmsg1(errmsg, _("error fetching Storage row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return retval;
       }
       sr->StorageId = str_to_int64(row[0]);
       sr->AutoChanger = atoi(row[1]); /* bool */
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -337,7 +335,6 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -365,7 +362,7 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
     if (num_rows > 0) {
       Mmsg1(errmsg, _("mediatype record %s already exists\n"), mr->MediaType);
       SqlFreeResult();
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -383,12 +380,11 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
   if (mr->MediaTypeId == 0) {
     Mmsg2(errmsg, _("Create db mediatype record %s failed: ERR=%s\n"), cmd,
           sql_strerror());
-    goto bail_out;
+    return retval;
   } else {
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -420,7 +416,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
     if (num_rows > 0) {
       Mmsg1(errmsg, _("Volume \"%s\" already exists.\n"), mr->VolumeName);
       SqlFreeResult();
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -486,7 +482,6 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
     MakeInchangerUnique(jcr, mr);
   }
 
-bail_out:
   return retval;
 }
 
@@ -522,7 +517,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
         Mmsg1(errmsg, _("error fetching Client row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return retval;
       }
       cr->ClientId = str_to_int64(row[0]);
       if (row[1]) {
@@ -532,7 +527,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
       }
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -556,7 +551,6 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -653,7 +647,7 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   if (GetCounterRecord(jcr, &mcr)) {
     memcpy(cr, &mcr, sizeof(CounterDbRecord));
     retval = true;
-    goto bail_out;
+    return retval;
   }
   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
@@ -668,7 +662,6 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -708,7 +701,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
               sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return retval;
       }
       fsr->FileSetId = str_to_int64(row[0]);
       if (row[1] == NULL) {
@@ -718,7 +711,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
       }
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -751,13 +744,12 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
     Mmsg2(errmsg, _("Create DB FileSet record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+    return retval;
   } else {
     fsr->created = true;
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -909,17 +901,16 @@ bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
 
   SplitPathAndFile(jcr, ar->fname);
 
-  if (!CreatePathRecord(jcr, ar)) { goto bail_out; }
+  if (!CreatePathRecord(jcr, ar)) { return retval; }
   Dmsg1(dbglevel, "CreatePathRecord: %s\n", esc_name);
 
   /* Now create master File record */
-  if (!CreateFileRecord(jcr, ar)) { goto bail_out; }
+  if (!CreateFileRecord(jcr, ar)) { return retval; }
   Dmsg0(dbglevel, "CreateFileRecord OK\n");
 
   Dmsg2(dbglevel, "CreateAttributes Path=%s File=%s\n", path, fname);
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -1099,11 +1090,11 @@ bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, const char* jobids)
 
   if (!*jobids) {
     Mmsg(errmsg, _("ERR=JobIds are empty\n"));
-    goto bail_out;
+    return retval;
   }
 
   FillQuery(SQL_QUERY::create_temp_basefile, (uint64_t)jcr->JobId);
-  if (!SqlQuery(cmd)) { goto bail_out; }
+  if (!SqlQuery(cmd)) { return retval; }
 
   FillQuery(buf, SQL_QUERY::select_recent_version, jobids, jobids);
   FillQuery(SQL_QUERY::create_temp_new_basefile, (uint64_t)jcr->JobId,
@@ -1111,7 +1102,6 @@ bool BareosDb::CreateBaseFileList(JobControlRecord* jcr, const char* jobids)
 
   retval = SqlQuery(cmd);
 
-bail_out:
   return retval;
 }
 
@@ -1185,7 +1175,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
     if (num_rows == 1) {
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -1203,7 +1193,6 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -1236,7 +1225,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
     if (num_rows == 1) {
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   }
@@ -1254,7 +1243,6 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -1327,12 +1315,11 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
     Mmsg2(errmsg, _("Create DB JobStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+    return retval;
   } else {
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -1384,12 +1371,12 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
     Mmsg2(errmsg, _("Create DB DeviceStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+
+    return retval;
   } else {
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 
@@ -1428,12 +1415,12 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
     Mmsg2(errmsg, _("Create DB TapeAlerts record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+
+    return retval;
   } else {
     retval = true;
   }
 
-bail_out:
   return retval;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -139,7 +139,7 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
     // Worked, now update the Media record with the EndFile and EndBlock
     Mmsg(cmd, "UPDATE Media SET EndFile=%u, EndBlock=%u WHERE MediaId=%u",
          jm->EndFile, jm->EndBlock, jm->MediaId);
-    if (!UPDATE_DB(jcr, cmd)) {
+    if (UPDATE_DB(jcr, cmd) == -1) {
       Mmsg2(errmsg, _("Update Media record %s failed: ERR=%s\n"), cmd,
             sql_strerror());
     } else {
@@ -483,7 +483,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
            "UPDATE Media SET LabelDate='%s' "
            "WHERE MediaId=%d",
            dt, mr->MediaId);
-      retval = UPDATE_DB(jcr, cmd);
+      retval = UPDATE_DB(jcr, cmd) > 0;
     }
     /*
      * Make sure that if InChanger is non-zero any other identical slot

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -68,15 +68,15 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
     if (num_rows == 0) {
       Mmsg(errmsg, _("No pool record %s exists\n"), pr->Name);
       SqlFreeResult();
-      goto bail_out;
+      return retval;
     } else if (num_rows != 1) {
       Mmsg(errmsg, _("Expecting one pool record, got %d\n"), num_rows);
       SqlFreeResult();
-      goto bail_out;
+      return retval;
     }
     if ((row = SqlFetchRow()) == NULL) {
       Mmsg1(errmsg, _("Error fetching row %s\n"), sql_strerror());
-      goto bail_out;
+      return retval;
     }
     pr->PoolId = str_to_int64(row[0]);
     SqlFreeResult();
@@ -95,7 +95,6 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
 
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -193,7 +192,7 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   bool retval = false;
 
   DbLocker _{this};
-  if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { goto bail_out; }
+  if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { return retval; }
   /* Do purge if not already purged */
   if (!bstrcmp(mr->VolStatus, "Purged")) {
     /* Delete associated records */
@@ -204,7 +203,6 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   SqlQuery(cmd);
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -219,16 +217,15 @@ bool BareosDb::PurgeMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   bool retval = false;
 
   DbLocker _{this};
-  if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { goto bail_out; }
+  if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { return retval; }
 
   DoMediaPurge(this, mr); /* Note, always purge */
 
   strcpy(mr->VolStatus, "Purged");
-  if (!UpdateMediaRecord(jcr, mr)) { goto bail_out; }
+  if (!UpdateMediaRecord(jcr, mr)) { return retval; }
 
   retval = true;
 
-bail_out:
   return retval;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES */

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -56,7 +56,7 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc, pr->Name, strlen(pr->Name));
   Mmsg(cmd, "SELECT PoolId FROM Pool WHERE Name='%s'", esc);
   Dmsg1(10, "selectpool: %s\n", cmd);
@@ -96,7 +96,6 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -193,7 +192,7 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 {
   bool retval = false;
 
-  DbLock(this);
+  DbLocker _{this};
   if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { goto bail_out; }
   /* Do purge if not already purged */
   if (!bstrcmp(mr->VolStatus, "Purged")) {
@@ -206,7 +205,6 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -220,7 +218,7 @@ bool BareosDb::PurgeMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 {
   bool retval = false;
 
-  DbLock(this);
+  DbLocker _{this};
   if (mr->MediaId == 0 && !GetMediaRecord(jcr, mr)) { goto bail_out; }
 
   DoMediaPurge(this, mr); /* Note, always purge */
@@ -231,7 +229,6 @@ bool BareosDb::PurgeMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES */

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -59,7 +59,6 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
                                 POOLMEM*& stime,
                                 char* job)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
@@ -94,12 +93,12 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
       if (!QUERY_DB(jcr, cmd)) {
         Mmsg2(errmsg, _("Query error for start time request: ERR=%s\nCMD=%s\n"),
               sql_strerror(), cmd);
-        return retval;
+        return false;
       }
       if ((row = SqlFetchRow()) == NULL) {
         SqlFreeResult();
         Mmsg(errmsg, _("No prior Full backup Job record found.\n"));
-        return retval;
+        return false;
       }
       SqlFreeResult();
       /* Now edit SQL command for Incremental Job */
@@ -112,7 +111,7 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
            edit_int64(jr->ClientId, ed1), edit_int64(jr->FileSetId, ed2));
     } else {
       Mmsg1(errmsg, _("Unknown level=%d\n"), jr->JobLevel);
-      return retval;
+      return false;
     }
   } else {
     Dmsg1(100, "Submitting: %s\n", cmd);
@@ -124,23 +123,22 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
     PmStrcpy(stime, ""); /* set EOS */
     Mmsg2(errmsg, _("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
-    return retval;
+    return false;
   }
 
   if ((row = SqlFetchRow()) == NULL) {
     Mmsg2(errmsg, _("No Job record found: ERR=%s\nCMD=%s\n"), sql_strerror(),
           cmd);
     SqlFreeResult();
-    return retval;
+    return false;
   }
   Dmsg2(100, "Got start time: %s, job: %s\n", row[0], row[1]);
   PmStrcpy(stime, row[0]);
   bstrncpy(job, row[1], MAX_NAME_LENGTH);
 
   SqlFreeResult();
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
@@ -149,8 +147,6 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
     std::string client_name,
     std::vector<char>& stime_out)
 {
-  auto retval = SqlFindResult::kError;
-
   std::vector<char> esc_jobname(MAX_ESCAPE_NAME_LENGTH);
   std::vector<char> esc_clientname(MAX_ESCAPE_NAME_LENGTH);
 
@@ -177,8 +173,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
   if (!QUERY_DB(jcr, cmd)) {
     Mmsg2(errmsg, _("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
-    retval = SqlFindResult::kError;
-    return retval;
+    return SqlFindResult::kError;
   }
 
   SQL_ROW row;
@@ -186,8 +181,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
     Mmsg2(errmsg, _("No Job record found: ERR=%s\nCMD=%s\n"), sql_strerror(),
           cmd);
     SqlFreeResult();
-    retval = SqlFindResult::kEmptyResultSet;
-    return retval;
+    return SqlFindResult::kEmptyResultSet;
   }
 
   Dmsg2(100, "Got start time: %s\n", row[0]);
@@ -200,9 +194,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
 
   SqlFreeResult();
 
-  retval = SqlFindResult::kSuccess;
-
-  return retval;
+  return SqlFindResult::kSuccess;
 }
 
 /**
@@ -220,7 +212,6 @@ bool BareosDb::FindLastJobStartTime(JobControlRecord* jcr,
                                     char* job,
                                     int JobLevel)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
@@ -240,21 +231,20 @@ bool BareosDb::FindLastJobStartTime(JobControlRecord* jcr,
   if (!QUERY_DB(jcr, cmd)) {
     Mmsg2(errmsg, _("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
-    return retval;
+    return false;
   }
   if ((row = SqlFetchRow()) == NULL) {
     SqlFreeResult();
     Mmsg(errmsg, _("No prior Full backup Job record found.\n"));
-    return retval;
+    return false;
   }
   Dmsg1(100, "Got start time: %s\n", row[0]);
   PmStrcpy(stime, row[0]);
   bstrncpy(job, row[1], MAX_NAME_LENGTH);
 
   SqlFreeResult();
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 /**
@@ -270,7 +260,6 @@ bool BareosDb::FindFailedJobSince(JobControlRecord* jcr,
                                   POOLMEM* stime,
                                   int& JobLevel)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
@@ -286,17 +275,16 @@ bool BareosDb::FindFailedJobSince(JobControlRecord* jcr,
        "ORDER BY StartTime DESC LIMIT 1",
        jr->JobType, L_FULL, L_DIFFERENTIAL, esc_jobname,
        edit_int64(jr->ClientId, ed1), edit_int64(jr->FileSetId, ed2), stime);
-  if (!QUERY_DB(jcr, cmd)) { return retval; }
+  if (!QUERY_DB(jcr, cmd)) { return false; }
 
   if ((row = SqlFetchRow()) == NULL) {
     SqlFreeResult();
-    return retval;
+    return false;
   }
   JobLevel = (int)*row[0];
   SqlFreeResult();
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 /**
@@ -311,7 +299,6 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
                              const char* Name,
                              JobDbRecord* jr)
 {
-  bool retval = false;
   SQL_ROW row;
   char ed1[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
@@ -346,14 +333,14 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
     }
   } else {
     Mmsg1(errmsg, _("Unknown Job level=%d\n"), jr->JobLevel);
-    return retval;
+    return false;
   }
   Dmsg1(100, "Query: %s\n", cmd);
-  if (!QUERY_DB(jcr, cmd)) { return retval; }
+  if (!QUERY_DB(jcr, cmd)) { return false; }
   if ((row = SqlFetchRow()) == NULL) {
     Mmsg1(errmsg, _("No Job found for: %s.\n"), cmd);
     SqlFreeResult();
-    return retval;
+    return false;
   }
 
   jr->JobId = str_to_int64(row[0]);
@@ -362,11 +349,10 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
   Dmsg1(100, "db_get_last_jobid: got JobId=%d\n", jr->JobId);
   if (jr->JobId <= 0) {
     Mmsg1(errmsg, _("No Job found for: %s\n"), cmd);
-    return retval;
+    return false;
   }
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 /**

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -64,7 +64,7 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_jobname, jr->Name, strlen(jr->Name));
   PmStrcpy(stime, "0000-00-00 00:00:00"); /* default */
   job[0] = 0;
@@ -141,7 +141,6 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -156,7 +155,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
   std::vector<char> esc_jobname(MAX_ESCAPE_NAME_LENGTH);
   std::vector<char> esc_clientname(MAX_ESCAPE_NAME_LENGTH);
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(nullptr, esc_jobname.data(), job_basename.c_str(),
                job_basename.size());
   EscapeString(nullptr, esc_clientname.data(), client_name.c_str(),
@@ -205,7 +204,6 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
   retval = SqlFindResult::kSuccess;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -229,7 +227,7 @@ bool BareosDb::FindLastJobStartTime(JobControlRecord* jcr,
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_jobname, jr->Name, strlen(jr->Name));
   PmStrcpy(stime, "0000-00-00 00:00:00"); /* default */
   job[0] = 0;
@@ -259,7 +257,6 @@ bool BareosDb::FindLastJobStartTime(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -281,7 +278,7 @@ bool BareosDb::FindFailedJobSince(JobControlRecord* jcr,
   char ed1[50], ed2[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc_jobname, jr->Name, strlen(jr->Name));
 
   /* Differential is since last Full backup */
@@ -303,7 +300,6 @@ bool BareosDb::FindFailedJobSince(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -324,7 +320,7 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
   char ed1[50];
   char esc_jobname[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   /* Find last full */
   Dmsg2(100, "JobLevel=%d JobType=%d\n", jr->JobLevel, jr->JobType);
   if (jr->JobLevel == L_VERIFY_CATALOG) {
@@ -375,7 +371,6 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -431,7 +426,7 @@ int BareosDb::FindNextVolume(JobControlRecord* jcr,
   char esc_type[MAX_ESCAPE_NAME_LENGTH];
   char esc_status[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
 
   EscapeString(jcr, esc_type, mr->MediaType, strlen(mr->MediaType));
   EscapeString(jcr, esc_status, mr->VolStatus, strlen(mr->VolStatus));
@@ -601,7 +596,6 @@ retry_fetch:
   }
 
 bail_out:
-  DbUnlock(this);
   Dmsg1(050, "Rtn numrows=%d\n", num_rows);
 
   return num_rows;

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -64,13 +64,12 @@ bool BareosDb::GetFileAttributesRecord(JobControlRecord* jcr,
   bool retval;
   Dmsg1(100, "db_get_file_attributes_record filename=%s \n", filename);
 
-  DbLock(this);
+  DbLocker _{this};
 
   SplitPathAndFile(jcr, filename);
   fdbr->PathId = GetPathRecord(jcr);
   retval = GetFileRecord(jcr, jr, fdbr);
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -243,7 +242,7 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
   char ed1[50];
   char esc[MAX_ESCAPE_NAME_LENGTH];
   bool search_by_jobname = (jr->JobId == 0);
-  DbLock(this);
+  DbLocker _{this};
   if (search_by_jobname) {
     EscapeString(jcr, esc, jr->Job, strlen(jr->Job));
     Mmsg(cmd,
@@ -312,7 +311,6 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -336,7 +334,7 @@ int BareosDb::GetJobVolumeNames(JobControlRecord* jcr,
   int i;
   int num_rows;
 
-  DbLock(this);
+  DbLocker _{this};
 
   // Get one entry per VolumeName, but "sort" by VolIndex
   Mmsg(cmd,
@@ -373,7 +371,6 @@ int BareosDb::GetJobVolumeNames(JobControlRecord* jcr,
   } else {
     Mmsg(errmsg, _("No Volume for JobId %d found in Catalog.\n"), JobId);
   }
-  DbUnlock(this);
 
   return retval;
 }
@@ -397,7 +394,7 @@ int BareosDb::GetJobVolumeParameters(JobControlRecord* jcr,
   VolumeParameters* Vols = NULL;
   int num_rows;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd,
        "SELECT VolumeName,MediaType,FirstIndex,LastIndex,StartFile,"
        "JobMedia.EndFile,StartBlock,JobMedia.EndBlock,"
@@ -467,7 +464,6 @@ int BareosDb::GetJobVolumeParameters(JobControlRecord* jcr,
     }
     SqlFreeResult();
   }
-  DbUnlock(this);
   return retval;
 }
 
@@ -481,10 +477,9 @@ int BareosDb::GetNumPoolRecords(JobControlRecord* jcr)
 {
   int retval = 0;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd, "SELECT count(*) from Pool");
   retval = GetSqlRecordMax(jcr);
-  DbUnlock(this);
 
   return retval;
 }
@@ -503,7 +498,7 @@ int BareosDb::GetPoolIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids)
   int i = 0;
   DBId_t* id;
 
-  DbLock(this);
+  DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT PoolId FROM Pool");
   if (QUERY_DB(jcr, cmd)) {
@@ -521,7 +516,6 @@ int BareosDb::GetPoolIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids)
     retval = 0;
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -539,7 +533,7 @@ int BareosDb::GetStorageIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
   int i = 0;
   DBId_t* id;
 
-  DbLock(this);
+  DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT StorageId FROM Storage");
   if (QUERY_DB(jcr, cmd)) {
@@ -557,7 +551,6 @@ int BareosDb::GetStorageIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
     retval = 0;
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -575,7 +568,7 @@ bool BareosDb::GetClientIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
   int i = 0;
   DBId_t* id;
 
-  DbLock(this);
+  DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT ClientId FROM Client ORDER BY Name");
   if (QUERY_DB(jcr, cmd)) {
@@ -591,7 +584,6 @@ bool BareosDb::GetClientIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
     Mmsg(errmsg, _("Client id select failed: ERR=%s\n"), sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   }
-  DbUnlock(this);
   return retval;
 }
 
@@ -611,7 +603,7 @@ bool BareosDb::GetPoolRecord(JobControlRecord* jcr, PoolDbRecord* pdbr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (pdbr->PoolId != 0) { /* find by id */
     Mmsg(
         cmd,
@@ -691,7 +683,6 @@ bool BareosDb::GetPoolRecord(JobControlRecord* jcr, PoolDbRecord* pdbr)
     Mmsg(errmsg, _("Pool record not found in Catalog.\n"));
   }
 
-  DbUnlock(this);
   return ok;
 }
 
@@ -711,7 +702,7 @@ bool BareosDb::GetStorageRecord(JobControlRecord* jcr, StorageDbRecord* sdbr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (sdbr->StorageId != 0) { /* find by id */
     Mmsg(cmd,
          "SELECT StorageId,Name,AutoChanger FROM Storage WHERE "
@@ -747,7 +738,6 @@ bool BareosDb::GetStorageRecord(JobControlRecord* jcr, StorageDbRecord* sdbr)
     SqlFreeResult();
   }
 
-  DbUnlock(this);
   return ok;
 }
 
@@ -767,7 +757,7 @@ bool BareosDb::GetClientRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (cdbr->ClientId != 0) { /* find by id */
     Mmsg(cmd,
          "SELECT ClientId,Name,Uname,AutoPrune,FileRetention,JobRetention "
@@ -810,7 +800,6 @@ bool BareosDb::GetClientRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
     Mmsg(errmsg, _("Client record not found in Catalog.\n"));
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -827,7 +816,7 @@ bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
   FillQuery(SQL_QUERY::select_counter_values, esc);
@@ -863,7 +852,6 @@ bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -883,7 +871,7 @@ int BareosDb::GetFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (fsr->FileSetId != 0) { /* find by id */
     Mmsg(cmd,
          "SELECT FileSetId,FileSet,MD5,CreateTime FROM FileSet "
@@ -920,7 +908,6 @@ int BareosDb::GetFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
   } else {
     Mmsg(errmsg, _("FileSet record not found in Catalog.\n"));
   }
-  DbUnlock(this);
   return retval;
 }
 
@@ -934,10 +921,9 @@ int BareosDb::GetNumMediaRecords(JobControlRecord* jcr)
 {
   int retval = 0;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd, "SELECT count(*) from Media");
   retval = GetSqlRecordMax(jcr);
-  DbUnlock(this);
   return retval;
 }
 
@@ -1015,7 +1001,7 @@ bool BareosDb::GetMediaIds(JobControlRecord* jcr,
   int i = 0;
   DBId_t* id;
 
-  DbLock(this);
+  DbLocker _{this};
   *ids = NULL;
 
   if (!PrepareMediaSqlQuery(jcr, mr, volumes)) {
@@ -1039,7 +1025,6 @@ bool BareosDb::GetMediaIds(JobControlRecord* jcr,
   SqlFreeResult();
   ok = true;
 bail_out:
-  DbUnlock(this);
   return ok;
 }
 
@@ -1059,7 +1044,7 @@ bool BareosDb::GetQueryDbids(JobControlRecord* jcr,
   int i = 0;
   bool ok = false;
 
-  DbLock(this);
+  DbLocker _{this};
   ids.num_ids = 0;
   if (QUERY_DB(jcr, query.c_str())) {
     ids.num_ids = SqlNumRows();
@@ -1079,7 +1064,6 @@ bool BareosDb::GetQueryDbids(JobControlRecord* jcr,
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
     ok = false;
   }
-  DbUnlock(this);
   return ok;
 }
 
@@ -1119,7 +1103,7 @@ bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   int num_rows;
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (mr->MediaId == 0 && mr->VolumeName[0] == 0) {
     Mmsg(cmd, "SELECT count(*) from Media");
     mr->MediaId = GetSqlRecordMax(jcr);
@@ -1241,7 +1225,6 @@ bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   }
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -1275,9 +1258,8 @@ bool BareosDb::GetFileList(JobControlRecord* jcr,
   PoolMem query2(PM_MESSAGE);
 
   if (!*jobids) {
-    DbLock(this);
+    DbLocker _{this};
     Mmsg(errmsg, _("ERR=JobIds are empty\n"));
-    DbUnlock(this);
     return false;
   }
 
@@ -1497,11 +1479,11 @@ bool BareosDb::GetVolumeJobids(JobControlRecord* jcr,
   char ed1[50];
   bool retval;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd, "SELECT DISTINCT JobId FROM JobMedia WHERE MediaId=%s",
        edit_int64(mr->MediaId, ed1));
   retval = SqlQueryWithHandler(cmd, DbListHandler, lst);
-  DbUnlock(this);
+
   return retval;
 }
 
@@ -1535,7 +1517,7 @@ bool BareosDb::get_quota_jobbytes(JobControlRecord* jcr,
 
   bstrutime(dt, sizeof(dt), schedtime);
 
-  DbLock(this);
+  DbLocker _{this};
 
   FillQuery(SQL_QUERY::get_quota_jobbytes, edit_uint64(jr->ClientId, ed1),
             edit_uint64(jr->JobId, ed2), dt);
@@ -1554,7 +1536,6 @@ bool BareosDb::get_quota_jobbytes(JobControlRecord* jcr,
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -1588,7 +1569,7 @@ bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord* jcr,
 
   bstrutime(dt, sizeof(dt), schedtime);
 
-  DbLock(this);
+  DbLocker _{this};
 
   FillQuery(SQL_QUERY::get_quota_jobbytes_nofailed,
             edit_uint64(jr->ClientId, ed1), edit_uint64(jr->JobId, ed2), dt);
@@ -1607,7 +1588,6 @@ bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord* jcr,
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -1623,7 +1603,7 @@ bool BareosDb::GetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
   int num_rows;
   bool retval = false;
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd,
        "SELECT GraceTime, QuotaLimit "
        "FROM Quota "
@@ -1650,7 +1630,6 @@ bool BareosDb::GetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
     Mmsg(errmsg, _("Quota record not found in Catalog.\n"));
   }
 
-  DbUnlock(this);
   return retval;
 }
 
@@ -1669,7 +1648,7 @@ int BareosDb::GetNdmpLevelMapping(JobControlRecord* jcr,
   int num_rows;
   int dumplevel = 0;
 
-  DbLock(this);
+  DbLocker _{this};
 
   esc_name = CheckPoolMemorySize(esc_name, strlen(filesystem) * 2 + 1);
   EscapeString(jcr, esc_name, filesystem, strlen(filesystem));
@@ -1705,7 +1684,6 @@ int BareosDb::GetNdmpLevelMapping(JobControlRecord* jcr,
   }
 
 bail_out:
-  DbUnlock(this);
   return dumplevel;
 }
 

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -262,7 +262,7 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
          edit_int64(jr->JobId, ed1));
   }
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return retval; }
 
   if ((row = SqlFetchRow()) == NULL) {
     if (search_by_jobname) {
@@ -272,7 +272,7 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
             edit_int64(jr->JobId, ed1));
     }
     SqlFreeResult();
-    goto bail_out;
+    return retval;
   }
 
   jr->VolSessionId = str_to_uint64(row[0]);
@@ -310,7 +310,6 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
   SqlFreeResult();
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -832,7 +831,7 @@ bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
         Mmsg1(errmsg, _("error fetching Counter row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return retval;
       }
       cr->MinValue = str_to_int64(row[0]);
       cr->MaxValue = str_to_int64(row[1]);
@@ -844,14 +843,13 @@ bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
       }
       SqlFreeResult();
       retval = true;
-      goto bail_out;
+      return retval;
     }
     SqlFreeResult();
   } else {
     Mmsg(errmsg, _("Counter record: %s not found in Catalog.\n"), cr->Counter);
   }
 
-bail_out:
   return retval;
 }
 
@@ -1007,13 +1005,13 @@ bool BareosDb::GetMediaIds(JobControlRecord* jcr,
   if (!PrepareMediaSqlQuery(jcr, mr, volumes)) {
     Mmsg(errmsg, _("Media id select failed: invalid parameter"));
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+    return ok;
   }
 
   if (!QUERY_DB(jcr, cmd)) {
     Mmsg(errmsg, _("Media id select failed: ERR=%s\n"), sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
-    goto bail_out;
+    return ok;
   }
 
   *num_ids = SqlNumRows();
@@ -1024,7 +1022,7 @@ bool BareosDb::GetMediaIds(JobControlRecord* jcr,
   }
   SqlFreeResult();
   ok = true;
-bail_out:
+
   return ok;
 }
 
@@ -1108,7 +1106,7 @@ bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
     Mmsg(cmd, "SELECT count(*) from Media");
     mr->MediaId = GetSqlRecordMax(jcr);
     retval = true;
-    goto bail_out;
+    return retval;
   }
   if (mr->MediaId != 0) { /* find by id */
     Mmsg(cmd,
@@ -1224,7 +1222,6 @@ bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
     }
   }
 
-bail_out:
   return retval;
 }
 
@@ -1666,24 +1663,23 @@ int BareosDb::GetNdmpLevelMapping(JobControlRecord* jcr,
         Mmsg1(errmsg, _("error fetching row: %s\n"), sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
         SqlFreeResult();
-        goto bail_out;
+        return dumplevel;
       } else {
         dumplevel = str_to_uint64(row[0]);
         dumplevel++; /* select next dumplevel */
         SqlFreeResult();
-        goto bail_out;
+        return dumplevel;
       }
     } else {
       Mmsg(errmsg, _("NDMP Dump Level record not found in Catalog.\n"));
       SqlFreeResult();
-      goto bail_out;
+      return dumplevel;
     }
   } else {
     Mmsg(errmsg, _("NDMP Dump Level record not found in Catalog.\n"));
-    goto bail_out;
+    return dumplevel;
   }
 
-bail_out:
   return dumplevel;
 }
 

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -66,23 +66,20 @@ bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
                             const char* description,
                             bool verbose)
 {
-  bool retval = false;
-
   DbLocker _{this};
 
   if (!SqlQuery(query, QF_STORE_RESULT)) {
     Mmsg(errmsg, _("Query failed: %s\n"), sql_strerror());
     if (verbose) { sendit->Decoration(errmsg); }
-    return retval;
+    return false;
   }
 
   sendit->ArrayStart(description);
   ListResult(jcr, sendit, type);
   sendit->ArrayEnd(description);
   SqlFreeResult();
-  retval = true;
 
-  return retval;
+  return true;
 }
 
 bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
@@ -144,8 +141,6 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("pools");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListClientRecords(JobControlRecord* jcr,
@@ -177,8 +172,6 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("clients");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListStorageRecords(JobControlRecord* jcr,
@@ -196,8 +189,6 @@ void BareosDb::ListStorageRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("storages");
 
   SqlFreeResult();
-
-  return;
 }
 
 /**
@@ -263,8 +254,6 @@ void BareosDb::ListMediaRecords(JobControlRecord* jcr,
   ListResult(jcr, sendit, type);
 
   SqlFreeResult();
-
-  return;
 }
 
 
@@ -313,7 +302,6 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("jobmedia");
 
   SqlFreeResult();
-  return;
 }
 
 
@@ -347,8 +335,6 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
   sendit->ArrayEnd("volumes");
 
   SqlFreeResult();
-
-  return;
 }
 
 
@@ -390,8 +376,6 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
   }
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListLogRecords(JobControlRecord* jcr,
@@ -452,8 +436,6 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("log");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
@@ -490,8 +472,6 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("joblog");
 
   SqlFreeResult();
-
-  return;
 }
 
 /**
@@ -520,8 +500,6 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("jobstats");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListJobRecords(JobControlRecord* jcr,
@@ -612,8 +590,6 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
   sendit->ArrayEnd("jobs");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListJobTotals(JobControlRecord* jcr,
@@ -647,8 +623,6 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
   sendit->ObjectEnd("jobtotals");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListFilesForJob(JobControlRecord* jcr,
@@ -691,8 +665,6 @@ void BareosDb::ListFilesForJob(JobControlRecord* jcr,
   sendit->ArrayEnd("filenames");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
@@ -727,8 +699,6 @@ void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
   sendit->ArrayEnd("files");
 
   SqlFreeResult();
-
-  return;
 }
 
 void BareosDb::ListFilesets(JobControlRecord* jcr,
@@ -786,8 +756,6 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
   sendit->ArrayEnd("filesets");
 
   SqlFreeResult();
-
-  return;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
           HAVE_DBI */

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -73,7 +73,7 @@ bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
   if (!SqlQuery(query, QF_STORE_RESULT)) {
     Mmsg(errmsg, _("Query failed: %s\n"), sql_strerror());
     if (verbose) { sendit->Decoration(errmsg); }
-    goto bail_out;
+    return retval;
   }
 
   sendit->ArrayStart(description);
@@ -82,7 +82,6 @@ bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
   SqlFreeResult();
   retval = true;
 
-bail_out:
   return retval;
 }
 
@@ -138,7 +137,7 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, query.c_str())) { goto bail_out; }
+  if (!QUERY_DB(jcr, query.c_str())) { return; }
 
   sendit->ArrayStart("pools");
   ListResult(jcr, sendit, type);
@@ -146,7 +145,6 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -172,7 +170,7 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
          clientfilter.c_str());
   }
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("clients");
   ListResult(jcr, sendit, type);
@@ -180,7 +178,6 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -192,7 +189,7 @@ void BareosDb::ListStorageRecords(JobControlRecord* jcr,
 
   Mmsg(cmd, "SELECT StorageId,Name,AutoChanger FROM Storage");
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("storages");
   ListResult(jcr, sendit, type);
@@ -200,7 +197,6 @@ void BareosDb::ListStorageRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -262,13 +258,12 @@ void BareosDb::ListMediaRecords(JobControlRecord* jcr,
 
   DbLocker _{this};
 
-  if (!QUERY_DB(jcr, query.c_str())) { goto bail_out; }
+  if (!QUERY_DB(jcr, query.c_str())) { return; }
 
   ListResult(jcr, sendit, type);
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -311,15 +306,13 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
            "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId");
     }
   }
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobmedia");
   ListResult(jcr, sendit, type);
   sendit->ArrayEnd("jobmedia");
 
   SqlFreeResult();
-
-bail_out:
   return;
 }
 
@@ -347,7 +340,7 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
          "AND JobMedia.JobId=%s",
          edit_int64(JobId, ed1));
   }
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("volumes");
   ListResult(jcr, sendit, type);
@@ -355,7 +348,6 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -383,7 +375,7 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
        "WHERE Job.Type = '%c' %s ORDER BY Job.PriorJobId DESC %s",
        (char)JT_JOB_COPY, str_jobids.c_str(), range);
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   if (SqlNumRows()) {
     if (JobIds && JobIds[0]) {
@@ -399,7 +391,6 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -454,7 +445,7 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
 
   DbLocker _{this};
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("log");
   ListResult(jcr, sendit, type);
@@ -462,7 +453,6 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -493,7 +483,7 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("joblog");
   ListResult(jcr, sendit, type);
@@ -501,7 +491,6 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -524,7 +513,7 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
        "WHERE JobStats.JobId=%s "
        "ORDER BY JobStats.SampleTime ",
        edit_int64(JobId, ed1));
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobstats");
   ListResult(jcr, sendit, type);
@@ -532,7 +521,6 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -617,7 +605,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobs");
   ListResult(jcr, sendit, type);
@@ -625,7 +613,6 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -640,7 +627,7 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
        "SELECT count(*) AS Jobs,sum(JobFiles) "
        "AS Files,sum(JobBytes) AS Bytes,Name AS Job FROM Job GROUP BY Name");
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobs");
   ListResult(jcr, sendit, HORZ_LIST);
@@ -653,7 +640,7 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
        "SELECT COUNT(*) AS Jobs,sum(JobFiles) "
        "AS Files,sum(JobBytes) As Bytes FROM Job");
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
 
   sendit->ObjectStart("jobtotals");
   ListResult(jcr, sendit, HORZ_LIST);
@@ -661,7 +648,6 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -701,12 +687,11 @@ void BareosDb::ListFilesForJob(JobControlRecord* jcr,
   }
 
   sendit->ArrayStart("filenames");
-  if (!BigSqlQuery(cmd, ::ListResult, &lctx)) { goto bail_out; }
+  if (!BigSqlQuery(cmd, ::ListResult, &lctx)) { return; }
   sendit->ArrayEnd("filenames");
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -738,12 +723,11 @@ void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
   }
 
   sendit->ArrayStart("files");
-  if (!BigSqlQuery(cmd, ::ListResult, &lctx)) { goto bail_out; }
+  if (!BigSqlQuery(cmd, ::ListResult, &lctx)) { return; }
   sendit->ArrayEnd("files");
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 
@@ -796,14 +780,13 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
          range);
   }
 
-  if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+  if (!QUERY_DB(jcr, cmd)) { return; }
   sendit->ArrayStart("filesets");
   ListResult(jcr, sendit, type);
   sendit->ArrayEnd("filesets");
 
   SqlFreeResult();
 
-bail_out:
   return;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -68,7 +68,7 @@ bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
 {
   bool retval = false;
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (!SqlQuery(query, QF_STORE_RESULT)) {
     Mmsg(errmsg, _("Query failed: %s\n"), sql_strerror());
@@ -83,7 +83,6 @@ bool BareosDb::ListSqlQuery(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  DbUnlock(this);
   return retval;
 }
 
@@ -108,7 +107,7 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
   PoolMem query(PM_MESSAGE);
   PoolMem select(PM_MESSAGE);
 
-  DbLock(this);
+  DbLocker _{this};
   EscapeString(jcr, escaped_pool_name, pdbr->Name, strlen(pdbr->Name));
 
   if (type == VERT_LIST) {
@@ -148,7 +147,7 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListClientRecords(JobControlRecord* jcr,
@@ -156,7 +155,7 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
                                  OutputFormatter* sendit,
                                  e_list_type type)
 {
-  DbLock(this);
+  DbLocker _{this};
   PoolMem clientfilter(PM_MESSAGE);
 
   if (clientname) { clientfilter.bsprintf("WHERE Name = '%s'", clientname); }
@@ -182,14 +181,14 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListStorageRecords(JobControlRecord* jcr,
                                   OutputFormatter* sendit,
                                   e_list_type type)
 {
-  DbLock(this);
+  DbLocker _{this};
 
   Mmsg(cmd, "SELECT StorageId,Name,AutoChanger FROM Storage");
 
@@ -202,7 +201,7 @@ void BareosDb::ListStorageRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 /**
@@ -261,7 +260,7 @@ void BareosDb::ListMediaRecords(JobControlRecord* jcr,
     }
   }
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (!QUERY_DB(jcr, query.c_str())) { goto bail_out; }
 
@@ -270,7 +269,7 @@ void BareosDb::ListMediaRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 
@@ -281,7 +280,7 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
 {
   char ed1[50];
 
-  DbLock(this);
+  DbLocker _{this};
   if (type == VERT_LIST) {
     if (JobId > 0) { /* do by JobId */
       Mmsg(cmd,
@@ -321,7 +320,7 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 
@@ -334,7 +333,7 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
 
   if (JobId <= 0) { return; }
 
-  DbLock(this);
+  DbLocker _{this};
   if (type == VERT_LIST) {
     Mmsg(cmd,
          "SELECT JobMediaId,JobId,Media.MediaId,Media.VolumeName "
@@ -357,7 +356,7 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 
@@ -374,7 +373,7 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
          JobIds, JobIds);
   }
 
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd,
        "SELECT DISTINCT Job.PriorJobId AS JobId, Job.Job, "
        "Job.JobId AS CopyJobId, Media.MediaType "
@@ -401,7 +400,7 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListLogRecords(JobControlRecord* jcr,
@@ -453,7 +452,7 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
     type = RAW_LIST;
   }
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
 
@@ -464,7 +463,7 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
@@ -478,7 +477,7 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
 
   if (JobId <= 0) { return; }
 
-  DbLock(this);
+  DbLocker _{this};
   if (count) {
     FillQuery(SQL_QUERY::list_joblog_count_1, edit_int64(JobId, ed1));
   } else {
@@ -503,7 +502,7 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 /**
@@ -518,7 +517,7 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
   char ed1[50];
 
   if (JobId <= 0) { return; }
-  DbLock(this);
+  DbLocker _{this};
   Mmsg(cmd,
        "SELECT DeviceId, SampleTime, JobId, JobFiles, JobBytes "
        "FROM JobStats "
@@ -534,7 +533,7 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListJobRecords(JobControlRecord* jcr,
@@ -600,7 +599,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
     PmStrcat(selection, temp.c_str());
   }
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (count) {
     FillQuery(SQL_QUERY::list_jobs_count, selection.c_str(), range);
@@ -627,14 +626,14 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListJobTotals(JobControlRecord* jcr,
                              JobDbRecord* jr,
                              OutputFormatter* sendit)
 {
-  DbLock(this);
+  DbLocker _{this};
 
   // List by Job
   Mmsg(cmd,
@@ -663,7 +662,7 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListFilesForJob(JobControlRecord* jcr,
@@ -673,7 +672,7 @@ void BareosDb::ListFilesForJob(JobControlRecord* jcr,
   char ed1[50];
   ListContext lctx(jcr, this, sendit, NF_LIST);
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (GetTypeIndex() == SQL_TYPE_MYSQL) {
     Mmsg(cmd,
@@ -708,7 +707,7 @@ void BareosDb::ListFilesForJob(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
@@ -718,7 +717,7 @@ void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
   char ed1[50];
   ListContext lctx(jcr, this, sendit, NF_LIST);
 
-  DbLock(this);
+  DbLocker _{this};
 
   if (GetTypeIndex() == SQL_TYPE_MYSQL) {
     Mmsg(cmd,
@@ -745,7 +744,7 @@ void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 
 void BareosDb::ListFilesets(JobControlRecord* jcr,
@@ -756,7 +755,7 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
 {
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
-  DbLock(this);
+  DbLocker _{this};
   if (jr->Name[0] != 0) {
     EscapeString(jcr, esc, jr->Name, strlen(jr->Name));
     Mmsg(cmd,
@@ -805,7 +804,7 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
   SqlFreeResult();
 
 bail_out:
-  DbUnlock(this);
+  return;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
           HAVE_DBI */

--- a/core/src/cats/sql_query.cc
+++ b/core/src/cats/sql_query.cc
@@ -130,12 +130,11 @@ bool BareosDb::SqlQuery(const char* query, int flags)
 
   Dmsg2(debuglevel, "called: %s with query %s\n", __PRETTY_FUNCTION__, query);
 
-  DbLock(this);
+  DbLocker _{this};
   retval = SqlQueryWithoutHandler(query, flags);
   if (!retval) {
     Mmsg(errmsg, _("Query failed: %s: ERR=%s\n"), query, sql_strerror());
   }
-  DbUnlock(this);
 
   return retval;
 }
@@ -148,12 +147,11 @@ bool BareosDb::SqlQuery(const char* query,
 
   Dmsg2(debuglevel, "called: %s with query %s\n", __PRETTY_FUNCTION__, query);
 
-  DbLock(this);
+  DbLocker _{this};
   retval = SqlQueryWithHandler(query, ResultHandler, ctx);
   if (!retval) {
     Mmsg(errmsg, _("Query failed: %s: ERR=%s\n"), query, sql_strerror());
   }
-  DbUnlock(this);
 
   return retval;
 }

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -462,7 +462,7 @@ void BareosDb::MakeInchangerUnique(JobControlRecord* jcr, MediaDbRecord* mr)
            mr->Slot, edit_int64(mr->StorageId, ed1), mr->VolumeName);
     }
     Dmsg1(100, "%s\n", cmd);
-    UPDATE_DB_NO_AFR(jcr, cmd);
+    UPDATE_DB_NO_AFFECTED_ROWS(jcr, cmd);
   }
 }
 

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -52,7 +52,6 @@ bool BareosDb::AddDigestToFileRecord(JobControlRecord* jcr,
                                      char* digest,
                                      int type)
 {
-  bool retval;
   char ed1[50];
   int len = strlen(digest);
 
@@ -61,9 +60,8 @@ bool BareosDb::AddDigestToFileRecord(JobControlRecord* jcr,
   EscapeString(jcr, esc_name, digest, len);
   Mmsg(cmd, "UPDATE File SET MD5='%s' WHERE FileId=%s", esc_name,
        edit_int64(FileId, ed1));
-  retval = UPDATE_DB(jcr, cmd) > 0;
 
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /* Mark the file record as being visited during database
@@ -73,15 +71,13 @@ bool BareosDb::MarkFileRecord(JobControlRecord* jcr,
                               FileId_t FileId,
                               JobId_t JobId)
 {
-  bool retval;
   char ed1[50], ed2[50];
 
   DbLocker _{this};
   Mmsg(cmd, "UPDATE File SET MarkId=%s WHERE FileId=%s", edit_int64(JobId, ed1),
        edit_int64(FileId, ed2));
-  retval = UPDATE_DB(jcr, cmd) > 0;
 
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -95,7 +91,6 @@ bool BareosDb::UpdateJobStartRecord(JobControlRecord* jcr, JobDbRecord* jr)
   char dt[MAX_TIME_LENGTH];
   time_t stime;
   btime_t JobTDate;
-  bool retval;
   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50];
 
   stime = jr->StartTime;
@@ -111,9 +106,8 @@ bool BareosDb::UpdateJobStartRecord(JobControlRecord* jcr, JobDbRecord* jr)
        edit_int64(jr->PoolId, ed3), edit_int64(jr->FileSetId, ed4),
        edit_int64(jr->JobId, ed5));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
   changes = 0;
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 // Update Long term statistics with all jobs that were run before age seconds
@@ -144,7 +138,6 @@ int BareosDb::UpdateStats(JobControlRecord* jcr, utime_t age)
  */
 bool BareosDb::UpdateJobEndRecord(JobControlRecord* jcr, JobDbRecord* jr)
 {
-  bool retval;
   char dt[MAX_TIME_LENGTH];
   char rdt[MAX_TIME_LENGTH];
   time_t ttime;
@@ -181,9 +174,7 @@ bool BareosDb::UpdateJobEndRecord(JobControlRecord* jcr, JobDbRecord* jr)
       jr->PoolId, jr->FileSetId, edit_uint64(JobTDate, ed2), rdt, PriorJobId,
       jr->HasBase, jr->PurgedFiles, edit_int64(jr->JobId, ed3));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -193,7 +184,6 @@ bool BareosDb::UpdateJobEndRecord(JobControlRecord* jcr, JobDbRecord* jr)
  */
 bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-  bool retval = false;
   char ed1[50], ed2[50];
   char esc_clientname[MAX_ESCAPE_NAME_LENGTH];
   char esc_uname[MAX_ESCAPE_NAME_LENGTH];
@@ -201,7 +191,7 @@ bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 
   DbLocker _{this};
   tcr = *cr;
-  if (!CreateClientRecord(jcr, &tcr)) { return retval; }
+  if (!CreateClientRecord(jcr, &tcr)) { return false; }
 
   EscapeString(jcr, esc_clientname, cr->Name, strlen(cr->Name));
   EscapeString(jcr, esc_uname, cr->Uname, strlen(cr->Uname));
@@ -211,9 +201,7 @@ bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        cr->AutoPrune, edit_uint64(cr->FileRetention, ed1),
        edit_uint64(cr->JobRetention, ed2), esc_uname, esc_clientname);
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -238,7 +226,6 @@ bool BareosDb::UpdateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
 
 bool BareosDb::UpdatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
 {
-  bool retval;
   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50], ed6[50];
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
@@ -264,21 +251,18 @@ bool BareosDb::UpdatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
        pr->LabelType, esc, edit_int64(pr->RecyclePoolId, ed5),
        edit_int64(pr->ScratchPoolId, ed6), pr->ActionOnPurge, pr->MinBlocksize,
        pr->MaxBlocksize, ed4);
-  retval = UPDATE_DB(jcr, cmd) > 0;
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 bool BareosDb::UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
 {
-  bool retval;
   char ed1[50];
 
   DbLocker _{this};
   Mmsg(cmd, "UPDATE Storage SET AutoChanger=%d WHERE StorageId=%s",
        sr->AutoChanger, edit_int64(sr->StorageId, ed1));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 
@@ -290,7 +274,6 @@ bool BareosDb::UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
  */
 bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 {
-  bool retval;
   char dt[MAX_TIME_LENGTH];
   time_t ttime;
   char ed1[50], ed2[50], ed3[50], ed4[50];
@@ -312,7 +295,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET FirstWritten='%s'"
          " WHERE VolumeName='%s'",
          dt, esc_medianame);
-    retval = UPDATE_DB(jcr, cmd) > 0;
+    UPDATE_DB(jcr, cmd);
     Dmsg1(400, "Firstwritten=%d\n", mr->FirstWritten);
   }
 
@@ -325,7 +308,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET LabelDate='%s' "
          "WHERE VolumeName='%s'",
          dt, esc_medianame);
-    retval = UPDATE_DB(jcr, cmd) > 0;
+    UPDATE_DB(jcr, cmd);
   }
 
   if (mr->LastWritten != 0) {
@@ -335,7 +318,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media Set LastWritten='%s' "
          "WHERE VolumeName='%s'",
          dt, esc_medianame);
-    retval = UPDATE_DB(jcr, cmd) > 0;
+    UPDATE_DB(jcr, cmd);
   }
 
   Mmsg(cmd,
@@ -363,7 +346,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 
   Dmsg1(400, "%s\n", cmd);
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
+  bool retval = UPDATE_DB(jcr, cmd) > 0;
 
   // Make sure InChanger is 0 for any record having the same Slot
   MakeInchangerUnique(jcr, mr);
@@ -379,7 +362,6 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
  */
 bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
 {
-  bool retval;
   char ed1[50], ed2[50], ed3[50], ed4[50], ed5[50];
   char esc[MAX_ESCAPE_NAME_LENGTH];
 
@@ -411,9 +393,7 @@ bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
 
   Dmsg1(400, "%s\n", cmd);
 
-  retval = UPDATE_DB(jcr, cmd) != -1;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) != -1;
 }
 
 
@@ -461,7 +441,6 @@ void BareosDb::MakeInchangerUnique(JobControlRecord* jcr, MediaDbRecord* mr)
  */
 bool BareosDb::UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr)
 {
-  bool retval;
   char ed1[50], ed2[50];
   time_t now = time(NULL);
 
@@ -470,9 +449,7 @@ bool BareosDb::UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr)
   Mmsg(cmd, "UPDATE Quota SET GraceTime=%s WHERE ClientId='%s'",
        edit_uint64(now, ed1), edit_uint64(jr->ClientId, ed2));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -483,7 +460,6 @@ bool BareosDb::UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr)
  */
 bool BareosDb::UpdateQuotaSoftlimit(JobControlRecord* jcr, JobDbRecord* jr)
 {
-  bool retval;
   char ed1[50], ed2[50];
 
   DbLocker _{this};
@@ -492,9 +468,7 @@ bool BareosDb::UpdateQuotaSoftlimit(JobControlRecord* jcr, JobDbRecord* jr)
        edit_uint64((jr->JobSumTotalBytes + jr->JobBytes), ed1),
        edit_uint64(jr->ClientId, ed2));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -505,7 +479,6 @@ bool BareosDb::UpdateQuotaSoftlimit(JobControlRecord* jcr, JobDbRecord* jr)
  */
 bool BareosDb::ResetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 {
-  bool retval;
   char ed1[50];
 
   DbLocker _{this};
@@ -514,9 +487,7 @@ bool BareosDb::ResetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        "UPDATE Quota SET GraceTime='0', QuotaLimit='0' WHERE ClientId='%s'",
        edit_uint64(cr->ClientId, ed1));
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 
 /**
@@ -530,7 +501,6 @@ bool BareosDb::UpdateNdmpLevelMapping(JobControlRecord* jcr,
                                       char* filesystem,
                                       int level)
 {
-  bool retval;
   char ed1[50], ed2[50], ed3[50];
 
   DbLocker _{this};
@@ -544,9 +514,7 @@ bool BareosDb::UpdateNdmpLevelMapping(JobControlRecord* jcr,
        edit_uint64(level, ed1), edit_uint64(jr->ClientId, ed2),
        edit_uint64(jr->FileSetId, ed3), esc_name);
 
-  retval = UPDATE_DB(jcr, cmd) > 0;
-
-  return retval;
+  return UPDATE_DB(jcr, cmd) > 0;
 }
 #endif /* HAVE_SQLITE3 || HAVE_MYSQL || HAVE_POSTGRESQL || HAVE_INGRES || \
           HAVE_DBI */

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -201,7 +201,7 @@ bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 
   DbLocker _{this};
   tcr = *cr;
-  if (!CreateClientRecord(jcr, &tcr)) { goto bail_out; }
+  if (!CreateClientRecord(jcr, &tcr)) { return retval; }
 
   EscapeString(jcr, esc_clientname, cr->Name, strlen(cr->Name));
   EscapeString(jcr, esc_uname, cr->Uname, strlen(cr->Uname));
@@ -213,7 +213,6 @@ bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
 
   retval = UPDATE_DB(jcr, cmd) > 0;
 
-bail_out:
   return retval;
 }
 

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -423,7 +423,7 @@ bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
 
   Dmsg1(400, "%s\n", cmd);
 
-  retval = UPDATE_DB(jcr, cmd);
+  retval = UPDATE_DB_NO_AFFECTED_ROWS(jcr, cmd);
 
   DbUnlock(this);
   return retval;

--- a/core/src/dird/autoprune.cc
+++ b/core/src/dird/autoprune.cc
@@ -102,7 +102,7 @@ void PruneVolumes(JobControlRecord* jcr,
   prune_list.JobId = (JobId_t*)malloc(sizeof(JobId_t) * prune_list.max_ids);
 
   ua = new_ua_context(jcr);
-  DbLock(jcr->db);
+  DbLocker _{jcr->db};
 
   edit_int64(mr->PoolId, ed1);
 
@@ -226,7 +226,6 @@ void PruneVolumes(JobControlRecord* jcr,
 
 bail_out:
   Dmsg0(100, "Leave prune volumes\n");
-  DbUnlock(jcr->db);
   FreeUaContext(ua);
   if (prune_list.JobId) { free(prune_list.JobId); }
   return;

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -212,7 +212,7 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
      * of a Storage daemon Job Session, when labeling/relabeling a
      * Volume, or when an EOF mark is written.
      */
-    DbLock(jcr->db);
+    DbLocker _{jcr->db};
     Dmsg3(400, "Update media %s oldStat=%s newStat=%s\n", sdmr.VolumeName,
           mr.VolStatus, sdmr.VolStatus);
     bstrncpy(mr.VolumeName, sdmr.VolumeName,
@@ -314,7 +314,6 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
     }
 
   bail_out:
-    DbUnlock(jcr->db);
 
     Dmsg1(400, ">CatReq response: %s", bs->msg);
     Dmsg1(400, "Leave catreq jcr 0x%x\n", jcr);

--- a/core/src/dird/newvol.cc
+++ b/core/src/dird/newvol.cc
@@ -65,7 +65,7 @@ bool newVolume(JobControlRecord* jcr, MediaDbRecord* mr, StorageResource* store)
   PoolDbRecord pr;
 
   // See if we can create a new Volume
-  DbLock(jcr->db);
+  DbLocker _{jcr->db};
   pr.PoolId = mr->PoolId;
   if (!jcr->db->GetPoolRecord(jcr, &pr)) { goto bail_out; }
   if (pr.MaxVols == 0 || pr.NumVols < pr.MaxVols) {
@@ -110,7 +110,6 @@ bool newVolume(JobControlRecord* jcr, MediaDbRecord* mr, StorageResource* store)
   }
 
 bail_out:
-  DbUnlock(jcr->db);
   return retval;
 }
 

--- a/core/src/dird/next_vol.cc
+++ b/core/src/dird/next_vol.cc
@@ -88,7 +88,7 @@ int FindNextVolumeForAppend(JobControlRecord* jcr,
   InChanger = store->autochanger;
 
   // Find the Next Volume for Append
-  DbLock(jcr->db);
+  DbLocker _{jcr->db};
   while (1) {
     //  1. Look for volume with "Append" status.
     SetStorageidInMr(store, mr);
@@ -206,7 +206,6 @@ int FindNextVolumeForAppend(JobControlRecord* jcr,
     break;
   }
 
-  DbUnlock(jcr->db);
   Dmsg1(debuglevel, "return ok=%d find_next_vol\n", ok);
 
   return ok;

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -449,7 +449,7 @@ void UpgradeCopies(UaContext* ua, const char* jobs)
 {
   PoolMem query(PM_MESSAGE);
 
-  DbLock(ua->db);
+  DbLocker _{ua->db};
 
   /* Do it in two times for mysql */
   ua->db->FillQuery(query, BareosDb::SQL_QUERY::uap_upgrade_copies_oldest_job,
@@ -467,8 +467,6 @@ void UpgradeCopies(UaContext* ua, const char* jobs)
 
   Mmsg(query, "DROP TABLE cpy_tmp");
   ua->db->SqlQuery(query.c_str());
-
-  DbUnlock(ua->db);
 }
 
 // Remove all records from catalog for a list of JobIds

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -327,7 +327,7 @@ void UpdateVolPool(UaContext* ua,
   if (!GetPoolDbr(ua, &pr)) { return; }
   mr->PoolId = pr.PoolId; /* set new PoolId */
 
-  DbLock(ua->db);
+  DbLocker _{ua->db};
   Mmsg(query, "UPDATE Media SET PoolId=%s WHERE MediaId=%s",
        edit_int64(mr->PoolId, ed1), edit_int64(mr->MediaId, ed2));
   if (!ua->db->SqlQuery(query.c_str())) {
@@ -343,7 +343,6 @@ void UpdateVolPool(UaContext* ua,
       ua->ErrorMsg("%s", ua->db->strerror());
     }
   }
-  DbUnlock(ua->db);
 }
 
 // Modify the RecyclePool of a Volume
@@ -366,7 +365,7 @@ void UpdateVolRecyclepool(UaContext* ua, char* val, MediaDbRecord* mr)
     poolname = _("*None*");
   }
 
-  DbLock(ua->db);
+  DbLocker _{ua->db};
   Mmsg(query, "UPDATE Media SET RecyclePoolId=%s WHERE MediaId=%s",
        edit_int64(mr->RecyclePoolId, ed1), edit_int64(mr->MediaId, ed2));
   if (!ua->db->SqlQuery(query.c_str())) {
@@ -374,7 +373,6 @@ void UpdateVolRecyclepool(UaContext* ua, char* val, MediaDbRecord* mr)
   } else {
     ua->InfoMsg(_("New RecyclePool is: %s\n"), poolname);
   }
-  DbUnlock(ua->db);
 }
 
 // Modify the Storage in which this Volume is located
@@ -388,14 +386,12 @@ void UpdateVolStorage(UaContext* ua, char* val, MediaDbRecord* mr)
   if (!GetStorageDbr(ua, &sr)) { return; }
   mr->StorageId = sr.StorageId; /* set new StorageId */
 
-  DbLock(ua->db);
+  DbLocker _{ua->db};
   Mmsg(query, "UPDATE Media SET StorageId=%s WHERE MediaId=%s",
        edit_int64(mr->StorageId, ed1), edit_int64(mr->MediaId, ed2));
   if (!ua->db->SqlQuery(query.c_str())) {
     ua->ErrorMsg("%s", ua->db->strerror());
   }
-
-  DbUnlock(ua->db);
 }
 
 // Refresh the Volume information from the Pool record
@@ -1289,12 +1285,11 @@ void UpdateInchangerForExport(UaContext* ua,
 
     Dmsg4(100, "Before make unique: Vol=%s slot=%d inchanger=%d sid=%d\n",
           mr.VolumeName, mr.Slot, mr.InChanger, mr.StorageId);
-    DbLock(ua->db);
+    DbLocker _{ua->db};
 
     // Set InChanger to zero for this Slot
     ua->db->MakeInchangerUnique(ua->jcr, &mr);
 
-    DbUnlock(ua->db);
     Dmsg4(100, "After make unique: Vol=%s slot=%d inchanger=%d sid=%d\n",
           mr.VolumeName, mr.Slot, mr.InChanger, mr.StorageId);
   }

--- a/systemtests/tests/python-bareos/test_update_all_volumes_all_pools.py
+++ b/systemtests/tests/python-bareos/test_update_all_volumes_all_pools.py
@@ -1,0 +1,83 @@
+#
+#   BAREOS - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import json
+import logging
+import os
+import re
+import subprocess
+from time import sleep
+import unittest
+import warnings
+
+import bareos.bsock
+from bareos.bsock.constants import Constants
+from bareos.bsock.protocolmessages import ProtocolMessages
+from bareos.bsock.protocolversions import ProtocolVersions
+from bareos.bsock.lowlevel import LowLevel
+import bareos.exceptions
+
+import bareos_unittest
+
+
+class PythonBareosUpdateAllVolumesAllPools(bareos_unittest.Json):
+    def test_updateAllVolumesAllPools(self):
+        """
+        This test checks if updating all volumes of a pool has the right message even if there are no volumes in the pool.
+        """
+        logger = logging.getLogger()
+
+        username = self.get_operator_username()
+        password = self.get_operator_password(username)
+
+        directorJson = bareos.bsock.DirectorConsoleJson(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
+        )
+
+        directorRegular = bareos.bsock.DirectorConsole(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
+        )
+
+        newrandompoolname = u"arandompool"
+
+        # check that we do not have any volumes
+        self.configure_add(
+            directorJson,
+            "pools",
+            newrandompoolname,
+            "pool={}".format(newrandompoolname)
+        )
+        directorRegular.call("reload")
+        directorRegular.call("update volume")
+        directorRegular.call("13") # choosing the `All Volumes from pool` option
+        result = directorRegular.call("1") # choosing the `arandompool` option
+
+        self.assertEqual(result.decode(), "All Volume defaults updated from \"{}\" Pool record.\n".format(newrandompoolname))


### PR DESCRIPTION
#### Description:

When trying to update all volumes from all pools using the update command, while not having any volumes configured, an error message is displayed mentioning that no rows were affected. The behavior is normal, but the message is misplaced. This PR fixes the issue.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
