### PR TITLE
debian: set postgres db parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Breaking Changes
 
 ### Fixed
+- debian: Let dbconfig create the Bareos catalog also with LC_COLLATE='C' and LC_CTYPE='C'. The create_bareos_database script did always do so. Requires dbconfig >= 2.0.21 [PR #1031]
 - fix wrong `packages_dir` in restapi workflow, so restapi packages will be released to PyPI [PR #1033]
 
 ### Added

--- a/core/README.dbconfig
+++ b/core/README.dbconfig
@@ -2,7 +2,7 @@ On Debian based systems (Debian, Ubuntu, Univention Corporate Server),
 database configuration can be done with help of the dbconfig system.
 
   * Package: dbconfig-common
-  * Homepage/Documentation: http://people.debian.org/~seanius/policy/dbconfig-common.html/
+  * Documentation: https://www.debian.org/doc/manuals/dbconfig-common/
 
 Install/update scenarios:
   * fresh install
@@ -84,7 +84,7 @@ postgresql
   * update from 13.2:
     * db_version is already 2002. It detects, nothing to do.
   * update dbconfig already configured
-    * ?
+
 
 mysql
 =====
@@ -98,7 +98,7 @@ mysql
   * update from 13.2:
     * db_version is already 2002. It detects, nothing to do.
   * update dbconfig already configured
-    * ?
+
 
 sqlite3
 =======
@@ -113,4 +113,3 @@ sqlite3
     * db_version is already 2002. It detects, nothing to do.
     * creates link from /var/lib/bareos/bareos.db to bareos
   * update dbconfig already configured
-    * ?

--- a/debian/bareos-database-common.postinst.in
+++ b/debian/bareos-database-common.postinst.in
@@ -46,13 +46,25 @@ if [ -r @scriptdir@/bareos-config-lib.sh ]; then
             esac
         fi
 
-        # dbc_pgsql_createdb_encoding: required for postgresql
+        # The Bareos catalog should be created with following settings:
+        # Encoding: SQL_ASCII
+        # Collate:  C
+        # Ctype: C
+        # While all recent versions of dbconfig support the parameter Encoding,
+        # Collate and Ctype are only supported in dbconfig >= 2.0.21.
+        # On older versions, these setting is ignored.
         dbc_pgsql_createdb_encoding="SQL_ASCII"
+        dbc_pgsql_createdb_collate="C"
+        dbc_pgsql_createdb_ctype="C"
 
         # dbc_dbfile_owner: only required for sqlite3
         dbc_dbfile_owner=`get_user_dir`:`get_group_dir`
 
-        # substitution is only done on installs, not on updates!
+        # While substitution on install is supported
+        # by all recent versions of dbconfig
+        # substitution on update requires dbconfig >= 2.0.9.
+        # As this has not been available on all platforms,
+        # we use our own substitution mechanism.
         #dbc_sql_substitutions="yes"
 
         # run dbconfig


### PR DESCRIPTION
The Bareos catalog should be created with following settings:
Encoding: SQL_ASCII
Collate:  C
Ctype: C
While all recent versions of dbconfig support the parameter Encoding,
Collate and Ctype are only supported in dbconfig >= 2.0.21.
On older versions, these setting is ignored.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- ~Required documentation changes are present and part of the PR~
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
