### PR TITLE
stored: enable labeling of tapes in devices even when `autoselect = no`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - Adapt percona-xtrabackup test to work on updated test environment [PR #978]
 - Fixed libdroplet xattr.h include issue by using sys/xattr.h [PR #991]
+- stored: enable labeling of tapes in drives even if `autoselect=no` [PR #1064] (backport of [PR #1021]) 
 
 ## [20.0.3] - 2021-09-14
 
@@ -465,7 +466,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #991]: https://github.com/bareos/bareos/pull/991
 [PR #1000]: https://github.com/bareos/bareos/pull/1000
 [PR #1001]: https://github.com/bareos/bareos/pull/1001
+[PR #1021]: https://github.com/bareos/bareos/pull/1021
 [PR #1045]: https://github.com/bareos/bareos/pull/1045
 [PR #1058]: https://github.com/bareos/bareos/pull/1058
 [PR #1061]: https://github.com/bareos/bareos/pull/1061
+[PR #1064]: https://github.com/bareos/bareos/pull/1064
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -970,11 +970,7 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
                  device_resource->resource_name_, devname.c_str());
             continue;
           }
-          if (!device_resource->dev->autoselect) {
-            Dmsg1(100, "Device %s not autoselect skipped.\n", devname.c_str());
-            continue; /* device is not available */
-          }
-          if (drive == kInvalidDriveNumber
+          if ((drive == kInvalidDriveNumber && device_resource->dev->autoselect)
               || drive == device_resource->dev->drive) {
             Dmsg1(20, "Found changer device %s\n",
                   device_resource->resource_name_);


### PR DESCRIPTION
### Description
(Backports PR #1021 without its tests, as they did not exist in 20)
When devices are set with the option autoselect=no, labeling and releasing is not possible as the device is skipped in the search. This PR handles this issue by not accounting for the autoselect attribute when searching devices. This has the same effect on the mount, unmount, as well as readlabel and autochanger commands. Backups are not affected.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- ~`bareos-check-sources --since-merge` does not report any problems~
- [x] `git status` should not report modifications in the source tree after building and testing