### PR TITLE
systemtests: add a test for the jobs last status table in webui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: provide a notification that NDMP restores are NOT supported by webui [PR #1020]
 - console: prune command gained support to prune multiple volumes at once [PR #966]
 - webui: introduce a job timeline chart [PR #1017]
+- systemtests: add a test for the jobs last status table in webui [PR #1024]
 
 ### Changed
 - docs: check if configuration directives are defined as CamelCase in core. Otherwise building the documentation will fail with an error [PR #1008]
@@ -364,6 +365,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1020]: https://github.com/bareos/bareos/pull/1020
 [PR #1022]: https://github.com/bareos/bareos/pull/1022
 [PR #1023]: https://github.com/bareos/bareos/pull/1023
+[PR #1024]: https://github.com/bareos/bareos/pull/1024
 [PR #1025]: https://github.com/bareos/bareos/pull/1025
 [PR #1026]: https://github.com/bareos/bareos/pull/1026
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -214,6 +214,7 @@ configure_file(
 message(STATUS "Looking for webui test requirements ...")
 
 set(AVAILABLE_WEBUI_SELENIUM_TESTS
+    "admin-client_link_on_dashboard"
     "admin-client_disabling"
     "admin-rerun_job"
     "admin-restore"

--- a/webui/tests/selenium/webui-selenium-test.py
+++ b/webui/tests/selenium/webui-selenium-test.py
@@ -293,6 +293,12 @@ class SeleniumTest(unittest.TestCase):
         self.login()
         self.logout()
 
+    def test_client_link_on_dashboard(self):
+        self.login()
+        self.select_navbar_element("dashboard")
+        self.wait_and_click(By.LINK_TEXT, self.client)
+        self.logout()
+
     def test_client_disabling(self):
         # This test navigates to clients, ensures client is enabled,
         # disables it, closes a possible modal, goes to dashboard and reenables client.


### PR DESCRIPTION
This is just a simple test to verify if we got an entry for a
particular client we expect to be present in the jobs last status
table on the dashboard.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
