### PR TITLE
stored: enable labeling of tapes in devices even when `autoselect = no`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Allow `release` command to be used in scripts [PR #961]
 - webui: format total jobs and total files language-sensitive [PR #996]
 - webui: update localization [PR #1018]
+- stored: enable labeling of tapes in drives even if `autoselect=no` [PR #1065] (backport of [PR #1021])
 
 ### Deprecated
 - Deprecated directives [PR #928] and [PR #949]
@@ -404,6 +405,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1018]: https://github.com/bareos/bareos/pull/1018
 [PR #1019]: https://github.com/bareos/bareos/pull/1019
 [PR #1020]: https://github.com/bareos/bareos/pull/1020
+[PR #1021]: https://github.com/bareos/bareos/pull/1021
 [PR #1022]: https://github.com/bareos/bareos/pull/1022
 [PR #1023]: https://github.com/bareos/bareos/pull/1023
 [PR #1024]: https://github.com/bareos/bareos/pull/1024
@@ -421,4 +423,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1052]: https://github.com/bareos/bareos/pull/1052
 [PR #1053]: https://github.com/bareos/bareos/pull/1053
 [PR #1055]: https://github.com/bareos/bareos/pull/1055
+[PR #1063]: https://github.com/bareos/bareos/pull/1063
+[PR #1065]: https://github.com/bareos/bareos/pull/1065
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -920,11 +920,7 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
                  device_resource->resource_name_, devname.c_str());
             continue;
           }
-          if (!device_resource->dev->autoselect) {
-            Dmsg1(100, "Device %s not autoselect skipped.\n", devname.c_str());
-            continue; /* device is not available */
-          }
-          if (drive == kInvalidDriveNumber
+          if ((drive == kInvalidDriveNumber && device_resource->dev->autoselect)
               || drive == device_resource->dev->drive) {
             Dmsg1(20, "Found changer device %s\n",
                   device_resource->resource_name_);

--- a/systemtests/tests/autochanger/CMakeLists.txt
+++ b/systemtests/tests/autochanger/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -22,13 +22,13 @@ if(AUTOCHANGER_TEST_ENABLED)
   create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
   # Make sure these tests run sequentially.
   set_tests_properties(
-    ${SYSTEMTEST_PREFIX}autochanger:backup-restore PROPERTIES RESOURCE_LOCK
-                                               autochanger_resource
+    ${SYSTEMTEST_PREFIX}autochanger:backup-restore
+    PROPERTIES RESOURCE_LOCK autochanger_resource
   )
-set_tests_properties(
-  ${SYSTEMTEST_PREFIX}autochanger:label-release-autoselect PROPERTIES RESOURCE_LOCK
-                                             autochanger_resource
-)
+  set_tests_properties(
+    ${SYSTEMTEST_PREFIX}autochanger:label-release-autoselect
+    PROPERTIES RESOURCE_LOCK autochanger_resource
+  )
 else()
   create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME} DISABLED)
 endif()

--- a/systemtests/tests/autochanger/test-setup
+++ b/systemtests/tests/autochanger/test-setup
@@ -1,6 +1,8 @@
+#!/bin/bash
+
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -17,18 +19,35 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
-if(AUTOCHANGER_TEST_ENABLED)
-  create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
-  # Make sure these tests run sequentially.
-  set_tests_properties(
-    ${SYSTEMTEST_PREFIX}autochanger:backup-restore PROPERTIES RESOURCE_LOCK
-                                               autochanger_resource
-  )
-set_tests_properties(
-  ${SYSTEMTEST_PREFIX}autochanger:label-release-autoselect PROPERTIES RESOURCE_LOCK
-                                             autochanger_resource
-)
-else()
-  create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME} DISABLED)
-endif()
+set -e
+set -o pipefail
+set -u
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+
+if ! ./invalidate_tapes.sh ${1:-}
+then
+  echo "Could not invalidate tapes"
+  exit 1
+fi
+
+if ! ./create_autochanger_configs.sh ${1:-}
+then
+  echo "Could not create autochanger configs"
+  exit 1
+fi
+
+# Fill ${BackupDirectory} with data.
+setup_data
+
+bin/bareos start
+
+# make sure, director is up and running.
+print_debug "$(bin/bconsole <<< "status dir")"

--- a/systemtests/tests/autochanger/testrunner
+++ b/systemtests/tests/autochanger/testrunner
@@ -109,11 +109,51 @@ restore jobid=${j} pool="${pool}" where=${tmp}/bareos_restores_${j} select all d
 EOF
 done
 
-echo "wait" >> bconsole_restore_jobs
-echo "messages" >> bconsole_restore_jobs
-
 # start all the restore jobs
 bin/bconsole < bconsole_restore_jobs
+
+testdevice0=tapedrive-0-.dev.tape.by-id.scsi-350223344ab000100-nst
+testdevice1=tapedrive-1-.dev.tape.by-id.scsi-350223344ab000200-nst
+
+# set devices to `autoselect = no` and wait for jobs to finish
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $tmp/log-label-release-autoselect-no.out
+setdevice storage=Tape-0  device=$testdevice0 autoselect=no
+wait
+messages
+
+label barcodes slot=8 drive=0 pool=Full-0 storage=Tape-0 yes
+setdevice storage=Tape-0  device=$testdevice0 autoselect=yes
+wait
+
+quit
+END_OF_DATA
+
+run_bconsole
+
+# Redo the backups, and check if drive 0 is still being used
+
+rm -f bconsole_backup_jobs
+echo "@$out $tmp/log-second-backups.out" >> bconsole_backup_jobs
+
+spooling="spooldata=yes"
+for i in $(seq ${NUMBER_OF_TEST_ROUNDS}); do
+  for j in $(seq ${NUMBER_OF_POOLS}); do
+    cat << EOF >> bconsole_backup_jobs
+run job=backup-bareos-fd level=Full storage=Tape-0 pool=Full-$(( j -1 )) ${spooling} yes
+status dir
+EOF
+    if [ $(( NUMBER_OF_SPOOLING_JOBS_PER_ROUND -j )) -le 0 ]; then
+      spooling=""
+    fi
+  done
+done
+
+echo "wait" >> bconsole_backup_jobs
+echo "messages" >> bconsole_backup_jobs
+
+# start all the jobs
+bin/bconsole < bconsole_backup_jobs
 
 check_for_zombie_jobs storage=Tape-0
 
@@ -125,6 +165,44 @@ for j in ${list_of_jobids}; do
      "$src" "$dst"
 done
 
+
+#testing for labeling and releasing when device is on autoselect=no
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/log-label-release-autoselect-no.out
+setdevice storage=Tape-0  device=$testdevice1 autoselect=no
+release storage=Tape-0 drive=1
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
 stop_bareos
+
+# check the that the labeling went through
+if  ! grep "Slot 8 successfully created." "$tmp"/log-label-release-autoselect-no.out &&
+      grep "3999 Device \"autochanger-0\" not found or could not be opened."
+ then
+  echo "Labeling of a device with autoselect=no was not successful. Check $tmp/log-label-release-autoselect-no.out" >&2
+  estat=1
+fi
+
+#check that release went through
+if ! grep "3921 Device \"\"tapedrive-1-.dev.tape.by-id.scsi-350223344ab000200-nst\" (/dev/tape/by-id/scsi-350223344ab000200-nst)\" already released."  "$tmp"/log-label-release-autoselect-no.out &&
+     grep "3999 Device \"autochanger-0\" not found or could not be opened." "$tmp"/log-label-release-autoselect-no.out
+   then
+  echo "Error releasing device. Check $tmp/log-label-release-autoselect-no.out" >&2
+  estat=1
+fi
+
+#check that the tapedrive works normally again after the manipulations
+if  ! grep "Using Device \"tapedrive-0" "$tmp"/log-second-backups.out; then
+  echo "An autoselected device was not used. Check $tmp/log-second-backups.out" >&2
+  estat=1
+fi
+
+
 end_test
 exit 0

--- a/systemtests/tests/autochanger/testrunner-backup-restore
+++ b/systemtests/tests/autochanger/testrunner-backup-restore
@@ -1,0 +1,116 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=./environment
+. ./environment
+. ./test-config
+
+#shellcheck source=../../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+
+on_error() {
+  local lc="${BASH_COMMAND}"
+  echo "Error occurred in testrunner script [${lc}]"
+  export estat=1
+  exit 1
+}
+trap 'on_error' ERR
+
+
+# remove jobs from previous runs
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $tmp/log-purge.out
+purge jobs yes
+2
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+
+echo "Set debug on the Tape-Storage daemon"
+tracefile="$(echo "setdebug level=200 trace=1 storage=Tape-0" | bin/bconsole | grep "^3000" | awk -F"tracefile=" '{print $2}' )"
+: > "${tracefile}" # clear tracefile
+
+echo "Label barcodes"
+for i in $(seq ${NUMBER_OF_POOLS}); do
+  pool=$(( i -1 )) #counts from 0
+  for j in $(seq ${NUMBER_OF_TAPES_PER_POOL}); do
+    slot=$(( j + pool * NUMBER_OF_TAPES_PER_POOL )) #counts from 1
+    echo "label barcodes slot=${slot} drive=0 pool=Full-${pool} storage=Tape-0 yes" | bin/bconsole | grep -E "(OK label|already exists)"
+  done
+done
+
+
+# create the test backup jobs
+rm -f bconsole_backup_jobs
+
+spooling="spooldata=yes"
+for i in $(seq ${NUMBER_OF_TEST_ROUNDS}); do
+  for j in $(seq ${NUMBER_OF_POOLS}); do
+    cat << EOF >> bconsole_backup_jobs
+run job=backup-bareos-fd level=Full storage=Tape-0 pool=Full-$(( j -1 )) ${spooling} yes
+status dir
+EOF
+    if [ $(( NUMBER_OF_SPOOLING_JOBS_PER_ROUND -j )) -le 0 ]; then
+      spooling=""
+    fi
+  done
+done
+
+echo "wait" >> bconsole_backup_jobs
+echo "messages" >> bconsole_backup_jobs
+
+# start all the jobs
+bin/bconsole < bconsole_backup_jobs
+
+# prepare the restore
+
+list_of_jobids=$(echo "list jobs" \
+  | bin/bconsole \
+  | grep "backup-bareos-fd" \
+  | sed 's/| *\([0-9]\{1,\}\).*$/\1/')
+
+if [ "${list_of_jobids}" -eq 0 ]; then
+  echo "no jobs found for restore"
+  export estat=1
+  exit 1
+fi
+
+
+rm -f bconsole_restore_jobs
+poolnumber=$((NUMBER_OF_POOLS));
+for j in ${list_of_jobids}; do
+  pool="Full-$((poolnumber -1))"
+  cat << EOF >> bconsole_restore_jobs
+restore jobid=${j} pool="${pool}" where=${tmp}/bareos_restores_${j} select all done yes
+EOF
+   poolnumber=$((poolnumber -1))
+done
+
+echo "wait" >> bconsole_restore_jobs
+echo "messages" >> bconsole_restore_jobs
+
+# start all the restore jobs
+bin/bconsole < bconsole_restore_jobs
+
+# does not compare fifo files
+for j in ${list_of_jobids}; do
+  src="${tmp}/data"
+  dst="${tmp}/bareos_restores_${j}/${tmp}/data"
+  diff --exclude="fifo*" --brief --recursive --no-dereference \
+     "$src" "$dst"
+done
+
+end_test
+exit 0

--- a/systemtests/tests/autochanger/testrunner-label-release-autoselect
+++ b/systemtests/tests/autochanger/testrunner-label-release-autoselect
@@ -15,7 +15,6 @@ export TestName
 
 start_test
 
-
 on_error() {
   local lc="${BASH_COMMAND}"
   echo "Error occurred in testrunner script [${lc}]"
@@ -23,30 +22,6 @@ on_error() {
   exit 1
 }
 trap 'on_error' ERR
-
-
-stop_bareos
-sleep 1
-
-"${rscripts}"/cleanup
-"${rscripts}"/setup
-
-
-if ! ./invalidate_tapes.sh ${1:-}
-then
-  echo "Could not invalidate tapes"
-  exit 1
-fi
-
-if ! ./create_autochanger_configs.sh ${1:-}
-then
-  echo "Could not create autochanger configs"
-  exit 1
-fi
-
-
-echo "Starting bareos"
-start_bareos
 
 echo "Set debug on the Tape-Storage daemon"
 tracefile="$(echo "setdebug level=200 trace=1 storage=Tape-0" | bin/bconsole | grep "^3000" | awk -F"tracefile=" '{print $2}' )"
@@ -57,14 +32,9 @@ for i in $(seq ${NUMBER_OF_POOLS}); do
   pool=$(( i -1 )) #counts from 0
   for j in $(seq ${NUMBER_OF_TAPES_PER_POOL}); do
     slot=$(( j + pool * NUMBER_OF_TAPES_PER_POOL )) #counts from 1
-    echo "label barcodes slot=${slot} drive=0 pool=Full-${pool} storage=Tape-0 yes" | bin/bconsole | grep "OK label"
+    echo "label barcodes slot=${slot} drive=0 pool=Full-${pool} storage=Tape-0 yes" | bin/bconsole | grep -E "(OK label|already exists)"
   done
 done
-
-
-# setup backup data
-setup_data
-
 
 # create the test backup jobs
 rm -f bconsole_backup_jobs
@@ -82,57 +52,29 @@ EOF
   done
 done
 
-echo "wait" >> bconsole_backup_jobs
-echo "messages" >> bconsole_backup_jobs
-
 # start all the jobs
 bin/bconsole < bconsole_backup_jobs
 
-# prepare the restore
+DevicesFromConfig=$(grep Device= ${current_test_directory}/etc/bareos/bareos-sd.d/autochanger/autochanger.conf | sed -n -e 's/^.*Device=//p')
+tapedevices=($DevicesFromConfig)
 
-list_of_jobids=$(echo "list jobs" \
-  | bin/bconsole \
-  | grep "backup-bareos-fd" \
-  | sed 's/| *\([0-9]\{1,\}\).*$/\1/')
-
-if [ "${list_of_jobids}" -eq 0 ]; then
-  echo "no jobs found for restore"
-  export estat=1
-  exit 1
-fi
-
-rm -f bconsole_restore_jobs
-for j in ${list_of_jobids}; do
-  pool="Full-$(( j -1 ))"
-  cat << EOF >> bconsole_restore_jobs
-restore jobid=${j} pool="${pool}" where=${tmp}/bareos_restores_${j} select all done yes
-EOF
-done
-
-# start all the restore jobs
-bin/bconsole < bconsole_restore_jobs
-
-testdevice0=tapedrive-0-.dev.tape.by-id.scsi-350223344ab000100-nst
-testdevice1=tapedrive-1-.dev.tape.by-id.scsi-350223344ab000200-nst
-
+rm -f $tmp/log-label-release-autoselect-no.out
 # set devices to `autoselect = no` and wait for jobs to finish
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out $tmp/log-label-release-autoselect-no.out
-setdevice storage=Tape-0  device=$testdevice0 autoselect=no
+setdevice storage=Tape-0  device=${tapedevices[0]} autoselect=no
 wait
 messages
 
 label barcodes slot=8 drive=0 pool=Full-0 storage=Tape-0 yes
-setdevice storage=Tape-0  device=$testdevice0 autoselect=yes
+setdevice storage=Tape-0  device=${tapedevices[0]} autoselect=yes
 wait
-
 quit
 END_OF_DATA
 
 run_bconsole
 
-# Redo the backups, and check if drive 0 is still being used
-
+# Redo the backup to check if drive 0 is still being used
 rm -f bconsole_backup_jobs
 echo "@$out $tmp/log-second-backups.out" >> bconsole_backup_jobs
 
@@ -152,57 +94,44 @@ done
 echo "wait" >> bconsole_backup_jobs
 echo "messages" >> bconsole_backup_jobs
 
-# start all the jobs
+# start all the jobs again
 bin/bconsole < bconsole_backup_jobs
 
-check_for_zombie_jobs storage=Tape-0
-
-# does not compare fifo files
-for j in ${list_of_jobids}; do
-  src="${tmp}/data"
-  dst="${tmp}/bareos_restores_${j}/${tmp}/data"
-  diff --exclude="fifo*" --brief --recursive --no-dereference \
-     "$src" "$dst"
-done
-
-
-#testing for labeling and releasing when device is on autoselect=no
+#testing for releasing when device is on autoselect=no
 cat <<END_OF_DATA >"$tmp/bconcmds"
-@$out /dev/null
-messages
 @$out $tmp/log-label-release-autoselect-no.out
-setdevice storage=Tape-0  device=$testdevice1 autoselect=no
-release storage=Tape-0 drive=1
+setdevice storage=Tape-0  device=${tapedevices[0]} autoselect=no
+release storage=Tape-0 drive=0
 messages
 quit
 END_OF_DATA
 
 run_bconsole
 
-stop_bareos
-
-# check the that the labeling went through
-if  ! grep "Slot 8 successfully created." "$tmp"/log-label-release-autoselect-no.out &&
-      grep "3999 Device \"autochanger-0\" not found or could not be opened."
- then
+#check the that the labeling went through
+if ! grep "Slot 8 successfully created." "$tmp"/log-label-release-autoselect-no.out &&
+   grep "3999 Device \"autochanger-0\" not found or could not be opened." "$tmp"/log-label-release-autoselect-no.out
+   then
   echo "Labeling of a device with autoselect=no was not successful. Check $tmp/log-label-release-autoselect-no.out" >&2
   estat=1
 fi
 
 #check that release went through
-if ! grep "3921 Device \"\"tapedrive-1-.dev.tape.by-id.scsi-350223344ab000200-nst\" (/dev/tape/by-id/scsi-350223344ab000200-nst)\" already released."  "$tmp"/log-label-release-autoselect-no.out &&
+if ! grep "3921 Device \"\"${tapedevices[0]}\" (.*)\" already released."  "$tmp"/log-label-release-autoselect-no.out &&
      grep "3999 Device \"autochanger-0\" not found or could not be opened." "$tmp"/log-label-release-autoselect-no.out
    then
-  echo "Error releasing device. Check $tmp/log-label-release-autoselect-no.out" >&2
+  echo "Releasing a device with autoselct=no was not successful. Check $tmp/log-label-release-autoselect-no.out" >&2
   estat=1
 fi
 
 #check that the tapedrive works normally again after the manipulations
-if  ! grep "Using Device \"tapedrive-0" "$tmp"/log-second-backups.out; then
-  echo "An autoselected device was not used. Check $tmp/log-second-backups.out" >&2
+if  ! grep "Using .* \"${tapedevices[0]}" "$tmp"/log-second-backups.out; then
+  echo "A device that was on autoselect=no and then back to autoselect=yes was not used. Check $tmp/log-second-backups.out" >&2
   estat=1
 fi
 
+
+check_for_zombie_jobs storage=Tape-0
 
 end_test
 exit 0


### PR DESCRIPTION
### Description
(Backports PR #1021)
When devices are set with the option autoselect=no, labeling and releasing is not possible as the device is skipped in the search. This PR handles this issue by not accounting for the autoselect attribute when searching devices. This has the same effect on the mount, unmount, as well as readlabel and autochanger commands. Backups are not affected.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [x] The decision towards a systemtest is reasonable compared to a unittest
- [x] Testname matches exactly what is being tested
- [x] Output of the test leads quickly to the origin of the fault
