### PR TITLE
Fix for gcc build with -Werror=maybe-uninitialized

### DIFF
--- a/core/src/ndmp/ndmjob_job.c
+++ b/core/src/ndmp/ndmjob_job.c
@@ -429,7 +429,7 @@ int jndex_tattle(void)
   char buf[100];
   struct ndmmedia* me;
   struct ndm_env_entry* nev;
-  int i;
+  int i=0;
 
   for (me = ji_media.head; me; me = me->next) {
     ndmmedia_to_str(me, buf);


### PR DESCRIPTION
Some linux deviates builds the code with the "-Werror=maybe-uninitialized" options.
When it will set, the build fails, because one variable in the code has no default value.
It will be an part for the fix of:
https://bugs.bareos.org/view.php?id=1412

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
