### PR TITLE
dird: director tries to connect to client when connection is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dir: fix crash when there are no jobs to consolidate [PR #1131]
 - webui: get volume and pool params from query instead of route [PR #1139]
 - FreeBSD packages: add missing ddl/update 2171_2192 and 2192_2210 files [PR #1147]
+- Fix director connects to client while `Connection From Director To Client` is disabled. [PR #1099]
 
 ### Changed
 - Qmsg: in case of syslog logging use adapted log priority instead of always LOG_ERR [PR #1134]

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -127,7 +127,7 @@ static bool connect_outbound_to_file_daemon(JobControlRecord* jcr,
   utime_t heart_beat;
 
   if (!IsConnectingToClientAllowed(jcr)) {
-    Dmsg1(120, "connecting to client \"%s\" is not allowed.\n",
+    Dmsg1(120, "Connection to client \"%s\" is not allowed.\n",
           jcr->impl->res.client->resource_name_);
     return false;
   }
@@ -227,6 +227,11 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
                          bool verbose,
                          UaContext* ua)
 {
+  if (!IsConnectingToClientAllowed(jcr) && !IsConnectFromClientAllowed(jcr)) {
+    Emsg1(M_WARNING, 0, _("Connecting to %s is not allowed.\n"),
+          jcr->impl->res.client->resource_name_);
+    return false;
+  }
   bool success = false;
   bool tcp_connect_failed = false;
   int connect_tries
@@ -1328,8 +1333,7 @@ void* HandleFiledConnection(ConnectionPool* connections,
 
   if (!IsConnectFromClientAllowed(client_resource)) {
     Emsg1(M_WARNING, 0,
-          "Client \"%s\" tries to connect, "
-          "but does not have the required permission.\n",
+          "Connection from client \"%s\" to director is not allowed.\n",
           client_name);
     return NULL;
   }

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -402,7 +402,7 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
   ConnectionPool* connections = get_client_connections();
 
   if (!IsConnectFromClientAllowed(jcr)) {
-    Dmsg1(120, "Client Initiated Connection from \"%s\" is not allowed.\n",
+    Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
           jcr->impl->res.client->resource_name_);
   } else {
     connection

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -468,3 +468,11 @@ endif() # NOT client-only
 if(NOT client-only)
   bareos_add_test(select_functions LINK_LIBRARIES dird_objects bareosfind bareossql GTest::gtest_main)
 endif() # NOT client-only
+
+if(NOT client-only)
+  bareos_add_test(
+    dir_fd_connection
+    LINK_LIBRARIES testing_common dird_objects bareos bareossql bareosfind
+                   GTest::gtest_main
+  )
+endif() # NOT client-only

--- a/core/src/tests/configs/dir_fd_connection/dir_to_fd_connection_no/bareos-dir.d/client/fd-no-connection.conf
+++ b/core/src/tests/configs/dir_fd_connection/dir_to_fd_connection_no/bareos-dir.d/client/fd-no-connection.conf
@@ -1,0 +1,6 @@
+Client {
+  Name = fd-no-connection
+  Address = localhost
+  Password = ""
+  Connection From Director To Client = no
+}

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -1,0 +1,46 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "testing_dir_common.h"
+
+#include "dird/ua.h"
+#include "dird/fd_cmds.cc"
+#include "dird/job.cc"
+
+TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
+{
+  InitDirGlobals();
+  std::string path_to_config
+      = std::string(RELATIVE_PROJECT_SOURCE_DIR
+                    "/configs/dir_fd_connection/dir_to_fd_connection_no/");
+
+  PConfigParser director_config(DirectorPrepareResources(path_to_config));
+
+
+  JobControlRecord* jcr = directordaemon::NewDirectorJcr();
+
+  jcr->impl->res.client = static_cast<directordaemon::ClientResource*>(
+      directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
+                                                "fd-no-connection"));
+  directordaemon::UaContext* ua = nullptr;
+
+  EXPECT_FALSE(ConnectToFileDaemon(jcr, 0, 0, false, ua));
+}

--- a/core/src/tests/testing_common.h
+++ b/core/src/tests/testing_common.h
@@ -24,10 +24,10 @@
 
 #if defined(HAVE_MINGW)
 #  include "include/bareos.h"
-#  include "gtest/gtest.h"
-#else
-#  include "gtest/gtest.h"
 #endif
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
 
 #include "lib/parse_conf.h"
 

--- a/core/src/tests/testing_dir_common.cc
+++ b/core/src/tests/testing_dir_common.cc
@@ -49,7 +49,6 @@ PConfigParser DirectorPrepareResources(const std::string& path_to_config)
   EXPECT_TRUE(parse_director_config_ok) << "Could not parse director config";
   if (!parse_director_config_ok) { return nullptr; }
 
-  Dmsg0(200, "Start UA server\n");
   directordaemon::me
       = (directordaemon::DirectorResource*)director_config->GetNextRes(
           directordaemon::R_DIRECTOR, nullptr);

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -977,6 +977,33 @@ case $1 in
 esac
 }
 
+expect_grep()
+{
+
+local usage="Usage: ${FUNCNAME[0]} <expected_result> <log_file> [error message]\n    Find expected_result in log_file. Optionally display custom error_message if not found."
+local expected_result="$1"
+local target_file="$2"
+local error_message="$3"
+
+if [ $# -lt 2  ] || [ $# -gt 3  ]; then
+    echo -e "${FUNCNAME[0]} : wrong number of parameters.\n${usage}"
+    exit 1
+fi
+
+if [ ! -f ${target_file} ]; then
+    echo "\"${target_file}\" does not exist or is not a file."
+    exit 1
+fi
+
+if ! grep -q "${expected_result}" "${target_file}"; then
+  echo "Expected line \"${expected_result}\" was not found in log file \"${target_file}\"." >&2
+  estat=1
+  if [ "${error_message}" != "" ]; then
+    echo "-->${error_message}" >&2
+  fi
+fi
+}
+
 REGRESS_DEBUG=${REGRESS_DEBUG:-0}
 if test "x${REGRESS_DEBUG}" = "x1"; then
    set_debug 1

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
@@ -49,6 +49,7 @@ wait
 @exec "sh -c 'touch ${tmp}/data/weird-files/file-3'"
 run job=$JobName level=Incremental yes
 wait
+messages
 END_OF_DATA
 run_bareos "$@"
 
@@ -118,24 +119,21 @@ run_bconsole
 stop_bareos
 
 check_job_canceled
-if ! grep "purged JobIds 1,2,3 as they were consolidated into Job 6" "$tmp"/log1.out; then
-  echo "consolidation did not work. Check $tmp/log1.out" >&2
-  estat=1
-fi
 
-if ! grep "purging empty jobids 7,8,9" "$tmp"/log2.out; then
-  echo "Removing of empty jobs did not work. Check $tmp/log2.out" >&2
-  estat=1
-fi
+expect_grep "purged JobIds 1,2,3 as they were consolidated into Job 6" \
+            "$tmp"/log1.out \
+            "consolidation of expected jobs did not happen."
 
-if ! grep "purging empty jobids 12" "$tmp"/log3.out; then
-  echo "Removing of empty jobs did not work. Check $tmp/log3.out" >&2
-  estat=1
-fi
+expect_grep "purging empty jobids 7,8,9" \
+            "$tmp"/log2.out \
+            "Removal of expected empty jobs was not successful."
 
-if ! grep "purged JobIds 6,4,11 as they were consolidated into Job 15" "$tmp"/log3.out; then
-  echo "consolidation did not work. Check $tmp/log3.out" >&2
-  estat=1
-fi
+expect_grep "purging empty jobids 12" \
+            "$tmp"/log3.out \
+            "Removal of expected empty jobs was not successful"
+
+expect_grep "purged JobIds 6,4,11 as they were consolidated into Job 15" \
+            "$tmp"/log3.out \
+            "consolidation of expected jobs did not happen."
 
 end_test


### PR DESCRIPTION
### Description

When `Connection From Director To Client = no`, the director tries anyway to connect but fails. Connection should not be even tried in the first place. This PR fixes the issue.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
