### PR TITLE
webui: fix uncaught TypeError if node.data is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fix several cases of undefined behaviour, memory corruption and memory leaks [PR #1060]
 - webui: fix undefined array key warning [PR #1098]
 - webui: fix deprecated notice required param follows optional param [PR #1097]
+- webui: fix uncaught TypeError if node.data is null [PR #1087]
 
 ### Added
 - Python plugins: add default module_path to search path [PR #1038]

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -179,15 +179,13 @@ $this->headTitle($title);
 
    <div class="col-md-9">
       <?php
-               echo '<strong>';
-               echo $this->translate("File selection");
-               echo '</strong>';
-             ?>
-             <div class="panel panel-default">
-                 <div id="filebrowser"></div>
-             </div>
-             <?php
+         echo '<strong>';
+         echo $this->translate("File selection");
+         echo '</strong>';
       ?>
+      <div class="panel panel-default">
+         <div id="filebrowser" style="width: 100%; height: 60vH;"></div>
+      </div>
    </div>
 
 </div>
@@ -365,94 +363,101 @@ $this->headTitle($title);
       $('#spinner').fadeOut('slow');
    });
 
-   $('#filebrowser').jstree({
-      'plugins' : [ "grid", "checkbox", "state", "sort", "search", "types" ],
-      'core' : {
-         'animation': false,
-         'force_text': true,
-         'error': function (e) {
-            $('#filebrowser').html(
-               "<h4>There was an error while loading data for this tree.</h4>" +
-               "<p><b>Error: </b>" + e.error + "</p>" +
-               "<p><b>Plugin: </b>" + e.plugin + "</p>" +
-               "<p><b>Reason: </b> " + e.reason + "</p>" +
-               "<p><b>Data:</b></p>" +
-               "<pre><code>" + e.data + "</code></pre>"
-            );
-            displayBvfsCacheUpdateInfo();
+   function showFileTree() {
+      $('#filebrowser').jstree({
+         'plugins' : [ "grid", "checkbox", "state", "sort", "search", "types" ],
+         'core' : {
+            'animation': false,
+            'force_text': true,
+            'error': function (e) {
+               $('#filebrowser').html(
+                  "<h4>There was an error while loading data for this tree.</h4>" +
+                  "<p><b>Error: </b>" + e.error + "</p>" +
+                  "<p><b>Plugin: </b>" + e.plugin + "</p>" +
+                  "<p><b>Reason: </b> " + e.reason + "</p>" +
+                  "<p><b>Data:</b></p>" +
+                  "<pre><code>" + e.data + "</code></pre>"
+               );
+               displayBvfsCacheUpdateInfo();
+            },
+            'data' :{
+               'url' : '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
+               'dataType' : 'json',
+               'data' : function (node) {
+                  return { 'id' : node.id };
+               },
+               timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+            },
          },
-         'data' :{
-            'url' : '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
-            'dataType' : 'json',
-            'data' : function (node) {
-               return { 'id' : node.id };
-            },
-            timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+         'state' : {
+            'key': 'restore'
          },
-      },
-       'state' : {
-           'key': 'restore'
-       },
-      'grid' : {
-         width: '100%',
-         height: '60vh',
-         fixedHeader: true,
-         resizable: false,
-         columns: [
-            {
-               width: '100%',
-               height: '100%',
-               header: '<?php echo $this->translate("Name"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               title: "_DATA_"
-            },
-            {
-               width: 100,
-               header: '<?php echo $this->translate("Mode"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               value: function(node) {
-                  return formatJSTreeGridModeItem(node.data.stat.mode);
+         'grid' : {
+            width: '100%',
+            height: '60vh',
+            fixedHeader: true,
+            resizable: false,
+            columns: [
+               {
+                  width: '100%',
+                  height: '100%',
+                  header: '<?php echo $this->translate("Name"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  title: "_DATA_"
+               },
+               {
+                  width: 100,
+                  header: '<?php echo $this->translate("Mode"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  value: function(node) {
+                     if(node.data === null) return null;
+                     return formatJSTreeGridModeItem(node.data.stat.mode);
+                  }
+               },
+               {
+                  width: 120,
+                  header: '<?php echo $this->translate("User"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  value: function(node) {
+                     if(node.data === null) return null;
+                     return formatJSTreeGridUserItem(node);
+                  }
+               },
+               {
+                  width: 120,
+                  header: '<?php echo $this->translate("Group"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  value: function(node) {
+                     if(node.data === null) return null;
+                     return formatJSTreeGridGroupItem(node);
+                  }
+               },
+               {
+                  width: 120,
+                  header: '<?php echo $this->translate("Size"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  value: function(node) {
+                     if(node.data === null) return null;
+                     return formatJSTreeGridSizeItem(node);
+                  }
+               },
+               {
+                  width: 150,
+                  header: '<?php echo $this->translate("Last modification"); ?>',
+                  headerClass: 'jsTreeGridHeader',
+                  value: function(node) {
+                     if(node.data === null) return null;
+                     return formatJSTreeGridLastModItem(node.data.stat.mtime);
+                  }
                }
-            },
-            {
-               width: 120,
-               header: '<?php echo $this->translate("User"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               value: function(node) {
-                  return formatJSTreeGridUserItem(node);
-               }
-            },
-            {
-               width: 120,
-               header: '<?php echo $this->translate("Group"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               value: function(node) {
-                  return formatJSTreeGridGroupItem(node);
-               }
-            },
-            {
-               width: 120,
-               header: '<?php echo $this->translate("Size"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               value: function(node) {
-                  return formatJSTreeGridSizeItem(node);
-               }
-            },
-            {
-               width: 150,
-               header: '<?php echo $this->translate("Last modification"); ?>',
-               headerClass: 'jsTreeGridHeader',
-               value: function(node) {
-                  return formatJSTreeGridLastModItem(node.data.stat.mtime);
-               }
-            }
-         ],
-      },
-      'search' : {
-         "case_sensitive" : false,
-         "show_only_matches" : false
-      }
-   });
+            ],
+         },
+         'search' : {
+            "case_sensitive" : false,
+            "show_only_matches" : false
+         }
+      });
+   }
 
    $('#jobid').change(function(event) {
       window.location.href = window.location.pathname + '?' + updateRestoreParams('jobid', this.value);
@@ -485,6 +490,10 @@ $this->headTitle($title);
    $(document).ready(function(){
 
       var errors = '<?php echo str_replace(array("\n","\r"), "", $this->errors); ?>';
+
+      if($('#client').val() !== "") {
+         showFileTree();
+      }
 
       if(errors.length > 0) {
          $("#modal-001").modal();

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -182,7 +182,7 @@ $this->headTitle($title);
                   echo '</strong>';
             ?>
                <div class="panel panel-default">
-               <div id="filebrowser"></div>
+               <div id="filebrowser" style="width: 100%; height: 60vH;"></div>
                </div>
          </div>
 
@@ -505,74 +505,78 @@ $("#filebrowser").bind("loading.jstree", function() {
    displayBvfsCacheUpdateInfo();
 });
 
-$('#filebrowser').jstree({
-   'plugins': ["grid", "state", "sort", "search", "types"],
-   'core': {
-      'animation': false,
-      'force_text': true,
-      'error': function (e) {
-         $('#filebrowser').html(
-            "<h4>There was an error while loading data for this tree.</h4>" +
-            "<p><b>Error: </b>" + e.error + "</p>" +
-            "<p><b>Plugin: </b>" + e.plugin + "</p>" +
-            "<p><b>Reason: </b> " + e.reason + "</p>" +
-            "<p><b>Data:</b></p>" +
-            "<pre><code>" + e.data + "</code></pre>"
-         );
-         displayBvfsCacheUpdateInfo();
+function showFileTree() {
+   $('#filebrowser').jstree({
+      'plugins': ["grid", "state", "sort", "search", "types"],
+      'core': {
+         'animation': false,
+         'force_text': true,
+         'error': function (e) {
+            $('#filebrowser').html(
+               "<h4>There was an error while loading data for this tree.</h4>" +
+               "<p><b>Error: </b>" + e.error + "</p>" +
+               "<p><b>Plugin: </b>" + e.plugin + "</p>" +
+               "<p><b>Reason: </b> " + e.reason + "</p>" +
+               "<p><b>Data:</b></p>" +
+               "<pre><code>" + e.data + "</code></pre>"
+            );
+            displayBvfsCacheUpdateInfo();
+         },
+         'multiple': false,
+         'data': {
+            'url': '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
+            'dataType': 'json',
+            'data': function (node) {
+               return {
+                  'id': node.id,
+                  'state': {'checkbox_disabled': true}
+               };
+            },
+            timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+         },
       },
-      'multiple': false,
-      'data': {
-         'url': '<?php echo $this->basePath() . "/restore/filebrowser?jobid=" . $this->restore_params['jobid'] . "&client=" . $this->restore_params['client'] . "&mergefilesets=" . $this->restore_params['mergefilesets'] . "&mergejobs=" . $this->restore_params['mergejobs'] . "&limit=" . $this->restore_params['limit']; ?>',
-         'dataType': 'json',
-         'data': function (node) {
-            return {
-               'id': node.id,
-               'state': {'checkbox_disabled': true}
-            };
-         },
-         timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+      'state' : {
+         'key': 'versions'
       },
-   },
-   'state' : {
-      'key': 'versions'
-   },
-   'grid': {
-      width: '100%',
-      height: '60vh',
-      fixedHeader: true,
-      resizable: false,
-      columns: [
-         {
-            width: '100%',
-            height: '100%',
-            header: '<?php echo $this->translate("Name"); ?>',
-            headerClass: 'jsTreeGridHeader',
-            title: "_DATA_"
-         },
-         {
-            width: 120,
-            header: '<?php echo $this->translate("Size"); ?>',
-            headerClass: 'jsTreeGridHeader',
-            value: function (node) {
-               return formatJSTreeGridSizeItem(node);
+      'grid': {
+         width: '100%',
+         height: '60vh',
+         fixedHeader: true,
+         resizable: false,
+         columns: [
+            {
+               width: '100%',
+               height: '100%',
+               header: '<?php echo $this->translate("Name"); ?>',
+               headerClass: 'jsTreeGridHeader',
+               title: "_DATA_"
+            },
+            {
+               width: 120,
+               header: '<?php echo $this->translate("Size"); ?>',
+               headerClass: 'jsTreeGridHeader',
+               value: function (node) {
+                  if(node.data === null) return null;
+                  return formatJSTreeGridSizeItem(node);
+               }
+            },
+            {
+               width: 150,
+               header: '<?php echo $this->translate("Last modification"); ?>',
+               headerClass: 'jsTreeGridHeader',
+               value: function (node) {
+                  if(node.data === null) return null;
+                  return formatJSTreeGridLastModItem(node.data.stat.mtime);
+               }
             }
-         },
-         {
-            width: 150,
-            header: '<?php echo $this->translate("Last modification"); ?>',
-            headerClass: 'jsTreeGridHeader',
-            value: function (node) {
-               return formatJSTreeGridLastModItem(node.data.stat.mtime);
-            }
-         }
-      ],
-   },
-   'search': {
-      "case_sensitive": false,
-      "show_only_matches": false
-   }
-});
+         ],
+      },
+      'search': {
+         "case_sensitive": false,
+         "show_only_matches": false
+      }
+   });
+}
 
 $('#jobid').change(function (event) {
    window.location.href = window.location.pathname + '?' + updateRestoreParams('jobid', this.value);
@@ -607,6 +611,10 @@ initTreeHandler();
 $(document).ready(function () {
 
    var errors = '<?php echo str_replace(array("\n", "\r"), "", $this->errors); ?>';
+
+   if($('#client').val() !== "") {
+      showFileTree();
+   }
 
    if (errors.length > 0) {
       $("#modal-001").modal();


### PR DESCRIPTION
This PR fixes the issue that on initial restore module load if no client is selected, an uncaught type error is thrown because node.data is null.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
