### PR TITLE
webui:  remove an unnecessary .bvfs_get_jobids and buildSubtree() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - systemtests: wait for mariadb shutdown [PR #1048]
 
 ### Changed
+- webui: remove an unnecessary .bvfs_get_jobids and buildSubtree() call [PR #1050]
 
 ### Deprecated
 

--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -481,9 +481,13 @@ class RestoreController extends AbstractActionController
     $this->setRestoreParams();
     $this->layout('layout/json');
 
-    return new ViewModel(array(
-      'items' => $this->buildSubtree()
-    ));
+    if($this->restore_params['client'] != null) {
+      $items = $this->buildSubtree();
+    } else {
+      $items = "{}";
+    }
+
+    return new ViewModel(array('items' => $items));
   }
 
   /**

--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -93,44 +93,12 @@ class RestoreController extends AbstractActionController
     $errors = null;
     $result = null;
 
-    if($this->restore_params['jobid'] == null && $this->restore_params['client'] != null) {
-      try {
-        $latestbackup = $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", 1);
-        if(empty($latestbackup)) {
-          $this->restore_params['jobid'] = null;
-        }
-        else {
-          $this->restore_params['jobid'] = $latestbackup[0]['jobid'];
-        }
-      }
-      catch(Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-
-    if(isset($this->restore_params['mergejobs']) && $this->restore_params['mergejobs'] == 1) {
-      $jobids = $this->restore_params['jobid'];
-    }
-    else {
-      try {
-        $jobids = $this->getRestoreModel()->getJobIds($this->bsock, $this->restore_params['jobid'], $this->restore_params['mergefilesets']);
-        $this->restore_params['jobids'] = $jobids;
-      }
-      catch(Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-
     if($this->restore_params['client'] != null) {
-      try {
-        $backups = $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", null);
-        $this->updateBvfsCache();
-      }
-      catch(Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-    else {
+      $this->handleJobId();
+      $this->handleJobMerge();
+      $backups = $this->getClientBackups();
+      $this->updateBvfsCache();
+    } else {
       $backups = null;
     }
 
@@ -158,7 +126,7 @@ class RestoreController extends AbstractActionController
       $clients,
       $filesets,
       $restorejobresources,
-      $jobids,
+      $this->restore_params['jobids'],
       $backups
     );
 
@@ -297,39 +265,12 @@ class RestoreController extends AbstractActionController
     $errors = null;
     $result = null;
 
-    if ($this->restore_params['jobid'] == null && $this->restore_params['client'] != null) {
-      try {
-        $latestbackup = $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", 1);
-        if (empty($latestbackup)) {
-          $this->restore_params['jobid'] = null;
-        } else {
-          $this->restore_params['jobid'] = $latestbackup[0]['jobid'];
-        }
-      } catch (Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-
-    if (isset($this->restore_params['mergejobs']) && $this->restore_params['mergejobs'] == 1) {
-      $jobids = $this->restore_params['jobid'];
+    if($this->restore_params['client'] != null) {
+      $this->handleJobId();
+      $this->handleJobMerge();
+      $backups = $this->getClientBackups();
+      $this->updateBvfsCache();
     } else {
-      try {
-        $jobids = $this->getRestoreModel()->getJobIds($this->bsock, $this->restore_params['jobid'], $this->restore_params['mergefilesets']);
-        $this->restore_params['jobids'] = $jobids;
-      } catch (Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-
-    if ($this->restore_params['client'] != null) {
-      try {
-        $backups = $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", null);
-        $this->updateBvfsCache();
-      } catch (Exception $e) {
-        echo $e->getMessage();
-      }
-    }
-    else {
       $backups = null;
     }
 
@@ -356,7 +297,7 @@ class RestoreController extends AbstractActionController
       $clients,
       $filesets,
       $restorejobresources,
-      $jobids,
+      $this->restore_params['jobids'],
       $backups
     );
 
@@ -454,6 +395,44 @@ class RestoreController extends AbstractActionController
 
     }
 
+  }
+
+  private function handleJobId()
+  {
+    if($this->restore_params['jobid'] == null) {
+      try {
+        $latestbackup = $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", 1);
+        if (empty($latestbackup)) {
+          $this->restore_params['jobid'] = null;
+        } else {
+          $this->restore_params['jobid'] = $latestbackup[0]['jobid'];
+        }
+      } catch (Exception $e) {
+        echo $e->getMessage();
+      }
+    }
+  }
+
+  private function handleJobMerge()
+  {
+    if(isset($this->restore_params['mergejobs']) && $this->restore_params['mergejobs'] == 1) {
+      $this->restore_params['jobids'] = $this->restore_params['jobid'];
+    } else {
+      try {
+        $this->restore_params['jobids'] = $this->getRestoreModel()->getJobIds($this->bsock, $this->restore_params['jobid'], $this->restore_params['mergefilesets']);
+      } catch (Exception $e) {
+        echo $e->getMessage();
+      }
+    }
+  }
+
+  private function getClientBackups()
+  {
+    try {
+      return $this->getClientModel()->getClientBackups($this->bsock, $this->restore_params['client'], "any", "desc", null);
+    } catch (Exception $e) {
+      echo $e->getMessage();
+    }
   }
 
   /**

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -382,7 +382,7 @@ $this->headTitle($title);
             displayBvfsCacheUpdateInfo();
          },
          'data' :{
-            'url' : '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
+            'url' : '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
             'dataType' : 'json',
             'data' : function (node) {
                return { 'id' : node.id };

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -523,7 +523,7 @@ $('#filebrowser').jstree({
       },
       'multiple': false,
       'data': {
-         'url': '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
+         'url': '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
          'dataType': 'json',
          'data': function (node) {
             return {


### PR DESCRIPTION
The purpose of this PR is to get rid of an unnecessary .bvfs_get_jobids and buildSubtree() call.

This PR also introduces new restore controller functions to eliminate redundant
controller code.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
