### PR TITLE
Fix context issue in bareos-dir python plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - debian: add missing python plugin dependencies [PR #1061] (backport of [PR #1045])
+- Fix context confusion in Director's Python plugins [PR #1077]
+
 
 ### Added
 - ndmp: introduce workaround for isilon 9.1.0.0 'Invalid nlist.tape_offset -1' error [PR #1058]
@@ -471,4 +473,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1058]: https://github.com/bareos/bareos/pull/1058
 [PR #1061]: https://github.com/bareos/bareos/pull/1061
 [PR #1064]: https://github.com/bareos/bareos/pull/1064
+[PR #1077]: https://github.com/bareos/bareos/pull/1077
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/dird/python/module/bareosdir.h
+++ b/core/src/plugins/dird/python/module/bareosdir.h
@@ -90,7 +90,7 @@ static bRC PyHandlePluginEvent(PluginContext* plugin_ctx,
 using namespace directordaemon;
 
 /* variables storing bareos pointers */
-PluginContext* plugin_context = NULL;
+thread_local PluginContext* plugin_context = NULL;
 
 MOD_INIT(bareosdir)
 {

--- a/core/src/plugins/dird/python/python-dir.cc
+++ b/core/src/plugins/dird/python/python-dir.cc
@@ -130,6 +130,7 @@ static bRC getPluginValue(PluginContext* bareos_plugin_ctx,
   bRC retval = bRC_Error;
 
   if (!plugin_priv_ctx) { goto bail_out; }
+  Bareosdir_set_plugin_context(bareos_plugin_ctx);
 
   PyEval_AcquireThread(plugin_priv_ctx->interpreter);
   retval = Bareosdir_PyGetPluginValue(bareos_plugin_ctx, var, value);
@@ -149,6 +150,7 @@ static bRC setPluginValue(PluginContext* bareos_plugin_ctx,
   bRC retval = bRC_Error;
 
   if (!plugin_priv_ctx) { return bRC_Error; }
+  Bareosdir_set_plugin_context(bareos_plugin_ctx);
 
   PyEval_AcquireThread(plugin_priv_ctx->interpreter);
   retval = Bareosdir_PySetPluginValue(bareos_plugin_ctx, var, value);
@@ -340,6 +342,8 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
       = (plugin_private_context*)plugin_ctx->plugin_private_context;
 
   if (!plugin_priv_ctx) { goto bail_out; }
+
+  Bareosdir_set_plugin_context(plugin_ctx);
 
   /*
    * First handle some events internally before calling python if it

--- a/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -4,4 +4,5 @@ Client {
   Address = @hostname@
   Password = "@fd_password@"          # password for FileDaemon
   FD PORT = @fd_port@
+  Maximum Concurrent Jobs = 10
 }

--- a/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
+++ b/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf.in
@@ -1,6 +1,23 @@
 Job {
-  Name = "backup-bareos-fd"
-  DIR Plugin Options ="@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-dir-test:output=@tmp@/test-plugin.log"
+  Name = "backup-bareos-fd1"
+  DIR Plugin Options ="@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-dir-test:output=@tmp@/test-plugin1.log"
   JobDefs = "DefaultJob"
-  Client = "bareos-fd"
+}
+
+Job {
+  Name = "backup-bareos-fd2"
+  DIR Plugin Options ="@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-dir-test:output=@tmp@/test-plugin2.log"
+  JobDefs = "DefaultJob"
+}
+
+Job {
+  Name = "backup-bareos-fd3"
+  DIR Plugin Options ="@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-dir-test:output=@tmp@/test-plugin3.log"
+  JobDefs = "DefaultJob"
+}
+
+Job {
+  Name = "backup-bareos-fd4"
+  DIR Plugin Options ="@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-dir-test:output=@tmp@/test-plugin4.log"
+  JobDefs = "DefaultJob"
 }

--- a/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/py2plug-dir/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -5,4 +5,5 @@ Storage {
   Device = FileStorage
   Media Type = File
   SD Port = @sd_port@
+  Maximum Concurrent Jobs = 10
 }

--- a/systemtests/tests/py2plug-dir/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/py2plug-dir/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,5 +1,12 @@
-Device {
+Autochanger {
   Name = FileStorage
+  Device = FileStorageDev
+  Changer Command = ""
+  Changer Device = /dev/null
+}
+
+Device {
+  Name = FileStorageDev
   Media Type = File
   Archive Device = storage
   LabelMedia = yes;                   # lets Bareos label unlabeled media
@@ -8,4 +15,5 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
+  Count = 10
 }

--- a/systemtests/tests/py2plug-dir/python-modules/BareosDirTest.py
+++ b/systemtests/tests/py2plug-dir/python-modules/BareosDirTest.py
@@ -22,6 +22,7 @@
 import bareosdir
 import BareosDirPluginBaseclass
 
+from time import time
 from sys import version_info
 
 
@@ -52,21 +53,31 @@ class BareosDirTest(BareosDirPluginBaseclass.BareosDirPluginBaseclass):
 
     def handle_plugin_event(self, event):
         super(BareosDirTest, self).handle_plugin_event(event)
+        job_name = repr(bareosdir.GetValue(bareosdir.bDirVarJobName))
+        job_id = repr(bareosdir.GetValue(bareosdir.bDirVarJobId))
+        microtime = round(time() * 1000)
+        msg_f = "%s Job:" + job_name + " JobId: " + job_id + " Time: " + repr(microtime) + "\n"
+
         if event == bareosdir.bDirEventJobStart:
-            self.toFile("bDirEventJobStart\n")
+            self.toFile(msg_f % "bDirEventJobStart")
 
         elif event == bareosdir.bDirEventJobEnd:
-            self.toFile("bDirEventJobEnd\n")
+            self.toFile(msg_f % "bDirEventJobEnd")
 
         elif event == bareosdir.bDirEventJobInit:
-            self.toFile("bDirEventJobInit\n")
+            self.toFile(msg_f % "bDirEventJobInit")
 
         elif event == bareosdir.bDirEventJobRun:
-            self.toFile("bDirEventJobRun\n")
+            self.toFile(msg_f % "bDirEventJobRun")
 
         return bareosdir.bRC_OK
 
     def toFile(self, text):
+        bareosdir.DebugMessage(
+            100,
+            "Writing string '%s' to '%s'\n"
+            % (text, self.outputfile),
+        )
         doc = open(self.outputfile, "a")
         doc.write(text)
         doc.close()

--- a/systemtests/tests/py2plug-dir/testrunner
+++ b/systemtests/tests/py2plug-dir/testrunner
@@ -15,11 +15,9 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-JobName=backup-bareos-fd
 #shellcheck source=../environment.in
 . ./environment
 
-JobName=backup-bareos-fd
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
 "${rscripts}"/cleanup
@@ -41,9 +39,12 @@ cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=200 dir
+setdebug level=200 trace=1 dir
 label volume=TestVolume001 storage=File pool=Full
-run job=$JobName yes
+run job=backup-bareos-fd1 yes
+run job=backup-bareos-fd2 yes
+run job=backup-bareos-fd3 yes
+run job=backup-bareos-fd4 yes
 status director
 status client
 status storage=File
@@ -57,8 +58,15 @@ check_for_zombie_jobs storage=File
 stop_bareos
 
 for i in bDirEventJobStart bDirEventJobInit bDirEventJobRun bDirEventJobEnd; do
-  if ! grep -q "$i" ${tmp}/test-plugin.log; then
+  if ! grep -q "$i" ${tmp}/test-plugin1.log; then
     set_error "Failed to find logged event $i"
+  fi
+done
+
+for i in 1 2 3 4; do
+  num="$(grep -c -F "Job:'backup-bareos-fd$i." "${tmp}/test-plugin$i.log")"
+  if [ $num -ne 4 ]; then
+    set_error "Mismatched job context on plugin event in backup-bareos-fd$i"
   fi
 done
 


### PR DESCRIPTION
**Backport of PR #1047 to bareos-20**

This PR adds a test that exposes a bug in python-dir's context handling and
provides an appropriate fix.
### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
