### PR TITLE
systemtests: fix python bareos fail on manual second runs with certain unit tests

### DIFF
--- a/systemtests/tests/python-bareos/test_list_command.py
+++ b/systemtests/tests/python-bareos/test_list_command.py
@@ -278,17 +278,18 @@ class PythonBareosListCommandTest(bareos_unittest.Base):
         )
 
         # check expected behavior when asking for specific volume by name
-        director.call("label volume=test_volume0001 pool=Full")
+        test_volume = "test_volume0001"
+        director.call("label volume={} pool=Full".format(test_volume))
         director.call("wait")
         result = director.call("list media=test_volume0001")
         self.assertEqual(
             result["volume"]["volumename"],
-            "test_volume0001",
+            test_volume,
         )
-        result = director.call("list volume=test_volume0001")
+        result = director.call("list volume={}".format(test_volume))
         self.assertEqual(
             result["volume"]["volumename"],
-            "test_volume0001",
+            test_volume,
         )
 
         # check expected behavior when asking for specific volume by mediaid
@@ -314,6 +315,7 @@ class PythonBareosListCommandTest(bareos_unittest.Base):
             "2",
         )
         director.call("delete volume=test_volume0001 yes")
+        os.remove("storage/{}".format(test_volume))
 
     def test_list_pool(self):
         """

--- a/systemtests/tests/python-bareos/test_update_all_volumes_all_pools.py
+++ b/systemtests/tests/python-bareos/test_update_all_volumes_all_pools.py
@@ -73,11 +73,19 @@ class PythonBareosUpdateAllVolumesAllPools(bareos_unittest.Json):
             directorJson,
             "pools",
             newrandompoolname,
-            "pool={}".format(newrandompoolname)
+            "pool={}".format(newrandompoolname),
         )
         directorRegular.call("reload")
         directorRegular.call("update volume")
-        directorRegular.call("13") # choosing the `All Volumes from pool` option
-        result = directorRegular.call("1") # choosing the `arandompool` option
+        directorRegular.call("13")  # choosing the `All Volumes from pool` option
+        result = directorRegular.call("1")  # choosing the `arandompool` option
 
-        self.assertEqual(result.decode(), "All Volume defaults updated from \"{}\" Pool record.\n".format(newrandompoolname))
+        self.assertEqual(
+            result.decode(),
+            'All Volume defaults updated from "{}" Pool record.\n'.format(
+                newrandompoolname
+            ),
+        )
+
+        directorRegular.call("delete pool={} yes".format(newrandompoolname))
+        os.remove("etc/bareos/bareos-dir.d/pool/{}.conf".format(newrandompoolname))


### PR DESCRIPTION
#### Description

When running `python-bareos` tests manually a second time, certain tests could fail. This PR fixes these issues

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- ~~[ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~~
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- ~~[] Required documentation changes are present and part of the PR~~
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
