### PR TITLE
jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: new login screen background and adapted logo to support Ukraine  [PR #1122]
 - console: multicolumn output: fill columns first [PR #1072]
 - cats: include only jobtypes in `list jobtotals` that write data to volumes [PR #1135]
+- jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1140]
 
 ### Deprecated
 

--- a/webui/public/js/jstreegrid.js
+++ b/webui/public/js/jstreegrid.js
@@ -235,15 +235,6 @@
 				this.uniq = Math.ceil(Math.random()*1000);
 				this.rootid = container.attr("id");
 
-				var msie = /msie/.test(navigator.userAgent.toLowerCase());
-				if (msie) {
-					var version = parseFloat(navigator.appVersion.split("MSIE")[1]);
-					if (version < 8) {
-						gs.defaultConf.display = "inline";
-						gs.defaultConf.zoom = "1";
-					}
-				}
-
 				// set up the classes we need
 				if (!styled) {
 					styled = true;


### PR DESCRIPTION
Starting in Chrome 101, the amount of information available in the
User Agent string will be reduced.

This PR removes the specific handling of IE < 8, to avoid issues
in Chrome >= 101.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
