### PR TITLE
cats:lib: removed comma formatting from jobId attribute in list jobs output.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -82,6 +82,7 @@ Frank Ueberschar
 Geoffrey McRae
 Graham Keeling
 Grzegorz Grabowski
+Hedi Ben Fradj
 Holger Weiss
 Howard Thomson
 I Smith

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - cats: management scripts remove db_driver support [PR #1081]
 - bconsole: multiple identical successive commands are only added to history once [PR #1162]
 - build: Now use solaris 11.4-11.4.42.0.0.111.0 [PR #1189]
+- bconsole: removed commas from jobid attribute in list jobs and llist jobs outputs [PR #1126]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -114,6 +115,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - clarifies Sphinx bareos-extension parallel_read_safe status to False [PR #1037]
 - fix incorrect link in contrib PythonFdPlugin [BUG #1450] [PR #1065]
 
+[PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768
 [PR #1010]: https://github.com/bareos/bareos/pull/1010
 [PR #1013]: https://github.com/bareos/bareos/pull/1013
@@ -162,6 +164,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1115]: https://github.com/bareos/bareos/pull/1115
 [PR #1120]: https://github.com/bareos/bareos/pull/1120
 [PR #1122]: https://github.com/bareos/bareos/pull/1122
+[PR #1126]: https://github.com/bareos/bareos/pull/1126
 [PR #1127]: https://github.com/bareos/bareos/pull/1127
 [PR #1131]: https://github.com/bareos/bareos/pull/1131
 [PR #1134]: https://github.com/bareos/bareos/pull/1134
@@ -176,6 +179,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1154]: https://github.com/bareos/bareos/pull/1154
 [PR #1155]: https://github.com/bareos/bareos/pull/1155
 [PR #1159]: https://github.com/bareos/bareos/pull/1159
+[PR #1162]: https://github.com/bareos/bareos/pull/1162
 [PR #1163]: https://github.com/bareos/bareos/pull/1163
 [PR #1169]: https://github.com/bareos/bareos/pull/1169
 [PR #1170]: https://github.com/bareos/bareos/pull/1170
@@ -183,7 +187,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1172]: https://github.com/bareos/bareos/pull/1172
 [PR #1177]: https://github.com/bareos/bareos/pull/1177
 [PR #1183]: https://github.com/bareos/bareos/pull/1183
-[PR #1170]: https://github.com/bareos/bareos/pull/1170
-[PR #1171]: https://github.com/bareos/bareos/pull/1171
-[PR #1172]: https://github.com/bareos/bareos/pull/1172
+[PR #1185]: https://github.com/bareos/bareos/pull/1185
+[PR #1189]: https://github.com/bareos/bareos/pull/1189
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -475,8 +475,8 @@ int BareosDb::ListResult(void* vctx, int nb_col, char** row)
           if (type == VERT_LIST) {
             if (col_len > max_len) { max_len = col_len; }
           } else {
-            if (SqlFieldIsNumeric(field->type)
-                && (int)field->max_length > 0) { /* fixup for commas */
+            if (SqlFieldIsNumeric(field->type) && (int)field->max_length > 0
+                && strcmp(field->name, "jobid") != 0) { /* fixup for commas */
               field->max_length += (field->max_length - 1) / 3;
             }
             if (col_len < (int)field->max_length) {
@@ -565,7 +565,8 @@ int BareosDb::ListResult(void* vctx, int nb_col, char** row)
         if (row[i] == NULL) {
           value.bsprintf(" %-*s |", max_len, "NULL");
         } else if (SqlFieldIsNumeric(field->type) && !jcr->gui
-                   && IsAnInteger(row[i])) {
+                   && IsAnInteger(row[i])
+                   && strcmp(field->name, "jobid") != 0) {
           value.bsprintf(" %*s |", max_len, add_commas(row[i], ewc));
         } else {
           value.bsprintf(" %-*s |", max_len, row[i]);
@@ -594,8 +595,12 @@ int BareosDb::ListResult(void* vctx, int nb_col, char** row)
         } else if (SqlFieldIsNumeric(field->type) && !jcr->gui
                    && IsAnInteger(row[i])) {
           key.bsprintf(" %*s: ", max_len, field->name);
-          value.bsprintf("%s\n", add_commas(row[i], ewc));
-        } else {
+          if (strcmp(field->name, "jobid") != 0) {
+            value.bsprintf("%s\n", add_commas(row[i], ewc));
+          } else {
+            value.bsprintf("%s\n", row[i]);
+          }
+
           key.bsprintf(" %*s: ", max_len, field->name);
           value.bsprintf("%s\n", row[i]);
         }
@@ -677,8 +682,8 @@ int BareosDb::ListResult(JobControlRecord* jcr,
         if (type == VERT_LIST) {
           if (col_len > max_len) { max_len = col_len; }
         } else {
-          if (SqlFieldIsNumeric(field->type)
-              && (int)field->max_length > 0) { /* fixup for commas */
+          if (SqlFieldIsNumeric(field->type) && (int)field->max_length > 0
+              && strcmp(field->name, "jobid") != 0) { /* fixup for commas */
             field->max_length += (field->max_length - 1) / 3;
           }
           if (col_len < (int)field->max_length) { col_len = field->max_length; }
@@ -766,6 +771,7 @@ int BareosDb::ListResult(JobControlRecord* jcr,
         send->ObjectStart();
         SqlFieldSeek(0);
         send->Decoration("|");
+
         for (int i = 0; i < num_fields; i++) {
           field = SqlFetchField();
           if (!field) { break; }
@@ -781,7 +787,12 @@ int BareosDb::ListResult(JobControlRecord* jcr,
             value.bsprintf(" %-*s |", max_len, "NULL");
           } else if (SqlFieldIsNumeric(field->type) && !jcr->gui
                      && IsAnInteger(row[i])) {
-            value.bsprintf(" %*s |", max_len, add_commas(row[i], ewc));
+            if (strcmp(field->name, "jobid") != 0) {
+              value.bsprintf(" %*s |", max_len, add_commas(row[i], ewc));
+            } else {
+              value.bsprintf(" %*s |", max_len, row[i]);
+            }
+
           } else {
             value.bsprintf(" %-*s |", max_len, row[i]);
           }
@@ -818,7 +829,12 @@ int BareosDb::ListResult(JobControlRecord* jcr,
           } else if (SqlFieldIsNumeric(field->type) && !jcr->gui
                      && IsAnInteger(row[i])) {
             key.bsprintf(" %*s: ", max_len, field->name);
-            value.bsprintf("%s\n", add_commas(row[i], ewc));
+            if (strcmp(field->name, "jobid") != 0) {
+              value.bsprintf("%s\n", add_commas(row[i], ewc));
+            } else {
+              value.bsprintf("%s\n", row[i]);
+            }
+
           } else {
             key.bsprintf(" %*s: ", max_len, field->name);
             value.bsprintf("%s\n", row[i]);


### PR DESCRIPTION
#### Description 

`List jobs` shows `jobId` with comma formatting. 
This PR fixes the issue by removing the commas from `jobid` attribute in the command output".

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
