### PR TITLE
webui: fix a layout corner case where top navbar is hiding navtabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #1374] Include zero-file incremental backups in always-incremental consolidation [PR #995]
 - fix crash in "status scheduler" command when job->client is unset [PR #965]
 - [Issue #847]: fix for CVE-2017-14610 PID files that could be exploited on certain systems [PR #928]
+- webui: fix a layout corner case where top navbar is hiding navtabs [PR #1022]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/webui/module/Application/view/layout/layout.phtml.in
+++ b/webui/module/Application/view/layout/layout.phtml.in
@@ -69,7 +69,15 @@ include 'version.php';
 <body>
 
 <style>
+@media (max-width: 1525px) {
+    body {
+      padding-top: 105px;
+    }
+}
 @media (max-width: 1480px) {
+    body {
+      padding-top: 60px;
+    }
     .navbar-header {
         float: none;
     }


### PR DESCRIPTION
At a certain display width the top navigation bar can overlap
navigation tabs below, this commit fixes the issue by adjusting
padding-top slightly.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
