### PR TITLE
webui: fix empty job timeline issue if date.timezone is not set in php.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix wrong `packages_dir` in restapi workflow, so restapi packages will be released to PyPI [PR #1033]
 - core cats: Add IF EXISTS in drop table statements fix for bug #1409 (Allow usage of ExitOnFatal) [PR #1035]
 - sql_get.cc: fix error logging in GetJobRecord() for jobname #1042
+- webui: fix empty job timeline issue if date.timezone is not set in php.ini [PR #1051]
 
 ### Added
 - tests: simplify test coverage analysis [PR #1010]

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -68,7 +68,6 @@ System Requirements
 
 -  On SUSE Linux Enterprise 12 you need the additional SUSE Linux Enterprise Module for Web Scripting 12.
 
-
 Installation
 ------------
 
@@ -549,3 +548,16 @@ If you prefer to use |webui| on Nginx with php5-fpm instead of Apache, a basic w
    }
 
 This will make the |webui| accessible at http://bareos:9100/ (assuming your DNS resolve the hostname :strong:`bareos` to the NGINX server).
+
+php.ini settings
+~~~~~~~~~~~~~~~~
+
+-  The |webui| relies on date functions. Set the date.timezone directive according to the timezone of your |dir|.
+
+   .. code-block:: php
+
+      [Date]
+      ; Defines the default timezone used by the date functions
+      ; http://php.net/date.timezone
+      date.timezone = Europe/Berlin
+

--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -671,6 +671,11 @@ class JobController extends AbstractActionController
 
         $jobs = array();
 
+        // Ensure a proper date.timezone setting for the job timeline.
+        // Surpress a possible error thrown by date_default_timezone_get()
+        // in older PHP versions with @ in front of the function call.
+        date_default_timezone_set(@date_default_timezone_get());
+
         foreach($result as $job) {
 
           $starttime = new \DateTime($job['starttime']);


### PR DESCRIPTION
This PR fixes an issue where the job timeline stays empty if the timezone   
parameter is not set in the php.ini configuration file.                        
                                                                               
If the timezone is unset it will be set to UTC.

Also this PR adds a php.ini settings section to the installation chapter of the webui.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

