### PR TITLE
Improve specfile to support SUSE 15.3

### DIFF
--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -229,9 +229,9 @@ BuildRequires: python3-devel >= 3.4
 %if 0%{?suse_version}
 
 # suse_version:
+#   1500: SLE_15
 #   1315: SLE_12
 #   1110: SLE_11
-#   1010: SLE_10
 
 BuildRequires: distribution-release
 BuildRequires: pwdutils

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -128,7 +128,7 @@ BuildRequires: devtoolset-8-gcc
 BuildRequires: devtoolset-8-gcc-c++
 %endif
 
-%if 0%{?sle_version} >= 150300
+%if 0%{?sle_version} >= 150300 || 0%{?suse_version} > 1500
 BuildRequires: gcc10
 BuildRequires: gcc10-c++
 %else
@@ -917,7 +917,7 @@ source /opt/rh/devtoolset-8/enable
 %endif
 
 # use modern compiler on suse
-%if 0%{?sle_version} >= 150300
+%if 0%{?sle_version} >= 150300 || 0%{?suse_version} > 1500
 CC=gcc-10  ; export CC
 CXX=g++-10 ; export CXX
 %else

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -237,6 +237,8 @@ BuildRequires: distribution-release
 BuildRequires: pwdutils
 BuildRequires: tcpd-devel
 BuildRequires: update-desktop-files
+BuildRequires: pkgconfig(libxml-2.0)
+BuildRequires: pkgconfig(json-c)
 
 %if 0%{?suse_version} > 1010
 # link identical files

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1605,7 +1605,7 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 
 %files storage-python2-plugin
 %defattr(-, root, root)
-%{plugin_dir}/python*-sd.so
+%{plugin_dir}/python-sd.so
 %{python2_sitelib}/bareossd*.so
 
 %files storage-python3-plugin


### PR DESCRIPTION
Without these changes, building in OBS failed for 15.3 and Tumbleweed

For reference see
https://build.opensuse.org/project/show/home:bmwiedemann:bareos

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- ~Separate commit for this PR in the CHANGELOG.md, PR number referenced is same~
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**