### PR TITLE
fix director crash when there are no jobs to consolidate

### DIFF
--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1327,6 +1327,8 @@ bool BareosDb::GetUsedBaseJobids(JobControlRecord* jcr,
  */
 db_list_ctx BareosDb::FilterZeroFileJobs(db_list_ctx& jobids)
 {
+  if (jobids.empty()) { return {}; }
+
   std::string query{"SELECT JobId FROM Job WHERE JobFiles = 0 AND JobId IN ("};
   query += jobids.Join(",") + ")";
 


### PR DESCRIPTION
**Backport of PR#1131 to bareos-21**

This fixes an issue where an empty job-list was passed to the sql-query
which made the query fail, which eventually crashes the director.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
- [ ] The decision towards a systemtest is reasonable compared to a unittest
- [ ] Testname matches exactly what is being tested
- [ ] Output of the test leads quickly to the origin of the fault
