### PR TITLE
debian: add missing python plugin dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,12 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+- debian: add missing python plugin dependencies [PR #1061] (backport of [PR #1045])
+
 ### Added
 - ndmp: introduce workaround for isilon 9.1.0.0 'Invalid nlist.tape_offset -1' error [PR #1058]
+
 
 ## [20.0.5] - 2021-12-20
 
@@ -461,5 +465,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #991]: https://github.com/bareos/bareos/pull/991
 [PR #1000]: https://github.com/bareos/bareos/pull/1000
 [PR #1001]: https://github.com/bareos/bareos/pull/1001
+[PR #1045]: https://github.com/bareos/bareos/pull/1045
 [PR #1058]: https://github.com/bareos/bareos/pull/1058
+[PR #1061]: https://github.com/bareos/bareos/pull/1061
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/debian/control.bareos-director-python2-plugin
+++ b/debian/control.bareos-director-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-director-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin

--- a/debian/control.bareos-director-python3-plugin
+++ b/debian/control.bareos-director-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-director-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin

--- a/debian/control.bareos-filedaemon-python2-plugin
+++ b/debian/control.bareos-filedaemon-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-filedaemon-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, bareos-filedaemon-python-plugins-common
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin

--- a/debian/control.bareos-filedaemon-python3-plugin
+++ b/debian/control.bareos-filedaemon-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-filedaemon-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, bareos-filedaemon-python-plugins-common
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python3-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin

--- a/debian/control.bareos-storage-python2-plugin
+++ b/debian/control.bareos-storage-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-storage-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin

--- a/debian/control.bareos-storage-python3-plugin
+++ b/debian/control.bareos-storage-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-storage-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin


### PR DESCRIPTION
(Backports some part of #1038)
Some dependencies are missing in the Debian package, while they exists in RPM.
This change adds them also to Debian.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing