### PR TITLE
Fix several cases of undefined behaviour, memory corruption and memory leaks

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -8,15 +8,12 @@ OS:
   ULC_deb:
     "OpenSSL_1.1":
       TYPE: scripted
-      IMAGE: debian9.0
+      IMAGE: "ubuntu18.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
       ARCH:
-        - i586
         - x86_64
       PROJECTPACKAGES:
-        i586:
-          - bareos
         x86_64:
           - bareos
 
@@ -65,19 +62,6 @@ OS:
        x86_64:
           - bareos
           - python-bareos
-
-  Univention:
-    "4.4":
-      TYPE: deb
-      IMAGE: univention4.4
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - python-bareos
-
 
   SLE:
     "15_SP3":
@@ -171,22 +155,6 @@ OS:
            - bareos
            - bareos-webui
            - bareos-vmware
-           - python-bareos
-    "9.0":
-      TYPE: deb
-      IMAGE: "debian9.0"
-      ARCH:
-        - i586
-        - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - bareos-vmware
-           - python-bareos
-        i586:
-           - bareos
-           - bareos-webui
            - python-bareos
 
   EL:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: fix empty job timeline issue if date.timezone is not set in php.ini [PR #1051]
 - Fix for wrong update message when updating all volumes from all pools with no existing volumes [PR #1015]
 - Fix context confusion in Director's Python plugins [PR #1047]
+- Fix several cases of undefined behaviour, memory corruption and memory leaks [PR #1060]
 
 ### Added
 - Python plugins: add default module_path to search path [PR #1038]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -55,6 +55,19 @@ endif(CCACHE_FOUND)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+option(ENABLE_SANITIZERS "Build with ASan/LSan/UBSan enabled" OFF)
+if(ENABLE_SANITIZERS)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fsanitize=address -fno-sanitize-recover")
+  else()
+    message(
+      FATAL_ERROR
+        "Cannot (yet) compile with sanitizers on ${CMAKE_C_COMPILER_ID}"
+    )
+  endif()
+endif()
+
 option(ENABLE_STATIC_RUNTIME_LIBS "Link C and C++ runtime libraries statically"
        OFF
 )

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -143,6 +143,11 @@ endif()
 check_cxx_compiler_flag(-Wno-unknown-pragmas compiler_has_no_unknown_pragmas)
 if(${compiler_has_no_unknown_pragmas})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
+endif()
+
+check_cxx_compiler_flag(-Winvalid-offsetof compiler_has_invalid_offsetof)
+if(compiler_has_invalid_offsetof)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-invalid-offsetof")
 endif()
 
 # warn on sign-conversion include(CheckCCompilerFlag)

--- a/core/src/cats/bdb_mysql.h
+++ b/core/src/cats/bdb_mysql.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -40,8 +40,9 @@ class JobControlRecord;
 #define MYSQL_CHANGES_PER_BATCH_INSERT 32
 
 class BareosDbMysql : public BareosDbPrivateInterface {
- private:
+ public:
   dlink<BareosDbMysql> link; /**< Queue control */
+ private:
   MYSQL* db_handle_;
   MYSQL instance_;
   MYSQL_RES* result_;

--- a/core/src/cats/bdb_postgresql.h
+++ b/core/src/cats/bdb_postgresql.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -33,8 +33,9 @@ struct AttributesDbRecord;
 class JobControlRecord;
 
 class BareosDbPostgresql : public BareosDbPrivateInterface {
- private:
+ public:
   dlink<BareosDbPostgresql> link; /**< Queue control */
+ private:
   PGconn* db_handle_;
   PGresult* result_;
   POOLMEM* buf_; /**< Buffer to manipulate queries */

--- a/core/src/cats/bdb_sqlite.h
+++ b/core/src/cats/bdb_sqlite.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -33,8 +33,9 @@ struct AttributesDbRecord;
 class JobControlRecord;
 
 class BareosDbSqlite : public BareosDbPrivateInterface {
- private:
+ public:
   dlink<BareosDbSqlite> link; /**< Queue control */
+ private:
   struct sqlite3* db_handle_;
   char** result_; /**< sql_store_results() and SqlQueryWithoutHandler() */
   char**

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -49,8 +49,7 @@ class pathid_cache {
  public:
   pathid_cache()
   {
-    hlink link;
-    cache_ppathid = new htable<char*, hlink>(&link, &link, NITEMS);
+    cache_ppathid = new htable<char*, hlink>(NITEMS);
     max_node = NITEMS;
     nodes = (hlink*)malloc(max_node * sizeof(hlink));
     nb_node = 0;

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -44,13 +44,13 @@ class pathid_cache {
   int nb_node;
   int max_node;
   alist<hlink*>* table_node;
-  htable* cache_ppathid;
+  htable<char*, hlink>* cache_ppathid;
 
  public:
   pathid_cache()
   {
     hlink link;
-    cache_ppathid = new htable(&link, &link, NITEMS);
+    cache_ppathid = new htable<char*, hlink>(&link, &link, NITEMS);
     max_node = NITEMS;
     nodes = (hlink*)malloc(max_node * sizeof(hlink));
     nb_node = 0;

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -50,8 +50,7 @@ class pathid_cache {
   pathid_cache()
   {
     hlink link;
-    cache_ppathid = (htable*)malloc(sizeof(htable));
-    cache_ppathid->init(&link, &link, NITEMS);
+    cache_ppathid = new htable(&link, &link, NITEMS);
     max_node = NITEMS;
     nodes = (hlink*)malloc(max_node * sizeof(hlink));
     nb_node = 0;
@@ -79,8 +78,7 @@ class pathid_cache {
 
   ~pathid_cache()
   {
-    cache_ppathid->destroy();
-    free(cache_ppathid);
+    delete cache_ppathid;
     delete table_node;
   }
 

--- a/core/src/cats/mysql.cc
+++ b/core/src/cats/mysql.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -120,9 +120,7 @@ BareosDbMysql::BareosDbMysql(JobControlRecord* jcr,
   result_ = NULL;
 
   // Put the db in the list.
-  if (db_list == NULL) {
-    db_list = new dlist<BareosDbMysql>(this, &this->link);
-  }
+  if (db_list == NULL) { db_list = new dlist<BareosDbMysql>(); }
   db_list->append(this);
 
   /* make the queries available using the queries variable from the parent class

--- a/core/src/cats/mysql.cc
+++ b/core/src/cats/mysql.cc
@@ -538,7 +538,7 @@ retry_query:
 
 void BareosDbMysql::SqlFreeResult(void)
 {
-    DbLocker _{this};
+  DbLocker _{this};
   if (result_) {
     mysql_free_result(result_);
     result_ = NULL;

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -126,9 +126,7 @@ BareosDbPostgresql::BareosDbPostgresql(JobControlRecord* jcr,
   result_ = NULL;
 
   // Put the db in the list.
-  if (db_list == NULL) {
-    db_list = new dlist<BareosDbPostgresql>(this, &this->link);
-  }
+  if (db_list == NULL) { db_list = new dlist<BareosDbPostgresql>(); }
   db_list->append(this);
 
   /* make the queries available using the queries variable from the parent class

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -157,7 +157,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
                client_name.size());
 
   constexpr const char* default_time{"0000-00-00 00:00:00"};
-  stime_out.resize(strlen(default_time));
+  stime_out.resize(strlen(default_time) + 1);
   strcpy(stime_out.data(), default_time);
 
   Mmsg(cmd,

--- a/core/src/cats/sqlite.cc
+++ b/core/src/cats/sqlite.cc
@@ -409,7 +409,7 @@ bool BareosDbSqlite::SqlQueryWithoutHandler(const char* query, int flags)
 
 void BareosDbSqlite::SqlFreeResult(void)
 {
-    DbLocker _{this};
+  DbLocker _{this};
   if (fields_) {
     free(fields_);
     fields_ = NULL;

--- a/core/src/cats/sqlite.cc
+++ b/core/src/cats/sqlite.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -120,9 +120,7 @@ BareosDbSqlite::BareosDbSqlite(JobControlRecord* jcr,
   lowlevel_errmsg_ = NULL;
 
   // Put the db in the list.
-  if (db_list == NULL) {
-    db_list = new dlist<BareosDbSqlite>(this, &this->link);
-  }
+  if (db_list == NULL) { db_list = new dlist<BareosDbSqlite>(); }
   db_list->append(this);
 
   /* make the queries available using the queries variable from the parent class

--- a/core/src/console/connect_to_director.cc
+++ b/core/src/console/connect_to_director.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -51,8 +51,8 @@ BareosSocket* ConnectToDirector(JobControlRecord& jcr,
   TlsResource* local_tls_resource;
   if (console_resource) {
     name = console_resource->resource_name_;
-    ASSERT(console_resource->password.encoding == p_encoding_md5);
-    password = &console_resource->password;
+    ASSERT(console_resource->password_.encoding == p_encoding_md5);
+    password = &console_resource->password_;
     local_tls_resource = console_resource;
   } else { /* default console */
     name = "*UserAgent*";

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,7 +54,7 @@ static ConsoleResource* res_cons;
 /* clang-format off */
 
 static ResourceItem cons_items[] = {
-  { "Name", CFG_TYPE_NAME, (std::size_t)&res_cons->resource_name_, reinterpret_cast<BareosResource**>(&res_cons), 0, CFG_ITEM_REQUIRED, NULL, NULL, "The name of this resource." },
+  { "Name", CFG_TYPE_NAME, ITEM(res_cons, resource_name_), 0, CFG_ITEM_REQUIRED, NULL, NULL, "The name of this resource." },
   { "Description", CFG_TYPE_STR, ITEM(res_cons, description_), 0, 0, NULL, NULL, NULL },
   { "RcFile", CFG_TYPE_DIR, ITEM(res_cons, rc_file), 0, 0, NULL, NULL, NULL },
   { "HistoryFile", CFG_TYPE_DIR, ITEM(res_cons, history_file), 0, 0, NULL, NULL, NULL },

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -59,7 +59,7 @@ static ResourceItem cons_items[] = {
   { "RcFile", CFG_TYPE_DIR, ITEM(res_cons, rc_file), 0, 0, NULL, NULL, NULL },
   { "HistoryFile", CFG_TYPE_DIR, ITEM(res_cons, history_file), 0, 0, NULL, NULL, NULL },
   { "HistoryLength", CFG_TYPE_PINT32, ITEM(res_cons, history_length), 0, CFG_ITEM_DEFAULT, "100", NULL, NULL },
-  { "Password", CFG_TYPE_MD5PASSWORD, ITEM(res_cons, password), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL },
+  { "Password", CFG_TYPE_MD5PASSWORD, ITEM(res_cons, password_), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL },
   { "Director", CFG_TYPE_STR, ITEM(res_cons, director), 0, 0, NULL, NULL, NULL },
   { "HeartbeatInterval", CFG_TYPE_TIME, ITEM(res_cons, heartbeat_interval), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
   TLS_COMMON_CONFIG(res_cons),
@@ -148,6 +148,7 @@ static void FreeResource(BareosResource* res, int type)
       if (p->rc_file) { free(p->rc_file); }
       if (p->history_file) { free(p->history_file); }
       if (p->password_.value) { free(p->password_.value); }
+      if (p->director) { free(p->director); }
       delete p;
       break;
     }

--- a/core/src/console/console_conf.h
+++ b/core/src/console/console_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -66,7 +66,6 @@ class ConsoleResource
 
   char* rc_file = nullptr;       /**< startup file */
   char* history_file = nullptr;  /**< command history file */
-  s_password password;           /**< UA server password */
   uint32_t history_length = 0;   /**< readline history length */
   char* director = nullptr;      /**< bind to director */
   utime_t heartbeat_interval{0}; /**< Interval to send heartbeats to Dir */

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -586,9 +586,10 @@ bool DoNativeBackup(JobControlRecord* jcr)
   if (!response(jcr, fd, OKbackup, "Backup", DISPLAY_ERROR)) { goto bail_out; }
 
   status = WaitForJobTermination(jcr);
-  jcr->db_batch->WriteBatchFileRecords(
-      jcr); /* used by bulk batch file insert */
-
+  if (jcr->batch_started) {
+    jcr->db_batch->WriteBatchFileRecords(
+        jcr); /* used by bulk batch file insert */
+  }
   if (jcr->HasBase && !jcr->db->CommitBaseFileAttributesRecord(jcr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
   }

--- a/core/src/dird/dbcheck_utils.cc
+++ b/core/src/dird/dbcheck_utils.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -150,6 +150,8 @@ void FreeNameList(NameList* name_list)
 {
   for (int i = 0; i < name_list->num_ids; i++) { free(name_list->name[i]); }
   name_list->num_ids = 0;
+  name_list->max_ids = 0;
+  free(name_list->name);
 }
 
 std::vector<int> get_deletable_storageids(

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3701,13 +3701,13 @@ static void DumpResource(int type,
   bool recurse = true;
   UaContext* ua = (UaContext*)sock;
   OutputFormatter* output_formatter = nullptr;
-  OutputFormatter* output_formatter_local = nullptr;
+  std::unique_ptr<OutputFormatter> output_formatter_local;
   if (ua) {
     output_formatter = ua->send;
   } else {
     output_formatter_local
-        = new OutputFormatter(sendit, nullptr, nullptr, nullptr);
-    output_formatter = output_formatter_local;
+        = std::make_unique<OutputFormatter>(sendit, nullptr, nullptr, nullptr);
+    output_formatter = output_formatter_local.get();
   }
 
   OutputFormatterResource output_formatter_resource
@@ -3767,7 +3767,6 @@ bail_out:
   if (recurse && res->next_) {
     DumpResource(type, res->next_, sendit, sock, hide_sensitive_data, verbose);
   }
-  if (output_formatter_local) { delete output_formatter_local; }
 }
 
 static void FreeResource(BareosResource* res, int type)

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -67,7 +67,6 @@ static void DecWriteStore(JobControlRecord* jcr);
 int JobqInit(jobq_t* jq, int max_workers, void* (*engine)(void* arg))
 {
   int status;
-  jobq_item_t* item = NULL;
 
   if ((status = pthread_attr_init(&jq->attr)) != 0) {
     BErrNo be;
@@ -102,9 +101,9 @@ int JobqInit(jobq_t* jq, int max_workers, void* (*engine)(void* arg))
   jq->valid = JOBQ_VALID;
 
   // Initialize the job queues
-  jq->waiting_jobs = new dlist<jobq_item_t>(item, &item->link);
-  jq->running_jobs = new dlist<jobq_item_t>(item, &item->link);
-  jq->ready_jobs = new dlist<jobq_item_t>(item, &item->link);
+  jq->waiting_jobs = new dlist<jobq_item_t>();
+  jq->running_jobs = new dlist<jobq_item_t>();
+  jq->ready_jobs = new dlist<jobq_item_t>();
 
   return 0;
 }

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -627,7 +627,7 @@ static bool regex_find_jobids(JobControlRecord* jcr,
   bool ok = false;
   PoolMem query(PM_MESSAGE);
 
-  item_chain = new dlist<uitem>(item, &item->link);
+  item_chain = new dlist<uitem>();
   if (!jcr->impl->res.job->selection_pattern) {
     Jmsg(jcr, M_FATAL, 0, _("No %s %s selection pattern specified.\n"),
          jcr->get_OperationName(), type);

--- a/core/src/dird/ndmp_dma_storage.cc
+++ b/core/src/dird/ndmp_dma_storage.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2015 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -441,7 +441,7 @@ dlist<vol_list_t>* ndmp_get_vol_list(UaContext* ua,
   NdmpFillStorageMappings(store, ndmp_sess);
 
   // Start with an empty dlist().
-  vol_list = new dlist<vol_list_t>(vl, &vl->link);
+  vol_list = new dlist<vol_list_t>();
 
   // Process the robot element status retrieved.
   smc = ndmp_sess->control_acb->smc_cb;

--- a/core/src/dird/ndmp_fhdb_mem.cc
+++ b/core/src/dird/ndmp_fhdb_mem.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2015-2015 Planets Communications B.V.
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -435,8 +435,7 @@ static inline void add_out_of_order_metadata(NIS* nis,
     item_size = sizeof(OOO_MD);
     nr_items = (nr_pages * B_PAGE_SIZE) / item_size;
 
-    meta_data = (htable*)malloc(sizeof(htable));
-    meta_data->init(md_entry, &md_entry->link, nr_items, nr_pages);
+    meta_data = new htable(md_entry, &md_entry->link, nr_items, nr_pages);
     ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata
         = meta_data;
   }
@@ -630,14 +629,12 @@ extern "C" int bndmp_fhdb_mem_add_node(struct ndmlog* ixlog,
         Jmsg(nis->jcr, M_FATAL, 0,
              _("NDMP protocol error, FHDB unable to process out of order "
                "metadata.\n"));
-        meta_data->destroy();
-        free(meta_data);
+        delete meta_data;
         ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata = NULL;
         return 1;
       }
 
-      meta_data->destroy();
-      free(meta_data);
+      delete meta_data;
       ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata = NULL;
     }
 

--- a/core/src/dird/ndmp_fhdb_mem.cc
+++ b/core/src/dird/ndmp_fhdb_mem.cc
@@ -111,7 +111,7 @@ struct ooo_metadata {
 };
 typedef struct ooo_metadata OOO_MD;
 
-using MetadataTable = htable<uint64_t, OOO_MD>;
+using MetadataTable = htable<uint64_t, OOO_MD, htableBufferSize::small>;
 
 struct fhdb_state_mem {
   N_TREE_ROOT* fhdb_root;
@@ -438,8 +438,7 @@ static inline void add_out_of_order_metadata(NIS* nis,
     item_size = sizeof(OOO_MD);
     nr_items = (nr_pages * B_PAGE_SIZE) / item_size;
 
-    meta_data
-        = new MetadataTable(md_entry, &md_entry->link, nr_items, nr_pages);
+    meta_data = new MetadataTable(md_entry, &md_entry->link, nr_items);
     ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata
         = meta_data;
   }

--- a/core/src/dird/ndmp_fhdb_mem.cc
+++ b/core/src/dird/ndmp_fhdb_mem.cc
@@ -415,7 +415,6 @@ static inline void add_out_of_order_metadata(NIS* nis,
                                              ndmp9_u_quad node)
 {
   N_TREE_NODE* nt_node;
-  OOO_MD* md_entry = NULL;
   MetadataTable* meta_data
       = ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata;
 
@@ -432,19 +431,13 @@ static inline void add_out_of_order_metadata(NIS* nis,
 
   // See if we already allocated the htable.
   if (!meta_data) {
-    uint32_t nr_pages, nr_items, item_size;
-
-    nr_pages = MIN_PAGES;
-    item_size = sizeof(OOO_MD);
-    nr_items = (nr_pages * B_PAGE_SIZE) / item_size;
-
-    meta_data = new MetadataTable(md_entry, &md_entry->link, nr_items);
+    meta_data = new MetadataTable();
     ((struct fhdb_state_mem*)nis->fhdb_state)->out_of_order_metadata
         = meta_data;
   }
 
   // Create a new entry and insert it into the hash with the node number as key.
-  md_entry = (OOO_MD*)meta_data->hash_malloc(sizeof(OOO_MD));
+  OOO_MD* md_entry = (OOO_MD*)meta_data->hash_malloc(sizeof(OOO_MD));
   md_entry->dir_node = dir_node;
   md_entry->nt_node = nt_node;
 

--- a/core/src/dird/ndmp_fhdb_mem.cc
+++ b/core/src/dird/ndmp_fhdb_mem.cc
@@ -111,7 +111,7 @@ struct ooo_metadata {
 };
 typedef struct ooo_metadata OOO_MD;
 
-using MetadataTable = htable<uint64_t, OOO_MD, htableBufferSize::small>;
+using MetadataTable = htable<uint64_t, OOO_MD, MonotonicBuffer::Size::Small>;
 
 struct fhdb_state_mem {
   N_TREE_ROOT* fhdb_root;

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -261,7 +261,6 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
   char* bp;
   char dev_name[MAX_NAME_LENGTH];
   char *field1, *field2, *field3, *field4, *field5;
-  vol_list_t* vl = nullptr;
   dlist<vol_list_t>* vol_list;
   BareosSocket* sd = nullptr;
 
@@ -278,7 +277,7 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
     sd->fsend(changerlistcmd, dev_name);
   }
 
-  vol_list = new dlist<vol_list_t>(vl, &vl->link);
+  vol_list = new dlist<vol_list_t>();
 
   // Read and organize list of Volumes
   while (BnetRecv(sd) >= 0) {
@@ -348,7 +347,7 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
       field5 = nullptr;
     }
 
-    vl = (vol_list_t*)malloc(sizeof(vol_list_t));
+    vol_list_t* vl = (vol_list_t*)malloc(sizeof(vol_list_t));
     {
       *vl = vol_list_t{};
     }

--- a/core/src/dird/stats.cc
+++ b/core/src/dird/stats.cc
@@ -301,6 +301,8 @@ extern "C" void* statistics_thread(void* arg)
   }  // while(!quit)
 
 bail_out:
+  jcr->db->CloseDatabase(jcr);
+  jcr->db = nullptr;
   FreeJcr(jcr);
 
   Dmsg0(200, "Finished statistics thread\n");

--- a/core/src/dird/ua.cc
+++ b/core/src/dird/ua.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -94,7 +94,12 @@ void FreeUaContext(UaContext* ua)
   if (ua->cmd) { FreePoolMemory(ua->cmd); }
   if (ua->args) { FreePoolMemory(ua->args); }
   if (ua->errmsg) { FreePoolMemory(ua->errmsg); }
-  if (ua->prompt) { free(ua->prompt); }
+  if (ua->prompt) {
+    for (int i = 0; i < ua->num_prompts; ++i) {
+      if (ua->prompt[i]) { free(ua->prompt[i]); }
+    }
+    free(ua->prompt);
+  }
   if (ua->send) { delete ua->send; }
   if (ua->UA_sock) {
     ua->UA_sock->close();

--- a/core/src/filed/accurate.h
+++ b/core/src/filed/accurate.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -113,8 +113,10 @@ struct CurFile {
 #endif
 
 class BareosAccurateFilelistHtable : public BareosAccurateFilelist {
+  using FileList = htable<char*, CurFile>;
+
  protected:
-  htable* file_list_;
+  FileList* file_list_;
   void destroy();
 
  public:

--- a/core/src/filed/accurate_htable.cc
+++ b/core/src/filed/accurate_htable.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,8 +44,7 @@ BareosAccurateFilelistHtable::BareosAccurateFilelistHtable(
   number_of_previous_files_ = number_of_files;
 
   CurFile* elt = NULL;
-  file_list_ = (htable*)malloc(sizeof(htable));
-  file_list_->init(elt, &elt->link, number_of_previous_files_);
+  file_list_ = new htable(elt, &elt->link, number_of_previous_files_);
   seen_bitmap_ = (char*)malloc(NbytesForBits(number_of_previous_files_));
   ClearAllBits(number_of_previous_files_, seen_bitmap_);
 }
@@ -176,11 +175,8 @@ bool BareosAccurateFilelistHtable::SendDeletedList()
 
 void BareosAccurateFilelistHtable::destroy()
 {
-  if (file_list_) {
-    file_list_->destroy();
-    free(file_list_);
-    file_list_ = NULL;
-  }
+  delete file_list_;
+  file_list_ = nullptr;
 
   if (seen_bitmap_) {
     free(seen_bitmap_);

--- a/core/src/filed/accurate_htable.cc
+++ b/core/src/filed/accurate_htable.cc
@@ -43,8 +43,7 @@ BareosAccurateFilelistHtable::BareosAccurateFilelistHtable(
   filenr_ = 0;
   number_of_previous_files_ = number_of_files;
 
-  CurFile* elt = NULL;
-  file_list_ = new FileList(elt, &elt->link, number_of_previous_files_);
+  file_list_ = new FileList(number_of_previous_files_);
   seen_bitmap_ = (char*)malloc(NbytesForBits(number_of_previous_files_));
   ClearAllBits(number_of_previous_files_, seen_bitmap_);
 }

--- a/core/src/filed/accurate_htable.cc
+++ b/core/src/filed/accurate_htable.cc
@@ -44,7 +44,7 @@ BareosAccurateFilelistHtable::BareosAccurateFilelistHtable(
   number_of_previous_files_ = number_of_files;
 
   CurFile* elt = NULL;
-  file_list_ = new htable(elt, &elt->link, number_of_previous_files_);
+  file_list_ = new FileList(elt, &elt->link, number_of_previous_files_);
   seen_bitmap_ = (char*)malloc(NbytesForBits(number_of_previous_files_));
   ClearAllBits(number_of_previous_files_, seen_bitmap_);
 }

--- a/core/src/findlib/find.cc
+++ b/core/src/findlib/find.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,6 +35,13 @@
 #include "find.h"
 #include "findlib/find_one.h"
 #include "lib/util.h"
+
+#if defined(HAVE_DARWIN_OS)
+/* the MacOS linker wants symbols for the destructors of these two types, so we
+ * have to force template instantiation. */
+template class alist<findFOPTS*>;
+template class dlist<dlistString>;
+#endif
 
 static const int debuglevel = 450;
 
@@ -456,13 +463,9 @@ int TermFindFiles(FindFilesPacket* ff)
 // Allocate a new include/exclude block.
 findIncludeExcludeItem* allocate_new_incexe(void)
 {
-  findIncludeExcludeItem* incexe;
-
-  incexe = (findIncludeExcludeItem*)malloc(sizeof(findIncludeExcludeItem));
-  *incexe = findIncludeExcludeItem{};
-  incexe->opts_list.init(1, true);
-  incexe->name_list.init();
-  incexe->plugin_list.init();
+  findIncludeExcludeItem* incexe
+      = (findIncludeExcludeItem*)malloc(sizeof(findIncludeExcludeItem));
+  new (incexe) findIncludeExcludeItem{};
 
   return incexe;
 }

--- a/core/src/findlib/find.h
+++ b/core/src/findlib/find.h
@@ -186,7 +186,8 @@ struct CurLink {
   char name[1];          /**< The name */
 };
 
-using LinkHash = htable<htable_binary_key, CurLink, htableBufferSize::medium>;
+using LinkHash
+    = htable<htable_binary_key, CurLink, MonotonicBuffer::Size::Medium>;
 
 
 /**

--- a/core/src/findlib/find.h
+++ b/core/src/findlib/find.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -61,6 +61,7 @@
 int Readdir_r(DIR* dirp, struct dirent* entry, struct dirent** result);
 #  endif
 #endif
+
 // For options FO_xxx values see src/fileopts.h
 enum
 {
@@ -185,6 +186,9 @@ struct CurLink {
   char name[1];          /**< The name */
 };
 
+using LinkHash = htable<htable_binary_key, CurLink>;
+
+
 /**
  * Definition of the FindFiles packet passed as the
  * first argument to the FindFiles callback subroutine.
@@ -250,7 +254,7 @@ struct FindFilesPacket {
   alist<const char*> drivetypes;       /**< Allowed drive types */
 
   // List of all hard linked files found
-  htable* linkhash{nullptr};       /**< Hard linked files */
+  LinkHash* linkhash{nullptr};       /**< Hard linked files */
   struct CurLink* linked{nullptr}; /**< Set if this file is hard linked */
 
   /*

--- a/core/src/findlib/find.h
+++ b/core/src/findlib/find.h
@@ -186,7 +186,7 @@ struct CurLink {
   char name[1];          /**< The name */
 };
 
-using LinkHash = htable<htable_binary_key, CurLink>;
+using LinkHash = htable<htable_binary_key, CurLink, htableBufferSize::medium>;
 
 
 /**

--- a/core/src/findlib/find_one.cc
+++ b/core/src/findlib/find_one.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1036,8 +1036,7 @@ int TermFindOne(FindFilesPacket* ff)
   if (ff->linkhash == NULL) { return 0; }
 
   count = ff->linkhash->size();
-  ff->linkhash->destroy();
-  free(ff->linkhash);
+  delete ff->linkhash;
   ff->linkhash = NULL;
 
   return count;

--- a/core/src/findlib/hardlink.cc
+++ b/core/src/findlib/hardlink.cc
@@ -63,7 +63,7 @@ CurLink* new_hardlink(JobControlRecord* jcr,
   uint8_t* new_key;
 
   if (!ff_pkt->linkhash) {
-    ff_pkt->linkhash = new htable(hl, &hl->link, 10000, 480);
+    ff_pkt->linkhash = new LinkHash(hl, &hl->link, 10000, 480);
   }
 
   len = strlen(fname) + 1;

--- a/core/src/findlib/hardlink.cc
+++ b/core/src/findlib/hardlink.cc
@@ -63,7 +63,7 @@ CurLink* new_hardlink(JobControlRecord* jcr,
   uint8_t* new_key;
 
   if (!ff_pkt->linkhash) {
-    ff_pkt->linkhash = new LinkHash(hl, &hl->link, 10000, 480);
+    ff_pkt->linkhash = new LinkHash(hl, &hl->link, 10000);
   }
 
   len = strlen(fname) + 1;

--- a/core/src/findlib/hardlink.cc
+++ b/core/src/findlib/hardlink.cc
@@ -45,8 +45,8 @@ CurLink* lookup_hardlink(JobControlRecord* jcr,
   binary_search_key[0] = dev;
   binary_search_key[1] = ino;
 
-  hl = (CurLink*)ff_pkt->linkhash->lookup((uint8_t*)binary_search_key,
-                                          sizeof(binary_search_key));
+  hl = (CurLink*)ff_pkt->linkhash->lookup(htable_binary_key{
+      (uint8_t*)binary_search_key, sizeof(binary_search_key)});
 
   return hl;
 }
@@ -83,7 +83,8 @@ CurLink* new_hardlink(JobControlRecord* jcr,
   new_key = (uint8_t*)ff_pkt->linkhash->hash_malloc(sizeof(binary_search_key));
   memcpy(new_key, binary_search_key, sizeof(binary_search_key));
 
-  ff_pkt->linkhash->insert(new_key, sizeof(binary_search_key), hl);
+  ff_pkt->linkhash->insert(
+      htable_binary_key{new_key, sizeof(binary_search_key)}, hl);
 
   return hl;
 }

--- a/core/src/findlib/hardlink.cc
+++ b/core/src/findlib/hardlink.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -63,8 +63,7 @@ CurLink* new_hardlink(JobControlRecord* jcr,
   uint8_t* new_key;
 
   if (!ff_pkt->linkhash) {
-    ff_pkt->linkhash = (htable*)malloc(sizeof(htable));
-    ff_pkt->linkhash->init(hl, &hl->link, 10000, 480);
+    ff_pkt->linkhash = new htable(hl, &hl->link, 10000, 480);
   }
 
   len = strlen(fname) + 1;

--- a/core/src/findlib/hardlink.cc
+++ b/core/src/findlib/hardlink.cc
@@ -58,16 +58,13 @@ CurLink* new_hardlink(JobControlRecord* jcr,
                       dev_t dev)
 {
   int len;
-  CurLink* hl = NULL;
   uint64_t binary_search_key[2];
   uint8_t* new_key;
 
-  if (!ff_pkt->linkhash) {
-    ff_pkt->linkhash = new LinkHash(hl, &hl->link, 10000);
-  }
+  if (!ff_pkt->linkhash) { ff_pkt->linkhash = new LinkHash(10000); }
 
   len = strlen(fname) + 1;
-  hl = (CurLink*)ff_pkt->linkhash->hash_malloc(sizeof(CurLink) + len);
+  CurLink* hl = (CurLink*)ff_pkt->linkhash->hash_malloc(sizeof(CurLink) + len);
   hl->digest = NULL;     /* Set later */
   hl->digest_stream = 0; /* Set later */
   hl->digest_len = 0;    /* Set later */

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2008-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -200,10 +200,12 @@ uint32_t SerializeXattrStream(JobControlRecord* jcr,
     if (current_xattr->value_length > 0 && current_xattr->value) {
       SerBytes(current_xattr->value, current_xattr->value_length);
 
-      Dmsg3(100, "Backup xattr named %s, value %.*s\n", current_xattr->name,
+      Dmsg3(100, "Backup xattr named %.*s, value %.*s\n",
+            current_xattr->name_length, current_xattr->name,
             current_xattr->value_length, current_xattr->value);
     } else {
-      Dmsg1(100, "Backup empty xattr named %s\n", current_xattr->name);
+      Dmsg1(100, "Backup empty xattr named %.*s\n", current_xattr->name_length,
+            current_xattr->name);
     }
   }
 
@@ -275,11 +277,13 @@ BxattrExitCode UnSerializeXattrStream(JobControlRecord* jcr,
       current_xattr->value = (char*)malloc(current_xattr->value_length);
       UnserBytes(current_xattr->value, current_xattr->value_length);
 
-      Dmsg3(100, "Restoring xattr named %s, value %*s\n", current_xattr->name,
+      Dmsg3(100, "Restoring xattr named %.*s, value %.*s\n",
+            current_xattr->name_length, current_xattr->name,
             current_xattr->value_length, current_xattr->value);
     } else {
       current_xattr->value = NULL;
-      Dmsg1(100, "Restoring empty xattr named %s\n", current_xattr->name);
+      Dmsg1(100, "Restoring empty xattr named %.*s\n",
+            current_xattr->name_length, current_xattr->name);
     }
 
     xattr_value_list->append(current_xattr);

--- a/core/src/include/jcr.h
+++ b/core/src/include/jcr.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,6 +44,7 @@
 #include "lib/tls_conf.h"
 #include "lib/breg.h"
 #include "lib/dlink.h"
+#include "lib/path_list.h"
 #include <unordered_set>
 
 
@@ -51,7 +52,6 @@ struct job_callback_item;
 class BareosDb;
 class BareosSocket;
 template <typename T> class dlist;
-class htable;
 class JobControlRecord;
 
 struct AttributesDbRecord;
@@ -230,7 +230,7 @@ class JobControlRecord {
   PluginContext* plugin_ctx{};  /**< Current plugin context */
   POOLMEM* comment{};       /**< Comment for this Job */
   int64_t max_bandwidth{};  /**< Bandwidth limit for this Job */
-  htable* path_list{};      /**< Directory list (used by findlib) */
+  PathList* path_list{};      /**< Directory list (used by findlib) */
   bool is_passive_client_connection_probing{}; /**< Set if director probes a passive client connection */
 
   JobControlRecordPrivate* impl{nullptr}; /* Pointer to implementation of each daemon */

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -58,7 +58,7 @@ set(BAREOS_SRCS
     crypto_wrap.cc
     daemon.cc
     devlock.cc
-    dlist.cc
+    dlist_string.cc
     edit.cc
     fnmatch.cc
     guid_to_name.cc

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -70,6 +70,7 @@ set(BAREOS_SRCS
     message.cc
     messages_resource.cc
     mntent_cache.cc
+    monotonic_buffer.cc
     output_formatter.cc
     output_formatter_resource.cc
     passphrase.cc

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -299,14 +299,17 @@ bool RemoveDefaultAddresses(dlist<IPADDR>* addrs,
       default_address = iaddr;
       if (default_address) {
         addrs->remove(default_address);
-        todelete = default_address;  // delete after the next pointer was used
-                                     // (during foreach_dlist())
+        todelete = default_address;
       }
     } else if (iaddr->GetType() != type) {
       Bsnprintf(buf, buflen,
                 _("the old style addresses cannot be mixed with new style"));
       return false;
     }
+  }
+  if (todelete) {
+    delete (todelete);
+    todelete = nullptr;
   }
   return true;
 }

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -288,12 +288,19 @@ bool RemoveDefaultAddresses(dlist<IPADDR>* addrs,
 {
   IPADDR* iaddr;
   IPADDR* default_address = nullptr;
+  IPADDR* todelete = nullptr;
+
   foreach_dlist (iaddr, addrs) {
+    if (todelete) {
+      delete (todelete);
+      todelete = nullptr;
+    }
     if (iaddr->GetType() == IPADDR::R_DEFAULT) {
       default_address = iaddr;
       if (default_address) {
         addrs->remove(default_address);
-        delete default_address;
+        todelete = default_address;  // delete after the next pointer was used
+                                     // (during foreach_dlist())
       }
     } else if (iaddr->GetType() != type) {
       Bsnprintf(buf, buflen,

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -436,12 +436,21 @@ void InitDefaultAddresses(dlist<IPADDR>** out, const char* port)
 
 void EmptyAddressList(dlist<IPADDR>* addrs)
 {
-  IPADDR* iaddr;
+  IPADDR* iaddr = nullptr;
+  IPADDR* addrtodelete = nullptr;
   foreach_dlist (iaddr, addrs) {
-    if (iaddr) {
-      addrs->remove(iaddr);
-      delete iaddr;
+    if (addrtodelete) {
+      delete (addrtodelete);
+      addrtodelete = nullptr;
     }
+    if (iaddr) {
+      addrtodelete = iaddr;
+      addrs->remove(iaddr);
+    }
+  }
+  if (addrtodelete) {
+    delete (addrtodelete);
+    addrtodelete = nullptr;
   }
 }
 

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -347,11 +347,8 @@ int AddAddress(dlist<IPADDR>** out,
   IPADDR::i_type intype = type;
 
   buf[0] = 0;
-  dlist<IPADDR>* addrs = (dlist<IPADDR>*)(*(out));
-  if (!addrs) {
-    IPADDR* tmp = 0;
-    addrs = *out = new dlist<IPADDR>(tmp, &tmp->link);
-  }
+  dlist<IPADDR>* addrs = *(out);
+  if (!addrs) { addrs = *out = new dlist<IPADDR>(); }
 
   type = (type == IPADDR::R_SINGLE_PORT || type == IPADDR::R_SINGLE_ADDR)
              ? IPADDR::R_SINGLE

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -347,9 +347,9 @@ int AddAddress(dlist<IPADDR>** out,
                char* buf,
                int buflen)
 {
-  IPADDR* iaddr;
-  IPADDR* jaddr;
-  dlist<IPADDR>* hostaddrs;
+  IPADDR* iaddr = nullptr;
+  IPADDR* jaddr = nullptr;
+  dlist<IPADDR>* hostaddrs = nullptr;
   unsigned short port;
   IPADDR::i_type intype = type;
 
@@ -406,17 +406,21 @@ int AddAddress(dlist<IPADDR>** out,
 
   } else {
     foreach_dlist (iaddr, hostaddrs) {
-      IPADDR* clone;
+      bool sameaddress = false;
       /* for duplicates */
       foreach_dlist (jaddr, addrs) {
-        if (IsSameIpAddress(iaddr, jaddr)) { goto skip; /* no price */ }
+        if (IsSameIpAddress(iaddr, jaddr)) {
+          sameaddress = true;
+          break;
+        }
       }
-      clone = new IPADDR(*iaddr);
-      clone->SetType(type);
-      clone->SetPortNet(port);
-      addrs->append(clone);
-    skip:
-      continue;
+      if (!sameaddress) {
+        IPADDR* clone = nullptr;
+        clone = new IPADDR(*iaddr);
+        clone->SetType(type);
+        clone->SetPortNet(port);
+        addrs->append(clone);
+      }
     }
   }
   FreeAddresses(hostaddrs);

--- a/core/src/lib/bnet.cc
+++ b/core/src/lib/bnet.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -391,11 +391,10 @@ dlist<IPADDR>* BnetHost2IpAddrs(const char* host,
                                 const char** errstr)
 {
   struct in_addr inaddr;
-  IPADDR* addr = 0;
   const char* errmsg;
   struct in6_addr inaddr6;
 
-  dlist<IPADDR>* addr_list = new dlist<IPADDR>(addr, &addr->link);
+  dlist<IPADDR>* addr_list = new dlist<IPADDR>();
   if (!host || host[0] == '\0') {
     if (family != 0) {
       addr_list->append(add_any(family));
@@ -404,12 +403,12 @@ dlist<IPADDR>* BnetHost2IpAddrs(const char* host,
       addr_list->append(add_any(AF_INET6));
     }
   } else if (inet_aton(host, &inaddr)) { /* MA Bug 4 */
-    addr = new IPADDR(AF_INET);
+    IPADDR* addr = new IPADDR(AF_INET);
     addr->SetType(IPADDR::R_MULTIPLE);
     addr->SetAddr4(&inaddr);
     addr_list->append(addr);
   } else if (inet_pton(AF_INET6, host, &inaddr6) == 1) {
-    addr = new IPADDR(AF_INET6);
+    IPADDR* addr = new IPADDR(AF_INET6);
     addr->SetType(IPADDR::R_MULTIPLE);
     addr->SetAddr6(&inaddr6);
     addr_list->append(addr);

--- a/core/src/lib/bsnprintf.cc
+++ b/core/src/lib/bsnprintf.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -457,8 +457,11 @@ static int32_t fmtstr(char* buffer,
   } else if (max < 0) {
     max = maxlen;
   }
-  strln = strlen(value);
-  if (strln > max) { strln = max; /* truncate to max */ }
+  if (max > 0) {
+    strln = strnlen(value, max);
+  } else {
+    strln = strlen(value);
+  }
   padlen = min - strln;
   if (padlen < 0) { padlen = 0; }
   if (flags & DP_F_MINUS) { padlen = -padlen; /* Left Justify */ }
@@ -467,7 +470,7 @@ static int32_t fmtstr(char* buffer,
     outch(' ');
     --padlen;
   }
-  while (*value && (cnt < max)) {
+  while ((cnt < max) && *value) {
     ch = *value++;
     outch(ch);
     ++cnt;

--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -556,7 +556,7 @@ void WritePidFile(int pidfile_fd,
 int DeletePidFile(const char* pidfile_path)
 {
 #if !defined(HAVE_WIN32)
-  unlink(pidfile_path);
+  if (pidfile_path) { unlink(pidfile_path); }
 #endif
   return 1;
 }

--- a/core/src/lib/crypto_cache.cc
+++ b/core/src/lib/crypto_cache.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -75,7 +75,7 @@ void ReadCryptoCache(const char* cache_file)
   }
 
   if (!cached_crypto_keys) {
-    cached_crypto_keys = new dlist<crypto_cache_entry_t>(cce, &cce->link);
+    cached_crypto_keys = new dlist<crypto_cache_entry_t>();
   }
 
   // Read as many crypto cache entries as available.
@@ -207,7 +207,7 @@ bool UpdateCryptoCache(const char* VolumeName, const char* EncryptionKey)
 
   // See if there are any cached encryption keys.
   if (!cached_crypto_keys) {
-    cached_crypto_keys = new dlist<crypto_cache_entry_t>(cce, &cce->link);
+    cached_crypto_keys = new dlist<crypto_cache_entry_t>();
 
     cce = (crypto_cache_entry_t*)malloc(sizeof(crypto_cache_entry_t));
     bstrncpy(cce->VolumeName, VolumeName, sizeof(cce->VolumeName));

--- a/core/src/lib/dlink.h
+++ b/core/src/lib/dlink.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -24,13 +24,8 @@
 #define BAREOS_LIB_DLINK_H_
 
 template <typename T> struct dlink {
-  T* next;
-  T* prev;
-  dlink()
-  {
-    next = nullptr;
-    prev = nullptr;
-  }
+  T* next{nullptr};
+  T* prev{nullptr};
 };
 
 #endif  // BAREOS_LIB_DLINK_H_

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -59,7 +59,12 @@ template <typename T> class dlist {
   uint32_t num_items{0};
 
  public:
+  dlist() = default;
   ~dlist() { destroy(); }
+  dlist(const dlist<T>& other) = delete;
+  dlist(dlist<T>&& other) = delete;
+  dlist<T>& operator=(const dlist<T>& other) = delete;
+  dlist<T>& operator=(dlist<T>&& other) = delete;
 
   void prepend(T* item)
   {

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -62,21 +62,7 @@ template <typename T> class dlist {
   uint32_t num_items;
 
  public:
-  /**
-   * Constructor called with the address of a
-   *   member of the list (not the list head), and
-   *   the address of the link within that member.
-   * If the link is at the beginning of the list member,
-   *   then there is no need to specify the link address
-   *   since the offset is zero.
-   */
-  dlist(T* item, dlink<T>* link) : dlist()
-  {
-    ASSERT(loffset == (int)((char*)link - (char*)item));
-  }
-
-  /* Constructor with link at head of item */
-  dlist(void) : head(nullptr), tail(nullptr), num_items(0)
+  dlist() : head(nullptr), tail(nullptr), num_items(0)
   {
     if constexpr (std::is_same<T, void>::value) {
       loffset = 0;

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -70,26 +70,23 @@ template <typename T> class dlist {
    *   then there is no need to specify the link address
    *   since the offset is zero.
    */
-  dlist(T* item, dlink<T>* link) { init(item, link); }
+  dlist(T* item, dlink<T>* link) : dlist()
+  {
+    ASSERT(loffset == (int)((char*)link - (char*)item));
+  }
 
   /* Constructor with link at head of item */
-  dlist(void) : head(nullptr), tail(nullptr), loffset(0), num_items(0) {}
-  ~dlist() { destroy(); }
-  void init(T* item, dlink<T>* link)
+  dlist(void) : head(nullptr), tail(nullptr), num_items(0)
   {
-    head = tail = NULL;
-    loffset = (int)((char*)link - (char*)item);
-    if (loffset < 0 || loffset > 5000) {
-      Emsg0(M_ABORT, 0, "Improper dlist initialization.\n");
+    if constexpr (std::is_same<T, void>::value) {
+      loffset = 0;
+    } else {
+      static_assert(offsetof(T, link) < INT16_MAX);
+      loffset = offsetof(T, link);
     }
-    num_items = 0;
   }
-  void init()
-  {
-    head = tail = nullptr;
-    loffset = 0;
-    num_items = 0;
-  }
+  ~dlist() { destroy(); }
+
   void prepend(T* item)
   {
     SetNext(item, head);

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,9 +23,6 @@
 /**
  * @file
  * Doubly linked list  -- dlist
- *
- * See the end of the file for the dlistString class which
- * facilitates storing strings in a dlist.
  */
 
 #ifndef BAREOS_LIB_DLIST_H_
@@ -33,6 +30,7 @@
 
 #include "include/bareos.h"
 #include "lib/dlink.h"
+#include "lib/dlist_string.h"
 #include "lib/message.h"
 #include "lib/message_severity.h"
 
@@ -364,34 +362,4 @@ template <typename T> class dlist {
   T* first() const { return head; }
   T* last() const { return tail; }
 };
-
-/**
- * C string helper routines for dlist
- *   The string (char *) is kept in the node
- *
- *   Kern Sibbald, February 2007
- *
- */
-class dlistString {
- public:
-  char* c_str() { return str_; }
-
- private:
-#ifdef __clang__
-#  pragma clang diagnostic push
-#  pragma clang diagnostic ignored "-Wunused-private-field"
-#endif
-  dlink<char> link_;
-#ifdef __clang__
-#  pragma clang diagnostic pop
-#endif
-  char str_[1];
-  /* !!! Don't put anything after this as this space is used
-   *     to hold the string in inline
-   */
-};
-
-extern dlistString* new_dlistString(const char* str, int len);
-extern dlistString* new_dlistString(const char* str);
-
 #endif  // BAREOS_LIB_DLIST_H_

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -64,12 +64,8 @@ template <typename T> class dlist {
  public:
   dlist() : head(nullptr), tail(nullptr), num_items(0)
   {
-    if constexpr (std::is_same<T, void>::value) {
-      loffset = 0;
-    } else {
-      static_assert(offsetof(T, link) < INT16_MAX);
-      loffset = offsetof(T, link);
-    }
+    static_assert(offsetof(T, link) < INT16_MAX);
+    loffset = offsetof(T, link);
   }
   ~dlist() { destroy(); }
 

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -34,8 +34,6 @@
 #include "lib/message.h"
 #include "lib/message_severity.h"
 
-/* In case you want to specifically specify the offset to the link */
-#define OFFSET(item, link) (int)((char*)(link) - (char*)(item))
 /**
  * There is a lot of extra casting here to work around the fact
  * that some compilers (Sun and Visual C++) do not accept
@@ -56,17 +54,11 @@
 #endif
 
 template <typename T> class dlist {
-  T* head;
-  T* tail;
-  int16_t loffset;
-  uint32_t num_items;
+  T* head{nullptr};
+  T* tail{nullptr};
+  uint32_t num_items{0};
 
  public:
-  dlist() : head(nullptr), tail(nullptr), num_items(0)
-  {
-    static_assert(offsetof(T, link) < INT16_MAX);
-    loffset = offsetof(T, link);
-  }
   ~dlist() { destroy(); }
 
   void prepend(T* item)
@@ -92,20 +84,12 @@ template <typename T> class dlist {
     num_items++;
   }
 
-  void SetPrev(T* item, T* prev)
-  {
-    ((dlink<T>*)(((char*)item) + loffset))->prev = prev;
-  }
+  void SetPrev(T* item, T* prev) { item->link.prev = prev; }
+  void SetNext(T* item, T* next) { item->link.next = next; }
 
-  void SetNext(T* item, T* next)
-  {
-    ((dlink<T>*)(((char*)item) + loffset))->next = next;
-  }
-
-  T* get_prev(T* item) { return ((dlink<T>*)(((char*)item) + loffset))->prev; }
-
-  T* get_next(T* item) { return ((dlink<T>*)(((char*)item) + loffset))->next; }
-  dlink<T>* get_link(T* item) { return (dlink<T>*)(((char*)item) + loffset); }
+  T* get_prev(T* item) { return item->link.prev; }
+  T* get_next(T* item) { return item->link.next; }
+  dlink<T>* get_link(T* item) { return &item->link; }
   void InsertBefore(T* item, T* where)
   {
     dlink<T>* where_link = get_link(where);

--- a/core/src/lib/dlist_string.cc
+++ b/core/src/lib/dlist_string.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,6 +28,7 @@
  */
 
 #include "lib/dlist.h"
+#include "lib/dlist_string.h"
 
 /* String helpers for dlist usage */
 
@@ -39,7 +40,7 @@ dlistString* new_dlistString(const char* str)
 dlistString* new_dlistString(const char* str, int len)
 {
   dlistString* node;
-  node = (dlistString*)malloc(sizeof(dlink<char*>) + len + 1);
+  node = (dlistString*)malloc(sizeof(dlistString) + len);
   bstrncpy(node->c_str(), str, len + 1);
   return node;
 }

--- a/core/src/lib/dlist_string.h
+++ b/core/src/lib/dlist_string.h
@@ -1,0 +1,50 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_DLIST_STRING_H_
+#define BAREOS_LIB_DLIST_STRING_H_
+
+#include "lib/dlink.h"
+
+/**
+ * C string helper routines for dlist
+ *   The string (char *) is kept in the node
+ *
+ *   Kern Sibbald, February 2007
+ *
+ */
+class dlistString {
+ public:
+  char* c_str() { return str_; }
+
+  dlink<char> link;
+
+ private:
+  char str_[1];
+  /* !!! Don't put anything after this as this space is used
+   *     to hold the string in inline
+   */
+};
+
+extern dlistString* new_dlistString(const char* str, int len);
+extern dlistString* new_dlistString(const char* str);
+
+#endif  // BAREOS_LIB_DLIST_STRING_H_

--- a/core/src/lib/dlist_string.h
+++ b/core/src/lib/dlist_string.h
@@ -35,7 +35,7 @@ class dlistString {
  public:
   char* c_str() { return str_; }
 
-  dlink<char> link;
+  dlink<dlistString> link;
 
  private:
   char str_[1];

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -340,7 +340,7 @@ char* edit_pthread(pthread_t val, char* buf, int buf_len)
 
   bstrncpy(buf, "0x", buf_len);
   for (i = sizeof(val); i; --i) {
-    Bsnprintf(mybuf, sizeof(mybuf), "%02x", (unsigned)(ptc[i]));
+    Bsnprintf(mybuf, sizeof(mybuf), "%02x", (unsigned)(ptc[i - 1]));
     bstrncat(buf, mybuf, buf_len);
   }
 

--- a/core/src/lib/guid_to_name.cc
+++ b/core/src/lib/guid_to_name.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2007-2011 Kern Sibbald
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,10 +47,9 @@ struct guitem {
 guid_list* new_guid_list()
 {
   guid_list* list;
-  guitem* item = nullptr;
   list = (guid_list*)malloc(sizeof(guid_list));
-  list->uid_list = new dlist<guitem>(item, &item->link);
-  list->gid_list = new dlist<guitem>(item, &item->link);
+  list->uid_list = new dlist<guitem>();
+  list->gid_list = new dlist<guitem>();
   return list;
 }
 

--- a/core/src/lib/htable.cc
+++ b/core/src/lib/htable.cc
@@ -155,10 +155,10 @@ void htableImpl::HashIndex(uint8_t* key, uint32_t keylen)
 }
 
 // tsize is the estimated number of entries in the hash table
-htableImpl::htableImpl(void* item, void* link, int tsize, int nr_pages)
+htableImpl::htableImpl(int t_loffset, int tsize, int nr_pages)
 {
   init(tsize, nr_pages);
-  loffset = (char*)link - (char*)item;
+  loffset = t_loffset;
 }
 
 void htableImpl::init(int tsize, int nr_pages)

--- a/core/src/lib/htable.h
+++ b/core/src/lib/htable.h
@@ -98,17 +98,9 @@ class htableImpl {
 
  public:
   htableImpl() = default;
-  htableImpl(void* item,
-             void* link,
-             int tsize = 31,
-             int nr_pages = 0,
-             int nr_entries = 4);
+  htableImpl(void* item, void* link, int tsize = 31, int nr_pages = 0);
   ~htableImpl() { destroy(); }
-  void init(void* item,
-            void* link,
-            int tsize = 31,
-            int nr_pages = 0,
-            int nr_entries = 4);
+  void init(int tsize = 31, int nr_pages = 0);
   bool insert(char* key, void* item);
   bool insert(uint32_t key, void* item);
   bool insert(uint64_t key, void* item);
@@ -140,14 +132,9 @@ template <typename Key, typename T> class htable {
 
  public:
   htable() { pimpl = std::make_unique<htableImpl>(); }
-  htable(T* item,
-         void* link,
-         int tsize = 31,
-         int nr_pages = 0,
-         int nr_entries = 4)
+  htable(T* item, hlink* link, int tsize = 31, int nr_pages = 0)
   {
-    pimpl
-        = std::make_unique<htableImpl>(item, link, tsize, nr_pages, nr_entries);
+    pimpl = std::make_unique<htableImpl>(item, link, tsize, nr_pages);
   }
   T* lookup(Key key)
   {

--- a/core/src/lib/htable.h
+++ b/core/src/lib/htable.h
@@ -41,6 +41,7 @@
 
 
 #include "include/config.h"
+#include "monotonic_buffer.h"
 
 typedef enum
 {
@@ -65,42 +66,29 @@ struct hlink {
   uint64_t hash;       /* Hash for this key */
 };
 
-struct h_mem {
-  struct h_mem* next; /* Next buffer */
-  int32_t rem;        /* Remaining bytes in big_buffer */
-  char* mem;          /* Memory pointer */
-  char first[1];      /* First byte */
-};
-
 class htableImpl {
-  hlink** table = nullptr;  /* Hash table */
-  int loffset = 0;          /* Link offset in item */
-  hlink* walkptr = nullptr; /* Table walk pointer */
-  uint64_t hash = 0;        /* Temp storage */
-  uint64_t total_size = 0;  /* Total bytes malloced */
-  uint32_t extend_length
-      = 0; /* Number of bytes to allocate when extending buffer */
-  uint32_t walk_index = 0;           /* Table walk index */
-  uint32_t num_items = 0;            /* Current number of items */
-  uint32_t max_items = 0;            /* Maximum items before growing */
-  uint32_t buckets = 0;              /* Size of hash table */
-  uint32_t index = 0;                /* Temp storage */
-  uint32_t mask = 0;                 /* "Remainder" mask */
-  uint32_t rshift = 0;               /* Amount to shift down */
-  uint32_t blocks = 0;               /* Blocks malloced */
-  struct h_mem* mem_block = nullptr; /* Malloc'ed memory block chain */
-  void MallocBigBuf(int size);       /* Get a big buffer */
-  void HashIndex(char* key);         /* Produce hash key,index */
-  void HashIndex(uint32_t key);      /* Produce hash key,index */
-  void HashIndex(uint64_t key);      /* Produce hash key,index */
+  hlink** table = nullptr;      /* Hash table */
+  int loffset = 0;              /* Link offset in item */
+  hlink* walkptr = nullptr;     /* Table walk pointer */
+  uint64_t hash = 0;            /* Temp storage */
+  uint32_t walk_index = 0;      /* Table walk index */
+  uint32_t num_items = 0;       /* Current number of items */
+  uint32_t max_items = 0;       /* Maximum items before growing */
+  uint32_t buckets = 0;         /* Size of hash table */
+  uint32_t index = 0;           /* Temp storage */
+  uint32_t mask = 0;            /* "Remainder" mask */
+  uint32_t rshift = 0;          /* Amount to shift down */
+  void HashIndex(char* key);    /* Produce hash key,index */
+  void HashIndex(uint32_t key); /* Produce hash key,index */
+  void HashIndex(uint64_t key); /* Produce hash key,index */
   void HashIndex(uint8_t* key, uint32_t key_len); /* Produce hash key,index */
   void grow_table();                              /* Grow the table */
 
  public:
   htableImpl() = default;
-  htableImpl(int t_loffset, int tsize = 31, int nr_pages = 0);
+  htableImpl(int t_loffset, int tsize = 31);
   ~htableImpl() { destroy(); }
-  void init(int tsize = 31, int nr_pages = 0);
+  void init(int tsize = 31);
   bool insert(char* key, void* item);
   bool insert(uint32_t key, void* item);
   bool insert(uint64_t key, void* item);
@@ -112,14 +100,8 @@ class htableImpl {
   void* first(); /* Get first item in table */
   void* next();  /* Get next item in table */
   void destroy();
-
- private:
-  void stats(); /* Print stats about the table */
- public:
-  uint32_t size();             /* Return size of table */
-  char* hash_malloc(int size); /* Malloc bytes for a hash entry */
- private:
-  void HashBigFree(); /* Free all hash allocated big buffers */
+  void stats();    /* Print stats about the table */
+  uint32_t size(); /* Return size of table */
 };
 
 struct htable_binary_key {
@@ -127,47 +109,28 @@ struct htable_binary_key {
   uint32_t len;
 };
 
-enum class htableBufferSize
-{
-  small,
-  medium,
-  large
-};
-
 template <typename Key,
           typename T,
-          enum htableBufferSize BufferSize = htableBufferSize::large>
+          enum MonotonicBuffer::Size BufferSize = MonotonicBuffer::Size::Large>
 class htable {
   std::unique_ptr<htableImpl> pimpl;
-
-  static constexpr int get_nr_pages(htableBufferSize bufsize)
-  {
-    switch (bufsize) {
-      case htableBufferSize::small:
-        return 1;
-      case htableBufferSize::medium:
-        return 512;
-      case htableBufferSize::large:
-        return 0;
-    }
-  }
+  MonotonicBuffer monobuf{BufferSize};
 
  public:
   htable(int tsize = 31)
   {
-    constexpr int nr_pages = get_nr_pages(BufferSize);
     if constexpr (std::is_same<T, hlink>::value) {
-      pimpl = std::make_unique<htableImpl>(0, tsize, nr_pages);
+      pimpl = std::make_unique<htableImpl>(0, tsize);
     } else {
-      pimpl = std::make_unique<htableImpl>(offsetof(T, link), tsize, nr_pages);
+      pimpl = std::make_unique<htableImpl>(offsetof(T, link), tsize);
     }
   }
   T* lookup(Key key)
   {
     if constexpr (std::is_same<Key, htable_binary_key>::value) {
-      return (T*)pimpl->lookup(key.ptr, key.len);
+      return static_cast<T*>(pimpl->lookup(key.ptr, key.len));
     } else {
-      return (T*)pimpl->lookup(key);
+      return static_cast<T*>(pimpl->lookup(key));
     }
   }
   bool insert(Key key, T* item)
@@ -179,9 +142,12 @@ class htable {
     }
   }
 
-  char* hash_malloc(int size) { return pimpl->hash_malloc(size); }
-  T* first() { return (T*)pimpl->first(); }
-  T* next() { return (T*)pimpl->next(); }
+  char* hash_malloc(int size)
+  {
+    return static_cast<char*>(monobuf.allocate(size));
+  }
+  T* first() { return static_cast<T*>(pimpl->first()); }
+  T* next() { return static_cast<T*>(pimpl->next()); }
   uint32_t size() { return pimpl->size(); }
 };
 

--- a/core/src/lib/htable.h
+++ b/core/src/lib/htable.h
@@ -135,12 +135,12 @@ struct htable_binary_key {
   uint32_t len;
 };
 
-class htable {
+template <typename Key, typename T> class htable {
   std::unique_ptr<htableImpl> pimpl;
 
  public:
   htable() { pimpl = std::make_unique<htableImpl>(); }
-  htable(void* item,
+  htable(T* item,
          void* link,
          int tsize = 31,
          int nr_pages = 0,
@@ -149,27 +149,26 @@ class htable {
     pimpl
         = std::make_unique<htableImpl>(item, link, tsize, nr_pages, nr_entries);
   }
-  void* lookup(char* key) { return pimpl->lookup(key); }
-  bool insert(char* key, void* item) { return pimpl->insert(key, item); }
-
-  void* lookup(uint32_t key) { return pimpl->lookup(key); }
-  bool insert(uint32_t key, void* item) { return pimpl->insert(key, item); }
-
-  void* lookup(uint64_t key) { return pimpl->lookup(key); }
-  bool insert(uint64_t key, void* item) { return pimpl->insert(key, item); }
-
-  void* lookup(htable_binary_key key)
+  T* lookup(Key key)
   {
-    return pimpl->lookup(key.ptr, key.len);
+    if constexpr (std::is_same<Key, htable_binary_key>::value) {
+      return (T*)pimpl->lookup(key.ptr, key.len);
+    } else {
+      return (T*)pimpl->lookup(key);
+    }
   }
-  bool insert(htable_binary_key key, void* item)
+  bool insert(Key key, T* item)
   {
-    return pimpl->insert(key.ptr, key.len, item);
+    if constexpr (std::is_same<Key, htable_binary_key>::value) {
+      return pimpl->insert(key.ptr, key.len, item);
+    } else {
+      return pimpl->insert(key, item);
+    }
   }
 
   char* hash_malloc(int size) { return pimpl->hash_malloc(size); }
-  void* first() { return pimpl->first(); }
-  void* next() { return pimpl->next(); }
+  T* first() { return (T*)pimpl->first(); }
+  T* next() { return (T*)pimpl->next(); }
   uint32_t size() { return pimpl->size(); }
 };
 

--- a/core/src/lib/htable.h
+++ b/core/src/lib/htable.h
@@ -127,13 +127,32 @@ struct htable_binary_key {
   uint32_t len;
 };
 
-template <typename Key, typename T> class htable {
+enum class htableBufferSize
+{
+  small,
+  medium,
+  large
+};
+
+template <typename Key,
+          typename T,
+          enum htableBufferSize BufferSize = htableBufferSize::large>
+class htable {
   std::unique_ptr<htableImpl> pimpl;
 
  public:
   htable() { pimpl = std::make_unique<htableImpl>(); }
-  htable(T* item, hlink* link, int tsize = 31, int nr_pages = 0)
+  htable(T* item, hlink* link, int tsize = 31)
   {
+    int nr_pages = 0;
+    if constexpr (BufferSize == htableBufferSize::large) {
+      nr_pages = 0;
+    } else if constexpr (BufferSize == htableBufferSize::medium) {
+      nr_pages = 512;
+    } else if constexpr (BufferSize == htableBufferSize::small) {
+      nr_pages = 1;
+    }
+
     pimpl = std::make_unique<htableImpl>(item, link, tsize, nr_pages);
   }
   T* lookup(Key key)

--- a/core/src/lib/jcr.cc
+++ b/core/src/lib/jcr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -192,7 +192,7 @@ JobControlRecord::JobControlRecord()
 
   MessageQueueItem* item = nullptr;
   msg_queue
-      = new dlist<MessageQueueItem>(item, &item->link_);  // calculate offset
+      = new dlist<MessageQueueItem>(item, &item->link);  // calculate offset
 
   int status;
   if ((status = pthread_mutex_init(&msg_queue_mutex, nullptr)) != 0) {

--- a/core/src/lib/jcr.cc
+++ b/core/src/lib/jcr.cc
@@ -190,9 +190,7 @@ JobControlRecord::JobControlRecord()
 {
   Dmsg0(100, "Construct JobControlRecord\n");
 
-  MessageQueueItem* item = nullptr;
-  msg_queue
-      = new dlist<MessageQueueItem>(item, &item->link);  // calculate offset
+  msg_queue = new dlist<MessageQueueItem>();
 
   int status;
   if ((status = pthread_mutex_init(&msg_queue_mutex, nullptr)) != 0) {
@@ -908,9 +906,8 @@ bool InitJcrSubsystem(int timeout)
 
 void InitJcrChain()
 {
-  JobControlRecord* jcr = nullptr;
   if (!job_control_record_chain) {
-    job_control_record_chain = new dlist<JobControlRecord>(jcr, &jcr->link);
+    job_control_record_chain = new dlist<JobControlRecord>();
   }
 }
 

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1559,6 +1559,7 @@ void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
   }
 
   item = (MessageQueueItem*)malloc(sizeof(MessageQueueItem));
+  new (item) MessageQueueItem();
   item->type_ = type;
   item->mtime_ = time(NULL);
   item->msg_ = strdup(buf.c_str());

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -819,6 +819,7 @@ void DispatchMessage(JobControlRecord* jcr,
               break;
             }
             d->mail_filename_ = name;
+            FreePoolMemory(name);
           }
           fputs(dt, d->file_pointer_);
           len = strlen(msg) + dtlen;

--- a/core/src/lib/message_queue_item.h
+++ b/core/src/lib/message_queue_item.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,7 +32,7 @@ class MessageQueueItem {
  public:
   MessageQueueItem() = default;
   virtual ~MessageQueueItem() = default;
-  dlink<MessageQueueItem> link_;
+  dlink<MessageQueueItem> link;
   int type_ = 0;
   utime_t mtime_ = {0};
   char* msg_{nullptr};

--- a/core/src/lib/mntent_cache.cc
+++ b/core/src/lib/mntent_cache.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -373,9 +373,7 @@ static void refresh_mount_cache(
  */
 static inline void InitializeMntentCache(void)
 {
-  mntent_cache_entry_t* mce = NULL;
-
-  mntent_cache_entries = new dlist<mntent_cache_entry_t>(mce, &mce->link);
+  mntent_cache_entries = new dlist<mntent_cache_entry_t>();
 
   // Refresh the cache.
   refresh_mount_cache(add_mntent_mapping);

--- a/core/src/lib/monotonic_buffer.cc
+++ b/core/src/lib/monotonic_buffer.cc
@@ -1,0 +1,84 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#include <cassert>
+#include <cstdint>
+#include <cstdlib>
+#include <stdexcept>
+#include "monotonic_buffer.h"
+
+struct MonotonicBuffer::Allocation {
+  struct Allocation* next; /* Next buffer */
+  size_t rem;              /* Remaining bytes in this buffer */
+  char* mem;               /* Memory pointer */
+  max_align_t first[1];    /* First byte */
+};
+
+static size_t get_alloc_size(MonotonicBuffer::Size size)
+{
+  switch (size) {
+    case MonotonicBuffer::Size::Small:
+      return 32 * 4096;
+    case MonotonicBuffer::Size::Medium:
+      return 512 * 4096;
+    case MonotonicBuffer::Size::Large:
+      return 2400 * 4096;
+  }
+  throw std::invalid_argument("unsupported MonotonicBuffer::Size");
+}
+
+/* round-up size to next multiple of alignof(max_align_t) */
+static size_t aligned_size(size_t size)
+{
+  constexpr auto mod = alignof(max_align_t);
+
+  auto rem = size % mod;
+  if (rem == 0) return size;
+  return size + mod - rem;
+}
+
+MonotonicBuffer::~MonotonicBuffer()
+{
+  while (mem_block_) {
+    Allocation* ptr = mem_block_;
+    mem_block_ = mem_block_->next;
+    free(ptr);
+  }
+}
+
+void* MonotonicBuffer::allocate(size_t size)
+{
+  const auto asize = aligned_size(size);
+  assert(asize >= size);
+
+  // allocate a new mem_block if needed
+  if (!mem_block_ || mem_block_->rem < asize) {
+    size_t alloc_size = get_alloc_size(grow_size_);
+    Allocation* hmem = (Allocation*)malloc(alloc_size);
+    hmem->next = mem_block_;
+    hmem->mem = static_cast<char*>(static_cast<void*>(hmem->first));
+    hmem->rem = alloc_size - offsetof(Allocation, first);
+    mem_block_ = hmem;
+  }
+  mem_block_->rem -= asize;
+  void* buf = mem_block_->mem;
+  mem_block_->mem += asize;
+  return buf;
+}

--- a/core/src/lib/monotonic_buffer.h
+++ b/core/src/lib/monotonic_buffer.h
@@ -1,0 +1,45 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_MONOTONIC_BUFFER_H_
+#define BAREOS_LIB_MONOTONIC_BUFFER_H_
+#include <cstddef>
+
+class MonotonicBuffer {
+ public:
+  enum class Size
+  {
+    Small,
+    Medium,
+    Large
+  };
+
+ private:
+  struct Allocation;
+  Allocation* mem_block_{nullptr};
+  Size grow_size_;
+
+ public:
+  MonotonicBuffer(Size grow_size = Size::Large) : grow_size_(grow_size) {}
+  ~MonotonicBuffer();
+  void* allocate(size_t size);
+};
+#endif  // BAREOS_LIB_MONOTONIC_BUFFER_H_

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,10 +43,17 @@ class ConfigParserStateMachine;
 class ConfigurationParser;
 
 /* For storing name_addr items in res_items table */
-/* clang-format off */
-#define ITEM(c, m) ((std::size_t)&c->m), reinterpret_cast<BareosResource**>(&c)
-#define ITEMC(c)   0,   reinterpret_cast<BareosResource**>(&c)
-/* clang-format on */
+
+/* using offsetof on non-standard-layout types is conditionally supported. As
+ * all the compiler we're currently using support this, it should be safe to
+ * use. It is at least safer to use than the undefined behaviour we previously
+ * utilized.
+ */
+#define ITEM(c, m)                                     \
+  offsetof(std::remove_pointer<decltype(c)>::type, m), \
+      reinterpret_cast<BareosResource**>(&c)
+#define ITEMC(c) 0, reinterpret_cast<BareosResource**>(&c)
+
 /*
  * Master Resource configuration structure definition
  * This is the structure that defines the resources that are available to

--- a/core/src/lib/path_list.cc
+++ b/core/src/lib/path_list.cc
@@ -28,23 +28,18 @@
 
 #define debuglevel 50
 
-typedef struct PrivateCurDir {
-  hlink link;
-  char fname[1];
-} CurDir;
-
 // Initialize the path hash table
-htable* path_list_init()
+PathList* path_list_init()
 {
   CurDir* elt = NULL;
-  return new htable(elt, &elt->link, 10000);
+  return new PathList(elt, &elt->link, 10000);
 }
 
 /*
  * Add a path to the hash when we create a directory with the replace=NEVER
  * option
  */
-bool PathListAdd(htable* path_list, uint32_t len, const char* fname)
+bool PathListAdd(PathList* path_list, uint32_t len, const char* fname)
 {
   CurDir* item;
 
@@ -63,7 +58,7 @@ bool PathListAdd(htable* path_list, uint32_t len, const char* fname)
   return true;
 }
 
-bool PathListLookup(htable* path_list, const char* fname)
+bool PathListLookup(PathList* path_list, const char* fname)
 {
   int len;
   bool found = false;
@@ -94,4 +89,4 @@ bool PathListLookup(htable* path_list, const char* fname)
   return found;
 }
 
-void FreePathList(htable* path_list) { delete path_list; }
+void FreePathList(PathList* path_list) { delete path_list; }

--- a/core/src/lib/path_list.cc
+++ b/core/src/lib/path_list.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,15 +36,8 @@ typedef struct PrivateCurDir {
 // Initialize the path hash table
 htable* path_list_init()
 {
-  htable* path_list;
   CurDir* elt = NULL;
-
-  path_list = (htable*)malloc(sizeof(htable));
-
-  // Hard to know in advance how many directories will be stored in this hash
-  path_list->init(elt, &elt->link, 10000);
-
-  return path_list;
+  return new htable(elt, &elt->link, 10000);
 }
 
 /*
@@ -101,8 +94,4 @@ bool PathListLookup(htable* path_list, const char* fname)
   return found;
 }
 
-void FreePathList(htable* path_list)
-{
-  path_list->destroy();
-  free(path_list);
-}
+void FreePathList(htable* path_list) { delete path_list; }

--- a/core/src/lib/path_list.cc
+++ b/core/src/lib/path_list.cc
@@ -29,11 +29,7 @@
 #define debuglevel 50
 
 // Initialize the path hash table
-PathList* path_list_init()
-{
-  CurDir* elt = NULL;
-  return new PathList(elt, &elt->link, 10000);
-}
+PathList* path_list_init() { return new PathList(10000); }
 
 /*
  * Add a path to the hash when we create a directory with the replace=NEVER

--- a/core/src/lib/path_list.h
+++ b/core/src/lib/path_list.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -21,11 +21,18 @@
 #ifndef BAREOS_LIB_PATH_LIST_H_
 #define BAREOS_LIB_PATH_LIST_H_
 
-class htable;
+#include "htable.h"
 
-htable* path_list_init();
-bool PathListLookup(htable* path_list, const char* fname);
-bool PathListAdd(htable* path_list, uint32_t len, const char* fname);
-void FreePathList(htable* path_list);
+typedef struct PrivateCurDir {
+  hlink link;
+  char fname[1];
+} CurDir;
+
+using PathList = htable<char*, CurDir>;
+
+PathList* path_list_init();
+bool PathListLookup(PathList* path_list, const char* fname);
+bool PathListAdd(PathList* path_list, uint32_t len, const char* fname);
+void FreePathList(PathList* path_list);
 
 #endif  // BAREOS_LIB_PATH_LIST_H_

--- a/core/src/lib/timer_thread.cc
+++ b/core/src/lib/timer_thread.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -204,6 +204,7 @@ static bool RunOneItem(TimerThread::Timer* p,
       = std::chrono::steady_clock::now();
 
   bool remove_from_list = false;
+  next_timer_run = min(p->scheduled_run_timepoint, next_timer_run);
   if (p->is_active && last_timer_run_timepoint > p->scheduled_run_timepoint) {
     LogMessage(p);
     p->user_callback(p);
@@ -215,7 +216,6 @@ static bool RunOneItem(TimerThread::Timer* p,
       p->scheduled_run_timepoint = last_timer_run_timepoint + p->interval;
     }
   }
-  next_timer_run = min(p->scheduled_run_timepoint, next_timer_run);
   return remove_from_list;
 }
 

--- a/core/src/lib/tree.cc
+++ b/core/src/lib/tree.cc
@@ -92,7 +92,7 @@ TREE_ROOT* new_tree(int count)
   root->type = TN_ROOT;
   root->fname = "";
   HL_ENTRY* entry = NULL;
-  new (&root->hardlinks) htable(entry, &entry->link, 0, 1);
+  new (&root->hardlinks) HardlinkTable(entry, &entry->link, 0, 1);
   return root;
 }
 

--- a/core/src/lib/tree.cc
+++ b/core/src/lib/tree.cc
@@ -92,7 +92,7 @@ TREE_ROOT* new_tree(int count)
   root->type = TN_ROOT;
   root->fname = "";
   HL_ENTRY* entry = NULL;
-  new (&root->hardlinks) HardlinkTable(entry, &entry->link, 0, 1);
+  new (&root->hardlinks) HardlinkTable(entry, &entry->link);
   return root;
 }
 

--- a/core/src/lib/tree.cc
+++ b/core/src/lib/tree.cc
@@ -91,8 +91,7 @@ TREE_ROOT* new_tree(int count)
   root->cached_path = GetPoolMemory(PM_FNAME);
   root->type = TN_ROOT;
   root->fname = "";
-  HL_ENTRY* entry = NULL;
-  new (&root->hardlinks) HardlinkTable(entry, &entry->link);
+  new (&root->hardlinks) HardlinkTable();
   return root;
 }
 

--- a/core/src/lib/tree.cc
+++ b/core/src/lib/tree.cc
@@ -91,7 +91,6 @@ TREE_ROOT* new_tree(int count)
   root->cached_path = GetPoolMemory(PM_FNAME);
   root->type = TN_ROOT;
   root->fname = "";
-  new (&root->hardlinks) HardlinkTable();
   return root;
 }
 

--- a/core/src/lib/tree.cc
+++ b/core/src/lib/tree.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,7 +92,7 @@ TREE_ROOT* new_tree(int count)
   root->type = TN_ROOT;
   root->fname = "";
   HL_ENTRY* entry = NULL;
-  root->hardlinks.init(entry, &entry->link, 0, 1);
+  new (&root->hardlinks) htable(entry, &entry->link, 0, 1);
   return root;
 }
 
@@ -157,7 +157,7 @@ void FreeTree(TREE_ROOT* root)
   struct s_mem *mem, *rel;
   uint32_t freed_blocks = 0;
 
-  root->hardlinks.destroy();
+  std::destroy_at(&root->hardlinks);
   for (mem = root->mem; mem;) {
     rel = mem;
     mem = mem->next;

--- a/core/src/lib/tree.h
+++ b/core/src/lib/tree.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2009 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -100,6 +100,16 @@ struct s_tree_node {
 };
 typedef struct s_tree_node TREE_NODE;
 
+/* hardlink hashtable entry */
+struct s_hl_entry {
+  uint64_t key;
+  hlink link;
+  TREE_NODE* node;
+};
+typedef struct s_hl_entry HL_ENTRY;
+
+using HardlinkTable = htable<uint64_t, HL_ENTRY>;
+
 struct s_tree_root {
   s_tree_root()
       : type{false}
@@ -138,17 +148,9 @@ struct s_tree_root {
   int cached_path_len{};       /* length of cached path */
   char* cached_path{};         /* cached current path */
   TREE_NODE* cached_parent{};  /* cached parent for above path */
-  htable hardlinks;            /* references to first occurence of hardlinks */
+  HardlinkTable hardlinks;     /* references to first occurence of hardlinks */
 };
 typedef struct s_tree_root TREE_ROOT;
-
-/* hardlink hashtable entry */
-struct s_hl_entry {
-  uint64_t key;
-  hlink link;
-  TREE_NODE* node;
-};
-typedef struct s_hl_entry HL_ENTRY;
 
 #ifdef HAVE_HPUX_OS
 #  pragma pack(pop)

--- a/core/src/lib/tree.h
+++ b/core/src/lib/tree.h
@@ -108,7 +108,7 @@ struct s_hl_entry {
 };
 typedef struct s_hl_entry HL_ENTRY;
 
-using HardlinkTable = htable<uint64_t, HL_ENTRY>;
+using HardlinkTable = htable<uint64_t, HL_ENTRY, htableBufferSize::small>;
 
 struct s_tree_root {
   s_tree_root()

--- a/core/src/lib/tree.h
+++ b/core/src/lib/tree.h
@@ -108,7 +108,7 @@ struct s_hl_entry {
 };
 typedef struct s_hl_entry HL_ENTRY;
 
-using HardlinkTable = htable<uint64_t, HL_ENTRY, htableBufferSize::small>;
+using HardlinkTable = htable<uint64_t, HL_ENTRY, MonotonicBuffer::Size::Small>;
 
 struct s_tree_root {
   s_tree_root()

--- a/core/src/lib/watchdog.cc
+++ b/core/src/lib/watchdog.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -80,7 +80,6 @@ bool IsWatchdog()
 int StartWatchdog(void)
 {
   int status;
-  watchdog_t* dummy = NULL;
   int errstat;
 
   if (wd_is_init) { return 0; }
@@ -92,8 +91,8 @@ int StartWatchdog(void)
     Jmsg1(NULL, M_ABORT, 0, _("Unable to initialize watchdog lock. ERR=%s\n"),
           be.bstrerror(errstat));
   }
-  wd_queue = new dlist<watchdog_t>(dummy, &dummy->link);
-  wd_inactive = new dlist<watchdog_t>(dummy, &dummy->link);
+  wd_queue = new dlist<watchdog_t>();
+  wd_inactive = new dlist<watchdog_t>();
   wd_is_init = true;
 
   if ((status = pthread_create(&wd_tid, NULL, watchdog_thread, NULL)) != 0) {

--- a/core/src/ndmp/ndmjob_job.c
+++ b/core/src/ndmp/ndmjob_job.c
@@ -429,18 +429,17 @@ int jndex_tattle(void)
   char buf[100];
   struct ndmmedia* me;
   struct ndm_env_entry* nev;
-  int i;
 
   for (me = ji_media.head; me; me = me->next) {
     ndmmedia_to_str(me, buf);
-    ndmjob_log(3, "ji me[%d] %s", i, buf);
+    ndmjob_log(3, "ji me[] %s", buf);
   }
 
   for (nev = ji_environment.head; nev; nev = nev->next) {
-    ndmjob_log(3, "ji env[%d] %s=%s", i, nev->pval.name, nev->pval.value);
+    ndmjob_log(3, "ji env[] %s=%s", nev->pval.name, nev->pval.value);
   }
 
-  for (i = 0; (i < n_file_arg) && (i < NDM_MAX_NLIST); i++) {
+  for (int i = 0; (i < n_file_arg) && (i < NDM_MAX_NLIST); i++) {
     if (nlist[i].fh_info.valid) {
       ndmjob_log(3, "ji fil[%d] fi=%lld %s", i, nlist[i].fh_info.value,
                  file_arg[i]);

--- a/core/src/ndmp/ndmjob_simulator.c
+++ b/core/src/ndmp/ndmjob_simulator.c
@@ -915,24 +915,27 @@ struct robot_state {
 
 static void robot_state_init(struct robot_state* rs)
 {
-  int i;
-
   /* invent some nice data, with some nice voltags and whatnot */
 
   NDMOS_API_BZERO(rs, sizeof(*rs));
 
   /* (nothing to do for MTEs) */
 
-  for (i = 0; i < STORAGE_COUNT; i++) {
+  for (uint8_t i = 0; i < STORAGE_COUNT; i++) {
     struct element_state* es = &rs->storage[i];
     es->full = 1;
 
     es->medium_type = 1; /* data */
     es->source_element = 0;
-    snprintf(es->pvoltag, sizeof(es->pvoltag),
-             "PTAG%02XXX                        ", i);
-    snprintf(es->avoltag, sizeof(es->avoltag),
-             "ATAG%02XXX                        ", i);
+
+    // write into a null-terminated string buffer, copy to
+    // destination buffer that will not be null-terminated
+    char buf[100];
+    sprintf(buf, "PTAG%02XXX                          ", i);
+    memmove(es->pvoltag, buf, sizeof(es->pvoltag));
+    sprintf(buf, "ATAG%02XXX                          ", i);
+    memmove(es->avoltag, buf, sizeof(es->avoltag));
+
   }
 
   /* (i/e are all empty) */
@@ -993,7 +996,7 @@ static int robot_state_move(struct ndm_session* sess,
   char dest_filename[NDMOS_CONST_PATH_MAX];
   struct element_state* dest_elt;
   struct stat st;
-  char pos[NDMOS_CONST_PATH_MAX];
+  char pos[NDMOS_CONST_PATH_MAX+4];
 
   /* TODO: audit that the tape device is not using this volume right now */
 

--- a/core/src/plugins/dird/python/CMakeLists.txt
+++ b/core/src/plugins/dird/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -66,6 +66,7 @@ if(Python2_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
 endif()
 
@@ -122,5 +123,6 @@ if(Python3_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python3modules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
 endif()

--- a/core/src/plugins/filed/cephfs/cephfs-fd.cc
+++ b/core/src/plugins/filed/cephfs/cephfs-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2015 Planets Communications B.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -118,8 +118,8 @@ struct plugin_ctx {
   POOLMEM* link_target;   /* Target symlink points to */
   POOLMEM* xattr_list;    /* List of xattrs */
   alist<dir_stack_entry*>* dir_stack; /* Stack of directories when recursing */
-  htable* path_list; /* Hash table with directories created on restore. */
-  struct dirent de;  /* Current directory entry being processed. */
+  PathList* path_list; /* Hash table with directories created on restore. */
+  struct dirent de;    /* Current directory entry being processed. */
   struct ceph_mount_info* cmount; /* CEPHFS mountpoint */
   struct ceph_dir_result* cdir;   /* CEPHFS directory handle */
   int cfd;                        /* CEPHFS file handle */

--- a/core/src/plugins/filed/gfapi/gfapi-fd.cc
+++ b/core/src/plugins/filed/gfapi/gfapi-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -147,7 +147,7 @@ struct plugin_ctx {
   POOLMEM* dirent_buffer; /* Temporary buffer for current dirent structure */
 #endif
   alist<dir_stack_entry*>* dir_stack; /* Stack of directories when recursing */
-  htable* path_list;      /* Hash table with directories created on restore. */
+  PathList* path_list;    /* Hash table with directories created on restore. */
   glfs_t* glfs;           /* Gluster volume handle */
   glfs_fd_t* gdir;        /* Gluster directory handle */
   glfs_fd_t* gfd;         /* Gluster file handle */

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -71,6 +71,7 @@ if(Python2_FOUND)
     PROPERTY
       ENVIRONMENT
       PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test/:${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/pyfiles
+      "LSAN_OPTIONS=fast_unwind_on_malloc=0 suppressions=${CMAKE_CURRENT_SOURCE_DIR}/test/lsan-suppressions.txt"
   )
   if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_property(TEST bareosfd-python2-module-tester PROPERTY DISABLED true)
@@ -94,6 +95,7 @@ if(Python3_FOUND AND NOT HAVE_WIN32)
     PROPERTY
       ENVIRONMENT
       PYTHONPATH=${CMAKE_CURRENT_SOURCE_DIR}/test/:${CMAKE_CURRENT_BINARY_DIR}/python3modules:${CMAKE_CURRENT_SOURCE_DIR}/pyfiles
+      "LSAN_OPTIONS=fast_unwind_on_malloc=0 suppressions=${CMAKE_CURRENT_SOURCE_DIR}/test/lsan-suppressions.txt"
   )
 endif()
 
@@ -127,6 +129,7 @@ if(Python2_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
   set_tests_properties(bareosfd-python2-module PROPERTIES LABELS "broken")
 endif()
@@ -164,6 +167,7 @@ if(Python3_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python3modules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
   add_test(
     NAME python-simple-test-example

--- a/core/src/plugins/filed/python/test/lsan-suppressions.txt
+++ b/core/src/plugins/filed/python/test/lsan-suppressions.txt
@@ -1,0 +1,6 @@
+leak:Py_InitializeEx
+leak:PyObject_Call
+leak:PyObject_Malloc
+leak:PyList_New
+leak:_PyEval_EvalFrameDefault
+leak:PyImport_Cleanup

--- a/core/src/plugins/stored/python/CMakeLists.txt
+++ b/core/src/plugins/stored/python/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -64,6 +64,7 @@ if(Python2_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/pythonmodules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
 endif()
 
@@ -117,5 +118,6 @@ if(Python3_FOUND)
       ENVIRONMENT
       "PYTHONPATH=${CMAKE_CURRENT_BINARY_DIR}/python3modules:${CMAKE_CURRENT_SOURCE_DIR}/test"
       LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../lib
+      "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
   )
 endif()

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2015-2017 Planets Communications B.V.
-   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -282,10 +282,8 @@ int ChunkedDevice::NrInflightChunks()
 }
 
 // Call back function for comparing two chunk_io_requests.
-static int CompareChunkIoRequest(void* item1, void* item2)
+static int CompareChunkIoRequest(ocbuf_item* ocbuf1, ocbuf_item* ocbuf2)
 {
-  storagedaemon::ocbuf_item* ocbuf1 = (storagedaemon::ocbuf_item*)item1;
-  storagedaemon::ocbuf_item* ocbuf2 = (storagedaemon::ocbuf_item*)item2;
   chunk_io_request* chunk1 = (chunk_io_request*)ocbuf1->data;
   chunk_io_request* chunk2 = (chunk_io_request*)ocbuf2->data;
 

--- a/core/src/stored/backends/droplet_device.cc
+++ b/core/src/stored/backends/droplet_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -377,8 +377,9 @@ bool DropletDevice::CheckRemoteConnection()
 
   auto status = check_path("bareos-test/");
 
-  const char* h = dpl_addrlist_get(ctx_->addrlist);
+  char* h = dpl_addrlist_get(ctx_->addrlist);
   std::string hostaddr{h != nullptr ? h : "???"};
+  free(h);
 
   switch (status) {
     case DPL_SUCCESS:
@@ -894,7 +895,10 @@ bool DropletDevice::initialize()
     }
 
     // If a bucketname was defined set it in the context.
-    if (bucketname_) { ctx_->cur_bucket = strdup(bucketname_); }
+    if (bucketname_) {
+      free(ctx_->cur_bucket);
+      ctx_->cur_bucket = strdup(bucketname_);
+    }
   }
 
   return true;

--- a/core/src/stored/backends/ordered_cbuf.cc
+++ b/core/src/stored/backends/ordered_cbuf.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2017 Planets Communications B.V.
-   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,8 +31,6 @@ namespace storagedaemon {
 // Initialize a new ordered circular buffer.
 int ordered_circbuf::init(int capacity)
 {
-  struct ocbuf_item* item = NULL;
-
   if (pthread_mutex_init(&lock_, NULL) != 0) { return -1; }
 
   if (pthread_cond_init(&notfull_, NULL) != 0) {
@@ -53,7 +51,8 @@ int ordered_circbuf::init(int capacity)
     data_->destroy();
     delete data_;
   }
-  data_ = new dlist<void>(item, &item->link);
+  static_assert(offsetof(ocbuf_item, link) == 0);
+  data_ = new dlist<void>();
 
   return 0;
 }

--- a/core/src/stored/backends/ordered_cbuf.cc
+++ b/core/src/stored/backends/ordered_cbuf.cc
@@ -52,7 +52,7 @@ int ordered_circbuf::init(int capacity)
     delete data_;
   }
   static_assert(offsetof(ocbuf_item, link) == 0);
-  data_ = new dlist<void>();
+  data_ = new dlist<ocbuf_item>();
 
   return 0;
 }
@@ -72,8 +72,8 @@ void ordered_circbuf::destroy()
 // Enqueue a new item into the ordered circular buffer.
 void* ordered_circbuf::enqueue(void* data,
                                uint32_t data_size,
-                               int compare(void* item1, void* item2),
-                               void update(void* item1, void* item2),
+                               int compare(ocbuf_item*, ocbuf_item*),
+                               void update(void*, void*),
                                bool use_reserved_slot,
                                bool no_signal)
 {

--- a/core/src/stored/backends/ordered_cbuf.h
+++ b/core/src/stored/backends/ordered_cbuf.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2017 Planets Communications B.V.
-   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,7 +39,7 @@ enum oc_peek_types
 };
 
 struct ocbuf_item {
-  dlink<void> link;
+  dlink<ocbuf_item> link;
   uint32_t data_size = 0;
   void* data = nullptr;
 };
@@ -54,8 +54,8 @@ class ordered_circbuf {
   pthread_cond_t notfull_
       = PTHREAD_COND_INITIALIZER; /* Full -> not full condition */
   pthread_cond_t notempty_
-      = PTHREAD_COND_INITIALIZER; /* Empty -> not empty condition */
-  dlist<void>* data_ = nullptr;   /* Circular buffer of pointers */
+      = PTHREAD_COND_INITIALIZER;     /* Empty -> not empty condition */
+  dlist<ocbuf_item>* data_ = nullptr; /* Circular buffer of pointers */
 
  public:
   ordered_circbuf(int capacity = OQSIZE);
@@ -64,8 +64,8 @@ class ordered_circbuf {
   void destroy();
   void* enqueue(void* data,
                 uint32_t data_size,
-                int compare(void* item1, void* item2),
-                void update(void* item1, void* item2),
+                int compare(ocbuf_item*, ocbuf_item*),
+                void update(void*, void*),
                 bool use_reserved_slot = false,
                 bool no_signal = false);
   void* dequeue(bool reserve_slot = false,

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -680,7 +680,7 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
     case STREAM_ACL_HURD_DEFAULT_ACL:
     case STREAM_ACL_HURD_ACCESS_ACL:
       if (extract) {
-        PmStrcpy(acl_data.last_fname, attr->fname);
+        PmStrcpy(acl_data.last_fname, attr->ofname);
         PushDelayedDataStream(rec->maskedStream, rec->data, rec->data_len);
       }
       break;
@@ -697,7 +697,7 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
     case STREAM_XATTR_LINUX:
     case STREAM_XATTR_NETBSD:
       if (extract) {
-        PmStrcpy(xattr_data.last_fname, attr->fname);
+        PmStrcpy(xattr_data.last_fname, attr->ofname);
         PushDelayedDataStream(rec->maskedStream, rec->data, rec->data_len);
       }
       break;

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -380,6 +380,7 @@ int main(int argc, char* argv[])
         "%7d Media\n%7d Pool\n%7d Job\n%7d File\n%7d RestoreObject\n",
         num_media, num_pools, num_jobs, num_files, num_restoreobjects);
   }
+  db->CloseDatabase(bjcr);
   DbFlushBackends();
 
   CleanDevice(bjcr->impl->dcr);

--- a/core/src/stored/read_record.cc
+++ b/core/src/stored/read_record.cc
@@ -119,14 +119,13 @@ static char* rec_state_bits_to_str(DeviceRecord* rec)
  */
 READ_CTX* new_read_context(void)
 {
-  DeviceRecord* rec = NULL;
   READ_CTX* rctx;
 
   rctx = (READ_CTX*)malloc(sizeof(READ_CTX));
   READ_CTX empty_READ_CTX;
   *rctx = empty_READ_CTX;
 
-  rctx->recs = new dlist<DeviceRecord>(rec, &rec->link);
+  rctx->recs = new dlist<DeviceRecord>();
   return rctx;
 }
 

--- a/core/src/stored/sd_backends.h
+++ b/core/src/stored/sd_backends.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2014 Planets Communications B.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,6 +32,7 @@ namespace storagedaemon {
 
 class BackendInterface {
  public:
+  virtual ~BackendInterface() {}
   virtual Device* GetDevice(JobControlRecord* jcr, DeviceType device_type) = 0;
   virtual void FlushDevice(void) = 0;
 };

--- a/core/src/stored/sd_stats.cc
+++ b/core/src/stored/sd_stats.cc
@@ -108,12 +108,8 @@ static dlist<job_statistics_t>* job_statistics = NULL;
 
 static inline void setup_statistics()
 {
-  device_statistics_t* dev_stats = NULL;
-  job_statistics_t* job_stats = NULL;
-
-  device_statistics
-      = new dlist<device_statistics_t>(dev_stats, &dev_stats->link);
-  job_statistics = new dlist<job_statistics_t>(job_stats, &job_stats->link);
+  device_statistics = new dlist<device_statistics_t>();
+  job_statistics = new dlist<job_statistics_t>();
 }
 
 void UpdateDeviceTapealert(const char* devname, uint64_t flags, utime_t now)
@@ -152,8 +148,7 @@ void UpdateDeviceTapealert(const char* devname, uint64_t flags, utime_t now)
   tape_alert->flags = flags;
 
   if (!dev_stats->device_tapealerts) {
-    dev_stats->device_tapealerts
-        = new dlist<device_tapealert_item>(tape_alert, &tape_alert->link);
+    dev_stats->device_tapealerts = new dlist<device_tapealert_item>();
   }
 
   P(mutex);
@@ -228,8 +223,7 @@ static inline void UpdateDeviceStatistics(const char* devname,
 
 
   if (!dev_stats->device_statistics) {
-    dev_stats->device_statistics
-        = new dlist<device_statistic_item>(dev_stat, &dev_stat->link);
+    dev_stats->device_statistics = new dlist<device_statistic_item>();
   }
 
   P(mutex);
@@ -307,8 +301,7 @@ void UpdateJobStatistics(JobControlRecord* jcr, utime_t now)
   }
 
   if (!job_stats->job_statistics) {
-    job_stats->job_statistics
-        = new dlist<jobstatistic_item>(job_stat, &job_stat->link);
+    job_stats->job_statistics = new dlist<jobstatistic_item>();
   }
 
   P(mutex);

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2013 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -799,12 +799,9 @@ bool FreeVolume(Device* dev)
 // Create the Volume list
 void CreateVolumeLists()
 {
-  VolumeReservationItem* vol = NULL;
-  if (vol_list == NULL) {
-    vol_list = new dlist<VolumeReservationItem>(vol, &vol->link);
-  }
+  if (vol_list == NULL) { vol_list = new dlist<VolumeReservationItem>(); }
   if (read_vol_list == NULL) {
-    read_vol_list = new dlist<VolumeReservationItem>(vol, &vol->link);
+    read_vol_list = new dlist<VolumeReservationItem>();
   }
 }
 
@@ -919,7 +916,7 @@ dlist<VolumeReservationItem>* dup_vol_list(JobControlRecord* jcr)
   Dmsg0(debuglevel, "lock volumes\n");
 
   Dmsg0(debuglevel, "duplicate vol list\n");
-  temp_vol_list = new dlist<VolumeReservationItem>(vol, &vol->link);
+  temp_vol_list = new dlist<VolumeReservationItem>();
   foreach_vol (vol) {
     VolumeReservationItem *nvol, *tvol;
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -168,8 +168,16 @@ endif()
 if(NOT client-only)
   bareos_add_test(
     test_dir_plugins
-    ADDITIONAL_SOURCES ${PROJECT_SOURCE_DIR}/src/dird/dir_plugins.cc
-    LINK_LIBRARIES bareos bareossql GTest::gtest_main
+    ADDITIONAL_SOURCES
+      ${PROJECT_SOURCE_DIR}/src/dird/dir_plugins.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/dird_conf.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/dird_globals.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/run_conf.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/inc_conf.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/ua_acl.cc
+      ${PROJECT_SOURCE_DIR}/src/dird/ua_audit.cc
+    LINK_LIBRARIES bareos bareossql bareosfind GTest::gtest_main
+                   ${OPENSSL_LIBRARIES}
   )
 endif() # NOT client-only
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -321,6 +321,13 @@ if(HAVE_EXECINFO_H
    AND HAVE_BACKTRACE_SYMBOLS
 )
   bareos_add_test(test_backtrace LINK_LIBRARIES bareos GTest::gtest_main)
+  # Backtrace doesn't work correctly when ASan is enabled, do we shoudn't test
+  # in that case
+  if(CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
+    set_tests_properties(
+      gtest:Backtrace.test_backtrace PROPERTIES DISABLED TRUE
+    )
+  endif()
 endif() # HAVE_EXECINFO_H ..
 
 if(NOT client-only)

--- a/core/src/tests/addresses_and_ports.cc
+++ b/core/src/tests/addresses_and_ports.cc
@@ -26,9 +26,6 @@
 #include "lib/watchdog.h"
 #include "lib/berrno.h"
 
-
-static void cleanup() { TermMsg(); }
-
 static bool create_and_bind_v4socket(int test_fd, int port)
 {
   int family = AF_INET;
@@ -130,7 +127,6 @@ static bool try_binding_director_port(std::string path_to_config,
   directordaemon::StopSocketServer();
   StopWatchdog();
 
-  cleanup();
   return result;
 }
 
@@ -157,8 +153,6 @@ static void check_addresses_list(std::string path_to_config,
   std::sort(director_addresses.begin(), director_addresses.end());
   std::sort(expected_addresses.begin(), expected_addresses.end());
   EXPECT_EQ(director_addresses, expected_addresses);
-
-  cleanup();
 }
 
 class AddressesAndPortsSetup : public ::testing::Test {

--- a/core/src/tests/addresses_and_ports.cc
+++ b/core/src/tests/addresses_and_ports.cc
@@ -26,6 +26,9 @@
 #include "lib/watchdog.h"
 #include "lib/berrno.h"
 
+
+static void cleanup() { TermMsg(); }
+
 static bool create_and_bind_v4socket(int test_fd, int port)
 {
   int family = AF_INET;
@@ -127,6 +130,7 @@ static bool try_binding_director_port(std::string path_to_config,
   directordaemon::StopSocketServer();
   StopWatchdog();
 
+  cleanup();
   return result;
 }
 
@@ -153,6 +157,8 @@ static void check_addresses_list(std::string path_to_config,
   std::sort(director_addresses.begin(), director_addresses.end());
   std::sort(expected_addresses.begin(), expected_addresses.end());
   EXPECT_EQ(director_addresses, expected_addresses);
+
+  cleanup();
 }
 
 class AddressesAndPortsSetup : public ::testing::Test {

--- a/core/src/tests/bsock_constructor_test.cc
+++ b/core/src/tests/bsock_constructor_test.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -171,8 +171,6 @@ TEST(bsock, bareossockettcp_copy_constructor_test)
   p->src_addr = nullptr;
   p->who_ = nullptr;
   p->host_ = nullptr;
-  p->msg = nullptr;
-  p->errmsg = nullptr;
   p->tid_ = nullptr;
   p->jcr_ = nullptr;
 

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -58,7 +58,6 @@ static void InitGlobals()
   console::director_resource = nullptr;
   console::console_resource = nullptr;
   console::me = nullptr;
-  InitMsg(NULL, NULL);
 }
 
 static PConfigParser ConsolePrepareResources(const std::string& path_to_config)
@@ -150,7 +149,6 @@ static bool do_connection_test(std::string path_to_config, TlsPolicy tls_policy)
 
   directordaemon::StopSocketServer();
   StopWatchdog();
-
   return true;
 }
 

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -68,8 +68,6 @@ class CatalogTest : public ::testing::Test {
 
 void CatalogTest::SetUp()
 {
-  InitMsg(nullptr, nullptr);
-
   // get environment
   {
     catalog_backend_name = getenv_std_string("DBTYPE");

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -119,6 +119,7 @@ void CatalogTest::SetUp()
 
 void CatalogTest::TearDown()
 {
+  db->CloseDatabase(jcr);
   DbSqlPoolDestroy();
   DbFlushBackends();
 
@@ -136,8 +137,6 @@ void CatalogTest::TearDown()
 TEST_F(CatalogTest, database)
 {
   std::vector<char> stime;
-  auto jcr = directordaemon::NewDirectorJcr();
-
   auto result = db->FindLastJobStartTimeForJobAndClient(jcr, "backup-bareos-fd",
                                                         "bareos-fd", stime);
 

--- a/core/src/tests/create_resource.cc
+++ b/core/src/tests/create_resource.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -64,8 +64,8 @@ console::ConsoleResource* CreateAndInitializeNewConsoleResource()
   cons->tls_cert_.ca_certfile_ = CERTDIR "/bareos-ca.pem";
   cons->tls_cert_.verify_peer_ = false;
   cons->resource_name_ = (char*)"clientname";
-  cons->password.encoding = p_encoding_md5;
-  cons->password.value = (char*)"verysecretpassword";
+  cons->password_.encoding = p_encoding_md5;
+  cons->password_.value = (char*)"verysecretpassword";
   return cons;
 }
 } /* namespace console */

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -118,7 +118,7 @@ void FreeDlist(dlist<ListItem>* list)
   delete (list);
 }
 
-void test_dlist_dynamic()
+TEST(dlist, dynamic)
 {
   dlist<ListItem>* list = NULL;
   ListItem* item = NULL;
@@ -174,8 +174,7 @@ TEST(dlist, dlist)
   int count;
   int index = 0;
 
-  jcr_chain = (dlist<MYJCR>*)malloc(sizeof(dlist<MYJCR>));
-  jcr_chain->init(jcr, &jcr->link);
+  jcr_chain = new dlist<MYJCR>(jcr, &jcr->link);
 
   for (int i = 0; i < 20; i++) {
     sprintf(buf, "%d", i);
@@ -199,8 +198,7 @@ TEST(dlist, dlist)
     index--;
     free(jcr->buf);
   }
-  jcr_chain->destroy();
-  free(jcr_chain);
+  delete jcr_chain;
 
   /* The following may seem a bit odd, but we create a chaing
    *  of jcr objects.  Within a jcr object, there is a buf
@@ -278,16 +276,20 @@ TEST(dlist, dlist)
     jcr->buf = NULL;
   }
   delete jcr_chain;
+}
 
+TEST(dlist, dlistString)
+{
   /* Finally, do a test using the dlistString string helper, which
    *  allocates a dlist node and stores the string directly in
    *  it.
    */
+  char buf[30];
+  int count{0};
   auto chain = std::make_unique<dlist<dlistString>>();
   chain->append(new_dlistString("This is a long test line"));
 #define CNT 6
   strcpy(buf, "ZZZ");
-  count = 0;
   for (int i = 0; i < CNT; i++) {
     for (int j = 0; j < CNT; j++) {
       for (int k = 0; k < CNT; k++) {
@@ -305,6 +307,4 @@ TEST(dlist, dlist)
   foreach_dlist (node, chain) {
   }
   chain->destroy();
-
-  test_dlist_dynamic();
 }

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -174,7 +174,7 @@ TEST(dlist, dlist)
   int count;
   int index = 0;
 
-  jcr_chain = new dlist<MYJCR>(jcr, &jcr->link);
+  jcr_chain = new dlist<MYJCR>();
 
   for (int i = 0; i < 20; i++) {
     sprintf(buf, "%d", i);
@@ -204,7 +204,7 @@ TEST(dlist, dlist)
    *  of jcr objects.  Within a jcr object, there is a buf
    *  that points to a malloced string containing data
    */
-  jcr_chain = new dlist<MYJCR>(jcr, &jcr->link);
+  jcr_chain = new dlist<MYJCR>();
   for (int i = 0; i < 20; i++) {
     sprintf(buf, "%d", i);
     jcr = (MYJCR*)malloc(sizeof(MYJCR));
@@ -232,7 +232,7 @@ TEST(dlist, dlist)
 
 
   /* Now do a binary insert for the list */
-  jcr_chain = new dlist<MYJCR>(jcr, &jcr->link);
+  jcr_chain = new dlist<MYJCR>();
 #define CNT 6
   strcpy(buf, "ZZZ");
   count = 0;

--- a/core/src/tests/globbing_test.cc
+++ b/core/src/tests/globbing_test.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -37,8 +37,10 @@ namespace directordaemon {
 bool DoReloadConfig() { return false; }
 }  // namespace directordaemon
 
-void InitContexts(UaContext* ua, TreeContext* tree)
+void InitContexts(UaContext*& ua, TreeContext* tree)
 {
+  ua = (UaContext*)malloc(sizeof(UaContext));
+  ua = new (ua) UaContext();
   ua->cmd = GetPoolMemory(PM_FNAME);
   ua->args = GetPoolMemory(PM_FNAME);
   ua->errmsg = GetPoolMemory(PM_FNAME);
@@ -83,17 +85,18 @@ int FakelsCmd(UaContext* ua, TreeContext* tree, std::string path)
 void PopulateTree(std::vector<std::string> files, TreeContext* tree)
 {
   int pnl, fnl;
-  char* filename = GetPoolMemory(PM_FNAME);
-  char* path = GetPoolMemory(PM_FNAME);
+  PoolMem filename{PM_FNAME};
+  PoolMem path{PM_FNAME};
 
   for (auto file : files) {
-    SplitPathAndFilename(file.c_str(), path, &pnl, filename, &fnl);
+    SplitPathAndFilename(file.c_str(), path.addr(), &pnl, filename.addr(),
+                         &fnl);
 
-    char* row0 = path;
-    char* row1 = filename;
+    char* row0 = path.c_str();
+    char* row1 = filename.c_str();
     char row2[] = "1";
     char row3[] = "2";
-    char row4[] = "ff";
+    char row4[] = "P0A CF2xg IGk B Po Po A 3Y BAA I BhjA7I BU+HEc BhjA7I A A C";
     char row5[] = "0";
     char row6[] = "0";
     char row7[] = "0";
@@ -102,6 +105,8 @@ void PopulateTree(std::vector<std::string> files, TreeContext* tree)
     InsertTreeHandler(tree, 0, row);
   }
 }
+
+void DestroyTree(TreeContext* tree) { FreeTree(tree->root); }
 
 
 TEST(globbing, globbing_in_markcmd)
@@ -115,9 +120,9 @@ TEST(globbing, globbing_in_markcmd)
   /* creating a ua context is usually done with
    * new_ua_context(JobControlRecord jcr) but database handling make it break in
    * this environment, while not being necessary for the test*/
-  UaContext ua;
+  UaContext* ua{nullptr};
   TreeContext tree;
-  InitContexts(&ua, &tree);
+  InitContexts(ua, &tree);
 
   const std::vector<std::string> files
       = {"/some/weirdfiles/normalefile",
@@ -157,47 +162,45 @@ TEST(globbing, globbing_in_markcmd)
   PopulateTree(files, &tree);
 
   // testing full paths
-  FakeCdCmd(&ua, &tree, "/");
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "*"), files.size());
+  FakeCdCmd(ua, &tree, "/");
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "*"), files.size());
 
   EXPECT_EQ(
-      FakeMarkCmd(&ua, &tree, "/testingwildcards/lonesubdirectory/whatever"),
-      1);
+      FakeMarkCmd(ua, &tree, "/testingwildcards/lonesubdirectory/whatever"), 1);
 
   EXPECT_EQ(
-      FakeMarkCmd(&ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 1);
+      FakeMarkCmd(ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 1);
 
   // Using full path while being in a different folder than root
-  FakeCdCmd(&ua, &tree, "/some/weirdfiles/");
+  FakeCdCmd(ua, &tree, "/some/weirdfiles/");
   EXPECT_EQ(
-      FakeMarkCmd(&ua, &tree, "/testingwildcards/lonesubdirectory/whatever"),
-      1);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "/testingwildcards/sub*"), 6);
+      FakeMarkCmd(ua, &tree, "/testingwildcards/lonesubdirectory/whatever"), 1);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "/testingwildcards/sub*"), 6);
 
   EXPECT_EQ(
-      FakeMarkCmd(&ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 0);
+      FakeMarkCmd(ua, &tree, "testingwildcards/lonesubdirectory/whatever"), 0);
 
   // Testing patterns in different folders
-  FakeCdCmd(&ua, &tree, "/some/weirdfiles/");
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "nope"), 0);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "potato"), 1);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "potato*"), 2);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "lonesubdirectory/*"), 1);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "subdirectory2/*"), 2);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "sub*/*"), 6);
+  FakeCdCmd(ua, &tree, "/some/weirdfiles/");
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "nope"), 0);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "potato"), 1);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "potato*"), 2);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "lonesubdirectory/*"), 1);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "subdirectory2/*"), 2);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "sub*/*"), 6);
 
-  FakeCdCmd(&ua, &tree, "/some/");
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "w*/sub*/*"), 12);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "wei*/sub*/*"), 6);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "wei*/subroza/*"), 0);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "w*efiles/sub*/*"), 6);
+  FakeCdCmd(ua, &tree, "/some/");
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "w*/sub*/*"), 12);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "wei*/sub*/*"), 6);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "wei*/subroza/*"), 0);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "w*efiles/sub*/*"), 6);
 
-  FakeCdCmd(&ua, &tree, "/testingwildcards/");
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "p?tato"), 1);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "subdirectory?/file1"), 1);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "subdirectory?/file?"), 6);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "subdirectory?/file[!2,!3]"), 4);
-  EXPECT_EQ(FakeMarkCmd(&ua, &tree, "su[a,b,c]directory?/file1"), 1);
+  FakeCdCmd(ua, &tree, "/testingwildcards/");
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "p?tato"), 1);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "subdirectory?/file1"), 1);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "subdirectory?/file?"), 6);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "subdirectory?/file[!2,!3]"), 4);
+  EXPECT_EQ(FakeMarkCmd(ua, &tree, "su[a,b,c]directory?/file1"), 1);
 
   /* The following two tests are commented out because they should be working
    * correctly, but as the second test suggests, fnmatch (which is the main
@@ -206,6 +209,7 @@ TEST(globbing, globbing_in_markcmd)
    */
   //  EXPECT_EQ(FakeMarkCmd(&ua, tree, "{*tory1,*tory2}/file1"), 1);
   //  EXPECT_EQ(fnmatch("{*tory1,*tory2}", "subdirectory1", 0), 0);
-
+  FreeUaContext(ua);
+  DestroyTree(&tree);
   delete me;
 }

--- a/core/src/tests/htable_test.cc
+++ b/core/src/tests/htable_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -58,12 +58,10 @@ TEST(htable, htable)
   HTABLEJCR* jcr = NULL;
   int count = 0;
 
-  jcrtbl = (htable*)malloc(sizeof(htable));
-
 #ifndef TEST_SMALL_HTABLE
-  jcrtbl->init(jcr, &jcr->link, NITEMS);
+  jcrtbl = new htable(jcr, &jcr->link, NITEMS);
 #else
-  jcrtbl->init(jcr, &jcr->link, NITEMS, 128);
+  jcrtbl = new htable(jcr, &jcr->link, NITEMS, 128);
 #endif
   for (int i = 0; i < NITEMS; i++) {
 #ifndef TEST_NON_CHAR
@@ -86,9 +84,8 @@ TEST(htable, htable)
     count++;
   }
 
-  jcrtbl->destroy();
+  delete jcrtbl;
   EXPECT_EQ(count, NITEMS);
-  free(jcrtbl);
 }
 
 struct RbListJobControlRecord {

--- a/core/src/tests/htable_test.cc
+++ b/core/src/tests/htable_test.cc
@@ -52,16 +52,17 @@ struct HTABLEJCR {
 #endif
 TEST(htable, htable)
 {
+  using JcrTable = htable<decltype(HTABLEJCR::key), HTABLEJCR>;
   char mkey[30];
-  htable* jcrtbl;
+  JcrTable* jcrtbl;
   HTABLEJCR *save_jcr = NULL, *item;
   HTABLEJCR* jcr = NULL;
   int count = 0;
 
 #ifndef TEST_SMALL_HTABLE
-  jcrtbl = new htable(jcr, &jcr->link, NITEMS);
+  jcrtbl = new JcrTable(jcr, &jcr->link, NITEMS);
 #else
-  jcrtbl = new htable(jcr, &jcr->link, NITEMS, 128);
+  jcrtbl = new JcrTable(jcr, &jcr->link, NITEMS, 128);
 #endif
   for (int i = 0; i < NITEMS; i++) {
 #ifndef TEST_NON_CHAR

--- a/core/src/tests/htable_test.cc
+++ b/core/src/tests/htable_test.cc
@@ -52,18 +52,19 @@ struct HTABLEJCR {
 #endif
 TEST(htable, htable)
 {
+#ifdef TEST_SMALL_HTABLE
   using JcrTable = htable<decltype(HTABLEJCR::key), HTABLEJCR>;
+#else
+  using JcrTable
+      = htable<decltype(HTABLEJCR::key), HTABLEJCR, htableBufferSize::medium>;
+#endif
   char mkey[30];
   JcrTable* jcrtbl;
   HTABLEJCR *save_jcr = NULL, *item;
   HTABLEJCR* jcr = NULL;
   int count = 0;
 
-#ifndef TEST_SMALL_HTABLE
-  jcrtbl = new JcrTable(jcr, &jcr->link, NITEMS);
-#else
-  jcrtbl = new JcrTable(jcr, &jcr->link, NITEMS, 128);
-#endif
+  jcrtbl = new JcrTable(NITEMS);
   for (int i = 0; i < NITEMS; i++) {
 #ifndef TEST_NON_CHAR
     int len;

--- a/core/src/tests/htable_test.cc
+++ b/core/src/tests/htable_test.cc
@@ -55,8 +55,8 @@ TEST(htable, htable)
 #ifdef TEST_SMALL_HTABLE
   using JcrTable = htable<decltype(HTABLEJCR::key), HTABLEJCR>;
 #else
-  using JcrTable
-      = htable<decltype(HTABLEJCR::key), HTABLEJCR, htableBufferSize::medium>;
+  using JcrTable = htable<decltype(HTABLEJCR::key), HTABLEJCR,
+                          MonotonicBuffer::Size::Medium>;
 #endif
   char mkey[30];
   JcrTable* jcrtbl;

--- a/core/src/tests/messages_resource.cc
+++ b/core/src/tests/messages_resource.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -152,4 +152,5 @@ TEST(messages_resource, send_message_to_all_configured_destinations)
   SetDbLogInsertCallback(DbLogInsertCallback_);
 
   DispatchMessage(&jcr, M_ERROR, 0, "\n!!!This is a test error message!!!\n");
+  TermMsg();
 }

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -74,7 +74,6 @@ class RunOnIncomingConnectIntervalTest : public ::testing::Test {
 void RunOnIncomingConnectIntervalTest::SetUp()
 {
   OSDependentInit();
-  InitMsg(nullptr, nullptr);
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/run-on-incoming-connect-interval/");

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -151,6 +151,7 @@ static void SchedulerJobCallback(JobControlRecord* jcr)
 
   // add job-name to map
   test_results.job_names[jcr->impl->res.job->resource_name_]++;
+  FreeJcr(jcr);
 }
 
 class MockDatabase : public BareosDb {

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -1,7 +1,7 @@
 /*
   BAREOS® - Backup Archiving REcovery Open Sourced
 
-  Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+  Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
   This program is Free Software; you can redistribute it and/or
   modify it under the terms of version three of the GNU Affero General Public
@@ -88,8 +88,6 @@ static void StopScheduler(std::chrono::milliseconds timeout)
 
 TEST_F(SchedulerTest, terminate)
 {
-  InitMsg(NULL, NULL); /* initialize message handler */
-
   std::string path_to_config_file
       = std::string(RELATIVE_PROJECT_SOURCE_DIR "/configs/scheduler-hourly");
 
@@ -180,8 +178,6 @@ static int CalculateAverage()
 
 TEST_F(SchedulerTest, hourly)
 {
-  InitMsg(NULL, NULL);
-
   if (debug) { std::cout << "Start test" << std::endl; }
 
   std::string path_to_config_file{
@@ -240,8 +236,6 @@ TEST_F(SchedulerTest, hourly)
 static void TestWithConfig(std::string path_to_config_file,
                            std::vector<uint8_t> wdays)
 {
-  InitMsg(NULL, NULL);
-
   if (debug) { std::cout << "Start test" << std::endl; }
 
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -277,6 +271,7 @@ static void TestWithConfig(std::string path_to_config_file,
   }
 
   if (debug) { std::cout << "End" << std::endl; }
+
   delete my_config;
 }
 
@@ -315,8 +310,6 @@ TEST_F(SchedulerTest, on_time_noday_noclient)
 
 TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
 {
-  InitMsg(NULL, NULL);
-
   if (debug) { std::cout << "Start test" << std::endl; }
 
   std::string path_to_config_file{std::string(
@@ -343,6 +336,5 @@ TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
 
   scheduler_thread.join();
   ASSERT_EQ(counter_of_number_of_jobs_run, 1);
-
   delete my_config;
 }

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -67,7 +67,6 @@ class sd : public ::testing::Test {
 void sd::SetUp()
 {
   OSDependentInit();
-  InitMsg(NULL, NULL);
 
   debug_level = 900;
 
@@ -103,7 +102,6 @@ void sd::TearDown()
   if (configfile) { free(configfile); }
   if (my_config) { delete my_config; }
 
-  TermMsg();
   TermReservationsLock();
 }
 

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -72,7 +72,6 @@ class ReservationTest : public ::testing::Test {
 void ReservationTest::SetUp()
 {
   OSDependentInit();
-  InitMsg(NULL, NULL);
 
   /* configfile is a global char* from stored_globals.h */
   configfile = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/sd_reservation/");
@@ -108,7 +107,6 @@ void ReservationTest::TearDown()
   if (configfile) { free(configfile); }
   if (my_config) { delete my_config; }
 
-  TermMsg();
   TermReservationsLock();
 }
 

--- a/core/src/tests/test_bsnprintf.cc
+++ b/core/src/tests/test_bsnprintf.cc
@@ -75,6 +75,11 @@ TEST(bsnprintf, len_param)
   // truncate the string by parameter
   EXPECT_EQ(Bsnprintf(dest, 100, "-%.*s-", 5, "Some String"), 7);
   EXPECT_STREQ(dest, "-Some -");
+
+  // fixed length string value with no null-terminator
+  const char fixed_str[] = {'a', 'b', 'c', 'd', 'e', 'f'};
+  EXPECT_EQ(Bsnprintf(dest, 100, "-%.*s-", 6, fixed_str), 8);
+  EXPECT_STREQ(dest, "-abcdef-");
 }
 
 TEST(bsnprintf, char)

--- a/core/src/tests/test_bsnprintf.cc
+++ b/core/src/tests/test_bsnprintf.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -103,18 +103,17 @@ TEST(bsnprintf, pointer)
 {
   char dest[100];
   void* null = nullptr;
-  void* ones = static_cast<void*>(static_cast<char*>(null) - 1);
+  void* ones = reinterpret_cast<void*>(UINTPTR_MAX);
 
   EXPECT_EQ(Bsnprintf(dest, 100, "%p", null), 1);
   EXPECT_STREQ(dest, "0");
-
-#if UINTPTR_MAX == 0xFFFFFFFF
-  EXPECT_EQ(Bsnprintf(dest, 100, "%p", ones), 8);
-  EXPECT_STREQ(dest, "ffffffff");
-#else
-  EXPECT_EQ(Bsnprintf(dest, 100, "%p", ones), 16);
-  EXPECT_STREQ(dest, "ffffffffffffffff");
-#endif
+  if constexpr (sizeof(void*) == 4) {
+    EXPECT_EQ(Bsnprintf(dest, 100, "%p", ones), 8);
+    EXPECT_STREQ(dest, "ffffffff");
+  } else {
+    EXPECT_EQ(Bsnprintf(dest, 100, "%p", ones), 16);
+    EXPECT_STREQ(dest, "ffffffffffffffff");
+  }
 }
 
 TEST(bsnprintf, integers)

--- a/core/src/tests/test_bsock.cc
+++ b/core/src/tests/test_bsock.cc
@@ -117,9 +117,9 @@ static void start_bareos_server(std::promise<bool>* promise,
   std::unique_ptr<BareosSocket> bs(create_new_bareos_socket(newsockfd));
 
   char* name = (char*)console_name.c_str();
-  s_password* password = new (s_password);
-  password->encoding = p_encoding_md5;
-  password->value = (char*)console_password.c_str();
+  s_password password;
+  password.encoding = p_encoding_md5;
+  password.value = (char*)console_password.c_str();
 
   bool success = false;
   if (bs->recv() <= 0) {
@@ -130,7 +130,7 @@ static void start_bareos_server(std::promise<bool>* promise,
           bs->message_length);
   } else {
     Dmsg1(10, "Cons->Dir: %s", bs->msg);
-    if (!bs->AuthenticateInboundConnection(NULL, nullptr, name, *password,
+    if (!bs->AuthenticateInboundConnection(NULL, nullptr, name, password,
                                            dir_cons_config.get())) {
       Dmsg0(10, "Server: inbound auth failed\n");
     } else {
@@ -195,9 +195,9 @@ static bool connect_to_server(std::string console_name,
 
   char* name = (char*)console_name.c_str();
 
-  s_password* password = new (s_password);
-  password->encoding = p_encoding_md5;
-  password->value = (char*)console_password.c_str();
+  s_password password;
+  password.encoding = p_encoding_md5;
+  password.value = (char*)console_password.c_str();
 
   std::shared_ptr<BareosSocketTCP> UA_sock(new BareosSocketTCP);
   UA_sock->sleep_time_after_authentication_error = 0;
@@ -214,7 +214,7 @@ static bool connect_to_server(std::string console_name,
     uint32_t response_id = kMessageIdUnknown;
     BStringList response_args;
     if (!UA_sock->ConsoleAuthenticateWithDirector(
-            &jcr, name, *password, cons_dir_config.get(), console_name,
+            &jcr, name, password, cons_dir_config.get(), console_name,
             response_args, response_id)) {
       Emsg0(M_ERROR, 0, "Authenticate Failed\n");
     } else {

--- a/core/src/tests/test_bsock.cc
+++ b/core/src/tests/test_bsock.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,7 +92,6 @@ void InitForTest()
 
   working_directory = "/tmp";
   MyNameIs(0, NULL, "bsock_test");
-  InitMsg(NULL, NULL);
 }
 
 static void clone_a_server_socket(BareosSocket* bs)

--- a/core/src/tests/test_config_parser_console.cc
+++ b/core/src/tests/test_config_parser_console.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,7 +35,6 @@ namespace console {
 TEST(ConfigParser, test_console_config)
 {
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
@@ -46,8 +45,6 @@ TEST(ConfigParser, test_console_config)
   my_config->DumpResources(PrintMessage, NULL);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 }  // namespace console

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,7 +35,6 @@ namespace directordaemon {
 TEST(ConfigParser_Dir, bareos_configparser_tests)
 {
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
@@ -45,14 +44,11 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   my_config->DumpResources(PrintMessage, NULL);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 TEST(ConfigParser_Dir, runscript_test)
 {
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/runscript-tests/bareos-dir.conf");
@@ -62,8 +58,6 @@ TEST(ConfigParser_Dir, runscript_test)
   my_config->DumpResources(PrintMessage, NULL);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 void test_config_directive_type(
@@ -73,7 +67,6 @@ void test_config_directive_type(
       ::testing::UnitTest::GetInstance()->current_test_info()->name());
 
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file
       = std::string(RELATIVE_PROJECT_SOURCE_DIR
@@ -93,8 +86,6 @@ void test_config_directive_type(
   test_func(me);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 

--- a/core/src/tests/test_config_parser_fd.cc
+++ b/core/src/tests/test_config_parser_fd.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,7 +35,6 @@ namespace filedaemon {
 TEST(ConfigParser, test_filed_config)
 {
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
@@ -46,8 +45,6 @@ TEST(ConfigParser, test_filed_config)
   my_config->DumpResources(PrintMessage, NULL);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 }  // namespace filedaemon

--- a/core/src/tests/test_config_parser_sd.cc
+++ b/core/src/tests/test_config_parser_sd.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,7 +35,6 @@ namespace storagedaemon {
 TEST(ConfigParser, test_stored_config)
 {
   OSDependentInit();
-  InitMsg(NULL, NULL); /* initialize message handler */
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
@@ -45,8 +44,6 @@ TEST(ConfigParser, test_stored_config)
   my_config->DumpResources(PrintMessage, NULL);
 
   delete my_config;
-
-  TermMsg(); /* Terminate message handler */
 }
 
 }  // namespace storagedaemon

--- a/core/src/tests/test_dir_plugins.cc
+++ b/core/src/tests/test_dir_plugins.cc
@@ -55,8 +55,6 @@ TEST(dir, dir_plugins)
   JobControlRecord* jcr1 = &mjcr1;
   JobControlRecord* jcr2 = &mjcr2;
 
-  InitMsg(NULL, NULL);
-
   OSDependentInit();
   (void)!getcwd(plugin_dir, sizeof(plugin_dir) - 1);
 
@@ -78,8 +76,6 @@ TEST(dir, dir_plugins)
   FreePlugins(jcr2);
 
   UnloadDirPlugins();
-
-  TermMsg();
 }
 
 } /* namespace directordaemon */

--- a/core/src/tests/test_dir_plugins.cc
+++ b/core/src/tests/test_dir_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -38,8 +38,6 @@
 #include "lib/edit.h"
 
 namespace directordaemon {
-
-DirectorResource* me = nullptr;
 
 bool DbGetPoolRecord(JobControlRecord*, BareosDb*, PoolDbRecord*);
 bool DbGetPoolRecord(JobControlRecord*, BareosDb*, PoolDbRecord*)

--- a/core/src/tests/test_fd_plugins.cc
+++ b/core/src/tests/test_fd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -96,8 +96,6 @@ TEST(fd, fd_plugins)
   JobControlRecord* jcr1 = &mjcr1;
   JobControlRecord* jcr2 = &mjcr2;
 
-  InitMsg(NULL, NULL);
-
   OSDependentInit();
 
   (void)!getcwd(plugin_dir, sizeof(plugin_dir) - 1);
@@ -120,7 +118,5 @@ TEST(fd, fd_plugins)
   FreePlugins(jcr2);
 
   UnloadFdPlugins();
-
-  TermMsg();
 }
 } /* namespace filedaemon */

--- a/core/src/tests/test_poolmem.cc
+++ b/core/src/tests/test_poolmem.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -76,6 +76,7 @@ TEST(poolmem, alloc)
   EXPECT_NE(pm6, pm5);
   EXPECT_EQ(SizeofPoolMemory(pm6), 128);
 
+  FreePoolMemory(pm0);
   FreePoolMemory(pm1);
   FreePoolMemory(pm2);
   FreePoolMemory(pm3);

--- a/core/src/tests/test_sd_plugins.cc
+++ b/core/src/tests/test_sd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -48,8 +48,6 @@ TEST(sd, sd_plugins)
   JobControlRecord* jcr1 = &mjcr1;
   JobControlRecord* jcr2 = &mjcr2;
 
-  InitMsg(NULL, NULL);
-
   OSDependentInit();
 
   (void)!getcwd(plugin_dir, sizeof(plugin_dir) - 1);
@@ -72,8 +70,6 @@ TEST(sd, sd_plugins)
   FreePlugins(jcr2);
 
   UnloadSdPlugins();
-
-  TermMsg();
 }
 
 } /* namespace storagedaemon */

--- a/core/src/tools/bscrypto.cc
+++ b/core/src/tools/bscrypto.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2012-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -201,7 +201,6 @@ int main(int argc, char* const* argv)
   }
 
   OSDependentInit();
-  InitMsg(NULL, NULL);
 
   if (dump_cache) {
     // Load any keys currently in the cache.

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -246,7 +246,7 @@ int main(int argc, char* argv[])
 #if defined(HAVE_WIN32)
   SOCKET s;
 #else
-  int s = 0, r = 0;
+  int s{}, r{};
   struct passwd* pwd;
 #endif
   char *cp, *p;

--- a/core/src/win32/findlib/win32.cc
+++ b/core/src/win32/findlib/win32.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -138,58 +138,6 @@ int get_win32_driveletters(findFILESET* fileset, char* szDrives)
   }
 
   return nCount;
-}
-
-/**
- * For VSS we need to know which windows virtual mountpoints are used, because
- * we create a snapshot of all used drives and virtual mountpoints. This
- * function returns the number of used virtual mountpoints and fills szVmps with
- * a list of all virtual mountpoints.
- */
-int get_win32_virtualmountpoints(findFILESET* fileset,
-                                 dlist<dlistString>** szVmps)
-{
-  int i, cnt;
-  char* fname;
-  struct stat sb;
-  dlistString* node;
-  findIncludeExcludeItem* incexe;
-  POOLMEM* devicename;
-
-  cnt = 0;
-  if (fileset) {
-    devicename = GetPoolMemory(PM_FNAME);
-    for (i = 0; i < fileset->include_list.size(); i++) {
-      incexe = (findIncludeExcludeItem*)fileset->include_list.get(i);
-      // Look through all files and check
-      foreach_dlist (node, &incexe->name_list) {
-        fname = node->c_str();
-
-        // See if the entry has the FILE_ATTRIBUTE_VOLUME_MOUNT_POINT flag set.
-        if (stat(fname, &sb) == 0) {
-          if (!(sb.st_rdev & FILE_ATTRIBUTE_VOLUME_MOUNT_POINT)) { continue; }
-        } else {
-          continue;
-        }
-
-        if (win32_get_vmp_devicename(fname, devicename)) {
-          // See if we need to allocate a new dlist.
-          if (!cnt) {
-            if (!*szVmps) {
-              *szVmps = (dlist<dlistString>*)malloc(sizeof(dlist<dlistString>));
-              (*szVmps)->init();
-            }
-          }
-
-          (*szVmps)->append(new_dlistString(devicename));
-          cnt++;
-        }
-      }
-    }
-    FreePoolMemory(devicename);
-  }
-
-  return cnt;
 }
 
 static inline bool WantedDriveType(const char* drive,

--- a/systemtests/tests/messages/testrunner
+++ b/systemtests/tests/messages/testrunner
@@ -38,7 +38,7 @@ rm -f "$mail_file"
 rm -f "$operator_file"
 
 function exit_error() {
-  [ "$1" == "" ] || echo "$1"
+  [ "${1:-}" == "" ] || echo "$1"
   estat=1
   end_test
   exit 1


### PR DESCRIPTION
This PR fixes a lot (hopefully most) of the issues that you will uncover when running ctest after building with `-fsanitize=address` and `-fsanitize=undefined`.

Besides a lot of smaller changes fixing undefined behaviour and memory leaks, this PR fixes a long-standing bug in Bvsnprintf() and refactors dlist and htable to be templatized and type-safe.
We also disable warnings for invalid uses of offsetof (see specific commit for details) and stop building packages for Debian 9 and Univention 4.4.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
