### PR TITLE
systemtests: wait for mariadb shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - tests: simplify test coverage analysis [PR #1010]
 - docs: Add chapter for mariabackup db plugin [PR #1016]
 - dird: extend the list command to be able to query volumes and pools by ID [PR #1041]
+- systemtests: wait for mariadb shutdown [PR #1048]
 
 ### Changed
 

--- a/systemtests/tests/py2plug-fd-mariabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-mariabackup/testrunner
@@ -28,8 +28,12 @@ JobName=backup-bareos-fd
 "${rscripts}"/setup
 
 shutdown_mysql_server(){
-[ -f "mysql/mysqld.pid" ] && kill "$(cat mysql/mysqld.pid)" || :
-[ -f "mysql/data/${HOSTNAME}.pid" ] && kill "$(cat mysql/data/${HOSTNAME}.pid)" || :
+for f in mysql/mysqld.pid "mysql/data/${HOSTNAME}.pid"; do
+  [ ! -r "$f" ] && continue
+  pid="$(cat "$f")"
+  kill "$pid"
+  wait "$pid"
+done
 }
 
 startup_mysql_server(){


### PR DESCRIPTION
The mariabackup plugin test did not wait for mariadb to shutdown after
killing it. This could lead to situations where mariadb was still
running but there was no pid file, eventually failing the test.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
