### PR TITLE
cats: include only jobtypes in `list jobtotals` that write data to volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+
+### Changed
+- cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]
+
 ## [21.1.2] - 2022-03-17
 
 ### Fixed

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -633,9 +633,11 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
   DbLock(this);
 
   // List by Job
+  // JobTypes BACKUP(B),ARCHIVE(A,a), JOB_COPY(C)
   Mmsg(cmd,
-       "SELECT count(*) AS Jobs,sum(JobFiles) "
-       "AS Files,sum(JobBytes) AS Bytes,Name AS Job FROM Job GROUP BY Name");
+       "SELECT COUNT(*) AS Jobs, SUM(JobFiles) "
+       "AS Files, SUM(JobBytes) AS Bytes, Name AS Job FROM Job WHERE Type IN "
+       "('B','A','a','C') GROUP BY Name");
 
   if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
 
@@ -646,9 +648,11 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
   SqlFreeResult();
 
   // Do Grand Total
+  // JobTypes BACKUP(B),ARCHIVE(A,a), JOB_COPY(C)
   Mmsg(cmd,
-       "SELECT COUNT(*) AS Jobs,sum(JobFiles) "
-       "AS Files,sum(JobBytes) As Bytes FROM Job");
+       "SELECT COUNT(*) AS Jobs, SUM(JobFiles) "
+       "AS Files, SUM(JobBytes) AS Bytes FROM Job WHERE Type IN "
+       "('B','A','a','C')");
 
   if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
 


### PR DESCRIPTION
**Backport of PR #1135 to bareos-21**

(cherry picked from commit 17bc5319e329144af7fc864905504168ba3515dd)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

