### PR TITLE
webui: fix empty job timeline issue if date.timezone is not set in php.ini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
-- doc: backport chapter for mariabackup db plugin [PR #1044]
+### Fixed
+- fix empty job timeline issue if date.timezone is not set in php.ini [PR #1053] (backport of [PR #1051])
+
+### Added
+
+### Changed
+
+### Removed
+
+### Documentation
+- backport chapter for mariabackup db plugin [PR #1044]
 
 ## [21.0.0] - 2021-12-21
 

--- a/core/src/stored/askdir.cc
+++ b/core/src/stored/askdir.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,8 +23,8 @@
 // Kern Sibbald, December 2000
 /**
  * @file
- * Subroutines to handle Catalog reqests sent to the Director
- * Reqests/commands from the Director are handled in dircmd.c
+ * Subroutines to handle Catalog requests sent to the Director
+ * Requests/commands from the Director are handled in dircmd.c
  */
 
 #include "include/bareos.h"

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -68,7 +68,6 @@ System Requirements
 
 -  On SUSE Linux Enterprise 12 you need the additional SUSE Linux Enterprise Module for Web Scripting 12.
 
-
 Installation
 ------------
 
@@ -549,3 +548,16 @@ If you prefer to use |webui| on Nginx with php5-fpm instead of Apache, a basic w
    }
 
 This will make the |webui| accessible at http://bareos:9100/ (assuming your DNS resolve the hostname :strong:`bareos` to the NGINX server).
+
+php.ini settings
+~~~~~~~~~~~~~~~~
+
+-  The |webui| relies on date functions. Set the date.timezone directive according to the timezone of your |dir|.
+
+   .. code-block:: php
+
+      [Date]
+      ; Defines the default timezone used by the date functions
+      ; http://php.net/date.timezone
+      date.timezone = Europe/Berlin
+

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -560,4 +560,3 @@ php.ini settings
       ; Defines the default timezone used by the date functions
       ; http://php.net/date.timezone
       date.timezone = Europe/Berlin
-

--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -671,6 +671,11 @@ class JobController extends AbstractActionController
 
         $jobs = array();
 
+        // Ensure a proper date.timezone setting for the job timeline.
+        // Surpress a possible error thrown by date_default_timezone_get()
+        // in older PHP versions with @ in front of the function call.
+        date_default_timezone_set(@date_default_timezone_get());
+
         foreach($result as $job) {
 
           $starttime = new \DateTime($job['starttime']);

--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify


### PR DESCRIPTION
This PR fixes an issue where the job timeline stays empty if the timezone
parameter is not set in the php.ini configuration file.
    
If the timezone is unset it will be set to UTC.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing


