### PR TITLE
webui: get volume and pool params from query instead of route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - debian: Let dbconfig create the Bareos catalog also with LC_COLLATE='C' and LC_CTYPE='C'. The create_bareos_database script did always do so. Requires dbconfig >= 2.0.21 [PR #1031]
 - fix wrong `packages_dir` in restapi workflow, so restapi packages will be released to PyPI [PR #1033]
 - core cats: Add IF EXISTS in drop table statements fix for bug #1409 (Allow usage of ExitOnFatal) [PR #1035]
-- sql_get.cc: fix error logging in GetJobRecord() for jobname #1042
+- sql_get.cc: fix error logging in GetJobRecord() for jobname [PR #1042]
 - webui: fix empty job timeline issue if date.timezone is not set in php.ini [PR #1051]
 - Fix for wrong update message when updating all volumes from all pools with no existing volumes [PR #1015]
 - Fix context confusion in Director's Python plugins [PR #1047]
@@ -37,6 +37,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: show DIR message if ACL prevents a job rerun [PR #1110]
 - webui: fix restore file tree rendering [PR #1127]
 - dir: fix crash when there are no jobs to consolidate [PR #1131]
+- webui: get volume and pool params from query instead of route [PR #1139]
 
 ### Changed
 - webui: remove an unnecessary .bvfs_get_jobids and buildSubtree() call [PR #1050]

--- a/webui/module/Media/src/Media/Controller/MediaController.php
+++ b/webui/module/Media/src/Media/Controller/MediaController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -130,7 +130,7 @@ class MediaController extends AbstractActionController
       );
     }
 
-    $volumename = $this->params()->fromRoute('id');
+    $volumename = $this->params()->fromQuery('volume');
 
     return new ViewModel(array(
       'volume' => $volumename,

--- a/webui/module/Pool/src/Pool/Controller/PoolController.php
+++ b/webui/module/Pool/src/Pool/Controller/PoolController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -130,7 +130,7 @@ class PoolController extends AbstractActionController
       );
     }
 
-    $poolname = $this->params()->fromRoute('id');
+    $poolname = $this->params()->fromQuery('pool');
 
     try {
       $this->bsock = $this->getServiceLocator()->get('director');

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -3,7 +3,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2020-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2020-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -488,11 +488,11 @@ function formatAutochangerStatus(value) {
 }
 
 function formatPoolName(value, basePath) {
-   return '<a href="' + basePath + '/pool/details/' + value + '">' + value + '</a>';
+   return '<a href="' + basePath + '/pool/details/?pool=' + value + '">' + value + '</a>';
 }
 
 function formatVolumeName(value, basePath) {
-   return '<a href="' + basePath + '/media/details/' + value + '">' + value + '</a>';
+   return '<a href="' + basePath + '/media/details/?volume=' + value + '">' + value + '</a>';
 }
 
 function clientsActionButtonsFormatter(value, row, index, basePath) {


### PR DESCRIPTION
Fixes #1441: Unable to view the pool details, when the pool name contains an space char

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

