### PR TITLE
webui: fix restore file tree rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - core cats: Add DROP VIEWS instruction in drop_bareos_table script [PR #1092]
 - Don't keep volume open after acquiring a read-storage failed in migrate/copy/virtual full [PR #1106]
 - webui: show DIR message if ACL prevents a job rerun [PR #1110]
+- webui: fix restore file tree rendering [PR #1127]
 
 ### Changed
 - webui: remove an unnecessary .bvfs_get_jobids and buildSubtree() call [PR #1050]

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -184,7 +184,9 @@ $this->headTitle($title);
          echo '</strong>';
       ?>
       <div class="panel panel-default">
-         <div id="filebrowser" style="width: 100%; height: 60vH;"></div>
+        <div id="filebrowser" style="width: 100%;">
+          <div style="height: 60vH;"></div>
+        </div>
       </div>
    </div>
 

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -182,7 +182,9 @@ $this->headTitle($title);
                   echo '</strong>';
             ?>
                <div class="panel panel-default">
-               <div id="filebrowser" style="width: 100%; height: 60vH;"></div>
+                <div id="filebrowser" style="width: 100%;">
+                  <div style="height: 60vH;"></div>
+                </div>
                </div>
          </div>
 


### PR DESCRIPTION
Do not set a fixed height on the outer container, it leads to a miscalculated tree height
on the inner container and the tree not rendering properly.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
