### PR TITLE
Fix python-bareos compilation on Tumbleweed

### DIFF
--- a/python-bareos/packaging/python-bareos.spec
+++ b/python-bareos/packaging/python-bareos.spec
@@ -29,7 +29,7 @@
 %define python2_build_requires python-rpm-macros python2-rpm-macros python-devel python-setuptools
 %endif
 
-%if 0%{?fedora} >= 35
+%if 0%{?fedora} >= 35 || 0%{?suse_version} >= 1550
 %define skip_python2 1
 %endif
 


### PR DESCRIPTION
Fix `python-bareos` compilation on Tumbleweed
because openSUSE Tumbleweed dropped unsupported `python2`


### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**