### PR TITLE
fix caching during bvfs_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - console: multicolumn output: fill columns first [PR #1072]
 - cats: include only jobtypes in `list jobtotals` that write data to volumes [PR #1135]
 - jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1140]
+- `bvfs_update` now uses `unordered_map` instead of `htable` for the pathid cache [PR #1138]
 
 ### Deprecated
 

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -34,56 +34,17 @@
 #  include "cats/bvfs.h"
 #  include "lib/edit.h"
 
+#  include <unordered_set>
+
 #  define dbglevel 10
 #  define dbglevel_sql 15
 
-#  define NITEMS 50000
 class pathid_cache {
- private:
-  hlink* nodes;
-  int nb_node;
-  int max_node;
-  alist<hlink*>* table_node;
-  htable<char*, hlink>* cache_ppathid;
+  std::unordered_set<uint64_t> cache;
 
  public:
-  pathid_cache()
-  {
-    cache_ppathid = new htable<char*, hlink>(NITEMS);
-    max_node = NITEMS;
-    nodes = (hlink*)malloc(max_node * sizeof(hlink));
-    nb_node = 0;
-    table_node = new alist<hlink*>(5, owned_by_alist);
-    table_node->append(nodes);
-  }
-
-  hlink* get_hlink()
-  {
-    if (++nb_node >= max_node) {
-      nb_node = 0;
-      nodes = (hlink*)malloc(max_node * sizeof(hlink));
-      table_node->append(nodes);
-    }
-    return nodes + nb_node;
-  }
-
-  bool lookup(char* pathid) { return (cache_ppathid->lookup(pathid) != NULL); }
-
-  void insert(char* pathid)
-  {
-    hlink* h = get_hlink();
-    cache_ppathid->insert(pathid, h);
-  }
-
-  ~pathid_cache()
-  {
-    delete cache_ppathid;
-    delete table_node;
-  }
-
- private:
-  pathid_cache(const pathid_cache&);            /* prohibit pass by value */
-  pathid_cache& operator=(const pathid_cache&); /* prohibit class assignment*/
+  void insert(uint64_t id) { cache.emplace(id); }
+  bool lookup(uint64_t id) const { return cache.find(id) != cache.end(); }
 };
 
 // Generic path handlers used for database queries.
@@ -109,12 +70,10 @@ void BareosDb::BuildPathHierarchy(JobControlRecord* jcr,
                                   char* org_pathid,
                                   char* new_path)
 {
-  char pathid[50];
-  AttributesDbRecord parent;
+  uint64_t pathid = str_to_int64(org_pathid);
   char* bkp = path;
 
   Dmsg1(dbglevel, "BuildPathHierarchy(%s)\n", new_path);
-  bstrncpy(pathid, org_pathid, sizeof(pathid));
 
   /*
    * Does the ppathid exist for this? use a memory cache ...
@@ -130,7 +89,8 @@ void BareosDb::BuildPathHierarchy(JobControlRecord* jcr,
        */
       goto bail_out;
     } else {
-      Mmsg(cmd, "SELECT PPathId FROM PathHierarchy WHERE PathId = %s", pathid);
+      Mmsg(cmd, "SELECT PPathId FROM PathHierarchy WHERE PathId = %llu",
+           pathid);
 
       if (!QUERY_DB(jcr, cmd)) { goto bail_out; /* Query failed, just leave */ }
 
@@ -146,17 +106,18 @@ void BareosDb::BuildPathHierarchy(JobControlRecord* jcr,
         path = bvfs_parent_dir(new_path);
         pnl = strlen(path);
 
+        AttributesDbRecord parent;
         if (!CreatePathRecord(jcr, &parent)) { goto bail_out; }
         ppathid_cache.insert(pathid);
 
         Mmsg(cmd,
-             "INSERT INTO PathHierarchy (PathId, PPathId) VALUES (%s,%lld)",
+             "INSERT INTO PathHierarchy (PathId, PPathId) VALUES (%llu,%llu)",
              pathid, (uint64_t)parent.PathId);
         if (!INSERT_DB(jcr, cmd)) {
           goto bail_out; /* Can't insert the record, just leave */
         }
 
-        edit_uint64(parent.PathId, pathid);
+        pathid = parent.PathId;
         /* continue with parent directory */
         new_path = path;
       }


### PR DESCRIPTION
This patch replaces the complicated `pathid_cache` based on `htable` with a
much simpler one based on `std::unordered_set`. It also changes the
interface to use `uint64_t` instead of `char*`.

This addresses a problem where htable broke when it grew, because the key-memory had been reused.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
