### PR TITLE
Qmsg: in case of syslog logging use adapted log priority instead of always LOG_ERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dir: fix crash when there are no jobs to consolidate [PR #1131]
 
 ### Changed
+- Qmsg: in case of syslog logging use adapted log priority instead of always LOG_ERR [PR #1134]
 - webui: remove an unnecessary .bvfs_get_jobids and buildSubtree() call [PR #1050]
 - git: set merge strategy for CHANGELOG.md to union [PR #1062]
 - webui: add timeline chart by jobs [PR #1059]

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -1531,6 +1531,57 @@ int Mmsg(std::vector<char>& msgbuf, const char* fmt, ...)
   }
 }
 
+// convert bareos message type to syslog log priority
+static int MessageTypeToLogPriority(int message_type)
+{
+  {
+    switch (message_type) {
+      case M_ABORT:
+        return LOG_EMERG;
+      case M_TERM:
+        return LOG_EMERG;
+
+      case M_DEBUG:
+        return LOG_DEBUG;
+      case M_FATAL:
+        return LOG_ALERT;
+
+      case M_ERROR:
+        return LOG_ERR;
+      case M_ERROR_TERM:
+        return LOG_ERR;
+
+      case M_WARNING:
+        return LOG_WARNING;
+
+      case M_INFO:
+        return LOG_INFO;
+      case M_SAVED:
+        return LOG_INFO;
+      case M_NOTSAVED:
+        return LOG_INFO;
+      case M_SKIPPED:
+        return LOG_INFO;
+      case M_MOUNT:
+        return LOG_INFO;
+
+      case M_RESTORED:
+        return LOG_INFO;
+      case M_SECURITY:
+        return LOG_INFO;
+      case M_ALERT:
+        return LOG_INFO;
+      case M_VOLMGMT:
+        return LOG_INFO;
+      case M_AUDIT:
+        return LOG_INFO;
+
+      default:
+        return LOG_ERR;
+    }
+  }
+}
+
 /*
  * We queue messages rather than print them directly. This
  * is generally used in low level routines (msg handler, bnet)
@@ -1569,7 +1620,7 @@ void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
 
   // If no jcr  or no JobId or no queue or dequeuing send to syslog
   if (!jcr || !jcr->JobId || !jcr->msg_queue || jcr->dequeuing_msgs) {
-    syslog(LOG_DAEMON | LOG_ERR, "%s", item->msg_);
+    syslog(LOG_DAEMON | MessageTypeToLogPriority(type), "%s", item->msg_);
     free(item->msg_);
     item->msg_ = nullptr;
     free(item);


### PR DESCRIPTION
In the case that normal logging is not possible, Qmsg() logs to syslog.
Instead of logging with severity LOG_ERR in this case without regarding
the message type, we now  translate the bareos message type to a syslog
severity.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted


##### Source code quality

- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] `bareos-check-sources --since-merge` does not report any problems
- [X] `git status` should not report modifications in the source tree after building and testing
