### PR TITLE
doc improve python action plugin example removing File = in Fileset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - split `Howtos.rst` file into one file per section [PR #1054]
 - split the very long `Plugins.rst` file into one file per Bareos plugin [PR #1046]
 - rework SD plugin scsicrypto linux sg_io ioctl subsection for cap_sys_rawio [PR #1057]
+- improve action Python plugin documentation, by removing File in Fileset example [PR #1079]
 
 
 [PR #1010]: https://github.com/bareos/bareos/pull/1010
@@ -67,4 +68,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1057]: https://github.com/bareos/bareos/pull/1057
 [PR #1059]: https://github.com/bareos/bareos/pull/1059
 [PR #1062]: https://github.com/bareos/bareos/pull/1062
+[PR #1079]: https://github.com/bareos/bareos/pull/1079
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PythonFdPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PythonFdPlugin.rst.inc
@@ -36,7 +36,6 @@ Command plugins are used to replace or extend the FileSet definition in the File
        Options {
          Signature = MD5
        }
-       File = "/etc"
        Plugin = "python3"
                 ":module_path=/usr/lib/bareos/plugins"
                 ":module_name=bareos-fd-mysql"
@@ -46,7 +45,7 @@ Command plugins are used to replace or extend the FileSet definition in the File
 .. index::
    single: MySQL; Backup
 
-This example uses the :ref:`MySQL plugin <backup-mysql-python>` to backup MySQL dumps in addition to :file:`/etc`.
+This example uses the :ref:`MySQL plugin <backup-mysql-python>` to backup MySQL dumps.
 
 Option Plugins
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR propose to clarify action python plugin example by removing File = in Fileset example.
Related to unbalanced call in restore and task 5084.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
