### PR TITLE
Qmsg: in case of syslog logging use adapted log priority instead of always LOG_ERR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]
 - jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1141]
 - `bvfs_update` now uses `unordered_map` instead of `htable` for the pathid cache [PR #1146]
+- Qmsg: in case of syslog logging use adapted log priority instead of always LOG_ERR [PR #1150]
 
 ## [21.1.2] - 2022-03-17
 

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -1530,6 +1530,57 @@ int Mmsg(std::vector<char>& msgbuf, const char* fmt, ...)
   }
 }
 
+// convert bareos message type to syslog log priority
+static int MessageTypeToLogPriority(int message_type)
+{
+  {
+    switch (message_type) {
+      case M_ABORT:
+        return LOG_EMERG;
+      case M_TERM:
+        return LOG_EMERG;
+
+      case M_DEBUG:
+        return LOG_DEBUG;
+      case M_FATAL:
+        return LOG_ALERT;
+
+      case M_ERROR:
+        return LOG_ERR;
+      case M_ERROR_TERM:
+        return LOG_ERR;
+
+      case M_WARNING:
+        return LOG_WARNING;
+
+      case M_INFO:
+        return LOG_INFO;
+      case M_SAVED:
+        return LOG_INFO;
+      case M_NOTSAVED:
+        return LOG_INFO;
+      case M_SKIPPED:
+        return LOG_INFO;
+      case M_MOUNT:
+        return LOG_INFO;
+
+      case M_RESTORED:
+        return LOG_INFO;
+      case M_SECURITY:
+        return LOG_INFO;
+      case M_ALERT:
+        return LOG_INFO;
+      case M_VOLMGMT:
+        return LOG_INFO;
+      case M_AUDIT:
+        return LOG_INFO;
+
+      default:
+        return LOG_ERR;
+    }
+  }
+}
+
 /*
  * We queue messages rather than print them directly. This
  * is generally used in low level routines (msg handler, bnet)
@@ -1567,7 +1618,7 @@ void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
 
   // If no jcr  or no JobId or no queue or dequeuing send to syslog
   if (!jcr || !jcr->JobId || !jcr->msg_queue || jcr->dequeuing_msgs) {
-    syslog(LOG_DAEMON | LOG_ERR, "%s", item->msg_);
+    syslog(LOG_DAEMON | MessageTypeToLogPriority(type), "%s", item->msg_);
     free(item->msg_);
     item->msg_ = nullptr;
     free(item);

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -77,6 +77,8 @@ static bool trace = false;
 #endif
 static bool hangup = false;
 
+static int MessageTypeToLogPriority(int message_type);
+
 /*
  * Walk back in a string from end looking for a
  * path separator.
@@ -745,40 +747,8 @@ void DispatchMessage(JobControlRecord* jcr,
            * Dispatch based on our internal message type to a matching syslog
            * one.
            */
-          switch (type) {
-            case M_ERROR:
-            case M_ERROR_TERM:
-              SendToSyslog(d->syslog_facility_ | LOG_ERR, msg);
-              break;
-            case M_ABORT:
-            case M_FATAL:
-              SendToSyslog(d->syslog_facility_ | LOG_CRIT, msg);
-              break;
-            case M_WARNING:
-              SendToSyslog(d->syslog_facility_ | LOG_WARNING, msg);
-              break;
-            case M_DEBUG:
-              SendToSyslog(d->syslog_facility_ | LOG_DEBUG, msg);
-              break;
-            case M_INFO:
-            case M_NOTSAVED:
-            case M_RESTORED:
-            case M_SAVED:
-            case M_SKIPPED:
-            case M_TERM:
-              SendToSyslog(d->syslog_facility_ | LOG_INFO, msg);
-              break;
-            case M_ALERT:
-            case M_AUDIT:
-            case M_MOUNT:
-            case M_SECURITY:
-            case M_VOLMGMT:
-              SendToSyslog(d->syslog_facility_ | LOG_NOTICE, msg);
-              break;
-            default:
-              SendToSyslog(d->syslog_facility_ | LOG_ERR, msg);
-              break;
-          }
+          SendToSyslog(d->syslog_facility_ | MessageTypeToLogPriority(type),
+                       msg);
           break;
         case MessageDestinationCode::kOperator:
           Dmsg1(850, "OPERATOR for following msg: %s\n", msg);
@@ -1533,51 +1503,38 @@ int Mmsg(std::vector<char>& msgbuf, const char* fmt, ...)
 // convert bareos message type to syslog log priority
 static int MessageTypeToLogPriority(int message_type)
 {
-  {
-    switch (message_type) {
-      case M_ABORT:
-        return LOG_EMERG;
-      case M_TERM:
-        return LOG_EMERG;
+  switch (message_type) {
+    case M_ERROR:
+    case M_ERROR_TERM:
+      return LOG_ERR;
 
-      case M_DEBUG:
-        return LOG_DEBUG;
-      case M_FATAL:
-        return LOG_ALERT;
+    case M_ABORT:
+    case M_FATAL:
+      return LOG_CRIT;
 
-      case M_ERROR:
-        return LOG_ERR;
-      case M_ERROR_TERM:
-        return LOG_ERR;
+    case M_WARNING:
+      return LOG_WARNING;
 
-      case M_WARNING:
-        return LOG_WARNING;
+    case M_DEBUG:
+      return LOG_DEBUG;
 
-      case M_INFO:
-        return LOG_INFO;
-      case M_SAVED:
-        return LOG_INFO;
-      case M_NOTSAVED:
-        return LOG_INFO;
-      case M_SKIPPED:
-        return LOG_INFO;
-      case M_MOUNT:
-        return LOG_INFO;
+    case M_INFO:
+    case M_NOTSAVED:
+    case M_RESTORED:
+    case M_SAVED:
+    case M_SKIPPED:
+    case M_TERM:
+      return LOG_INFO;
 
-      case M_RESTORED:
-        return LOG_INFO;
-      case M_SECURITY:
-        return LOG_INFO;
-      case M_ALERT:
-        return LOG_INFO;
-      case M_VOLMGMT:
-        return LOG_INFO;
-      case M_AUDIT:
-        return LOG_INFO;
+    case M_ALERT:
+    case M_AUDIT:
+    case M_MOUNT:
+    case M_SECURITY:
+    case M_VOLMGMT:
+      return LOG_NOTICE;
 
-      default:
-        return LOG_ERR;
-    }
+    default:
+      return LOG_ERR;
   }
 }
 


### PR DESCRIPTION
This PR is a **backport** of #1134 

in the case that normal logging is not possible, Qmsg() logs to syslog. Instead of logging with severity LOG_ERR in this case without regarding the message type, we now translate the bareos message type to a syslog severity.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing