### PR TITLE
webui: client details now can be displayed for client names containing dots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix crash in "status scheduler" command when job->client is unset [PR #965]
 - [Issue #847]: fix for CVE-2017-14610 PID files that could be exploited on certain systems [PR #928]
 - webui: fix a layout corner case where top navbar is hiding navtabs [PR #1022]
+- webui: client details now can be displayed for client names containing dots [PR #1023]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]

--- a/webui/module/Client/src/Client/Controller/ClientController.php
+++ b/webui/module/Client/src/Client/Controller/ClientController.php
@@ -195,7 +195,7 @@ class ClientController extends AbstractActionController
 
     return new ViewModel(
       array(
-        'client' => $this->params()->fromRoute('id')
+        'client' => $this->params()->fromQuery('client')
       )
     );
   }

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -435,10 +435,6 @@ function formatScheduleName(value, basePath) {
    return '<a href="' + basePath + '/schedule/details?schedule=' + value + '">' + value + '</a>';
 }
 
-function formatClientName(value, basePath) {
-   return '<a href="' + basePath + '/client/details/' + value + '">' + value + '</a>';
-}
-
 function formatFilesetName(value, row, index, basePath) {
    return '<a href="' + basePath + '/fileset/details/' + row.filesetid + '">' + row.fileset + '</a>';
 }

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -34,7 +34,7 @@ function formatJobName(value, basePath, displayRange) {
 }
 
 function formatClientName(value, basePath) {
-   return '<a href="' + basePath + '/client/details/' + value + '">' + value + '</a>';
+   return '<a href="' + basePath + '/client/details?client=' + value + '">' + value + '</a>';
 }
 
 function formatJobType(data) {


### PR DESCRIPTION
This PR fixes a routing issues with client names that contain dots.

We now use query parameters for the link generation instead of
a route segment.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
