### PR TITLE
webui: show DIR message if ACL prevents a job rerun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: fix uncaught TypeError if node.data is null [PR #1087]
 - core cats: Add DROP VIEWS instruction in drop_bareos_table script [PR #1092]
 - Don't keep volume open after acquiring a read-storage failed in migrate/copy/virtual full [PR #1106]
+- webui: show DIR message if ACL prevents a job rerun [PR #1110]
 
 ### Added
 - Python plugins: add default module_path to search path [PR #1038]

--- a/webui/module/Job/src/Job/Controller/JobController.php
+++ b/webui/module/Job/src/Job/Controller/JobController.php
@@ -90,6 +90,7 @@ class JobController extends AbstractActionController
     }
 
     $form = new JobForm($jobs, $jobname, $period, $status);
+    $result = null;
 
     $action = $this->params()->fromQuery('action');
     if(empty($action)) {
@@ -113,7 +114,6 @@ class JobController extends AbstractActionController
       if($action == "rerun") {
         try {
           $jobid = $this->params()->fromQuery('jobid');
-          $result = null;
           $module_config = $this->getServiceLocator()->get('ModuleManager')->getModule('Application')->getConfig();
           $invalid_commands = $this->CommandACLPlugin()->getInvalidCommands(
             $module_config['console_commands']['Job']['optional']
@@ -128,8 +128,10 @@ class JobController extends AbstractActionController
             );
           } else {
             $result = $this->getJobModel()->rerunJob($this->bsock, $jobid);
-            $jobid = rtrim( substr( $result, strrpos($result, "=") + 1 ) );
-            return $this->redirect()->toRoute('job', array('action' => 'details', 'id' => $jobid));
+            if(!preg_match("/authorization/i", $result)) {
+              $jobid = rtrim( substr( $result, strrpos($result, "=") + 1 ) );
+              return $this->redirect()->toRoute('job', array('action' => 'details', 'id' => $jobid));
+            }
           }
         }
         catch(Exception $e) {


### PR DESCRIPTION
In case ACL settings prevent to rerun a job, e.g. lack of access to particular resources,
it should fail gracefully with an error message.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
