### PR TITLE
fix director crash when there are no jobs to consolidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Don't keep volume open after acquiring a read-storage failed in migrate/copy/virtual full [PR #1106]
 - webui: show DIR message if ACL prevents a job rerun [PR #1110]
 - webui: fix restore file tree rendering [PR #1127]
+- dir: fix crash when there are no jobs to consolidate [PR #1131]
 
 ### Changed
 - webui: remove an unnecessary .bvfs_get_jobids and buildSubtree() call [PR #1050]
@@ -101,10 +102,14 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1088]: https://github.com/bareos/bareos/pull/1088
 [PR #1089]: https://github.com/bareos/bareos/pull/1089
 [PR #1092]: https://github.com/bareos/bareos/pull/1092
+[PR #1093]: https://github.com/bareos/bareos/pull/1093
 [PR #1097]: https://github.com/bareos/bareos/pull/1097
 [PR #1098]: https://github.com/bareos/bareos/pull/1098
 [PR #1106]: https://github.com/bareos/bareos/pull/1106
 [PR #1110]: https://github.com/bareos/bareos/pull/1110
 [PR #1115]: https://github.com/bareos/bareos/pull/1115
-[PR #1093]: https://github.com/bareos/bareos/pull/1093
+[PR #1120]: https://github.com/bareos/bareos/pull/1120
+[PR #1122]: https://github.com/bareos/bareos/pull/1122
+[PR #1127]: https://github.com/bareos/bareos/pull/1127
+[PR #1131]: https://github.com/bareos/bareos/pull/1131
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1299,6 +1299,8 @@ bool BareosDb::GetUsedBaseJobids(JobControlRecord* jcr,
  */
 db_list_ctx BareosDb::FilterZeroFileJobs(db_list_ctx& jobids)
 {
+  if (jobids.empty()) { return {}; }
+
   std::string query{"SELECT JobId FROM Job WHERE JobFiles = 0 AND JobId IN ("};
   query += jobids.Join(",") + ")";
 


### PR DESCRIPTION
This fixes an issue where an empty job-list was passed to the sql-query
which made the query fail, which eventually crashes the director.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
