### PR TITLE
console: multicolumn output: fill columns first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -507,4 +507,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1125]: https://github.com/bareos/bareos/pull/1125
 [PR #1128]: https://github.com/bareos/bareos/pull/1128
 [PR #1132]: https://github.com/bareos/bareos/pull/1132
+[PR #1090]: https://github.com/bareos/bareos/pull/1090
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Consolidation now purges candidate jobs with no files instead of ignoring them [PR #1056]
 - Virtual Full will now terminate if one if the input jobs had its files pruned [PR #1070]
 - webui: new login screen background and adapted logo to support Ukraine  [PR #1117]
+- console: multicolumn output: fill columns first [PR #1133]
 
 ### Security
 - webui: update jquery from v3.2.0 to v3.6.0 [PR #1084]

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1123,20 +1123,49 @@ std::string FormatMulticolumnPrompts(const UaContext* ua,
 
   std::string output{};
 
-  for (int i = 1; i < ua->num_prompts; i++) {
-    std::string prompt = ua->prompt[i];
+  const int number_output_lines
+      = (ua->num_prompts + prompts_perline - 1) / prompts_perline;
+  std::cout << "number_output_lines = " << ua->num_prompts << "/ "
+            << prompts_perline << "= " << number_output_lines << std::endl;
+  int current_line = 1;
+  int current_column = 1;
+  // for (int i = 1; i < ua->num_prompts; i++) {
+  for (int i = 1; i < number_output_lines * prompts_perline; i++) {
     if (ua->num_prompts > min_lines_threshold) {
-      if (i % prompts_perline == 0 || i == ua->num_prompts - 1) {
+      current_line = ((i - 1) / prompts_perline);
+      current_column = (i - 1) % prompts_perline;
+      int index = current_line + 1 + (current_column) * (number_output_lines);
+      std::string prompt;
+      // if (i % prompts_perline == 0 || i == ua->num_prompts - 1) {
+      if (i % prompts_perline == 0) {
+        if (index < ua->num_prompts) {
+          prompt = ua->prompt[index];
+          snprintf(formatted_prompt.data(), max_formatted_prompt_length,
+                   "%*d: %s\n", max_prompt_index_length, index, prompt.c_str());
+        } else {
+          snprintf(formatted_prompt.data(), max_formatted_prompt_length, "\n");
+        }
+        // add last column with newline
+      } else {
+        // add next column
+        if (index < ua->num_prompts) {
+          prompt = ua->prompt[index];
+          snprintf(formatted_prompt.data(), max_formatted_prompt_length,
+                   "%*d: %-*s ", max_prompt_index_length, index,
+                   max_prompt_length, prompt.c_str());
+        } else {
+          snprintf(formatted_prompt.data(), max_formatted_prompt_length, "\n");
+        }
+      }
+
+    } else {
+      if (i < ua->num_prompts) {
+        std::string prompt = ua->prompt[i];
         snprintf(formatted_prompt.data(), max_formatted_prompt_length,
                  "%*d: %s\n", max_prompt_index_length, i, prompt.c_str());
       } else {
-        snprintf(formatted_prompt.data(), max_formatted_prompt_length,
-                 "%*d: %-*s ", max_prompt_index_length, i, max_prompt_length,
-                 prompt.c_str());
+        snprintf(formatted_prompt.data(), max_formatted_prompt_length, "\n");
       }
-    } else {
-      snprintf(formatted_prompt.data(), max_formatted_prompt_length,
-               "%*d: %s\n", max_prompt_index_length, i, prompt.c_str());
     }
 
     output += formatted_prompt.data();

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1093,14 +1093,13 @@ void AddPrompt(UaContext* ua, std::string&& prompt)
   AddPrompt(ua, p.c_str());
 }
 
-
 /**
  * Formats the prompts of a UaContext to be displayed in a multicolumn output
  * when possible
  */
-std::string FormatMulticolumnPrompts(const UaContext* ua,
-                                     const int window_width,
-                                     const int min_lines_threshold)
+std::string FormatPrompts(const UaContext* ua,
+                          const int window_width,
+                          const int min_lines_threshold)
 {
   unsigned int max_prompt_length = 1;
 
@@ -1134,7 +1133,6 @@ std::string FormatMulticolumnPrompts(const UaContext* ua,
   std::vector<std::vector<char>> formatted_prompts_container;
 
   std::string output{};
-  int index = 0;
 
   if (ua->num_prompts > min_lines_threshold
       && window_width > max_formatted_prompt_length * 2) {
@@ -1147,6 +1145,8 @@ std::string FormatMulticolumnPrompts(const UaContext* ua,
 
       formatted_prompts_container.push_back(formatted_prompt);
     }
+
+    int index = 0;
     for (int i = 0; i < number_output_lines; i++) {
       index = i;
       while (static_cast<size_t>(index) < formatted_prompts_container.size()) {
@@ -1204,8 +1204,7 @@ int DoPrompt(UaContext* ua,
   if (ua->batch) {
     // First print the choices he wanted to make
     ua->SendMsg(ua->prompt[0]);
-    ua->SendMsg(FormatMulticolumnPrompts(ua, window_width, min_lines_threshold)
-                    .c_str());
+    ua->SendMsg(FormatPrompts(ua, window_width, min_lines_threshold).c_str());
 
     // Now print error message
     ua->SendMsg(_("Your request has multiple choices for \"%s\". Selection is "
@@ -1225,8 +1224,7 @@ int DoPrompt(UaContext* ua,
       ua->SendMsg("%s", ua->prompt[i]);
     }
   } else {
-    ua->SendMsg(FormatMulticolumnPrompts(ua, window_width, min_lines_threshold)
-                    .c_str());
+    ua->SendMsg(FormatPrompts(ua, window_width, min_lines_threshold).c_str());
   }
 
 

--- a/core/src/dird/ua_select.h
+++ b/core/src/dird/ua_select.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -59,9 +59,9 @@ bool SelectClientDbr(UaContext* ua, ClientDbRecord* cr);
 void StartPrompt(UaContext* ua, const char* msg);
 void AddPrompt(UaContext* ua, const char* prompt);
 void AddPrompt(UaContext* ua, std::string&& prompt);
-std::string FormatMulticolumnPrompts(const UaContext* ua,
-                                     int window_width,
-                                     int min_lines_threshold);
+std::string FormatPrompts(const UaContext* ua,
+                          int window_width,
+                          int min_lines_threshold);
 int DoPrompt(UaContext* ua,
              const char* automsg,
              const char* msg,

--- a/core/src/tests/multicolumn_prompts.cc
+++ b/core/src/tests/multicolumn_prompts.cc
@@ -35,9 +35,9 @@ namespace directordaemon {
 bool DoReloadConfig() { return false; }
 }  // namespace directordaemon
 
-TEST(multicolumprompts, test0)
-{
-  UaContext ua;
+class PromptsFormatting : public ::testing::Test {
+ protected:
+  void SetUp() override { ua = new_ua_context(&jcr); }
 
   void TearDown() override { FreeUaContext(ua); }
 
@@ -53,13 +53,12 @@ TEST(multicolumprompts, test0)
   UaContext* ua{};
 };
 
-TEST_F(MulticolumPrompts, ReturnsNothingOnAnEmptyList)
+TEST_F(PromptsFormatting, ReturnsNothingOnAnEmptyList)
 {
   const char* list[] = {nullptr};
   PopulateUaWithPrompts(ua, list);
 
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -68,13 +67,12 @@ TEST_F(MulticolumPrompts, ReturnsNothingOnAnEmptyList)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, ReturnsSingleElementWhenOnlyOnePromptIsAvailable)
+TEST_F(PromptsFormatting, ReturnsSingleElementWhenOnlyOnePromptIsAvailable)
 {
   const char* list[] = {_("bareos1"), nullptr};
   PopulateUaWithPrompts(ua, list);
 
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -83,7 +81,7 @@ TEST_F(MulticolumPrompts, ReturnsSingleElementWhenOnlyOnePromptIsAvailable)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Formatting10Elements_StandardWidthNoThreshold)
+TEST_F(PromptsFormatting, Formatting10Elements_StandardWidthNoThreshold)
 {
   const char* list[] = {_("bareos1"), _("bareos2"),  _("bareos3"), _("bareos4"),
                         _("bareos5"), _("bareos6"),  _("bareos7"), _("bareos8"),
@@ -92,8 +90,7 @@ TEST_F(MulticolumPrompts, Formatting10Elements_StandardWidthNoThreshold)
   PopulateUaWithPrompts(ua, list);
 
   lines_threshold = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -104,7 +101,7 @@ TEST_F(MulticolumPrompts, Formatting10Elements_StandardWidthNoThreshold)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Formatting15Elements_StandardWidthNoThreshold)
+TEST_F(PromptsFormatting, Formatting15Elements_StandardWidthNoThreshold)
 {
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
@@ -116,8 +113,7 @@ TEST_F(MulticolumPrompts, Formatting15Elements_StandardWidthNoThreshold)
   PopulateUaWithPrompts(ua, list);
 
   lines_threshold = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
   /* clang-format off */
   EXPECT_STREQ(
       output.c_str(),
@@ -127,7 +123,7 @@ TEST_F(MulticolumPrompts, Formatting15Elements_StandardWidthNoThreshold)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Formatting16Elements_StandardWidthNoThreshold)
+TEST_F(PromptsFormatting, Formatting16Elements_StandardWidthNoThreshold)
 {
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
@@ -138,8 +134,7 @@ TEST_F(MulticolumPrompts, Formatting16Elements_StandardWidthNoThreshold)
   PopulateUaWithPrompts(ua, list);
 
   lines_threshold = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -150,7 +145,7 @@ TEST_F(MulticolumPrompts, Formatting16Elements_StandardWidthNoThreshold)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Formatting21Elements_StandardWidthNoThreshold)
+TEST_F(PromptsFormatting, Formatting21Elements_StandardWidthNoThreshold)
 {
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
@@ -162,8 +157,7 @@ TEST_F(MulticolumPrompts, Formatting21Elements_StandardWidthNoThreshold)
   PopulateUaWithPrompts(ua, list);
 
   lines_threshold = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -175,15 +169,14 @@ TEST_F(MulticolumPrompts, Formatting21Elements_StandardWidthNoThreshold)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts,
+TEST_F(PromptsFormatting,
        NoMulticolumnformattingWhenNumberOfElementsLessThanThreshold)
 {
   const char* list[] = {_("List last 20 Jobs run"), _("Cancel"), nullptr};
 
   PopulateUaWithPrompts(ua, list);
 
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -193,7 +186,7 @@ TEST_F(MulticolumPrompts,
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, FormatsForVeryLargeWidth)
+TEST_F(PromptsFormatting, FormatsForVeryLargeWidth)
 {
   const char* list[]
       = {_("List last 20 Jobs run"),
@@ -215,8 +208,7 @@ TEST_F(MulticolumPrompts, FormatsForVeryLargeWidth)
 
   window_width = 5000;
   lines_threshold = 10;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(
@@ -237,7 +229,7 @@ TEST_F(MulticolumPrompts, FormatsForVeryLargeWidth)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Format15Elements_SmallWidth10LineThreshold)
+TEST_F(PromptsFormatting, Format15Elements_SmallWidth10LineThreshold)
 {
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
@@ -250,8 +242,7 @@ TEST_F(MulticolumPrompts, Format15Elements_SmallWidth10LineThreshold)
 
   window_width = 60;
   lines_threshold = 10;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(output.c_str(),
@@ -262,7 +253,7 @@ TEST_F(MulticolumPrompts, Format15Elements_SmallWidth10LineThreshold)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts, Formatting_NoWidth)
+TEST_F(PromptsFormatting, Formatting_NoWidth)
 {
   const char* list[]
       = {_("bareos1"), _("bareos2"),  _("bareos3"),  _("bareos4"),
@@ -272,8 +263,7 @@ TEST_F(MulticolumPrompts, Formatting_NoWidth)
   PopulateUaWithPrompts(ua, list);
 
   window_width = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(output.c_str(),
@@ -291,7 +281,7 @@ TEST_F(MulticolumPrompts, Formatting_NoWidth)
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts,
+TEST_F(PromptsFormatting,
        FormatPromptsContainingSpacesAndRegularPrompts_StandartWidthNoThreshold)
 {
   const char* list[] = {_(""), _("Listsaved"), _("Cancel"), nullptr};
@@ -299,8 +289,7 @@ TEST_F(MulticolumPrompts,
   PopulateUaWithPrompts(ua, list);
 
   lines_threshold = 0;
-  std::string output
-      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  std::string output = FormatPrompts(ua, window_width, lines_threshold);
 
   /* clang-format off */
   EXPECT_STREQ(output.c_str(),
@@ -310,14 +299,14 @@ TEST_F(MulticolumPrompts,
   /* clang-format on */
 }
 
-TEST_F(MulticolumPrompts,
+TEST_F(PromptsFormatting,
        FormatPromptsContainingOnlySpacesPrompts_StandartWidthNoThreshold)
 {
   const char* list[] = {_(""), _(" "), _("  "), nullptr};
 
   PopulateUaWithPrompts(ua, list);
 
-  std::string output = FormatMulticolumnPrompts(&ua, 80, 20);
+  std::string output = FormatPrompts(ua, 80, 20);
 
   /* clang-format off */
   EXPECT_STREQ(output.c_str(),

--- a/core/src/tests/multicolumn_prompts.cc
+++ b/core/src/tests/multicolumn_prompts.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -27,6 +27,7 @@
 #endif
 
 #include "dird/ua_select.h"
+#include "include/jcr.h"
 
 using namespace directordaemon;
 
@@ -38,6 +39,73 @@ TEST(multicolumprompts, test0)
 {
   UaContext ua;
 
+  void TearDown() override { FreeUaContext(ua); }
+
+  void PopulateUaWithPrompts(UaContext* ua, const char** list)
+  {
+    StartPrompt(ua, "start");
+    for (int i = 0; list[i]; ++i) { AddPrompt(ua, list[i]); }
+  }
+
+  int window_width{80};
+  int lines_threshold{20};
+  JobControlRecord jcr{};
+  UaContext* ua{};
+};
+
+TEST_F(MulticolumPrompts, ReturnsNothingOnAnEmptyList)
+{
+  const char* list[] = {nullptr};
+  PopulateUaWithPrompts(ua, list);
+
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(
+      output.c_str(),
+      "");
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts, ReturnsSingleElementWhenOnlyOnePromptIsAvailable)
+{
+  const char* list[] = {_("bareos1"), nullptr};
+  PopulateUaWithPrompts(ua, list);
+
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(
+      output.c_str(),
+      "1: bareos1\n");
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts, Formatting10Elements_StandardWidthNoThreshold)
+{
+  const char* list[] = {_("bareos1"), _("bareos2"),  _("bareos3"), _("bareos4"),
+                        _("bareos5"), _("bareos6"),  _("bareos7"), _("bareos8"),
+                        _("bareos9"), _("bareos10"), nullptr};
+
+  PopulateUaWithPrompts(ua, list);
+
+  lines_threshold = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(
+      output.c_str(),
+      " 1: bareos1   3: bareos3   5: bareos5   7: bareos7   9: bareos9  \n"
+      " 2: bareos2   4: bareos4   6: bareos6   8: bareos8  10: bareos10 \n"
+     );
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts, Formatting15Elements_StandardWidthNoThreshold)
+{
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
       _("bareos6"),  _("bareos7"),  _("bareos8"),  _("bareos9"),  _("bareos10"),
@@ -45,63 +113,88 @@ TEST(multicolumprompts, test0)
 
       nullptr};
 
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
+  PopulateUaWithPrompts(ua, list);
 
-  std::string output = FormatMulticolumnPrompts(&ua, 80, 1);
-
+  lines_threshold = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+  /* clang-format off */
   EXPECT_STREQ(
       output.c_str(),
       " 1: bareos1   4: bareos4   7: bareos7  10: bareos10 13: bareos13 \n"
       " 2: bareos2   5: bareos5   8: bareos8  11: bareos11 14: bareos14 \n"
-      " 3: bareos3   6: bareos6   9: bareos9  12: bareos12 15: bareos15 ");
+      " 3: bareos3   6: bareos6   9: bareos9  12: bareos12 15: bareos15 \n");
+  /* clang-format on */
 }
 
-TEST(multicolumprompts, test1)
+TEST_F(MulticolumPrompts, Formatting16Elements_StandardWidthNoThreshold)
 {
-  UaContext ua;
+  const char* list[] = {
+      _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
+      _("bareos6"),  _("bareos7"),  _("bareos8"),  _("bareos9"),  _("bareos10"),
+      _("bareos11"), _("bareos12"), _("bareos13"), _("bareos14"), _("bareos15"),
+      _("bareos16"), nullptr};
 
-  const char* list[]
-      = {_("List last 20 Jobs run"),
-         _("List Jobs where a given File is saved"),
-         _("Enter list of comma separated JobIds to select"),
-         _("Enter SQL list command"),
-         _("Select the most recent backup for a client"),
-         _("Select backup for a client before a specified time"),
-         _("Enter a list of files to restore"),
-         _("Enter a list of files to restore before a specified time"),
-         _("Find the JobIds of the most recent backup for a client"),
-         _("Find the JobIds for a backup for a client before a specified time"),
-         _("Enter a list of directories to restore for found JobIds"),
-         _("Select full restore to a specified Job date"),
-         _("Cancel"),
-         nullptr};
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
+  PopulateUaWithPrompts(ua, list);
 
-  std::string output = FormatMulticolumnPrompts(&ua, 80, 20);
+  lines_threshold = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
 
+  /* clang-format off */
   EXPECT_STREQ(
       output.c_str(),
-      " 1: List last 20 Jobs run\n"
-      " 2: List Jobs where a given File is saved\n"
-      " 3: Enter list of comma separated JobIds to select\n"
-      " 4: Enter SQL list command\n"
-      " 5: Select the most recent backup for a client\n"
-      " 6: Select backup for a client before a specified time\n"
-      " 7: Enter a list of files to restore\n"
-      " 8: Enter a list of files to restore before a specified time\n"
-      " 9: Find the JobIds of the most recent backup for a client\n"
-      "10: Find the JobIds for a backup for a client before a specified time\n"
-      "11: Enter a list of directories to restore for found JobIds\n"
-      "12: Select full restore to a specified Job date\n"
-      "13: Cancel\n");
+      " 1: bareos1   4: bareos4   7: bareos7  10: bareos10 13: bareos13 16: bareos16 \n"
+      " 2: bareos2   5: bareos5   8: bareos8  11: bareos11 14: bareos14 \n"
+      " 3: bareos3   6: bareos6   9: bareos9  12: bareos12 15: bareos15 \n");
+  /* clang-format on */
 }
 
-TEST(multicolumprompts, test2)
+TEST_F(MulticolumPrompts, Formatting21Elements_StandardWidthNoThreshold)
 {
-  UaContext ua;
+  const char* list[] = {
+      _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
+      _("bareos6"),  _("bareos7"),  _("bareos8"),  _("bareos9"),  _("bareos10"),
+      _("bareos11"), _("bareos12"), _("bareos13"), _("bareos14"), _("bareos15"),
+      _("bareos16"), _("bareos17"), _("bareos18"), _("bareos19"), _("bareos20"),
+      _("bareos21"), nullptr};
 
+  PopulateUaWithPrompts(ua, list);
+
+  lines_threshold = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(
+      output.c_str(),
+      " 1: bareos1   5: bareos5   9: bareos9  13: bareos13 17: bareos17 21: bareos21 \n"
+      " 2: bareos2   6: bareos6  10: bareos10 14: bareos14 18: bareos18 \n"
+      " 3: bareos3   7: bareos7  11: bareos11 15: bareos15 19: bareos19 \n"
+      " 4: bareos4   8: bareos8  12: bareos12 16: bareos16 20: bareos20 \n");
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts,
+       NoMulticolumnformattingWhenNumberOfElementsLessThanThreshold)
+{
+  const char* list[] = {_("List last 20 Jobs run"), _("Cancel"), nullptr};
+
+  PopulateUaWithPrompts(ua, list);
+
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(
+      output.c_str(),
+      "1: List last 20 Jobs run\n"
+      "2: Cancel\n");
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts, FormatsForVeryLargeWidth)
+{
   const char* list[]
       = {_("List last 20 Jobs run"),
          _("List Jobs where a given File is saved"),
@@ -117,11 +210,15 @@ TEST(multicolumprompts, test2)
          _("Select full restore to a specified Job date"),
          _("Cancel"),
          nullptr};
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
 
-  std::string output = FormatMulticolumnPrompts(&ua, 5000, 1);
+  PopulateUaWithPrompts(ua, list);
 
+  window_width = 5000;
+  lines_threshold = 10;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
   EXPECT_STREQ(
       output.c_str(),
       " 1: List last 20 Jobs run                                             "
@@ -136,13 +233,12 @@ TEST(multicolumprompts, test2)
       "10: Find the JobIds for a backup for a client before a specified time "
       "11: Enter a list of directories to restore for found JobIds           "
       "12: Select full restore to a specified Job date                       "
-      "13: Cancel\n");
+      "13: Cancel                                                            \n");
+  /* clang-format on */
 }
 
-TEST(multicolumprompts, test3)
+TEST_F(MulticolumPrompts, Format15Elements_SmallWidth10LineThreshold)
 {
-  UaContext ua;
-
   const char* list[] = {
       _("bareos1"),  _("bareos2"),  _("bareos3"),  _("bareos4"),  _("bareos5"),
       _("bareos6"),  _("bareos7"),  _("bareos8"),  _("bareos9"),  _("bareos10"),
@@ -150,48 +246,83 @@ TEST(multicolumprompts, test3)
 
       nullptr};
 
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
+  PopulateUaWithPrompts(ua, list);
 
-  std::string output = FormatMulticolumnPrompts(&ua, 60, 10);
+  window_width = 60;
+  lines_threshold = 10;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
 
+  /* clang-format off */
   EXPECT_STREQ(output.c_str(),
-               " 1: bareos1   5: bareos5   9: bareos9  13: bareos13\n"
-               " 2: bareos2   6: bareos6  10: bareos10 14: bareos14\n"
-               " 3: bareos3   7: bareos7  11: bareos11 15: bareos15\n"
-               " 4: bareos4   8: bareos8  12: bareos12\n");
+               " 1: bareos1   5: bareos5   9: bareos9  13: bareos13 \n"
+               " 2: bareos2   6: bareos6  10: bareos10 14: bareos14 \n"
+               " 3: bareos3   7: bareos7  11: bareos11 15: bareos15 \n"
+               " 4: bareos4   8: bareos8  12: bareos12 \n");
+  /* clang-format on */
 }
 
-TEST(multicolumprompts, test4)
+TEST_F(MulticolumPrompts, Formatting_NoWidth)
 {
-  UaContext ua;
+  const char* list[]
+      = {_("bareos1"), _("bareos2"),  _("bareos3"),  _("bareos4"),
+         _("bareos5"), _("bareos6"),  _("bareos7"),  _("bareos8"),
+         _("bareos9"), _("bareos10"), _("bareos11"), nullptr};
 
+  PopulateUaWithPrompts(ua, list);
+
+  window_width = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
+
+  /* clang-format off */
+  EXPECT_STREQ(output.c_str(),
+               " 1: bareos1\n"
+               " 2: bareos2\n"
+               " 3: bareos3\n"
+               " 4: bareos4\n"
+               " 5: bareos5\n"
+               " 6: bareos6\n"
+               " 7: bareos7\n"
+               " 8: bareos8\n"
+               " 9: bareos9\n"
+               "10: bareos10\n"
+               "11: bareos11\n");
+  /* clang-format on */
+}
+
+TEST_F(MulticolumPrompts,
+       FormatPromptsContainingSpacesAndRegularPrompts_StandartWidthNoThreshold)
+{
   const char* list[] = {_(""), _("Listsaved"), _("Cancel"), nullptr};
 
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
+  PopulateUaWithPrompts(ua, list);
 
-  std::string output = FormatMulticolumnPrompts(&ua, 80, 1);
+  lines_threshold = 0;
+  std::string output
+      = FormatMulticolumnPrompts(ua, window_width, lines_threshold);
 
+  /* clang-format off */
   EXPECT_STREQ(output.c_str(),
                "1:           "
                "2: Listsaved "
-               "3: Cancel\n");
+               "3: Cancel    \n");
+  /* clang-format on */
 }
 
-TEST(multicolumprompts, test5)
+TEST_F(MulticolumPrompts,
+       FormatPromptsContainingOnlySpacesPrompts_StandartWidthNoThreshold)
 {
-  UaContext ua;
-
   const char* list[] = {_(""), _(" "), _("  "), nullptr};
 
-  StartPrompt(&ua, "start");
-  for (int i = 0; list[i]; ++i) { AddPrompt(&ua, list[i]); }
+  PopulateUaWithPrompts(ua, list);
 
   std::string output = FormatMulticolumnPrompts(&ua, 80, 20);
 
+  /* clang-format off */
   EXPECT_STREQ(output.c_str(),
                "1: \n"
                "2:  \n"
                "3:   \n");
+  /* clang-format on */
 }

--- a/core/src/tests/multicolumn_prompts.cc
+++ b/core/src/tests/multicolumn_prompts.cc
@@ -50,12 +50,11 @@ TEST(multicolumprompts, test0)
 
   std::string output = FormatMulticolumnPrompts(&ua, 80, 1);
 
-  EXPECT_STREQ(output.c_str(),
-               " 1: bareos1   2: bareos2   3: bareos3   4: bareos4   5: "
-               "bareos5   6: bareos6\n"
-               " 7: bareos7   8: bareos8   9: bareos9  10: bareos10 11: "
-               "bareos11 12: bareos12\n"
-               "13: bareos13 14: bareos14 15: bareos15\n");
+  EXPECT_STREQ(
+      output.c_str(),
+      " 1: bareos1   4: bareos4   7: bareos7  10: bareos10 13: bareos13 \n"
+      " 2: bareos2   5: bareos5   8: bareos8  11: bareos11 14: bareos14 \n"
+      " 3: bareos3   6: bareos6   9: bareos9  12: bareos12 15: bareos15 ");
 }
 
 TEST(multicolumprompts, test1)
@@ -157,10 +156,10 @@ TEST(multicolumprompts, test3)
   std::string output = FormatMulticolumnPrompts(&ua, 60, 10);
 
   EXPECT_STREQ(output.c_str(),
-               " 1: bareos1   2: bareos2   3: bareos3   4: bareos4\n"
-               " 5: bareos5   6: bareos6   7: bareos7   8: bareos8\n"
-               " 9: bareos9  10: bareos10 11: bareos11 12: bareos12\n"
-               "13: bareos13 14: bareos14 15: bareos15\n");
+               " 1: bareos1   5: bareos5   9: bareos9  13: bareos13\n"
+               " 2: bareos2   6: bareos6  10: bareos10 14: bareos14\n"
+               " 3: bareos3   7: bareos7  11: bareos11 15: bareos15\n"
+               " 4: bareos4   8: bareos8  12: bareos12\n");
 }
 
 TEST(multicolumprompts, test4)

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -34,7 +34,7 @@ If you have any questions or problems, please give a comment in the PR.
 
 ##### Tests
 
-- [ ] Decision taken that a system- or unittest is required (if not, then remove this paragraph)
-- [ ] The decision towards a systemtest is reasonable compared to a unittest
+- [ ] Decision taken that a test is required (if not, then remove this paragraph)
+- [ ] The choice of the type of test (unit test or systemtest) is reasonable
 - [ ] Testname matches exactly what is being tested
-- [ ] Output of the test leads quickly to the origin of the fault
+- [ ] On a fail, output of the test leads quickly to the origin of the fault


### PR DESCRIPTION
#### Description
This PR is a backport of #1072 

The multicolumn output puts the items line by line like this:
```
1  2  3  
4  5  6
7  8  9 
```
This PR make the output look like this:
```
1  4  7
2  5  8
3  6  9
```
Which is much better for human consumption.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
