### PR TITLE
dird: stored: remove statistics thread messages

### DIFF
--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -467,8 +467,6 @@ int main(int argc, char* argv[])
   DbgJcrAddHook(
       DbDebugPrint); /* used to debug BareosDb connexion after fatal signal */
 
-  //   InitDeviceResources();
-
   StartStatisticsThread();
 
   Dmsg0(200, "Start UA server\n");

--- a/core/src/dird/stats.cc
+++ b/core/src/dird/stats.cc
@@ -320,13 +320,7 @@ bool StartStatisticsThread(void)
   }
   int status;
 
-  if (!me->stats_collect_interval || !collectstatistics) {
-    Emsg1(M_INFO, 0,
-          _("Director Statistics Thread will not be started. Modify your "
-            "configuration if you want to activate it.\n"));
-
-    return false;
-  }
+  if (!me->stats_collect_interval || !collectstatistics) { return false; }
 
   quit = false;
 

--- a/core/src/stored/sd_stats.cc
+++ b/core/src/stored/sd_stats.cc
@@ -416,9 +416,6 @@ bool StartStatisticsThread(void)
   // First see if device and job stats collection is enabled.
   if (!me->stats_collect_interval
       || (!me->collect_dev_stats && !me->collect_job_stats)) {
-    Emsg1(M_INFO, 0,
-          _("Director Statistics Thread was not started. Modify your "
-            "configuration if you want to activate it.\n"));
     return false;
   }
 
@@ -434,12 +431,7 @@ bool StartStatisticsThread(void)
       if (device_resource->collectstats) { cnt++; }
     }
 
-    if (cnt == 0) {
-      Emsg1(M_INFO, 0,
-            _("Director Statistics Thread was not started. Modify your "
-              "configuration if you want to activate it.\n"));
-      return false;
-    }
+    if (cnt == 0) { return false; }
   }
 
   if ((status


### PR DESCRIPTION
### Description

When the statistics threads are not activated, a message shows up to inform the user. This message pops up every time a reload happens. This PR removes that message.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

