### PR TITLE
jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]
+- jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1141]
 
 ## [21.1.2] - 2022-03-17
 

--- a/webui/public/js/jstreegrid.js
+++ b/webui/public/js/jstreegrid.js
@@ -232,15 +232,6 @@
 				this.uniq = Math.ceil(Math.random()*1000);
 				this.rootid = container.attr("id");
 
-				var msie = /msie/.test(navigator.userAgent.toLowerCase());
-				if (msie) {
-					var version = parseFloat(navigator.appVersion.split("MSIE")[1]);
-					if (version < 8) {
-						gs.defaultConf.display = "inline";
-						gs.defaultConf.zoom = "1";
-					}
-				}
-
 				// set up the classes we need
 				if (!styled) {
 					styled = true;


### PR DESCRIPTION
**Backport of PR #1140 to bareos-21**

Starting in Chrome 101, the amount of information available in the
User Agent string will be reduced.

This PR removes the specific handling of IE < 8, to avoid issues
in Chrome >= 101.

(cherry picked from commit 09f916cfa1fac5faebe5a088fd7bf55d3654febf)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
