### PR TITLE
consolidate: purge jobids without files before starting the consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - gitignore: cleanup .gitignore files [PR #1067]
 - webui: update jstree from v3.3.8 to v3.3.12 [PR #1088]
 - webui: update jstree-grid plugin [PR #1089]
+- Consolidation now purges candidate jobs with no files instead of ignoring them [PR #1056]
 
 ### Deprecated
 

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -488,6 +488,11 @@ typedef struct sql_field {
 } SQL_FIELD;
 #endif
 
+class BareosSqlError : public std::runtime_error {
+ public:
+  BareosSqlError(const char* what) : std::runtime_error(what) {}
+};
+
 class BareosDb : public BareosDbQueryEnum {
  protected:
   brwlock_t lock_; /**< Transaction lock */
@@ -740,6 +745,7 @@ class BareosDb : public BareosDbQueryEnum {
   bool AccurateGetJobids(JobControlRecord* jcr,
                          JobDbRecord* jr,
                          db_list_ctx* jobids);
+  db_list_ctx FilterZeroFileJobs(db_list_ctx& jobids);
   bool GetUsedBaseJobids(JobControlRecord* jcr,
                          const char* jobids,
                          db_list_ctx* result);
@@ -1023,8 +1029,8 @@ struct SqlPoolEntry {
   int id = 0; /**< Unique ID, connection numbering can have holes and the pool
              is not sorted on it */
   int reference_count = 0; /**< Reference count for this entry */
-  time_t last_update = 0; /**< When was this connection last updated either used
-                         or put back on the pool */
+  time_t last_update = 0;  /**< When was this connection last updated either
+                          used  or put back on the pool */
   BareosDb* db_handle = nullptr; /**< Connection handle to the database */
   dlink<SqlPoolEntry> link;      /**< list management */
 };
@@ -1040,8 +1046,8 @@ struct SqlPoolDescriptor {
   int max_connections
       = 0; /**< Maximum number of connections in the connection pool
             */
-  int increment_connections = 0; /**< Increase/Decrease the number of connection
-                                in the pool with this value */
+  int increment_connections = 0; /**< Increase/Decrease the number of
+                                connection in the pool with this value */
   int idle_timeout = 0;     /**< Number of seconds to wait before tearing down a
                            connection */
   int validate_timeout = 0; /**< Number of seconds after which an idle

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -650,6 +650,8 @@ class BareosDb : public BareosDbQueryEnum {
   bool DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pool_dbr);
   bool DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
   bool PurgeMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
+  void PurgeFiles(const char* jobids);
+  void PurgeJobs(const char* jobids);
 
   /* sql_find.c */
 
@@ -904,6 +906,7 @@ class BareosDb : public BareosDbQueryEnum {
   bool MarkFileRecord(JobControlRecord* jcr, FileId_t FileId, JobId_t JobId);
   void MakeInchangerUnique(JobControlRecord* jcr, MediaDbRecord* mr);
   int UpdateStats(JobControlRecord* jcr, utime_t age);
+  void UpgradeCopies(const char* jobids);
 
   /* Low level methods */
   bool MatchDatabase(const char* db_driver,

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -620,8 +620,10 @@ retry_query:
       retval = true;
       break;
     case PGRES_FATAL_ERROR:
-      Dmsg1(50, "Result status fatal: %s\n", query);
-      if (exit_on_fatal_) { Emsg0(M_ERROR_TERM, 0, "Fatal database error\n"); }
+      Dmsg1(50, "Result status fatal: %s, %s\n", query, sql_strerror());
+      if (exit_on_fatal_) {
+        Emsg1(M_ERROR_TERM, 0, "Fatal database error: %s\n", sql_strerror());
+      }
 
       if (try_reconnect_ && !transaction_) {
         /*

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -321,25 +321,7 @@ static bool PurgeJobsFromClient(UaContext* ua, ClientResource* client)
 // Remove File records from a list of JobIds
 void PurgeFilesFromJobs(UaContext* ua, const char* jobs)
 {
-  PoolMem query(PM_MESSAGE);
-
-  Mmsg(query, "DELETE FROM File WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete File sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM BaseFiles WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete BaseFiles sql=%s\n", query.c_str());
-
-  /*
-   * Now mark Job as having files purged. This is necessary to
-   * avoid having too many Jobs to process in future prunings. If
-   * we don't do this, the number of JobId's in our in memory list
-   * could grow very large.
-   */
-  Mmsg(query, "UPDATE Job SET PurgedFiles=1 WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Mark purged sql=%s\n", query.c_str());
+  ua->db->PurgeFiles(jobs);
 }
 
 /**
@@ -447,66 +429,13 @@ static bool PurgeQuotaFromClient(UaContext* ua, ClientResource* client)
  */
 void UpgradeCopies(UaContext* ua, const char* jobs)
 {
-  PoolMem query(PM_MESSAGE);
-
-  DbLocker _{ua->db};
-
-  /* Do it in two times for mysql */
-  ua->db->FillQuery(query, BareosDb::SQL_QUERY::uap_upgrade_copies_oldest_job,
-                    JT_JOB_COPY, jobs, jobs);
-
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Upgrade copies Log sql=%s\n", query.c_str());
-
-  /* Now upgrade first copy to Backup */
-  Mmsg(query,
-       "UPDATE Job SET Type='B' " /* JT_JOB_COPY => JT_BACKUP  */
-       "WHERE JobId IN ( SELECT JobId FROM cpy_tmp )");
-
-  ua->db->SqlQuery(query.c_str());
-
-  Mmsg(query, "DROP TABLE cpy_tmp");
-  ua->db->SqlQuery(query.c_str());
+  ua->db->UpgradeCopies(jobs);
 }
 
 // Remove all records from catalog for a list of JobIds
 void PurgeJobsFromCatalog(UaContext* ua, const char* jobs)
 {
-  PoolMem query(PM_MESSAGE);
-
-  /* Delete (or purge) records associated with the job */
-  PurgeFilesFromJobs(ua, jobs);
-
-  Mmsg(query, "DELETE FROM JobMedia WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete JobMedia sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM Log WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete Log sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM RestoreObject WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete RestoreObject sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM PathVisibility WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete PathVisibility sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM NDMPJobEnvironment WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete NDMPJobEnvironment sql=%s\n", query.c_str());
-
-  Mmsg(query, "DELETE FROM JobStats WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete JobStats sql=%s\n", query.c_str());
-
-  UpgradeCopies(ua, jobs);
-
-  /* Now remove the Job record itself */
-  Mmsg(query, "DELETE FROM Job WHERE JobId IN (%s)", jobs);
-  ua->db->SqlQuery(query.c_str());
-  Dmsg1(050, "Delete Job sql=%s\n", query.c_str());
+  ua->db->PurgeJobs(jobs);
 }
 
 void PurgeFilesFromVolume(UaContext* ua, MediaDbRecord* mr) {

--- a/core/src/dird/vbackup.cc
+++ b/core/src/dird/vbackup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2008-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -482,7 +482,7 @@ static bool CreateBootstrapFile(JobControlRecord* jcr, char* jobids)
   rx.JobIds = jobids;
 
   if (!jcr->db->OpenBatchConnection(jcr)) {
-    Jmsg0(jcr, M_FATAL, 0, "Can't get batch sql connexion");
+    Jmsg0(jcr, M_FATAL, 0, "Can't get batch sql connection");
     return false;
   }
 

--- a/core/src/lib/bstringlist.h
+++ b/core/src/lib/bstringlist.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -38,13 +38,11 @@ class BStringList : public std::vector<std::string> {
   std::string Join(char separator) const;
   std::string JoinReadable() const;
   std::string Join() const;
+  std::string Join(const char* separator) const;
   void Append(const std::vector<std::string>& vec);
   void Append(char character);
   void Append(const char* str);
   void PopFront();
-
- private:
-  std::string Join(const char* separator) const;
 };
 
 #endif  // BAREOS_LIB_BSTRINGLIST_H_

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -132,7 +132,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
    * - Multiple records of data
    * - EOD record
    *
-   * The Stream header is just used to sychronize things, and
+   * The Stream header is just used to synchronize things, and
    * none of the stream header is written to tape.
    * The Multiple records of data, contain first the Attributes,
    * then after another stream header, the file data, then

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
@@ -1,7 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 #
-# Run a simple backup
-#   then restore it.
+# Run a full backup, followed by 3 accurate incrementals
+# then do a consolidation. The first 3 jobs will got consolidated
+# the last incremental is kept 
+# (job->AlwaysIncrementalKeepNumber default is 1)
+#
+# Run a batch of 3 incrementals with no files 
+# Run consolidation : jobid with no files will get purged
+#
+# Run a batch of 3 incrementals the second with no files
+# Then a consolidation: VF and last incremental of first run
+# plus first incremental of 3rd run are consolidated when
+# 2nd increment with no files is purged
+# Last incremental is kept as is.
 #
 TestName="$(basename "$(pwd)")"
 export TestName
@@ -26,7 +37,6 @@ cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=100 storage=File
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName level=Full yes
 wait
@@ -39,6 +49,11 @@ wait
 @exec "sh -c 'touch ${tmp}/data/weird-files/file-3'"
 run job=$JobName level=Incremental yes
 wait
+END_OF_DATA
+run_bareos "$@"
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out $tmp/log1.out
 run job=Consolidate yes
 wait
 status director
@@ -50,7 +65,6 @@ messages
 wait
 quit
 END_OF_DATA
-
 run_bareos "$@"
 
 # Consolidating zero-file incremental backups
@@ -66,8 +80,33 @@ run job=$JobName level=Incremental yes
 wait
 run job=$JobName level=Incremental yes
 wait
+run job=Consolidate yes
+wait
 messages
+quit
+END_OF_DATA
+run_bareos "$@"
 
+# Consolidating a zero-file job in the middle of incremental backups
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log3.out
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-4'"
+run job=$JobName level=Incremental yes
+wait
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-5'"
+run job=$JobName level=Incremental yes
+wait
+status director
+status client
+status storage=File
+wait
+messages
+wait
 run job=Consolidate yes
 wait
 messages
@@ -79,9 +118,23 @@ run_bconsole
 stop_bareos
 
 check_job_canceled
+if ! grep "purged JobIds 1,2,3 as they were consolidated into Job 6" "$tmp"/log1.out; then
+  echo "consolidation did not work. Check $tmp/log1.out" >&2
+  estat=1
+fi
 
-if ! grep "purged JobIds 6,4,7,8 as they were consolidated into Job 11" "$tmp"/log2.out; then
-  echo "Zero file backups were not consolidated. Check $tmp/log2.out" >&2
+if ! grep "purging empty jobids 7,8,9" "$tmp"/log2.out; then
+  echo "Removing of empty jobs did not work. Check $tmp/log2.out" >&2
+  estat=1
+fi
+
+if ! grep "purging empty jobids 12" "$tmp"/log3.out; then
+  echo "Removing of empty jobs did not work. Check $tmp/log3.out" >&2
+  estat=1
+fi
+
+if ! grep "purged JobIds 6,4,11 as they were consolidated into Job 15" "$tmp"/log3.out; then
+  echo "consolidation did not work. Check $tmp/log3.out" >&2
   estat=1
 fi
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The consolidation job now purges jobs without files from the jobid list before starting the consolidation. This makes sure that jobs without are cleaned up before and consolidation of jobs that do not have any files is never tried.

Also, the current postgresql query code reacts to an PGRES_FATAL_ERROR either by exiting the daemon (if exit on fatal is set) or by simply returning a normal error returning the error string from the database.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
