### PR TITLE
docs: create MariaDB mariabackup plugin chapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+- doc: backport chapter for mariabackup db plugin [PR #1044]
+
 ## [21.0.0] - 2021-12-21
 
 * 300+ PRs
@@ -393,4 +395,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1027]: https://github.com/bareos/bareos/pull/1027
 [PR #1028]: https://github.com/bareos/bareos/pull/1028
 [PR #1029]: https://github.com/bareos/bareos/pull/1029
+[PR #1031]: https://github.com/bareos/bareos/pull/1031
+[PR #1044]: https://github.com/bareos/bareos/pull/1044
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/CMakeLists.txt
+++ b/docs/manuals/CMakeLists.txt
@@ -1,6 +1,6 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2019-2021 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/docs/manuals/CMakeLists.txt
+++ b/docs/manuals/CMakeLists.txt
@@ -21,6 +21,8 @@ cmake_minimum_required(VERSION 3.0)
 
 project(bareos-docs NONE)
 
+set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
+
 # commands building json files ######
 add_custom_command(
   OUTPUT

--- a/docs/manuals/source/TasksAndConcepts/Plugins.rst
+++ b/docs/manuals/source/TasksAndConcepts/Plugins.rst
@@ -1907,7 +1907,7 @@ You can append options to the plugin call as key=value pairs, separated by â€™:â
 
 -  :strong:`restorecommand` to modify the command for restore. Default setting is: :command:`mbstream -x -C`
 
--  :strong:`strictIncremental`: By default (false), an incremental backup will create data, even if the Log Sequence Number (LSN) was not increased since last backup. This is to ensure, that eventual changes to MYISAM/ARIA/Rocks tables get into the backup. MYISAM/ARIA/Rocks does not support incremental backups, you will always get a full backup of these tables. If set to true, no data will be written into backup, if the LSN was not changed.
+-  :strong:`strictIncremental`: By default (false), an incremental backup will create data even if the Log Sequence Number (LSN) was not increased since last backup. This is to ensure that eventual changes to MYISAM/ARIA/Rocks tables get into the backup. MYISAM/ARIA/Rocks does not support incremental backups, you will always get a full backup of these tables. If set to true, no data will be written into backup, if the LSN was not changed.
 
 
 Restore with mariabackup Plugin

--- a/docs/manuals/source/conf.py
+++ b/docs/manuals/source/conf.py
@@ -71,7 +71,8 @@ rst_epilog = """
 .. |traymonitor| replace:: Bareos Traymonitor
 .. |bareosWebui| replace:: Bareos Webui
 .. |webui| replace:: Bareos WebUI
-.. |mysql| replace:: MySQL/MariaDB
+.. |mariadb| replace:: MariaDB
+.. |mysql| replace:: MySQL
 .. |postgresql| replace:: PostgreSQL
 .. |sqlite| replace:: Sqlite
 .. |vmware| replace:: VMware


### PR DESCRIPTION
docs: create MariaDB mariabackup plugin chapter

    - Add a mariadb replacement shortcut in conf.py
    - Remove MariaDB from mysql shortcut in conf.py
      Used mysql shortcuts are about catalog (deleted in next Bareos 21 version)
    - Rework and adjust Perconna XtraBackup chapter with actual information
      (version supported, examples, documentation link)
    - Add mariabackup plugin chapter

 backported by cherry-pick except CHANGELOG.md

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
