### PR TITLE
NDMP_BAREOS AutoXFlate support (backport PR #1013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Fixed
+- NDMP_BAREOS: support autoxflate plugin [PR #1090] (backport of [PR #1013])
 - debian: add missing python plugin dependencies [PR #1045]
 - fix empty job timeline issue if date.timezone is not set in php.ini [PR #1053] (backport of [PR #1051])
 
@@ -403,6 +404,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #999]: https://github.com/bareos/bareos/pull/999
 [PR #1007]: https://github.com/bareos/bareos/pull/1007
 [PR #1008]: https://github.com/bareos/bareos/pull/1008
+[PR #1013]: https://github.com/bareos/bareos/pull/1013
 [PR #1017]: https://github.com/bareos/bareos/pull/1017
 [PR #1018]: https://github.com/bareos/bareos/pull/1018
 [PR #1019]: https://github.com/bareos/bareos/pull/1019
@@ -431,4 +433,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1066]: https://github.com/bareos/bareos/pull/1066
 [PR #1079]: https://github.com/bareos/bareos/pull/1079
 [PR #1080]: https://github.com/bareos/bareos/pull/1080
+[PR #1090]: https://github.com/bareos/bareos/pull/1090
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -345,7 +345,7 @@ static char* get_first_keyword()
  */
 static char* get_previous_keyword(int current_point, int nb)
 {
-  int i, end = -1, start, inquotes = 0;
+  int i, end = -1, start = 0, inquotes = 0;
   char* s = NULL;
 
   while (nb-- >= 0) {

--- a/core/src/lib/compression.cc
+++ b/core/src/lib/compression.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -471,10 +471,8 @@ static bool decompress_with_zlib(JobControlRecord* jcr,
     compress_len = jcr->compress.inflate_buffer_size;
   }
 
-  /*
-   * See if this is a compressed stream with the new compression header or an
-   * old one.
-   */
+  // See if this is a compressed stream with the new compression header or an
+  // old one.
   if (with_header) {
     cbuf = (const unsigned char*)*data + sizeof(comp_stream_header);
     real_compress_len = *length - sizeof(comp_stream_header);

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -110,6 +110,36 @@ struct plugin_ctx {
 
 static int const debuglevel = 200;
 
+
+// Does the mode contain OUT
+static bool AutoxflateModeContainsOut(AutoXflateMode mode)
+{
+  return (mode == AutoXflateMode::IO_DIRECTION_OUT
+          || mode == AutoXflateMode::IO_DIRECTION_INOUT);
+}
+
+// Does the mode contain IN
+static bool AutoxflateModeContainsIn(AutoXflateMode mode)
+{
+  return (mode == AutoXflateMode::IO_DIRECTION_IN
+          || mode == AutoXflateMode::IO_DIRECTION_INOUT);
+}
+
+// what streams can be decompressed by the plugin
+static bool IsCompressedStreamWeHandle(int streamtype)
+{
+  return (streamtype == STREAM_COMPRESSED_DATA
+          || streamtype == STREAM_WIN32_COMPRESSED_DATA
+          || streamtype == STREAM_SPARSE_COMPRESSED_DATA);
+}
+
+// what streams can be compressed by the plugin
+static bool IsUncompressedStreamWeHandle(int streamtype)
+{
+  return (streamtype == STREAM_FILE_DATA || streamtype == STREAM_WIN32_DATA
+          || streamtype == STREAM_SPARSE_DATA);
+}
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -174,7 +204,7 @@ static bRC newPlugin(PluginContext* ctx)
    * bSdEventSetupRecordTranslation - Setup the buffers for doing record
    * translation. bSdEventReadRecordTranslation - Perform read-side record
    * translation. bSdEventWriteRecordTranslation - Perform write-side record
-   * translantion.
+   * translation.
    */
   bareos_core_functions->registerBareosEvents(
       ctx, 4, bSdEventJobEnd, bSdEventSetupRecordTranslation,
@@ -330,29 +360,14 @@ static bRC setup_record_translation(PluginContext* ctx, void* value)
       break;
   }
 
-  // Setup auto deflation/inflation of streams when enabled for this device.
-  switch (dcr->autodeflate) {
-    case AutoXflateMode::IO_DIRECTION_NONE:
-      break;
-    case AutoXflateMode::IO_DIRECTION_OUT:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
-      if (!SetupAutoDeflation(ctx, dcr)) { return bRC_Error; }
-      did_setup = true;
-      break;
-    default:
-      break;
+  if (AutoxflateModeContainsOut(dcr->autodeflate)) {
+    if (!SetupAutoDeflation(ctx, dcr)) { return bRC_Error; }
+    did_setup = true;
   }
 
-  switch (dcr->autoinflate) {
-    case AutoXflateMode::IO_DIRECTION_NONE:
-      break;
-    case AutoXflateMode::IO_DIRECTION_OUT:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
-      if (!SetupAutoInflation(ctx, dcr)) { return bRC_Error; }
-      did_setup = true;
-      break;
-    default:
-      break;
+  if (AutoxflateModeContainsIn(dcr->autoinflate)) {
+    if (!SetupAutoInflation(ctx, dcr)) { return bRC_Error; }
+    did_setup = true;
   }
 
   if (did_setup) {
@@ -368,30 +383,20 @@ static bRC setup_record_translation(PluginContext* ctx, void* value)
 static bRC handle_read_translation(PluginContext* ctx, void* value)
 {
   DeviceControlRecord* dcr;
-  bool swap_record = false;
+  bool record_was_swapped = false;
 
   // Unpack the arguments passed in.
   dcr = (DeviceControlRecord*)value;
   if (!dcr) { return bRC_Error; }
 
   // See if we need to perform auto deflation/inflation of streams.
-  switch (dcr->autoinflate) {
-    case AutoXflateMode::IO_DIRECTION_IN:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
-      swap_record = AutoInflateRecord(ctx, dcr);
-      break;
-    default:
-      break;
+  if (AutoxflateModeContainsIn(dcr->autoinflate)) {
+    record_was_swapped = AutoInflateRecord(ctx, dcr);
   }
 
-  if (!swap_record) {
-    switch (dcr->autodeflate) {
-      case AutoXflateMode::IO_DIRECTION_IN:
-      case AutoXflateMode::IO_DIRECTION_INOUT:
-        swap_record = AutoDeflateRecord(ctx, dcr);
-        break;
-      default:
-        break;
+  if (!record_was_swapped) {
+    if (AutoxflateModeContainsOut(dcr->autodeflate)) {
+      record_was_swapped = AutoDeflateRecord(ctx, dcr);
     }
   }
 
@@ -401,33 +406,21 @@ static bRC handle_read_translation(PluginContext* ctx, void* value)
 static bRC handle_write_translation(PluginContext* ctx, void* value)
 {
   DeviceControlRecord* dcr;
-  bool swap_record = false;
+  bool record_was_swapped = false;
 
   // Unpack the arguments passed in.
   dcr = (DeviceControlRecord*)value;
   if (!dcr) { return bRC_Error; }
 
   // See if we need to perform auto deflation/inflation of streams.
-  switch (dcr->autoinflate) {
-    case AutoXflateMode::IO_DIRECTION_OUT:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
-      swap_record = AutoInflateRecord(ctx, dcr);
-      break;
-    default:
-      break;
+  if (AutoxflateModeContainsOut(dcr->autoinflate)) {
+    record_was_swapped = AutoInflateRecord(ctx, dcr);
   }
-
-  if (!swap_record) {
-    switch (dcr->autodeflate) {
-      case AutoXflateMode::IO_DIRECTION_OUT:
-      case AutoXflateMode::IO_DIRECTION_INOUT:
-        swap_record = AutoDeflateRecord(ctx, dcr);
-        break;
-      default:
-        break;
+  if (!record_was_swapped) {
+    if (AutoxflateModeContainsOut(dcr->autodeflate)) {
+      record_was_swapped = AutoDeflateRecord(ctx, dcr);
     }
   }
-
   return bRC_OK;
 }
 
@@ -447,10 +440,8 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
     goto bail_out;
   }
 
-  /*
-   * See if we need to create a new compression buffer or make sure the existing
-   * is big enough.
-   */
+  // See if we need to create a new compression buffer or make sure the
+  // existing is big enough.
   if (!jcr->compress.deflate_buffer) {
     jcr->compress.deflate_buffer = GetMemory(compress_buf_size);
     jcr->compress.deflate_buffer_size = compress_buf_size;
@@ -507,7 +498,8 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
       pZfastStream = (zfast_stream*)jcr->compress.workset.pZFAST;
       if ((zstat = fastlzlibSetCompressor(pZfastStream, compressor)) != Z_OK) {
         Jmsg(ctx, M_FATAL,
-             _("autoxflate-sd: Compression fastlzlibSetCompressor error: %d\n"),
+             _("autoxflate-sd: Compression fastlzlibSetCompressor error: "
+               "%d\n"),
              zstat);
         jcr->setJobStatus(JS_ErrorTerminated);
         goto bail_out;
@@ -536,10 +528,8 @@ static bool SetupAutoInflation(PluginContext* ctx, DeviceControlRecord* dcr)
 
   SetupDecompressionBuffers(jcr, &decompress_buf_size);
   if (decompress_buf_size > 0) {
-    /*
-     * See if we need to create a new compression buffer or make sure the
-     * existing is big enough.
-     */
+    // See if we need to create a new compression buffer or make sure the
+    // existing is big enough.
     if (!jcr->compress.inflate_buffer) {
       jcr->compress.inflate_buffer = GetMemory(decompress_buf_size);
       jcr->compress.inflate_buffer_size = decompress_buf_size;
@@ -575,13 +565,10 @@ static bool AutoDeflateRecord(PluginContext* ctx, DeviceControlRecord* dcr)
   p_ctx = (struct plugin_ctx*)ctx->plugin_private_context;
   if (!p_ctx) { goto bail_out; }
 
-  /*
-   * See what our starting point is. When dcr->after_rec is set we already have
-   * a translated record by another SD plugin. Then we use that translated
-   * record as the starting point otherwise we start at dcr->before_rec. When an
-   * earlier translation already happened we can free that record when we have a
-   * success full translation here as that record is of no use anymore.
-   */
+  // When dcr->after_rec is set we already have a translated record by another
+  // SD plugin which we need to translate and to free after successful
+  // translation.
+  // Otherwise we start from dcr->before_rec.
   if (dcr->after_rec) {
     rec = dcr->after_rec;
     intermediate_value = true;
@@ -589,35 +576,14 @@ static bool AutoDeflateRecord(PluginContext* ctx, DeviceControlRecord* dcr)
     rec = dcr->before_rec;
   }
 
-  /*
-   * We only do autocompression for the following stream types:
-   *
-   * - STREAM_FILE_DATA
-   * - STREAM_WIN32_DATA
-   * - STREAM_SPARSE_DATA
-   */
-  switch (rec->maskedStream) {
-    case STREAM_FILE_DATA:
-    case STREAM_WIN32_DATA:
-    case STREAM_SPARSE_DATA:
-      break;
-    default:
-      goto bail_out;
-  }
+  if (!IsUncompressedStreamWeHandle(rec->maskedStream)) { goto bail_out; }
 
-  /*
-   * Clone the data from the original DeviceRecord to the converted one.
-   * As we use the compression buffers for the data we need a new
-   * DeviceRecord without a new memory buffer so we call new_record here
-   * with the with_data boolean set explicitly to false.
-   */
-  nrec = bareos_core_functions->new_record(false);
+  // Clone the data from the original DeviceRecord to the converted one.
+  nrec = bareos_core_functions->new_record(/* with_data = */ false);
   bareos_core_functions->CopyRecordState(nrec, rec);
 
-  /*
-   * Setup the converted DeviceRecord to point with its data buffer to the
-   * compression buffer.
-   */
+  // Setup the converted DeviceRecord to point with its data buffer to the
+  // compression buffer.
   nrec->data = dcr->jcr->compress.deflate_buffer;
   switch (rec->maskedStream) {
     case STREAM_FILE_DATA:
@@ -707,10 +673,8 @@ bail_out:
   return retval;
 }
 
-/**
- * Inflate (uncompress) the content of a read record and return the data as an
- * alternative datastream.
- */
+// Inflate (uncompress) the content of a read record and return the data as an
+// alternative datastream.
 static bool AutoInflateRecord(PluginContext* ctx, DeviceControlRecord* dcr)
 {
   DeviceRecord *rec, *nrec;
@@ -721,51 +685,25 @@ static bool AutoInflateRecord(PluginContext* ctx, DeviceControlRecord* dcr)
   p_ctx = (struct plugin_ctx*)ctx->plugin_private_context;
   if (!p_ctx) { goto bail_out; }
 
-  /*
-   * See what our starting point is. When dcr->after_rec is set we already have
-   * a translated record by another SD plugin. Then we use that translated
-   * record as the starting point otherwise we start at dcr->before_rec. When an
-   * earlier translation already happened we can free that record when we have a
-   * success full translation here as that record is of no use anymore.
-   */
+  // When dcr->after_rec is set we already have a translated record by another
+  // SD plugin which we need to translate and to free after successful
+  // translation.
+  // Otherwise we start from dcr->before_rec.
   if (dcr->after_rec) {
     rec = dcr->after_rec;
     intermediate_value = true;
   } else {
     rec = dcr->before_rec;
   }
+  if (!IsCompressedStreamWeHandle(rec->maskedStream)) { goto bail_out; }
 
-  /*
-   * We only do auto inflation for the following stream types:
-   *
-   * - STREAM_COMPRESSED_DATA
-   * - STREAM_WIN32_COMPRESSED_DATA
-   * - STREAM_SPARSE_COMPRESSED_DATA
-   */
-  switch (rec->maskedStream) {
-    case STREAM_COMPRESSED_DATA:
-    case STREAM_WIN32_COMPRESSED_DATA:
-    case STREAM_SPARSE_COMPRESSED_DATA:
-      break;
-    default:
-      goto bail_out;
-  }
-
-  /*
-   * Clone the data from the original DeviceRecord to the converted one.
-   * As we use the compression buffers for the data we need a new
-   * DeviceRecord without a new memory buffer so we call new_record here
-   * with the with_data boolean set explicitly to false.
-   */
-  nrec = bareos_core_functions->new_record(false);
+  // Clone the data from the original DeviceRecord to the converted one.
+  nrec = bareos_core_functions->new_record(/* with_data = */ false);
   bareos_core_functions->CopyRecordState(nrec, rec);
 
-  /*
-   * Setup the converted record to point to the original data.
-   * The DecompressData function will decompress that data and
-   * then update the pointers with the data in the compression buffer
-   * and with the length of the decompressed data.
-   */
+  // Setup the converted record to point to the original data. The
+  // DecompressData function will decompress the data in the
+  // compression buffer and set the length of the decompressed data.
   nrec->data = rec->data;
   nrec->data_len = rec->data_len;
 

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -429,7 +429,9 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
       case STREAM_COMPRESSED_DATA:  // Got compressed data ndmp cannot handle
         Jmsg0(jcr, M_ERROR, 0,
               _("Encountered STREAM_COMPRESSED_DATA which cannot be handled by "
-                "NDMP.\n"));
+                "NDMP. Make sure read device device will inflate and not "
+                "deflate when reading. "
+                "(IN:[DEV->inflate=yes->deflate=no->SD])\n"));
         return false;
       default:  // corrupted stream of records, give an EOF
         Jmsg1(jcr, M_ERROR, 0, _("Encountered an unknown stream type %d\n"),

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -425,7 +425,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
         *data_length = 0;
         return true;
       case STREAM_COMPRESSED_DATA:  // Got compressed data ndmp cannot handle
-        Jmsg0(jcr, M_ERROR, 0,
+        Jmsg0(jcr, M_FATAL, 0,
               _("Encountered STREAM_COMPRESSED_DATA which cannot be handled by "
                 "NDMP. Make sure read device device will inflate and not "
                 "deflate when reading. "

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -385,9 +385,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
     if (rctx->rec->FileIndex < 0) { continue; }
 
     DeviceRecord* rec = rctx->rec;
-    // Perform record translations only if data is compressed
-    // as NDMP needs to be decompressed in any case
-    //    if (rctx->rec->maskedStream == STREAM_COMPRESSED_DATA) {
+
     dcr->before_rec = rctx->rec;
     dcr->after_rec = NULL;
 
@@ -408,7 +406,6 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
       Dmsg1(400, _("recstream: %d, rctxstream: %d .\n"), rec->maskedStream,
             rctx->rec->maskedStream);
     }
-    //    }  // not compressed, go on
 
     switch (rec->maskedStream) {
       case STREAM_UNIX_ATTRIBUTES:  // Start of the dump, read the next record.

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -331,6 +331,7 @@ bail_out:
   return retval;
 }
 
+
 /**
  * Read a record using the native routines.
  *

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -348,7 +348,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
 
   if (!rctx) { return false; }
 
-  while (!done) {
+  while (ok && !done) {
     // See if there are any records left to process.
     if (!IsBlockEmpty(rctx->rec)) {
       if (!ReadNextRecordFromBlock(dcr, rctx, &done)) {
@@ -436,7 +436,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
 
   if (done) { *data_length = 0; }
 
-  return true;
+  return ok;
 }
 
 // Generate virtual file attributes for the whole NDMP stream.

--- a/core/src/stored/read_record.cc
+++ b/core/src/stored/read_record.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -476,16 +476,6 @@ bool ReadRecords(DeviceControlRecord* dcr,
          */
         rec = (dcr->after_rec) ? dcr->after_rec : dcr->before_rec;
         ok = RecordCb(dcr, rec);
-
-        /*
-         * We can just release the translated record here as the record may not
-         * be changed by the record callback so any changes made don't need to
-         * be copied back to the original DeviceRecord.
-         */
-        if (dcr->after_rec) {
-          FreeRecord(dcr->after_rec);
-          dcr->after_rec = NULL;
-        }
       }
     }
     Dmsg2(debuglevel, "After end recs in block. pos=%u:%u\n", dcr->dev->file,

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -246,7 +246,7 @@ int main(int argc, char* argv[])
 #if defined(HAVE_WIN32)
   SOCKET s;
 #else
-  int s, r;
+  int s = 0, r = 0;
   struct passwd* pwd;
 #endif
   char *cp, *p;

--- a/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -8,4 +8,8 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
+  Auto Inflate = in
+  Auto Deflate = out
+  Auto Deflate Algorithm = gzip
+
 }

--- a/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -8,7 +8,6 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
-  Auto Inflate = in
   Auto Deflate = out
   Auto Deflate Algorithm = gzip
 

--- a/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage2.conf
+++ b/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage2.conf
@@ -8,4 +8,8 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
+  Auto Inflate = in
+  Auto Deflate = out
+  Auto Deflate Algorithm = gzip
+
 }

--- a/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage2.conf
+++ b/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/device/FileStorage2.conf
@@ -8,7 +8,6 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
-  Auto Inflate = in
   Auto Deflate = out
   Auto Deflate Algorithm = gzip
 

--- a/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/ndmp/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -4,6 +4,8 @@ Storage {
   NDMP Enable = yes
   NDMP Log Level = 7
   NDMP Snooping = yes
+  Plugin Directory = "@SD_PLUGINS_DIR_TO_TEST@"
+  Plugin Names = "autoxflate"
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
 }


### PR DESCRIPTION
This PR is the backport to 21 of PR #1013 
NDMP backups (using NDMP BAREOS) could be configured to use the autoxflate plugin on used storage devices
Unfortunately, the stream was not deflated during restore resulting in non-recoverable Backups.
This PR adds the feature to deflate compressed packages before sending them back to the NDMP data agent

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**
