### PR TITLE
webui: fix deprecated notice required param follows optional param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - debian: add missing python plugin dependencies [PR #1045]
 - fix empty job timeline issue if date.timezone is not set in php.ini [PR #1053] (backport of [PR #1051])
 - Fix context confusion in Director's Python plugins [PR #1076]
+- webui: fix deprecated notice required param follows optional param [PR #1100]
 
 ### Added
 - ndmp: introduce workaround for isilon 9.1.0.0 'Invalid nlist.tape_offset -1' error [PR #1049]

--- a/webui/module/Fileset/src/Fileset/Model/FilesetModel.php
+++ b/webui/module/Fileset/src/Fileset/Model/FilesetModel.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (C) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -56,7 +56,7 @@ class FilesetModel
     *
     * @return array
     */
-   public function getFileset(&$bsock=null, $id)
+   public function getFileset(&$bsock=null, $id=null)
    {
       if(isset($bsock, $id)) {
          $cmd = 'llist fileset filesetid='.$id.'';


### PR DESCRIPTION
**Backport of PR #1097 to bareos-21**

When declaring a function or a method, adding a required parameter after
optional parameters is deprecated since PHP 8.0.

(cherry picked from commit cc32dad26499fdee22ce3c10a00fe8764afa9f0d)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
