### PR TITLE
webui: fix undefined array key warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - debian: add missing python plugin dependencies [PR #1061] (backport of [PR #1045])
 - Fix context confusion in Director's Python plugins [PR #1077]
-
+- webui: fix undefined array key warning [PR #1103]
 
 ### Added
 - ndmp: introduce workaround for isilon 9.1.0.0 'Invalid nlist.tape_offset -1' error [PR #1058]

--- a/webui/module/Pool/src/Pool/Model/PoolModel.php
+++ b/webui/module/Pool/src/Pool/Model/PoolModel.php
@@ -149,7 +149,11 @@ class PoolModel
 
          $matches = [];
          preg_match('/\s*Next\s*Pool\s*=\s*("|\')?(?<value>.*)(?(1)\1|)/i', $result, $matches);
-         return $matches["value"];
+         if(array_key_exists('value', $matches)) {
+           return $matches["value"];
+         } else {
+           return null;
+         }
       }
       else {
          throw new \Exception('Missing argument.');


### PR DESCRIPTION
**Backport of PR #1098 to bareos-20**

This PR fixes the issue that a PHP warning is thrown because
of a missing check if the array key exists.

(cherry picked from commit 998e4277b130076d43ecf6d61128c1275f5382c4)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
