### PR TITLE
cancel virtual backups if none of the jobids contains files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: update jstree from v3.3.8 to v3.3.12 [PR #1088]
 - webui: update jstree-grid plugin [PR #1089]
 - Consolidation now purges candidate jobs with no files instead of ignoring them [PR #1056]
+- Virtual Full will now terminate if one if the input jobs had its files pruned [PR #1070]
 
 ### Deprecated
 

--- a/core/src/cats/sql.h
+++ b/core/src/cats/sql.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,5 +25,12 @@ int DbStrtimeHandler(void* ctx, int num_fields, char** row);
 int DbListHandler(void* ctx, int num_fields, char** row);
 void DbDebugPrint(JobControlRecord* jcr, FILE* fp);
 int DbIntHandler(void* ctx, int num_fields, char** row);
+
+// This template allows you to easily use an object with operator() or a lambda
+//      SqlQuery(query, ObjectHandler<decltype(obj)>, &obj)
+template <typename T> int ObjectHandler(void* ctx, int num_fields, char** row)
+{
+  return static_cast<T*>(ctx)->operator()(num_fields, row) ? 0 : 1;
+}
 
 #endif  // BAREOS_CATS_SQL_H_

--- a/core/src/lib/mem_pool.cc
+++ b/core/src/lib/mem_pool.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -42,6 +42,9 @@
  *
  * Kern E. Sibbald
  */
+#if defined(HAVE_WIN32)
+#  include "compat.h"
+#endif
 #include "lib/mem_pool.h"
 
 #include <stdarg.h>

--- a/core/src/lib/mem_pool.h
+++ b/core/src/lib/mem_pool.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -30,6 +30,7 @@
 
 #include <stdarg.h>
 #include <string.h>
+#include <string>
 #include "include/bc_types.h"
 
 POOLMEM* GetPoolMemory(int pool) noexcept;
@@ -71,17 +72,18 @@ class PoolMem {
     mem = GetPoolMemory(PM_NAME);
     *mem = 0;
   }
-  PoolMem(int pool)
+  explicit PoolMem(int pool)
   {
     mem = GetPoolMemory(pool);
     *mem = 0;
   }
-  PoolMem(const char* str)
+  explicit PoolMem(const char* str)
   {
     mem = GetPoolMemory(PM_NAME);
     *mem = 0;
     strcpy(str);
   }
+  explicit PoolMem(const std::string& str) : PoolMem(str.c_str()) {}
   ~PoolMem()
   {
     FreePoolMemory(mem);

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -34,7 +34,9 @@
 #include "include/version_numbers.h"
 
 #include <algorithm>
+#include <sstream>
 #include <string>
+#include <vector>
 
 // Various BAREOS Utility subroutines
 
@@ -773,8 +775,7 @@ void MakeSessionKey(char* key, char* seed, int mode)
   MD5_CTX md5c;
   unsigned char md5key[16], md5key1[16];
   char s[1024];
-
-#define ss sizeof(s)
+  constexpr int32_t ss = sizeof(s);
 
   s[0] = 0;
   if (seed != NULL) { bstrncat(s, seed, sizeof(s)); }
@@ -1126,4 +1127,13 @@ bool pm_append(void* pm_string, const char* fmt, ...)
   pm->strcat(additionalstring);
 
   return true;
+}
+
+std::vector<std::string> split_string(const std::string& str, char delim)
+{
+  std::istringstream ss(str);
+  std::vector<std::string> parts;
+  std::string part;
+  while (std::getline(ss, part, delim)) { parts.push_back(part); }
+  return parts;
 }

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -76,5 +76,6 @@ std::string getenv_std_string(std::string env_var);
 void StringToLowerCase(std::string& s);
 void StringToLowerCase(std::string& out, const std::string& in);
 bool pm_append(void* pm_string, const char* fmt, ...);
+std::vector<std::string> split_string(const std::string& str, char delim);
 
 #endif  // BAREOS_LIB_UTIL_H_

--- a/systemtests/tests/virtualfull/testrunner
+++ b/systemtests/tests/virtualfull/testrunner
@@ -10,10 +10,10 @@ TestName="$(basename "$(pwd)")"
 export TestName
 
 JobName=backup-bareos-fd
-#shellcheck source=../environment.in
+#shellcheck source=../../environment.in
 . ./environment
 
-#shellcheck source=../scripts/functions
+#shellcheck source=../../scripts/functions
 . "${rscripts}"/functions
 "${rscripts}"/cleanup
 "${rscripts}"/setup
@@ -23,6 +23,9 @@ JobName=backup-bareos-fd
 
 # Fill ${BackupDirectory} with data.
 setup_data
+
+# clean out logfile
+rm -f log/bareos.log
 
 start_test
 
@@ -51,9 +54,7 @@ messages
 list jobs
 @# make sure we really restore the virtualfull
 purge volume=TestVolume001
-delete volume=TestVolume001
 purge volume=TestVolume002
-delete volume=TestVolume002
 status director
 status client
 status storage=File
@@ -78,8 +79,70 @@ END_OF_DATA
 run_bconsole "$tmp/bconcmds2"
 
 check_for_zombie_jobs storage=File
+check_restore_diff "${BackupDirectory}"
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds3"
+@$out /dev/null
+messages
+@$out $tmp/log3.out
+run job=$JobName level=Full yes
+wait
+messages
+list jobs
+@exec "sh -c 'touch ${tmp}/data/*.c'"
+run job=$JobName level=Incremental yes
+wait
+run job=$JobName level=Incremental yes
+wait
+run job=$JobName level=Incremental yes
+wait
+messages
+purge files jobid=5 yes
+list jobs
+@$out $tmp/log4.out
+run job=$JobName jobid=7,8 level=VirtualFull yes
+wait
+messages
+@$out $tmp/log5.out
+run job=$JobName jobid=3,2,6 level=VirtualFull yes
+wait
+messages
+@$out $tmp/log6.out
+run job=$JobName jobid=3,5,6 level=VirtualFull yes
+wait
+messages
+list jobs
+quit
+END_OF_DATA
+
+run_bconsole "$tmp/bconcmds3"
+check_for_zombie_jobs storage=File
+check_two_logs
 stop_bareos
 
-check_two_logs
-check_restore_diff "${BackupDirectory}"
+if ! grep -q "Consolidating JobIds 1,2 containing 74 files" "$tmp/log1.out"; then
+  echo "Consolidation message was not emitted" >&2
+  cat "$tmp/log1.out"
+  estat=1
+fi
+
+if ! grep -q "Fatal error: Could not create bootstrap file" "$tmp/log4.out"; then
+  echo "Job with no files contained did not fail as expected" >&2
+  cat "$tmp/log4.out"
+  estat=1
+fi
+
+if ! grep -q "Termination:.*Backup Error" "$tmp/log5.out"; then
+  echo "Consolidating missing jobids did not fail as expected" >&2
+  cat "$tmp/log5.out"
+  estat=1
+fi
+
+if ! grep -q "Termination:.*Backup Error" "$tmp/log6.out"; then
+  echo "Consolidating jobs with pruned files did not fail as expected" >&2
+  cat "$tmp/log6.out"
+  estat=1
+fi
+
 end_test


### PR DESCRIPTION
Virtual backups consolidating jobids that contain no files failed when creating the bootstrap file.
This PR now checks for the number of files before creating the bootstrap file and cancels the consolidation if no files exist.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General

- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
