### PR TITLE
systemtests: run diff with LANG=C during recovery check

### DIFF
--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -720,7 +720,7 @@ check_restore_diff()
    else
      DIFFTOOL='diff'
    fi
-   OUT="$($DIFFTOOL --no-dereference -ur --exclude="fifo*" "${dest}" "${tmp}/bareos-restores/${dest}")"
+   OUT="$(LANG=C $DIFFTOOL --no-dereference -ur --exclude="fifo*" "${dest}" "${tmp}/bareos-restores/${dest}")"
    result=$(( result + $?))
    if is_debug; then
        printf "%s\n" "$OUT"


### PR DESCRIPTION
In the test set of files we have a file with a filename that is not
utf8. On Solaris diff crashes if the language is set to something with
utf8 but a filename appears that cannot be encoded in utf8:

  diff: cannot compare file names 'filename-with-non-utf8-bytestring->C�N' and \
       'filename-with-non-utf8-bytestring->C�N': Illegal byte sequence
  diff: program error
  exit(134) is called. Set test to failure and end test.

This commit makes sure that diff is called with LANG=C.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
