### PR TITLE
dird: avoid crash in job listing when "current" and "count" are both specified at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [Issue #847]: fix for CVE-2017-14610 PID files that could be exploited on certain systems [PR #928]
 - webui: fix a layout corner case where top navbar is hiding navtabs [PR #1022]
 - webui: client details now can be displayed for client names containing dots [PR #1023]
+- dird: avoid crash in job listing when "current" and "count" are both specified at the same time [PR #1026]
 
 ### Added
 - systemtests: make database credentials configurable [PR #950]
@@ -357,7 +358,10 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #999]: https://github.com/bareos/bareos/pull/999
 [PR #1007]: https://github.com/bareos/bareos/pull/1007
 [PR #1008]: https://github.com/bareos/bareos/pull/1008
+[PR #1017]: https://github.com/bareos/bareos/pull/1017
 [PR #1018]: https://github.com/bareos/bareos/pull/1018
 [PR #1020]: https://github.com/bareos/bareos/pull/1020
 [PR #1022]: https://github.com/bareos/bareos/pull/1022
+[PR #1023]: https://github.com/bareos/bareos/pull/1023
+[PR #1026]: https://github.com/bareos/bareos/pull/1026
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -591,29 +591,29 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
 
     switch (llist) {
       case VERT_LIST:
-        if (!count) {
+        if (!count) {  // count result is one column, no filtering
           SetAclFilter(ua, 2, Job_ACL);      /* JobName */
           SetAclFilter(ua, 7, Client_ACL);   /* ClientName */
           SetAclFilter(ua, 21, Pool_ACL);    /* PoolName */
           SetAclFilter(ua, 24, FileSet_ACL); /* FilesetName */
-        }
-        if (current) {
-          SetResFilter(ua, 2, R_JOB);      /* JobName */
-          SetResFilter(ua, 7, R_CLIENT);   /* ClientName */
-          SetResFilter(ua, 21, R_POOL);    /* PoolName */
-          SetResFilter(ua, 24, R_FILESET); /* FilesetName */
+          if (current) {
+            SetResFilter(ua, 2, R_JOB);      /* JobName */
+            SetResFilter(ua, 7, R_CLIENT);   /* ClientName */
+            SetResFilter(ua, 21, R_POOL);    /* PoolName */
+            SetResFilter(ua, 24, R_FILESET); /* FilesetName */
+          }
         }
         if (enabled) { SetEnabledFilter(ua, 2, R_JOB); /* JobName */ }
         if (disabled) { SetDisabledFilter(ua, 2, R_JOB); /* JobName */ }
         break;
       default:
-        if (!count) {
+        if (!count) {  // count result is one column, no filtering
           SetAclFilter(ua, 1, Job_ACL);    /* JobName */
           SetAclFilter(ua, 2, Client_ACL); /* ClientName */
-        }
-        if (current) {
-          SetResFilter(ua, 1, R_JOB);    /* JobName */
-          SetResFilter(ua, 2, R_CLIENT); /* ClientName */
+          if (current) {
+            SetResFilter(ua, 1, R_JOB);    /* JobName */
+            SetResFilter(ua, 2, R_CLIENT); /* ClientName */
+          }
         }
         if (enabled) { SetEnabledFilter(ua, 1, R_JOB); /* JobName */ }
         if (disabled) { SetDisabledFilter(ua, 1, R_JOB); /* JobName */ }


### PR DESCRIPTION
If both keywords count and current were given in the "list jobs" command, the output filter for the
rows were set while the result only will contain one column. When the
filter accesses the non-existent column it crashes.

Now only the filters for current are set if count is not set.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

