### PR TITLE
Fix stale volumes/devices in bareos-sd after failure to acquire a read device on MAC jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Security
 - webui: update jquery from v3.2.0 to v3.6.0 [PR #1085]
 
+### Changed
+- Don't keep volume open after acquiring a read-storage failed in migrate/copy/virtual full [PR #1114]
+
+
 ## [20.0.5] - 2021-12-20
 
 ### Fixed

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1631,11 +1631,13 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
     WaitForStorageDaemonTermination(jcr);
     WaitForStorageDaemonTermination(mig_jcr);
     jcr->setJobStatus(jcr->impl->SDJobStatus);
-    mig_jcr->db_batch->WriteBatchFileRecords(mig_jcr);
+    if (mig_jcr->batch_started) {
+      mig_jcr->db_batch->WriteBatchFileRecords(mig_jcr);
+    }
   } else {
     WaitForStorageDaemonTermination(jcr);
     jcr->setJobStatus(jcr->impl->SDJobStatus);
-    jcr->db_batch->WriteBatchFileRecords(jcr);
+    if (jcr->batch_started) { jcr->db_batch->WriteBatchFileRecords(jcr); }
   }
 
 bail_out:

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2006-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -775,11 +775,7 @@ bail_out:
          job_elapsed / 3600, job_elapsed % 3600 / 60, job_elapsed % 60,
          edit_uint64_with_suffix(jcr->JobBytes / job_elapsed, ec1));
 
-    /*
-     * Release the device -- and send final Vol info to DIR
-     */
-    ReleaseDevice(jcr->impl->dcr);
-
+    // send final Vol info to DIR
     if (!ok || JobCanceled(jcr)) {
       DiscardAttributeSpool(jcr);
     } else {
@@ -787,6 +783,9 @@ bail_out:
     }
   }
 
+  if (!jcr->impl->remote_replicate && jcr->impl->dcr) {
+    if (!ReleaseDevice(jcr->impl->dcr)) { ok = false; }
+  }
   if (jcr->impl->read_dcr) {
     if (!ReleaseDevice(jcr->impl->read_dcr)) { ok = false; }
   }


### PR DESCRIPTION
Backport of PR #1106 to bareos-20
### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing