### PR TITLE
cats: remove in update_bareos_table if PGSQLVERSION block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - sql_get.cc: fix error logging in GetJobRecord() for jobname #1042
 - webui: fix empty job timeline issue if date.timezone is not set in php.ini [PR #1051]
 - Fix for wrong update message when updating all volumes from all pools with no existing volumes [PR #1015]
+- core cats: Remove PGSQLVERSION if block in update_bareos_table to support all PG version [PR #1068]
 
 ### Added
 - Python plugins: add default module_path to search path [PR #1038]
@@ -65,4 +66,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1057]: https://github.com/bareos/bareos/pull/1057
 [PR #1059]: https://github.com/bareos/bareos/pull/1059
 [PR #1062]: https://github.com/bareos/bareos/pull/1062
+[PR #1068]: https://github.com/bareos/bareos/pull/1068
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/update_bareos_tables.in
+++ b/core/src/cats/update_bareos_tables.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -168,21 +168,12 @@ do
          retval=$?
          ;;
       postgresql)
-         PGOPTIONS='--client-min-messages=warning' psql -f ${temp_sql_schema} -d ${db_name} $*
+         PGOPTIONS='--client-min-messages=warning' psql -f "${temp_sql_schema}" -d "${db_name}" $*
          retval=$?
          if [ $retval -eq 0 ] && [ ${end_version} -eq 2210 ]; then
-             PGSQLVERSION=`PGOPTIONS='--client-min-messages=warning' psql -d template1 -c 'SELECT version()' $* 2>/dev/null | \
-                    awk '/PostgreSQL/ { print $2 }' | \
-                    cut -d '.' -f 1,2`
-             case ${PGSQLVERSION} in
-                 10.*|11.*|12.*)
-                     PGOPTIONS='--client-min-messages=warning' psql -d ${db_name} -c 'ALTER SEQUENCE basefiles_baseid_seq AS BIGINT'
-                     result=$?
-                     if [ $result -ne 0 ]; then
-                         echo "WARNING: Failed to update sequence basefiles_baseid_seq"
-                     fi
-                     ;;
-             esac
+             if ! r="$(PGOPTIONS='--client-min-messages=warning' psql -d "${db_name}" -c 'ALTER SEQUENCE basefiles_baseid_seq AS BIGINT')" ; then
+                warn "WARNING: Failed to update sequence basefiles_baseid_seq ${r}"
+             fi
          fi
          ;;
    esac


### PR DESCRIPTION
- remove limited PGSQLVERSION block to allow `alter sequence basefiles_baseid_seq`
  execution in any majog PG.

This small changes, align update_bareos_table to same code as create_bareos_table.
It will allow a quick and easy backport to 21 before drastic changes.

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
