### PR TITLE
webui: get volume and pool params from query instead of route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Fixed
+- webui: get volume and pool params from query instead of route [PR #1144]
 
 ### Changed
 - cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]

--- a/webui/module/Media/src/Media/Controller/MediaController.php
+++ b/webui/module/Media/src/Media/Controller/MediaController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -130,7 +130,7 @@ class MediaController extends AbstractActionController
       );
     }
 
-    $volumename = $this->params()->fromRoute('id');
+    $volumename = $this->params()->fromQuery('volume');
 
     return new ViewModel(array(
       'volume' => $volumename,

--- a/webui/module/Pool/src/Pool/Controller/PoolController.php
+++ b/webui/module/Pool/src/Pool/Controller/PoolController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2013-2019 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -130,7 +130,7 @@ class PoolController extends AbstractActionController
       );
     }
 
-    $poolname = $this->params()->fromRoute('id');
+    $poolname = $this->params()->fromQuery('pool');
 
     try {
       $this->bsock = $this->getServiceLocator()->get('director');

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -3,7 +3,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (c) 2020-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (c) 2020-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -488,11 +488,11 @@ function formatAutochangerStatus(value) {
 }
 
 function formatPoolName(value, basePath) {
-   return '<a href="' + basePath + '/pool/details/' + value + '">' + value + '</a>';
+   return '<a href="' + basePath + '/pool/details/?pool=' + value + '">' + value + '</a>';
 }
 
 function formatVolumeName(value, basePath) {
-   return '<a href="' + basePath + '/media/details/' + value + '">' + value + '</a>';
+   return '<a href="' + basePath + '/media/details/?volume=' + value + '">' + value + '</a>';
 }
 
 function clientsActionButtonsFormatter(value, row, index, basePath) {


### PR DESCRIPTION
**Backport of PR #1139 to bareos-21**

Fixes #1441: Unable to view the pool details, when the pool name contains an space char

(cherry picked from commit 90dbf701820d623c435fc1fadbd4ae154232c625)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
