### PR TITLE
docs howto improve dbcopy migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - split the very long `Plugins.rst` file into one file per Bareos plugin [PR #1046]
 - rework SD plugin scsicrypto linux sg_io ioctl subsection for cap_sys_rawio [PR #1057]
 - improve action Python plugin documentation, by removing File in Fileset example [PR #1079]
-
+- Improve Mysql - PostgreSQL howto [PR #1093] fixing [BUG #1429]
 
 [PR #1010]: https://github.com/bareos/bareos/pull/1010
 [PR #1013]: https://github.com/bareos/bareos/pull/1013
@@ -106,4 +106,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1106]: https://github.com/bareos/bareos/pull/1106
 [PR #1110]: https://github.com/bareos/bareos/pull/1110
 [PR #1115]: https://github.com/bareos/bareos/pull/1115
+[PR #1093]: https://github.com/bareos/bareos/pull/1093
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - split the very long `Plugins.rst` file into one file per Bareos plugin [PR #1046]
 - rework SD plugin scsicrypto linux sg_io ioctl subsection for cap_sys_rawio [PR #1057]
 - improve action Python plugin documentation, by removing File in Fileset example [PR #1079]
-- Improve Mysql - PostgreSQL howto [PR #1093] fixing [BUG #1429]
+- improve Mysql - PostgreSQL howto [PR #1093] fixing [BUG #1429]
 
 [PR #1010]: https://github.com/bareos/bareos/pull/1010
 [PR #1013]: https://github.com/bareos/bareos/pull/1013

--- a/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
@@ -30,7 +30,12 @@ Make a backup of your old database
 Prepare the new database
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Firstly, create a new |postgresql| database as described in :ref:`section-CreateDatabase`.
+.. warning::
+
+   Don't start the |dir| before completing the migration.
+   Otherwise the |dir| will already insert data into the new |postgresql| catalog while :command:`bareos-dbcopy` will skip every table already containing data.
+
+Firstly, create a new |postgresql| database as described in :ref:`section-CreateDatabase`,
 You have to give the dbtype to the script, so the right db engine is used.
 
 .. code-block:: shell-session
@@ -44,12 +49,6 @@ You have to give the dbtype to the script, so the right db engine is used.
 Both |mysql| and |postgresql| need to have the same Bareos database scheme version,
 i.e. have the schema from the identical Bareos version
 (this should be the case automatically, when upgrading the |mysql| catalog to Bareos 20 and creating a Bareos 20 |postgresql| catalog).
-
-.. warning::
-
-   Don't start the |dir| before completing the migration.
-   Otherwise the |dir| will already insert data into the new |postgresql| catalog while :command:`bareos-dbcopy` will skip every table already containing data.
-
 
 Add the new |postgresql| database to the current |dir| configuration,
 but **do not remove** the |mysql| database from the config, yet.

--- a/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
@@ -31,10 +31,15 @@ Prepare the new database
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Firstly, create a new |postgresql| database as described in :ref:`section-CreateDatabase`.
-Add the new |postgresql| database to the current |dir| configuration,
-but **do not remove** the |mysql| database from the config, yet.
-Both catalog resources must be present
-during the migration process.
+You have to give the dbtype to the script, so the right db engine is used.
+
+.. code-block:: shell-session
+   :caption: Run creating script with db type specified
+
+   su - postgres /usr/lib/bareos/scripts/create_bareos_database postgresql
+   su - postgres /usr/lib/bareos/scripts/make_bareos_tables postgresql
+   su - postgres /usr/lib/bareos/scripts/grant_bareos_privileges postgresql
+
 
 Both |mysql| and |postgresql| need to have the same Bareos database scheme version,
 i.e. have the schema from the identical Bareos version
@@ -45,6 +50,10 @@ i.e. have the schema from the identical Bareos version
    Don't start the |dir| before completing the migration.
    Otherwise the |dir| will already insert data into the new |postgresql| catalog while :command:`bareos-dbcopy` will skip every table already containing data.
 
+
+Add the new |postgresql| database to the current |dir| configuration,
+but **do not remove** the |mysql| database from the config, yet.
+Both catalog resources must be present during the migration process.
 
 These are the catalog resources used in this example:
 
@@ -76,28 +85,31 @@ Run bareos-dbcopy
 ~~~~~~~~~~~~~~~~~
 
 Once the databases are running you can start to copy the contents from |mysql|
-to |postgresql|. Depending on the size of your database the copy process can run
-up to several hours. In our tests with a database containing 160 Million rows
-in the file table took about 5 hours to copy (the testsystem was equipped with SSDs).
+to |postgresql|.
 
 .. note::
 
    Please run bareos-dbcopy as user **bareos** to avoid problems with access rights.
-   To start the shell as user **bareos** you can use this command:
-   ``su -s /bin/bash - bareos``
-
+   See example below how to start the shell as user **bareos** and run dbcopy.
 
 .. code-block:: shell-session
-   :caption: Run the bareos-dbcopy command
+   :caption: Run the bareos-dbcopy command as bareos user
 
-   # run this command as user bareos:
+   # Start the shell as bareos user
+   su -s /bin/bash - bareos
+
+   # run the command as user bareos:
    bareos-dbcopy -c <path-to-bareos-config> MyCatalog MyCatalog-psql
+
+
+Depending on the size of your database the copy process can run up to several hours.
+In our tests with a database containing 160 Million rows in the file table took about
+5 hours to copy (the testsystem was equipped with SSDs).
 
 
 *bareos-dbcopy* will then examine the databases and copy the tables one by one.
 The *file table* is by far the largest table and usually takes the longest time
 to copy.
-
 
 
 .. code-block:: shell-session
@@ -171,3 +183,12 @@ tasks need to be done:
 * start the |dir|
 
 The migration is now completed.
+
+   Please run bareos-dbcopy as user **bareos** to avoid problems with access rights.
+   To start the shell as user **bareos** you can use this command:
+
+.. note::
+
+   Once you are ready to upgrade to :sinceVersion:`21.0.0: PostgreSQL`, **remove** the package
+   **bareos-database-mysql** from your installation.
+   We've made the upgrade process failing on purpose to avoid unattended upgrade.

--- a/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/MigrateABareosCatalogFromMySqlToPostgresql.rst.inc
@@ -183,9 +183,6 @@ tasks need to be done:
 
 The migration is now completed.
 
-   Please run bareos-dbcopy as user **bareos** to avoid problems with access rights.
-   To start the shell as user **bareos** you can use this command:
-
 .. note::
 
    Once you are ready to upgrade to :sinceVersion:`21.0.0: PostgreSQL`, **remove** the package


### PR DESCRIPTION
Document PostgreSQL creation scripts with dbtype. [BUG#1429](https://bugs.bareos.org/view.php?id=1429)
Clarify execution command sequence by reordering blocks.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- ~~[ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [X] Source code changes are understandable
- ~~[ ] Variable and function names are meaningful~~
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR
- [X] `bareos-check-sources --since-merge` does not report any problems
- [X] `git status` should not report modifications in the source tree after building and testing

##### Tests

- ~~[ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)~~
- ~~[ ] The decision towards a systemtest is reasonable compared to a unittest~~
- ~~[ ] Testname matches exactly what is being tested~~
- ~~[ ] Output of the test leads quickly to the origin of the fault~~
