### PR TITLE
fix caching during bvfs_update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]
 - jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1141]
+- `bvfs_update` now uses `unordered_map` instead of `htable` for the pathid cache [PR #1146]
 
 ## [21.1.2] - 2022-03-17
 


### PR DESCRIPTION
**Backport of PR#1138 to bareos-21**

This patch replaces the complicated pathid_cache based on htable with a
much simpler one based on std::unordered_set. It also changes the
interface to use uint64_t instead of char*

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
