### PR TITLE
SD plugin scsicrypto check, set, unset cap_sys_rawio capabilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ debian/bareos-database-common.postinst
 debian/bareos-database-postgresql.dirs
 debian/bareos-database-postgresql.install
 debian/bareos-database-tools.install
+debian/bareos-database-tools.postinst
 debian/bareos-director-python-plugin.install
 debian/bareos-director-python-plugins-common.install
 debian/bareos-director-python2-plugin.install
@@ -76,7 +77,9 @@ debian/bareos-storage.install
 debian/bareos-storage.postinst
 debian/bareos-storage.preinst
 debian/bareos-storage.service
+debian/bareos-storage-tape.postinst
 debian/bareos-tools.install
+debian/bareos-tools.postinst
 debian/bareos-traymonitor.install
 debian/bareos-traymonitor.postinst
 debian/bareos-universal-client.install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Added
 ￼- ndmp: introduce workaround for isilon 9.1.0.0 'Invalid nlist.tape_offset -1' error [PR #1043]
-￼
+- packaging: installation and upgrade will check for the presence of :file:`.enable-cap_sys_rawio` in your bareos config dir and will configure the required cap_sys_rawio capabilities [PR #1057]
+
 ### Breaking Changes
 
 ### Fixed
@@ -43,19 +44,25 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - clarifies MySQL catalog migration process [PR #1054]
 - split `Howtos.rst` file into one file per section [PR #1054]
 - split the very long `Plugins.rst` file into one file per Bareos plugin [PR #1046]
-
+- rework SD plugin scsicrypto linux sg_io ioctl subsection for cap_sys_rawio [PR #1057]
 
 
 [PR #1010]: https://github.com/bareos/bareos/pull/1010
 [PR #1015]: https://github.com/bareos/bareos/pull/1015
 [PR #1016]: https://github.com/bareos/bareos/pull/1016
+[PR #1021]: https://github.com/bareos/bareos/pull/1021
 [PR #1031]: https://github.com/bareos/bareos/pull/1031
 [PR #1033]: https://github.com/bareos/bareos/pull/1033
 [PR #1035]: https://github.com/bareos/bareos/pull/1035
+[PR #1038]: https://github.com/bareos/bareos/pull/1038
 [PR #1041]: https://github.com/bareos/bareos/pull/1041
 [PR #1043]: https://github.com/bareos/bareos/pull/1043
 [PR #1046]: https://github.com/bareos/bareos/pull/1046
 [PR #1048]: https://github.com/bareos/bareos/pull/1048
+[PR #1050]: https://github.com/bareos/bareos/pull/1050
 [PR #1051]: https://github.com/bareos/bareos/pull/1051
 [PR #1054]: https://github.com/bareos/bareos/pull/1054
+[PR #1057]: https://github.com/bareos/bareos/pull/1057
+[PR #1059]: https://github.com/bareos/bareos/pull/1059
+[PR #1062]: https://github.com/bareos/bareos/pull/1062
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1762,6 +1762,12 @@ if [ -e %1.rpmupdate.%{version}.keep ]; then \
    rm %1.rpmupdate.%{version}.keep; \
 fi; \
 %nil
+
+%define post_scsicrypto() \
+if [ -f "%{_sysconfdir}/%{name}/.enable-cap_sys_rawio" ]; then \
+   %{script_dir}/bareos-config set_scsicrypto_capabilities; \
+fi\
+%nil
 %post webui
 
 %if 0%{?suse_version} >= 1110
@@ -1797,6 +1803,9 @@ a2enmod php5 &> /dev/null || true
 %posttrans director
 %posttrans_restore_file /etc/%{name}/bareos-dir.conf
 
+%post tools
+%post_scsicrypto
+
 %post storage
 %post_backup_file /etc/%{name}/bareos-sd.conf
 # pre script has already generated the storage daemon user,
@@ -1804,6 +1813,7 @@ a2enmod php5 &> /dev/null || true
 %{script_dir}/bareos-config setup_sd_user
 %{script_dir}/bareos-config initialize_local_hostname
 %{script_dir}/bareos-config initialize_passwords
+%post_scsicrypto
 %if 0%{?suse_version} >= 1210
 %service_add_post bareos-sd.service
 /bin/systemctl enable bareos-sd.service >/dev/null 2>&1 || true
@@ -1833,10 +1843,11 @@ a2enmod php5 &> /dev/null || true
 
 %post storage-tape
 %post_backup_file /etc/%{name}/bareos-sd.d/device-tape-with-autoloader.conf
+%post_scsicrypto
 
 %posttrans storage-tape
 %posttrans_restore_file /etc/%{name}/bareos-sd.d/device-tape-with-autoloader.conf
-
+%post_scsicrypto
 
 %post filedaemon
 %post_backup_file /etc/%{name}/bareos-fd.conf
@@ -1892,6 +1903,9 @@ a2enmod php5 &> /dev/null || true
 
 %post database-postgresql
 /sbin/ldconfig
+
+%post database-tools
+%post_scsicrypto
 
 %postun database-postgresql
 /sbin/ldconfig

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -14,8 +14,6 @@ User=@sd_user@
 Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
-# enable this for scsicrypto-sd
-# CapabilityBoundingSet=cap_sys_rawio+ep
 SuccessExitStatus=0 15
 Restart=on-failure
 

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -234,68 +234,58 @@ get_database_utility_path()
     fi
 }
 
-export  SCSICRYPTO_CMDS="${BAREOS_SBIN_DIR}/bareos-sd ${BAREOS_SBIN_DIR}/bscrypto ${BAREOS_SBIN_DIR}/btape ${BAREOS_SBIN_DIR}/bextract ${BAREOS_SBIN_DIR}/bls"
-[ ${os_type} = Linux ] && \
+_scsicrypto_cmds="bareos-sd bscrypto btape bextract bls"
 check_scsicrypto_capabilities()
 {
-  export CAP_MISSING_CONF=0
-  # Check capabilities status of needed binaries
+  if [ "${os_type}" != "Linux" ];then
+      error "check_scsicrypto_capabilities() is not supported on this platform"
+      return 1
+  fi
+  cap_missing_conf=0
   if ( [ "$(command -v getcap)" = "" ] || [ "$(command -v setcap)" = "" ] ); then
       error "getcap and setcap commands are mandatory"
       return 1
   fi
-  for C in ${SCSICRYPTO_CMDS};do
-    R=$(setcap -v cap_sys_rawio=ep ${C})
-    if [ ${?} -ne 0 ];then
-       warn "${R}"
-       export CAP_MISSING_CONF=1
+  for c in ${_scsicrypto_cmds};do
+    if ! r="$(setcap -v cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
+       warn "${r}"
+       cap_missing_conf=1
     fi
   done
-  if [ ${CAP_MISSING_CONF} -ne 0 ];then
+  if [ ${cap_missing_conf} -ne 0 ];then
     warn "one of the tools are not configured for scsi crypto."
     warn "run set_scsicrypto_capabilities to fix capabilities."
   else
-    info "All tools have capabilities set."
+    info "All tools have cap_sys_rawio=ep set."
   fi
 }
-[ ${os_type} != Linux ] && \
-check_scsicrypto_capabilities()
-{
-   error "check_scsicrypto_capabilities() is not supported on this platform"
-   return 1
-}
 
-[ ${os_type} = Linux ] && \
 set_scsicrypto_capabilities()
 {
-  for C in ${SCSICRYPTO_CMDS};do
-    R=$(setcap cap_sys_rawio+ep ${C})
-    if [ ${?} -ne 0 ];then
-       error "setcap ${C} has failed - ${R}"
+  if [ "${os_type}" != "Linux" ];then
+      error "set_scsicrypto_capabilities() is not supported on this platform"
+      return 1
+  fi
+  for c in ${_scsicrypto_cmds};do
+    if ! r="$(setcap cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
+       error "setcap on ${c} has failed - ${r}"
        return 1
     fi
   done
 }
-[ ${os_type} != Linux ] && \
-set_scsicrypto_capabilities()
-{
-   error "set_scsicrypto_capabilities() is not supported on this platform"
-   return 1
-}
 
-[ ${os_type} = Linux ] && \
 unset_scsicrypto_capabilities()
 {
-  for C in ${SCSICRYPTO_CMDS};do
-    setcap -r ${C}
-    #Erreur message are show directly
+  if [ "${os_type}" != "Linux" ];then
+      error "unset_scsicrypto_capabilities() is not supported on this platform"
+      return 1
+  fi
+  for c in ${_scsicrypto_cmds};do
+    if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
+       error "setcap -r on ${c} has failed - ${r}"
+       return 1
+    fi
   done
-}
-[ ${os_type} != Linux ] && \
-unset_scsicrypto_capabilities()
-{
-   error "unset_scsicrypto_capabilities() is not supported on this platform"
-   return 1
 }
 
 

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -252,9 +252,11 @@ check_scsicrypto_capabilities()
     cap_missing_conf=1
   fi
   for c in ${_scsicrypto_cmds};do
-    if ! r="$(setcap -v cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
-       warn "${r}"
-       cap_missing_conf=1
+    if [ -x "${BAREOS_SBIN_DIR}/${c}" ]; then
+      if ! r="$(setcap -v cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
+        warn "${r}"
+        cap_missing_conf=1
+      fi
     fi
   done
   if [ ${cap_missing_conf} -ne 0 ];then
@@ -272,18 +274,20 @@ set_scsicrypto_capabilities()
       return 1
   fi
   for c in ${_scsicrypto_cmds};do
-    # Need to affect the bareos group (debian)
-    if ! r="$(chgrp "${STORAGE_DAEMON_GROUP}" "${BAREOS_SBIN_DIR}/${c}")"; then
-        error "Setting group to ${STORAGE_DAEMON_GROUP} failed on ${c}"
+    if [ -x "${BAREOS_SBIN_DIR}/${c}" ]; then
+      # Need to affect the bareos group (debian)
+      if ! r="$(chgrp "${STORAGE_DAEMON_GROUP}" "${BAREOS_SBIN_DIR}/${c}")"; then
+          error "Setting group to ${STORAGE_DAEMON_GROUP} failed on ${c}"
+          return 1
+      fi
+      if ! r="$(chmod o-rwx "${BAREOS_SBIN_DIR}/${c}")"; then
+          error "Setting chmod o-rwx failed on ${c}"
+          return 1
+      fi
+      if ! r="$(setcap cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
+        error "setcap on ${c} has failed - ${r}"
         return 1
-    fi
-    if ! r="$(chmod o-rwx "${BAREOS_SBIN_DIR}/${c}")"; then
-        error "Setting chmod o-rwx failed on ${c}"
-        return 1
-    fi
-    if ! r="$(setcap cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
-       error "setcap on ${c} has failed - ${r}"
-       return 1
+      fi
     fi
   done
   echo "cap_sys_rawio+ep capabilities enabled on $(date "+%F %X")" > "${_scsicrypto_config_file}"
@@ -296,17 +300,19 @@ unset_scsicrypto_capabilities()
       return 1
   fi
   for c in ${_scsicrypto_cmds};do
-    if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
-       error "setcap -r on ${c} has failed - ${r}"
-       return 1
-    fi
-    if ! r="$(chmod o+rx "${BAREOS_SBIN_DIR}/${c}")"; then
-        error "Restoring chmod o+rx failed on ${c}"
-        return 1
-    fi
-    if ! r="$(chgrp root "${BAREOS_SBIN_DIR}/${c}")"; then
-        error "Restoring group to root failed on ${c}"
-        return 1
+    if [ -x "${BAREOS_SBIN_DIR}/${c}" ]; then
+      if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
+          # Don't fail if binary did had capabilities set.
+          warning "setcap -r on ${c} has failed - ${r}"
+      fi
+      if ! r="$(chmod o+rx "${BAREOS_SBIN_DIR}/${c}")"; then
+          warning "Restoring chmod o+rx failed on ${c}"
+          return 1
+      fi
+      if ! r="$(chgrp root "${BAREOS_SBIN_DIR}/${c}")"; then
+          warning "Restoring group to root failed on ${c}"
+          return 1
+      fi
     fi
   done
   rm -f "${_scsicrypto_config_file}"

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -235,7 +235,7 @@ get_database_utility_path()
 }
 
 _scsicrypto_cmds="bareos-sd bcopy bextract bls bscan bscrypto btape"
-_scsicrypto_config_file="${BAREOS_CONFIG_DIR}/.enable-capabilities"
+_scsicrypto_config_file="${BAREOS_CONFIG_DIR}/.enable-cap_sys_rawio"
 check_scsicrypto_capabilities()
 {
   if [ "${os_type}" != "Linux" ];then
@@ -286,7 +286,7 @@ set_scsicrypto_capabilities()
        return 1
     fi
   done
-  echo "cap_sys_rawio+ep capabilities enabled" > "${_scsicrypto_config_file}"
+  echo "cap_sys_rawio+ep capabilities enabled on $(date "+%F %X")" > "${_scsicrypto_config_file}"
 }
 
 unset_scsicrypto_capabilities()

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -272,14 +272,18 @@ set_scsicrypto_capabilities()
       return 1
   fi
   for c in ${_scsicrypto_cmds};do
+    # Need to affect the bareos group (debian)
+    if ! r="$(chgrp "${STORAGE_DAEMON_GROUP}" "${BAREOS_SBIN_DIR}/${c}")"; then
+        error "Setting group to ${STORAGE_DAEMON_GROUP} failed on ${c}"
+        return 1
+    fi
+    if ! r="$(chmod o-rwx "${BAREOS_SBIN_DIR}/${c}")"; then
+        error "Setting chmod o-rwx failed on ${c}"
+        return 1
+    fi
     if ! r="$(setcap cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
        error "setcap on ${c} has failed - ${r}"
        return 1
-    else
-      if ! r="$(chmod 0750 "${BAREOS_SBIN_DIR}/${c}")"; then
-         error "Adjusting chmod failed on ${c}"
-         return 1
-      fi
     fi
   done
   echo "cap_sys_rawio+ep capabilities enabled" > "${_scsicrypto_config_file}"
@@ -295,11 +299,14 @@ unset_scsicrypto_capabilities()
     if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
        error "setcap -r on ${c} has failed - ${r}"
        return 1
-    else
-      if ! r="$(chmod 0755 "${BAREOS_SBIN_DIR}/${c}")"; then
-         error "Ajusting chmod failed on ${c}"
-         return 1
-      fi
+    fi
+    if ! r="$(chmod o+rx "${BAREOS_SBIN_DIR}/${c}")"; then
+        error "Restoring chmod o+rx failed on ${c}"
+        return 1
+    fi
+    if ! r="$(chgrp root "${BAREOS_SBIN_DIR}/${c}")"; then
+        error "Restoring group to root failed on ${c}"
+        return 1
     fi
   done
   rm -f "${_scsicrypto_config_file}"

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -302,7 +302,7 @@ unset_scsicrypto_capabilities()
   for c in ${_scsicrypto_cmds};do
     if [ -x "${BAREOS_SBIN_DIR}/${c}" ]; then
       if ! r="$(setcap -q -r "${BAREOS_SBIN_DIR}/${c}")"; then
-          # Don't fail if binary did had capabilities set.
+          # Don't fail if binary had capabilities set.
           warn "setcap -r on ${c} has failed - ${r}"
       fi
       if ! r="$(chmod o+rx "${BAREOS_SBIN_DIR}/${c}")"; then

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -234,7 +234,7 @@ get_database_utility_path()
     fi
 }
 
-_scsicrypto_cmds="bareos-sd bscrypto btape bextract bls"
+_scsicrypto_cmds="bareos-sd bcopy bextract bls bscan bscrypto btape"
 check_scsicrypto_capabilities()
 {
   if [ "${os_type}" != "Linux" ];then

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -301,16 +301,16 @@ unset_scsicrypto_capabilities()
   fi
   for c in ${_scsicrypto_cmds};do
     if [ -x "${BAREOS_SBIN_DIR}/${c}" ]; then
-      if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
+      if ! r="$(setcap -q -r "${BAREOS_SBIN_DIR}/${c}")"; then
           # Don't fail if binary did had capabilities set.
-          warning "setcap -r on ${c} has failed - ${r}"
+          warn "setcap -r on ${c} has failed - ${r}"
       fi
       if ! r="$(chmod o+rx "${BAREOS_SBIN_DIR}/${c}")"; then
-          warning "Restoring chmod o+rx failed on ${c}"
+          error "Restoring chmod o+rx failed on ${c}"
           return 1
       fi
       if ! r="$(chgrp root "${BAREOS_SBIN_DIR}/${c}")"; then
-          warning "Restoring group to root failed on ${c}"
+          error "Restoring group to root failed on ${c}"
           return 1
       fi
     fi

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -234,6 +234,71 @@ get_database_utility_path()
     fi
 }
 
+export  SCSICRYPTO_CMDS="/usr/sbin/bareos-sd /usr/sbin/bscrypto /usr/sbin/btape /usr/sbin/bextract /usr/sbin/bls"
+[ ${os_type} = Linux ] && \
+check_scsicrypto_capabilities()
+{
+  export CAP_MISSING_CONF=0
+  # Check capabilities status of needed binaries
+  if ( [ "$(command -v getcap)" = "" ] || [ "$(command -v setcap)" = "" ] ); then
+      error "getcap and setcap commands are mandatory"
+      return 1
+  fi
+  for C in ${SCSICRYPTO_CMDS};do
+    R=$(setcap -v cap_sys_rawio=ep ${C})
+    if [ ${?} -ne 0 ];then
+       warn "${R}"
+       export CAP_MISSING_CONF=1
+    fi
+  done
+  if [ ${CAP_MISSING_CONF} -ne 0 ];then
+    warn "one of the tools are not configured for scsi crypto."
+    warn "run set_scsicrypto_capabilities to fix capabilities."
+  else
+    info "All tools have capabilities set."
+  fi
+}
+[ ${os_type} != Linux ] && \
+check_scsicrypto_capabilities()
+{
+   error "check_scsicrypto_capabilities() is not supported on this platform"
+   return 1
+}
+
+[ ${os_type} = Linux ] && \
+set_scsicrypto_capabilities()
+{
+  for C in ${SCSICRYPTO_CMDS};do
+    R=$(setcap cap_sys_rawio+ep ${C})
+    if [ ${?} -ne 0 ];then
+       error "setcap ${C} has failed - ${R}"
+       return 1
+    fi
+  done
+}
+[ ${os_type} != Linux ] && \
+set_scsicrypto_capabilities()
+{
+   error "set_scsicrypto_capabilities() is not supported on this platform"
+   return 1
+}
+
+[ ${os_type} = Linux ] && \
+unset_scsicrypto_capabilities()
+{
+  for C in ${SCSICRYPTO_CMDS};do
+    setcap -r ${C}
+    #Erreur message are show directly
+  done
+}
+[ ${os_type} != Linux ] && \
+unset_scsicrypto_capabilities()
+{
+   error "unset_scsicrypto_capabilities() is not supported on this platform"
+   return 1
+}
+
+
 [ ${os_type} = Linux ] && \
 setup_sd_user()
 {

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -235,16 +235,21 @@ get_database_utility_path()
 }
 
 _scsicrypto_cmds="bareos-sd bcopy bextract bls bscan bscrypto btape"
+_scsicrypto_config_file="${BAREOS_CONFIG_DIR}/.enable-capabilities"
 check_scsicrypto_capabilities()
 {
   if [ "${os_type}" != "Linux" ];then
       error "check_scsicrypto_capabilities() is not supported on this platform"
       return 1
   fi
-  cap_missing_conf=0
   if ( [ "$(command -v getcap)" = "" ] || [ "$(command -v setcap)" = "" ] ); then
       error "getcap and setcap commands are mandatory"
       return 1
+  fi
+  if [ -f "${_scsicrypto_config_file}" ];then
+    cap_missing_conf=0
+  else
+    cap_missing_conf=1
   fi
   for c in ${_scsicrypto_cmds};do
     if ! r="$(setcap -v cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
@@ -253,8 +258,8 @@ check_scsicrypto_capabilities()
     fi
   done
   if [ ${cap_missing_conf} -ne 0 ];then
-    warn "one of the tools are not configured for scsi crypto."
-    warn "run set_scsicrypto_capabilities to fix capabilities."
+    warn "One of the tools are not configured for scsi crypto."
+    warn "Run set_scsicrypto_capabilities to fix capabilities."
   else
     info "All tools have cap_sys_rawio=ep set."
   fi
@@ -270,8 +275,14 @@ set_scsicrypto_capabilities()
     if ! r="$(setcap cap_sys_rawio=ep "${BAREOS_SBIN_DIR}/${c}")"; then
        error "setcap on ${c} has failed - ${r}"
        return 1
+    else
+      if ! r="$(chmod 0750 "${BAREOS_SBIN_DIR}/${c}")"; then
+         error "Adjusting chmod failed on ${c}"
+         return 1
+      fi
     fi
   done
+  echo "cap_sys_rawio+ep capabilities enabled" > "${_scsicrypto_config_file}"
 }
 
 unset_scsicrypto_capabilities()
@@ -284,8 +295,14 @@ unset_scsicrypto_capabilities()
     if ! r="$(setcap -r "${BAREOS_SBIN_DIR}/${c}")"; then
        error "setcap -r on ${c} has failed - ${r}"
        return 1
+    else
+      if ! r="$(chmod 0755 "${BAREOS_SBIN_DIR}/${c}")"; then
+         error "Ajusting chmod failed on ${c}"
+         return 1
+      fi
     fi
   done
+  rm -f "${_scsicrypto_config_file}"
 }
 
 

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -234,7 +234,7 @@ get_database_utility_path()
     fi
 }
 
-export  SCSICRYPTO_CMDS="/usr/sbin/bareos-sd /usr/sbin/bscrypto /usr/sbin/btape /usr/sbin/bextract /usr/sbin/bls"
+export  SCSICRYPTO_CMDS="${BAREOS_SBIN_DIR}/bareos-sd ${BAREOS_SBIN_DIR}/bscrypto ${BAREOS_SBIN_DIR}/btape ${BAREOS_SBIN_DIR}/bextract ${BAREOS_SBIN_DIR}/bls"
 [ ${os_type} = Linux ] && \
 check_scsicrypto_capabilities()
 {

--- a/debian/bareos-database-tools.postinst.in
+++ b/debian/bareos-database-tools.postinst.in
@@ -17,22 +17,6 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-daemon_user=bareos
-daemon_group=bareos
-
-#director_daemon_user=$daemon_user
-storage_daemon_user=$daemon_user
-#file_daemon_user=root
-storage_daemon_group=$daemon_group
-
-
-
-permissions()
-{
-  chown ${storage_daemon_user}:${daemon_group} /var/lib/bareos/storage/
-  chmod 750 /var/lib/bareos/storage/
-}
-
 scsicrypto()
 {
 if [ -f "@confdir@/.enable-cap_sys_rawio" ]; then
@@ -42,16 +26,6 @@ fi
 
 case "$1" in
     configure)
-        /usr/lib/bareos/scripts/bareos-config deploy_config "@configtemplatedir@" "@confdir@" "bareos-sd" || true
-        permissions
-        /usr/lib/bareos/scripts/bareos-config setup_sd_user
-        # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
-            ucr set \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all="ACCEPT" \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all/en="bareos-sd"
-            #invoke-rc.d univention-firewall restart
-        fi
         scsicrypto
     ;;
 

--- a/debian/bareos-storage-tape.postinst.in
+++ b/debian/bareos-storage-tape.postinst.in
@@ -17,22 +17,6 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-daemon_user=bareos
-daemon_group=bareos
-
-#director_daemon_user=$daemon_user
-storage_daemon_user=$daemon_user
-#file_daemon_user=root
-storage_daemon_group=$daemon_group
-
-
-
-permissions()
-{
-  chown ${storage_daemon_user}:${daemon_group} /var/lib/bareos/storage/
-  chmod 750 /var/lib/bareos/storage/
-}
-
 scsicrypto()
 {
 if [ -f "@confdir@/.enable-cap_sys_rawio" ]; then
@@ -42,16 +26,6 @@ fi
 
 case "$1" in
     configure)
-        /usr/lib/bareos/scripts/bareos-config deploy_config "@configtemplatedir@" "@confdir@" "bareos-sd" || true
-        permissions
-        /usr/lib/bareos/scripts/bareos-config setup_sd_user
-        # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
-            ucr set \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all="ACCEPT" \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all/en="bareos-sd"
-            #invoke-rc.d univention-firewall restart
-        fi
         scsicrypto
     ;;
 

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -14,8 +14,6 @@ User=@sd_user@
 Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
-# enable this for scsicrypto-sd
-# CapabilityBoundingSet=cap_sys_rawio+ep
 SuccessExitStatus=0 15
 Restart=on-failure
 

--- a/debian/bareos-tools.postinst.in
+++ b/debian/bareos-tools.postinst.in
@@ -17,22 +17,6 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-daemon_user=bareos
-daemon_group=bareos
-
-#director_daemon_user=$daemon_user
-storage_daemon_user=$daemon_user
-#file_daemon_user=root
-storage_daemon_group=$daemon_group
-
-
-
-permissions()
-{
-  chown ${storage_daemon_user}:${daemon_group} /var/lib/bareos/storage/
-  chmod 750 /var/lib/bareos/storage/
-}
-
 scsicrypto()
 {
 if [ -f "@confdir@/.enable-cap_sys_rawio" ]; then
@@ -42,16 +26,6 @@ fi
 
 case "$1" in
     configure)
-        /usr/lib/bareos/scripts/bareos-config deploy_config "@configtemplatedir@" "@confdir@" "bareos-sd" || true
-        permissions
-        /usr/lib/bareos/scripts/bareos-config setup_sd_user
-        # on Univention distributions the ucr command allows to open the firewall
-        if [ -x "/etc/init.d/univention-firewall" ] && which ucr >/dev/null 2>&1; then
-            ucr set \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all="ACCEPT" \
-                security/packetfilter/package/bareos-storage/tcp/@sd_port@/all/en="bareos-sd"
-            #invoke-rc.d univention-firewall restart
-        fi
         scsicrypto
     ;;
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -49,7 +49,7 @@ The volume label is written in unencrypted form to the volume, so we can always 
 
 If you don’t want to use the scsicrypto-sd plugin when doing DR and you are only reading one volume, you can also set the crypto key using the bscrypto tool. Because we use the mixed decryption mode, in which you can read both encrypted and unencrypted data from a volume, you can set the right encryption key before reading the volume label.
 
-If you need to read more than one volume, you better use the scsicrypto-sd plugin with tools like bscan/bextract, as the plugin will then auto-load the correct encryption key when it loads the volume, similiarly to what the storage daemon does when performing backups and restores.
+If you need to read more than one volume, you better use the scsicrypto-sd plugin with tools like bscan/bextract, as the plugin will then auto-load the correct encryption key when it loads the volume, similarly to what the storage daemon does when performing backups and restores.
 
 The volume label is unencrypted, so a volume can also be recognized by a non-encrypted installation, but it won’t be able to read the actual data from it. Using an encrypted volume label doesn’t add much security (there is no security-related info in the volume label anyhow) and it makes it harder to recognize either a labeled volume with encrypted data or an unlabeled new volume (both would return an IO-error on read of the label.)
 
@@ -83,29 +83,73 @@ Linux (SG_IO ioctl interface):
 
 The user running the storage daemon needs the following additional capabilities: :index:`\ <single: Platform; Linux; Privileges>`\
 
--  :strong:`CAP_SYS_RAWIO` (see capabilities(7))
+-  :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7))
 
    -  On older kernels you might need :strong:`CAP_SYS_ADMIN`. Try :strong:`CAP_SYS_RAWIO` first and if that doesn’t work try :strong:`CAP_SYS_ADMIN`
 
 -  If you are running the storage daemon as another user than root (which has the :strong:`CAP_SYS_RAWIO` capability), you need to add it to the current set of capabilities.
 
--  If you are using systemd, you could add this additional capability to the CapabilityBoundingSet parameter.
+-  If you are using systemd, you could add this additional capability to the AmbientCapabilities=CAP_SYS_RAWIO parameter.
 
-   -  For systemd add the following to the bareos-sd.service: :strong:`Capabilities=cap_sys_rawio+ep`
+   -  For systemd add the following to the bareos-sd.service: :strong:`AmbientCapabilities=CAP_SYS_RAWIO`
+   -  To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
 
-You can also set up the extra capability on :command:`bscrypto` and :command:`bareos-sd` by running the following commands:
+.. warning::
+
+   As of systemd version 249 There's no mechanism to pass restricted flag (+ep), so the result will always be full CAP_SYS_RAWIO (eip)
+
+You can also set up the extra capability on :command:`bscrypto`,:command:`bareos-sd`,:command:`bls`,:command:`bextract` and :command:`btape` by running the following commands:
 
 .. code-block:: shell-session
 
-   setcap cap_sys_rawio=ep bscrypto
-   setcap cap_sys_rawio=ep bareos-sd
+   setcap cap_sys_rawio=ep /usr/sbin/bscrypto
+   setcap cap_sys_rawio=ep /usr/sbin/bareos-sd
+   setcap cap_sys_rawio=ep /usr/sbin/bls
+   setcap cap_sys_rawio=ep /usr/sbin/bextract
+   setcap cap_sys_rawio=ep /usr/sbin/btape
+
+
+With our helper
+
+.. code-block:: shell-session
+
+   /usr/lib/bareos/script/bareos-config.sh set_scsicrypto_capabilities
+
+Remove the setting with
+
+.. code-block:: shell-session
+
+   getcap -v /usr/sbin/bscrypto
+   getcap -v /usr/sbin/bareos-sd
+   getcap -v /usr/sbin/bls
+   getcap -v /usr/sbin/bextract
+   getcap -v /usr/sbin/btape
+
+
+With our helper
+
+.. code-block:: shell-session
+
+   /usr/lib/bareos/script/bareos-config.sh unset_scsicrypto_capabilities
+
 
 Check the setting with
 
 .. code-block:: shell-session
 
-   getcap -v bscrypto
-   getcap -v bareos-sd
+   getcap -v /usr/sbin/bscrypto
+   getcap -v /usr/sbin/bareos-sd
+   getcap -v /usr/sbin/bls
+   getcap -v /usr/sbin/bextract
+   getcap -v /usr/sbin/btape
+
+
+With our helper
+
+.. code-block:: shell-session
+
+   /usr/lib/bareos/script/bareos-config.sh check_scsicrypto_capabilities
+
 
 :command:`getcap` and :command:`setcap` are part of libcap-progs.
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -91,8 +91,8 @@ If :command:`bareos-sd` does not have the appropriate capabilities, all other ta
 
 .. note::
 
-    Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file :file:`.enable-cap_sys_rawio` presence in your bareos config dir, setting back the previously set capabilities if present.
-    This mean if you want capabilities automatically setup during package install, you can just create the :file:`/etc/bareos/.enable-cap_sys_rawio` file.
+    Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` package installation and upgrade will check for the presence of :file:`.enable-cap_sys_rawio` in your bareos config dir and will configure the required capabilities.
+    If you want capabilities automatically set up during package install, you can just create :file:`/etc/bareos/.enable-cap_sys_rawio`.
 
     Before :sinceVersion:`21.0.1: scscicrypto capabilities handling` it is mandatory to setup capabilities manually after each update (see below).
 
@@ -166,8 +166,8 @@ Check the setting manually
 .. warning::
 
    Adding capabilities like cap_sys_rawio to binaries can increase their abuse.
-   We recommend also to restrict a bit more their ownership to root as owner and bareos as group, plus setting chmod to 0750. Doing so will restrict execution to only root or any member of bareos group.
-   All those step are done for you by our helper.
+   We also recommend to restrict a bit more their ownership to root as owner and bareos as group, plus setting chmod to 0750. Doing so will restrict execution root and members of group bareos.
+   All these steps are done for you by our helper.
 
 
    **systemd** (not recommended)

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -92,7 +92,7 @@ If :command:`bareos-sd` does not have the appropriate capabilities, all other ta
 **systemd** (not recommended)
 
 
-To add the capabilities to bareos-sd.service you can add in file `/etc/systemd/system/bareos-sd.d/override.conf` a section containing the :strong:`AmbientCapabilities=CAP_SYS_RAWIO` line.
+To add the capabilities to bareos-sd.service you can add in file :file:`/etc/systemd/system/bareos-sd.d/override.conf` a section containing the :strong:`AmbientCapabilities=CAP_SYS_RAWIO` line.
 The easiest way to create this file is to use the following instructions as root.
 
 .. code-block:: shell-session
@@ -101,7 +101,7 @@ The easiest way to create this file is to use the following instructions as root
 
 Fill the file with the following content, then save and exit
 
-.. code-block::
+.. code-block:: cfg
 
    ### Editing /etc/systemd/system/bareos-storage.service.d/override.conf
    ### Anything between here and the comment below will become the new contents of the file

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -81,7 +81,11 @@ The following additional security is needed for the following operating systems:
 Linux (SG_IO ioctl interface):
 
 
-The user running the storage daemon needs the following additional capabilities: :index:`\ <single: Platform; Linux; Privileges>`\
+.. index::
+  single: Platform; Linux; Privileges
+ 
+To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO` must be set.
+The |sd| normally runs a user **bareos**. Running it as **root** is not recommended.
 
 -  :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7))
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -84,30 +84,82 @@ Linux (SG_IO ioctl interface):
 .. index::
   single: Platform; Linux; Privileges
 
-To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO+EP` must be set.
+To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7)) must be set.
 The |sd| normally runs as user **bareos**. Running it as **root** is not recommended.
 
 If :command:`bareos-sd` does not have the appropriate capabilities, all other tape operations may still work correctly, but you will get "Unable to perform SG\_IO ioctl" errors.
 
--  :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7))
+**systemd** (not recommended)
 
--  For systemd add the following to the bareos-sd.service: :strong:`AmbientCapabilities=CAP_SYS_RAWIO`.
-   To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
+
+To add the capabilities to bareos-sd.service you can add in file `/etc/systemd/system/bareos-sd.d/override.conf` a section containing the :strong:`AmbientCapabilities=CAP_SYS_RAWIO` line.
+The easiest way to create this file is to use the following instructions as root.
+
+.. code-block:: shell-session
+
+   systemctl edit bareos-sd.service
+
+Fill the file with the following content, then save and exit
+
+.. code-block::
+
+   ### Editing /etc/systemd/system/bareos-storage.service.d/override.conf
+   ### Anything between here and the comment below will become the new contents of the file
+
+   [Service]
+   AmbientCapabilities=CAP_SYS_RAWIO
+
+
+Reload systemd configuration and restart bareos-sd
+
+.. code-block:: shell-session
+
+   systemctl daemon-reload
+
+   systemctl restart bareos-sd
+
+   systemctl status bareos-sd
+      ● bareos-storage.service - Bareos Storage Daemon service
+      Loaded: loaded (/lib/systemd/system/bareos-storage.service; enabled; vendor preset: enabled)
+      Drop-In: /etc/systemd/system/bareos-storage.service.d
+      └─override.conf
+      Active: active (running) since Tue 2022-02-01 15:12:49 CET; 5s ago
+      Docs: man:bareos-sd(8)
+      Main PID: 11142 (bareos-sd)
+      Tasks: 2 (limit: 2298)
+      Memory: 1.1M
+      CPU: 8ms
+      CGroup: /system.slice/bareos-storage.service
+      └─11142 /usr/sbin/bareos-sd -f
+
+      systemd[1]: Started Bareos Storage Daemon service.
+
+
+To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
+
+.. code-block:: shell-session
+
+   root:~# getpcaps 11142
+   11142: cap_sys_rawio=eip
+
 
 .. warning::
 
    As of systemd version 249 There's no mechanism to pass restricted flag (+ep), so the result will always be full CAP_SYS_RAWIO (eip)
 
+
+**setcap binaries** (recommended)
+
 You can also set up the extra capability on :command:`bareos-sd`, :command:`bcopy`, :command:`bextract`, :command:`bls`, :command:`bscan`, :command:`bscrypto`, :command:`btape` by running the following commands:
 
-Check the setting with our helper
+Set the setting with our helper
 
 .. code-block:: shell-session
 
    /usr/lib/bareos/script/bareos-config.sh set_scsicrypto_capabilities
 
 
-Check the setting manually
+Set the setting manually
 
 .. code-block:: shell-session
 
@@ -126,7 +178,7 @@ Remove the setting with our helper
 
    /usr/lib/bareos/script/bareos-config.sh unset_scsicrypto_capabilities
 
-Check the setting manually
+Remove the setting manually
 
 .. code-block:: shell-session
 
@@ -164,8 +216,9 @@ Check the setting manually
 
 .. warning::
 
-   Adding capabilities like cap_sys_rawio to binaries can increase their abuse, so we recommend also to restrict a bit more their ownership to 0750.
-   Doing so restrict execution to only root or any member of bareos group.
+   Adding capabilities like cap_sys_rawio to binaries can increase their abuse.
+   We recommend also to restrict a bit more their ownership to root as owner and bareos as group, plus setting chmod to 0750. Doing so will restrict execution to only root or any member of bareos group.
+   All those step are done for you by our helper.
 
 
 .. note::

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -83,14 +83,11 @@ Linux (SG_IO ioctl interface):
 
 .. index::
   single: Platform; Linux; Privileges
- 
-To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO` must be set.
+
+To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO+EP` must be set.
 The |sd| normally runs a user **bareos**. Running it as **root** is not recommended.
 
 -  :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7))
-
-   -  On older kernels you might need :strong:`CAP_SYS_ADMIN`. Try :strong:`CAP_SYS_RAWIO` first and if that doesn’t work try :strong:`CAP_SYS_ADMIN`
-
 
 -  If you are using systemd, you could add this additional capability to the AmbientCapabilities=CAP_SYS_RAWIO parameter.
 
@@ -105,10 +102,12 @@ You can also set up the extra capability on :command:`bscrypto`,:command:`bareos
 
 .. code-block:: shell-session
 
-   setcap cap_sys_rawio=ep /usr/sbin/bscrypto
    setcap cap_sys_rawio=ep /usr/sbin/bareos-sd
-   setcap cap_sys_rawio=ep /usr/sbin/bls
+   setcap cap_sys_rawio=ep /usr/sbin/bcopy
    setcap cap_sys_rawio=ep /usr/sbin/bextract
+   setcap cap_sys_rawio=ep /usr/sbin/bls
+   setcap cap_sys_rawio=ep /usr/sbin/bscan
+   setcap cap_sys_rawio=ep /usr/sbin/bscrypto
    setcap cap_sys_rawio=ep /usr/sbin/btape
 
 
@@ -118,15 +117,18 @@ With our helper
 
    /usr/lib/bareos/script/bareos-config.sh set_scsicrypto_capabilities
 
+
 Remove the setting with
 
 .. code-block:: shell-session
 
-   getcap -v /usr/sbin/bscrypto
-   getcap -v /usr/sbin/bareos-sd
-   getcap -v /usr/sbin/bls
-   getcap -v /usr/sbin/bextract
-   getcap -v /usr/sbin/btape
+   setcap -r /usr/sbin/bareos-sd
+   setcap -r /usr/sbin/bcopy
+   setcap -r /usr/sbin/bextract
+   setcap -r /usr/sbin/bls
+   setcap -r /usr/sbin/bscan
+   setcap -r /usr/sbin/bscrypto
+   setcap -r /usr/sbin/btape
 
 
 With our helper
@@ -140,10 +142,12 @@ Check the setting with
 
 .. code-block:: shell-session
 
-   getcap -v /usr/sbin/bscrypto
    getcap -v /usr/sbin/bareos-sd
-   getcap -v /usr/sbin/bls
+   getcap -v /usr/sbin/bcopy
    getcap -v /usr/sbin/bextract
+   getcap -v /usr/sbin/bls
+   getcap -v /usr/sbin/bscan
+   getcap -v /usr/sbin/bscrypto
    getcap -v /usr/sbin/btape
 
 
@@ -158,10 +162,19 @@ With our helper
 
 If :command:`bareos-sd` does not have the appropriate capabilities, all other tape operations may still work correctly, but you will get "Unable to perform SG\_IO ioctl" errors.
 
+.. warning::
+
+Our actual packaging doesn't respect the capabilities settings you could have add to your system.
+If you are using scsicrypto we recommend to set again capabilities after any software update.
+
+
 Solaris (USCSI ioctl interface):
 
 
-The user running the storage daemon needs the following additional privileges: :index:`\ <single: Platform; Solaris; Privileges>`\
+The user running the storage daemon needs the following additional privileges:
+
+.. index::
+  single: Platform; Solaris; Privileges
 
 -  :strong:`PRIV_SYS_DEVICES` (see privileges(5))
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -85,20 +85,29 @@ Linux (SG_IO ioctl interface):
   single: Platform; Linux; Privileges
 
 To perform the operations required for **scsicrypto**, the programs must either run as user **root** or the additional capability :strong:`CAP_SYS_RAWIO+EP` must be set.
-The |sd| normally runs a user **bareos**. Running it as **root** is not recommended.
+The |sd| normally runs as user **bareos**. Running it as **root** is not recommended.
+
+If :command:`bareos-sd` does not have the appropriate capabilities, all other tape operations may still work correctly, but you will get "Unable to perform SG\_IO ioctl" errors.
 
 -  :strong:`CAP_SYS_RAWIO+EP` (see capabilities(7))
 
--  If you are using systemd, you could add this additional capability to the AmbientCapabilities=CAP_SYS_RAWIO parameter.
-
-   -  For systemd add the following to the bareos-sd.service: :strong:`AmbientCapabilities=CAP_SYS_RAWIO`
-   -  To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
+-  For systemd add the following to the bareos-sd.service: :strong:`AmbientCapabilities=CAP_SYS_RAWIO`.
+   To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
 
 .. warning::
 
    As of systemd version 249 There's no mechanism to pass restricted flag (+ep), so the result will always be full CAP_SYS_RAWIO (eip)
 
-You can also set up the extra capability on :command:`bscrypto`,:command:`bareos-sd`,:command:`bls`,:command:`bextract` and :command:`btape` by running the following commands:
+You can also set up the extra capability on :command:`bareos-sd`, :command:`bcopy`, :command:`bextract`, :command:`bls`, :command:`bscan`, :command:`bscrypto`, :command:`btape` by running the following commands:
+
+Check the setting with our helper
+
+.. code-block:: shell-session
+
+   /usr/lib/bareos/script/bareos-config.sh set_scsicrypto_capabilities
+
+
+Check the setting manually
 
 .. code-block:: shell-session
 
@@ -111,14 +120,13 @@ You can also set up the extra capability on :command:`bscrypto`,:command:`bareos
    setcap cap_sys_rawio=ep /usr/sbin/btape
 
 
-With our helper
+Remove the setting with our helper
 
 .. code-block:: shell-session
 
-   /usr/lib/bareos/script/bareos-config.sh set_scsicrypto_capabilities
+   /usr/lib/bareos/script/bareos-config.sh unset_scsicrypto_capabilities
 
-
-Remove the setting with
+Check the setting manually
 
 .. code-block:: shell-session
 
@@ -131,14 +139,14 @@ Remove the setting with
    setcap -r /usr/sbin/btape
 
 
-With our helper
+Check the setting with our helper
 
 .. code-block:: shell-session
 
-   /usr/lib/bareos/script/bareos-config.sh unset_scsicrypto_capabilities
+   /usr/lib/bareos/script/bareos-config.sh check_scsicrypto_capabilities
 
 
-Check the setting with
+Check the setting manually
 
 .. code-block:: shell-session
 
@@ -151,21 +159,19 @@ Check the setting with
    getcap -v /usr/sbin/btape
 
 
-With our helper
-
-.. code-block:: shell-session
-
-   /usr/lib/bareos/script/bareos-config.sh check_scsicrypto_capabilities
-
-
 :command:`getcap` and :command:`setcap` are part of libcap-progs.
 
-If :command:`bareos-sd` does not have the appropriate capabilities, all other tape operations may still work correctly, but you will get "Unable to perform SG\_IO ioctl" errors.
 
 .. warning::
 
-Our actual packaging doesn't respect the capabilities settings you could have add to your system.
-If you are using scsicrypto we recommend to set again capabilities after any software update.
+   Adding capabilities like cap_sys_rawio to binaries can increase their abuse, so we recommend also to restrict a bit more their ownership to 0750.
+   Doing so restrict execution to only root or any member of bareos group.
+
+
+.. note::
+
+   Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file `.enable-capabilities` presence in your bareos config dir, setting back the previously set capabilities if present.
+   Before it is mandatory to setup capabilities manually after each update.
 
 
 Solaris (USCSI ioctl interface):

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -91,7 +91,6 @@ The |sd| normally runs a user **bareos**. Running it as **root** is not recommen
 
    -  On older kernels you might need :strong:`CAP_SYS_ADMIN`. Try :strong:`CAP_SYS_RAWIO` first and if that doesn’t work try :strong:`CAP_SYS_ADMIN`
 
--  If you are running the storage daemon as another user than root (which has the :strong:`CAP_SYS_RAWIO` capability), you need to add it to the current set of capabilities.
 
 -  If you are using systemd, you could add this additional capability to the AmbientCapabilities=CAP_SYS_RAWIO parameter.
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -223,7 +223,7 @@ Check the setting manually
 
 .. note::
 
-   Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file `.enable-capabilities` presence in your bareos config dir, setting back the previously set capabilities if present.
+   Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file :file:`.enable-cap_sys_rawio` presence in your bareos config dir, setting back the previously set capabilities if present.
    Before it is mandatory to setup capabilities manually after each update.
 
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -89,63 +89,12 @@ The |sd| normally runs as user **bareos**. Running it as **root** is not recomme
 
 If :command:`bareos-sd` does not have the appropriate capabilities, all other tape operations may still work correctly, but you will get "Unable to perform SG\_IO ioctl" errors.
 
-**systemd** (not recommended)
+.. note::
 
+    Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file :file:`.enable-cap_sys_rawio` presence in your bareos config dir, setting back the previously set capabilities if present.
+    This mean if you want capabilities automatically setup during package install, you can just create the :file:`/etc/bareos/.enable-cap_sys_rawio` file.
 
-To add the capabilities to bareos-sd.service you can add in file :file:`/etc/systemd/system/bareos-sd.d/override.conf` a section containing the :strong:`AmbientCapabilities=CAP_SYS_RAWIO` line.
-The easiest way to create this file is to use the following instructions as root.
-
-.. code-block:: shell-session
-
-   systemctl edit bareos-sd.service
-
-Fill the file with the following content, then save and exit
-
-.. code-block:: cfg
-
-   ### Editing /etc/systemd/system/bareos-storage.service.d/override.conf
-   ### Anything between here and the comment below will become the new contents of the file
-
-   [Service]
-   AmbientCapabilities=CAP_SYS_RAWIO
-
-
-Reload systemd configuration and restart bareos-sd
-
-.. code-block:: shell-session
-
-   systemctl daemon-reload
-
-   systemctl restart bareos-sd
-
-   systemctl status bareos-sd
-      ● bareos-storage.service - Bareos Storage Daemon service
-      Loaded: loaded (/lib/systemd/system/bareos-storage.service; enabled; vendor preset: enabled)
-      Drop-In: /etc/systemd/system/bareos-storage.service.d
-      └─override.conf
-      Active: active (running) since Tue 2022-02-01 15:12:49 CET; 5s ago
-      Docs: man:bareos-sd(8)
-      Main PID: 11142 (bareos-sd)
-      Tasks: 2 (limit: 2298)
-      Memory: 1.1M
-      CPU: 8ms
-      CGroup: /system.slice/bareos-storage.service
-      └─11142 /usr/sbin/bareos-sd -f
-
-      systemd[1]: Started Bareos Storage Daemon service.
-
-
-To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
-
-.. code-block:: shell-session
-
-   root:~# getpcaps 11142
-   11142: cap_sys_rawio=eip
-
-
-.. warning::
-
-   As of systemd version 249 There's no mechanism to pass restricted flag (+ep), so the result will always be full CAP_SYS_RAWIO (eip)
+    Before :sinceVersion:`21.0.1: scscicrypto capabilities handling` it is mandatory to setup capabilities manually after each update (see below).
 
 
 **setcap binaries** (recommended)
@@ -221,10 +170,63 @@ Check the setting manually
    All those step are done for you by our helper.
 
 
-.. note::
+   **systemd** (not recommended)
 
-   Since :sinceVersion:`21.0.1: scscicrypto capabilities handling` during package update post-install will react according to file :file:`.enable-cap_sys_rawio` presence in your bareos config dir, setting back the previously set capabilities if present.
-   Before it is mandatory to setup capabilities manually after each update.
+To add the capabilities to bareos-sd.service you can add in file :file:`/etc/systemd/system/bareos-sd.d/override.conf` a section containing the :strong:`AmbientCapabilities=CAP_SYS_RAWIO` line.
+The easiest way to create this file is to use the following instructions as root.
+
+.. code-block:: shell-session
+
+   systemctl edit bareos-sd.service
+
+Fill the file with the following content, then save and exit
+
+.. code-block:: cfg
+
+   ### Editing /etc/systemd/system/bareos-storage.service.d/override.conf
+   ### Anything between here and the comment below will become the new contents of the file
+
+   [Service]
+   AmbientCapabilities=CAP_SYS_RAWIO
+
+
+Reload systemd configuration and restart bareos-sd
+
+.. code-block:: shell-session
+
+   systemctl daemon-reload
+
+   systemctl restart bareos-sd
+
+   systemctl status bareos-sd
+      ● bareos-storage.service - Bareos Storage Daemon service
+      Loaded: loaded (/lib/systemd/system/bareos-storage.service; enabled; vendor preset: enabled)
+      Drop-In: /etc/systemd/system/bareos-storage.service.d
+      └─override.conf
+      Active: active (running) since Tue 2022-02-01 15:12:49 CET; 5s ago
+      Docs: man:bareos-sd(8)
+      Main PID: 11142 (bareos-sd)
+      Tasks: 2 (limit: 2298)
+      Memory: 1.1M
+      CPU: 8ms
+      CGroup: /system.slice/bareos-storage.service
+      └─11142 /usr/sbin/bareos-sd -f
+
+      systemd[1]: Started Bareos Storage Daemon service.
+
+
+To check status of capabilities of the running daemon you can use the :command:`getpcaps` followed by the pid of bareos-sd.
+
+.. code-block:: shell-session
+
+   root:~# getpcaps 11142
+   11142: cap_sys_rawio=eip
+
+
+.. warning::
+
+   As of systemd version 249 There's no mechanism to pass restricted flag (+ep), so the result will always be full CAP_SYS_RAWIO (eip)
+
 
 
 Solaris (USCSI ioctl interface):


### PR DESCRIPTION
- Platform: bareos-sd.service 
  + Remove CapabilityBoundingSet=CAP_SYS_RAWIO as the daemon doesn't run with root.
  + Discourage the use of AmbientCapabilities due to the lack of flag support in systemd.
- Packaging: add postinstall hooks for enabling cap_sys_rawio capabilities
- Doc: review section about linux sg_io ioctl interface
   + Explain the usage of our bareos-config help and related scsicrypto functions
      - bareos-config check_scsicrypto_capabilities
      - bareos-config set_scsicrypto_capabilities
      - bareos-config unset_scsicrypto_capabilities

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
