### PR TITLE
Refactor config reloading by using shared pointers instead of callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: Now use solaris 11.4-11.4.42.0.0.111.0 [PR #1189]
 - bconsole: removed commas from jobid attribute in list jobs and llist jobs outputs [PR #1126]
 - testing: matrix.yml: run multiple tests sequentially [PR #1193]
-- console: aborting job run if jobid doesn't exist in catalog [PR 1188]
+- console: aborting job run if jobid doesn't exist in catalog [PR #1188]
 - daemons: changed daemon CLI arguments parsing [PR #1187]
+- config parser: Refactor config reloading by using shared pointers instead of callbacks [PR #1151]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -35,8 +35,8 @@
 
 namespace console {
 
-static BareosResource* sres_head[R_NUM];
-static BareosResource** res_head = sres_head;
+/* static BareosResource* sres_head[R_NUM]; */
+/* static BareosResource** res_head = sres_head; */
 
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
@@ -262,7 +262,7 @@ ConfigurationParser* InitConsConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code, R_NUM,
-      resources, res_head, default_config_filename.c_str(), "bconsole.d",
+      resources, default_config_filename.c_str(), "bconsole.d",
       ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
       FreeResource);
   if (config) { config->r_own_ = R_CONSOLE; }

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -35,7 +35,7 @@
 
 namespace console {
 
-static BareosResource* sres_head[R_LAST - R_FIRST + 1];
+static BareosResource* sres_head[R_NUM];
 static BareosResource** res_head = sres_head;
 
 static bool SaveResource(int type, ResourceItem* items, int pass);
@@ -169,7 +169,7 @@ static void FreeResource(BareosResource* res, int type)
 
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type - R_FIRST;
+  int rindex = type;
   int i;
   int error = 0;
 
@@ -261,10 +261,10 @@ static void ConfigReadyCallback(ConfigurationParser& my_config) {}
 ConfigurationParser* InitConsConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code,
-      R_FIRST, R_LAST, resources, res_head, default_config_filename.c_str(),
-      "bconsole.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
-      DumpResource, FreeResource);
+      configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code, R_NUM,
+      resources, res_head, default_config_filename.c_str(), "bconsole.d",
+      ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
+      FreeResource);
   if (config) { config->r_own_ = R_CONSOLE; }
   return config;
 }
@@ -282,7 +282,7 @@ bool PrintConfigSchemaJson(PoolMem& buffer)
   json_t* bconsole = json_object();
   json_object_set(json_resource_object, "bconsole", bconsole);
 
-  ResourceTable* resources = my_config->resources_;
+  ResourceTable* resources = my_config->resource_definitions_;
   for (; resources->name; ++resources) {
     json_object_set(bconsole, resources->name, json_items(resources->items));
   }

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -35,9 +35,6 @@
 
 namespace console {
 
-/* static BareosResource* sres_head[R_NUM]; */
-/* static BareosResource** res_head = sres_head; */
-
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
 static void DumpResource(int type,

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -166,7 +166,6 @@ static void FreeResource(BareosResource* res, int type)
 
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type;
   int i;
   int error = 0;
 
@@ -176,7 +175,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
         Emsg2(M_ABORT, 0,
               _("%s item is required in %s resource, but not found.\n"),
-              items[i].name, resources[rindex].name);
+              items[i].name, resources[type].name);
       }
     }
   }
@@ -225,7 +224,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
 
   if (!error) {
     BareosResource* new_resource = nullptr;
-    switch (resources[rindex].rcode) {
+    switch (resources[type].rcode) {
       case R_DIRECTOR: {
         new_resource = res_dir;
         res_dir = nullptr;
@@ -238,7 +237,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       }
       default:
         Emsg1(M_ERROR_TERM, 0, "Unknown resource type: %d\n",
-              resources[rindex].rcode);
+              resources[type].rcode);
         return false;
     }
     error = my_config->AppendToResourcesChain(new_resource, type) ? 0 : 1;

--- a/core/src/console/console_conf.h
+++ b/core/src/console/console_conf.h
@@ -42,15 +42,14 @@ static const std::string default_config_filename("bconsole.conf");
 
 enum
 {
-  R_CONSOLE = 1001,
+  R_CONSOLE = 0,
   R_DIRECTOR,
-  R_FIRST = R_CONSOLE,
-  R_LAST = R_DIRECTOR /* Keep this updated */
+  R_NUM  /* number of entries */
 };
 
 enum
 {
-  R_NAME = 1020,
+  R_NAME = 0,
   R_ADDRESS,
   R_PASSWORD,
   R_TYPE,

--- a/core/src/console/console_conf.h
+++ b/core/src/console/console_conf.h
@@ -44,7 +44,7 @@ enum
 {
   R_CONSOLE = 0,
   R_DIRECTOR,
-  R_NUM  /* number of entries */
+  R_NUM /* number of entries */
 };
 
 enum

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -617,7 +617,7 @@ bool DoReloadConfig()
     int num_rcodes = my_config->r_num_;
     for (int i = 0; i < num_rcodes; i++) {
       // restore original config
-      my_config->res_head_[i] = prev_config.res_table[i];
+      my_config->res_head_container_->res_head_[i] = prev_config.res_table[i];
     }
 
     // me is changed above by CheckResources()

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -105,12 +105,12 @@ struct resource_table_reference {
 
 static void FreeSavedResources(resource_table_reference* table)
 {
-  int num = my_config->r_last_ - my_config->r_first_ + 1;
+  int num = my_config->r_num_;
 
   if (!table->res_table) { return; }
 
   for (int j = 0; j < num; j++) {
-    my_config->FreeResourceCb_(table->res_table[j], my_config->r_first_ + j);
+    my_config->FreeResourceCb_(table->res_table[j], j);
   }
   free(table->res_table);
 }
@@ -559,7 +559,7 @@ bool DoReloadConfig()
 
   DbSqlPoolFlush();
 
-  prev_config.res_table = my_config->SaveResources();
+  prev_config.res_table = my_config->CopyResourceTable();
   prev_config.JobCount = 0;
 
   Dmsg0(100, "Reloading config file\n");
@@ -568,30 +568,9 @@ bool DoReloadConfig()
   my_config->ClearWarnings();
   bool ok = my_config->ParseConfig();
 
-  if (!ok || !CheckResources() || !CheckCatalog(UPDATE_CATALOG)
-      || !InitializeSqlPooling()) {
-    Jmsg(nullptr, M_ERROR, 0, _("Please correct the configuration in %s\n"),
-         my_config->get_base_config_path().c_str());
-    Jmsg(nullptr, M_ERROR, 0, _("Resetting to previous configuration.\n"));
-
-    resource_table_reference temp_config;
-    temp_config.res_table = my_config->SaveResources();
-
-    int num_rcodes = my_config->r_last_ - my_config->r_first_ + 1;
-    for (int i = 0; i < num_rcodes; i++) {
-      // restore original config
-      my_config->res_head_[i] = prev_config.res_table[i];
-    }
-
-    // me is changed above by CheckResources()
-    me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
-    my_config->own_resource_ = me;
-
-    FreeSavedResources(&temp_config);
-    goto bail_out;
-
-  } else {  // parse config ok
-
+  // parse config successful
+  if (ok && CheckResources() && CheckCatalog(UPDATE_CATALOG)
+      && InitializeSqlPooling()) {
     JobControlRecord* jcr;
     int num_running_jobs = 0;
     resource_table_reference* new_table = nullptr;
@@ -625,9 +604,28 @@ bool DoReloadConfig()
       FreeSavedResources(&prev_config);
     }
     StartStatisticsThread();
+
+
+  } else {  // parse config failed
+    Jmsg(nullptr, M_ERROR, 0, _("Please correct the configuration in %s\n"),
+         my_config->get_base_config_path().c_str());
+    Jmsg(nullptr, M_ERROR, 0, _("Resetting to previous configuration.\n"));
+
+    resource_table_reference temp_config;
+    temp_config.res_table = my_config->CopyResourceTable();
+
+    int num_rcodes = my_config->r_num_;
+    for (int i = 0; i < num_rcodes; i++) {
+      // restore original config
+      my_config->res_head_[i] = prev_config.res_table[i];
+    }
+
+    // me is changed above by CheckResources()
+    me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+    my_config->own_resource_ = me;
+    FreeSavedResources(&temp_config);
   }
 
-bail_out:
   UnlockRes(my_config);
   UnlockJobs();
   is_reloading = false;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -501,7 +501,7 @@ bool DoReloadConfig()
 
   DbSqlPoolFlush();
 
-  my_config->BackupResourceTable();
+  auto backup_table = my_config->BackupResourceTable();
   Dmsg0(100, "Reloading config file\n");
 
 
@@ -519,7 +519,6 @@ bool DoReloadConfig()
     SetWorkingDirectory(me->working_directory);
     Dmsg0(10, "Director's configuration file reread successfully.\n");
     Dmsg0(10, "Releasing previous configuration resource table.\n");
-    my_config->ReleasePreviousResourceTable();
 
     StartStatisticsThread();
 
@@ -528,7 +527,7 @@ bool DoReloadConfig()
          my_config->get_base_config_path().c_str());
 
     Jmsg(nullptr, M_ERROR, 0, _("Resetting to previous configuration.\n"));
-    my_config->RestoreResourceTable();
+    my_config->RestoreResourceTable(std::move(backup_table));
     // me is changed above by CheckResources()
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
     assert(me);

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -508,9 +508,10 @@ bool DoReloadConfig()
 
   DbSqlPoolFlush();
 
-  BareosResource** saved_res_table = my_config->CopyResourceTable();
-
+  my_config->BackupResourceTable();
+  my_config->ClearResourceTables();
   Dmsg0(100, "Reloading config file\n");
+
 
   my_config->err_type_ = M_ERROR;
   my_config->ClearWarnings();
@@ -528,27 +529,22 @@ bool DoReloadConfig()
 
     // remove our reference to current config so it will be freed when last job
     // owning it finishes
-    my_config->ResetResHeadContainer();
-    free(saved_res_table);
-    StartStatisticsThread();
+    my_config->ResetResHeadContainerPrevious();
 
+    StartStatisticsThread();
 
   } else {  // parse config failed
     Jmsg(nullptr, M_ERROR, 0, _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
     Jmsg(nullptr, M_ERROR, 0, _("Resetting to previous configuration.\n"));
 
-    int num_rcodes = my_config->r_num_;
-    for (int i = 0; i < num_rcodes; i++) {
-      // restore original config
-      my_config->res_head_container_->res_head_[i] = saved_res_table[i];
-      //    my_config->res_head_[i] = res_table[i];
-    }
-    free(saved_res_table);
-
+    my_config->RestoreResourceTable();
     // me is changed above by CheckResources()
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+    assert(me);
     my_config->own_resource_ = me;
+
+    StartStatisticsThread();
   }
 
   UnlockRes(my_config);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -77,7 +77,7 @@ extern struct s_kw RunFields[];
  * types. Note, these should be unique for each
  * daemon though not a requirement.
  */
-static BareosResource* sres_head[R_LAST - R_FIRST + 1];
+static BareosResource* sres_head[R_NUM];
 static BareosResource** res_head = sres_head;
 static PoolMem* configure_usage_string = NULL;
 
@@ -812,7 +812,7 @@ json_t* json_datatype(const int type, ResourceItem items[])
 bool PrintConfigSchemaJson(PoolMem& buffer)
 {
   DatatypeName* datatype;
-  ResourceTable* resources = my_config->resources_;
+  ResourceTable* resources = my_config->resource_definitions_;
 
   json_t* json = json_object();
   json_object_set_new(json, "format-version", json_integer(2));
@@ -826,7 +826,7 @@ bool PrintConfigSchemaJson(PoolMem& buffer)
   json_object_set(resource, "bareos-dir", bareos_dir);
 
   for (int r = 0; resources[r].name; r++) {
-    ResourceTable resource = my_config->resources_[r];
+    ResourceTable resource = my_config->resource_definitions_[r];
     json_object_set(bareos_dir, resource.name, json_items(resource.items));
   }
 
@@ -2531,7 +2531,7 @@ static void StoreActiononpurge(LEX* lc, ResourceItem* item, int index, int pass)
  */
 static void StoreDevice(LEX* lc, ResourceItem* item, int index, int pass)
 {
-  int rindex = R_DEVICE - R_FIRST;
+  int rindex = R_DEVICE;
 
   if (pass == 1) {
     LexGetToken(lc, BCT_NAME);
@@ -3669,7 +3669,7 @@ static void CreateAndAddUserAgentConsoleResource(ConfigurationParser& my_config)
   c->tls_enable_ = true;
   c->resource_name_ = strdup("*UserAgent*");
   c->description_ = strdup("root console definition");
-  c->rcode_ = 1013;
+  c->rcode_ = R_CONSOLE;
   c->rcode_str_ = "R_CONSOLE";
   c->refcnt_ = 1;
   c->internal_ = true;
@@ -3681,7 +3681,7 @@ ConfigurationParser* InitDirConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb,
-      PrintConfigCb, exit_code, R_FIRST, R_LAST, resources, res_head,
+      PrintConfigCb, exit_code, R_NUM, resources, res_head,
       default_config_filename.c_str(), "bareos-dir.d", ConfigBeforeCallback,
       ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
   if (config) { config->r_own_ = R_DIRECTOR; }
@@ -3995,7 +3995,7 @@ static void FreeResource(BareosResource* res, int type)
  */
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type - R_FIRST;
+  int rindex = type;
   BareosResource* allocated_resource = *resources[rindex].allocated_resource_;
 
   switch (type) {

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -77,8 +77,6 @@ extern struct s_kw RunFields[];
  * types. Note, these should be unique for each
  * daemon though not a requirement.
  */
-/* static BareosResource* sres_head[R_NUM]; */
-/* static BareosResource** res_head = sres_head; */
 static PoolMem* configure_usage_string = NULL;
 
 extern void StoreInc(LEX* lc, ResourceItem* item, int index, int pass);
@@ -2533,24 +2531,25 @@ static void StoreDevice(LEX* lc,
                         ResourceItem* item,
                         int index,
                         int pass,
-                        BareosResource** res_head)
+                        BareosResource** configuration_resources)
 {
   int rindex = R_DEVICE;
 
   if (pass == 1) {
     LexGetToken(lc, BCT_NAME);
-    if (!res_head[rindex]) {
+    if (!configuration_resources[rindex]) {
       DeviceResource* device_resource = new DeviceResource;
       device_resource->rcode_ = R_DEVICE;
       device_resource->resource_name_ = strdup(lc->str);
-      res_head[rindex] = device_resource; /* store first entry */
+      configuration_resources[rindex] = device_resource; /* store first entry */
       Dmsg3(900, "Inserting first %s res: %s index=%d\n",
             my_config->ResToStr(R_DEVICE), device_resource->resource_name_,
             rindex);
     } else {
       bool found = false;
       BareosResource* next;
-      for (next = res_head[rindex]; next->next_; next = next->next_) {
+      for (next = configuration_resources[rindex]; next->next_;
+           next = next->next_) {
         if (bstrcmp(next->resource_name_, lc->str)) {
           found = true;  // already defined
           break;
@@ -2580,7 +2579,7 @@ static void StoreMigtype(LEX* lc,
                          ResourceItem* item,
                          int index,
                          int pass,
-                         BareosResource** res_head)
+                         BareosResource** configuration_resources)
 {
   LexGetToken(lc, BCT_NAME);
   // Store the type both in pass 1 and pass 2
@@ -3216,7 +3215,7 @@ static void ParseConfigCb(LEX* lc,
                           ResourceItem* item,
                           int index,
                           int pass,
-                          BareosResource** res_head)
+                          BareosResource** configuration_resources)
 {
   switch (item->type) {
     case CFG_TYPE_AUTOPASSWORD:
@@ -3235,7 +3234,7 @@ static void ParseConfigCb(LEX* lc,
       StoreAuthtype(lc, item, index, pass);
       break;
     case CFG_TYPE_DEVICE:
-      StoreDevice(lc, item, index, pass, res_head);
+      StoreDevice(lc, item, index, pass, configuration_resources);
       break;
     case CFG_TYPE_JOBTYPE:
       StoreJobtype(lc, item, index, pass);
@@ -3256,7 +3255,7 @@ static void ParseConfigCb(LEX* lc,
       StoreRunscript(lc, item, index, pass);
       break;
     case CFG_TYPE_MIGTYPE:
-      StoreMigtype(lc, item, index, pass, res_head);
+      StoreMigtype(lc, item, index, pass, configuration_resources);
       break;
     case CFG_TYPE_INCEXC:
       StoreInc(lc, item, index, pass);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -77,8 +77,8 @@ extern struct s_kw RunFields[];
  * types. Note, these should be unique for each
  * daemon though not a requirement.
  */
-static BareosResource* sres_head[R_NUM];
-static BareosResource** res_head = sres_head;
+/* static BareosResource* sres_head[R_NUM]; */
+/* static BareosResource** res_head = sres_head; */
 static PoolMem* configure_usage_string = NULL;
 
 extern void StoreInc(LEX* lc, ResourceItem* item, int index, int pass);
@@ -2529,7 +2529,11 @@ static void StoreActiononpurge(LEX* lc, ResourceItem* item, int index, int pass)
  * first reference. The details of the resource are obtained
  * later from the SD.
  */
-static void StoreDevice(LEX* lc, ResourceItem* item, int index, int pass)
+static void StoreDevice(LEX* lc,
+                        ResourceItem* item,
+                        int index,
+                        int pass,
+                        BareosResource** res_head)
 {
   int rindex = R_DEVICE;
 
@@ -2572,7 +2576,11 @@ static void StoreDevice(LEX* lc, ResourceItem* item, int index, int pass)
 }
 
 // Store Migration/Copy type
-static void StoreMigtype(LEX* lc, ResourceItem* item, int index, int pass)
+static void StoreMigtype(LEX* lc,
+                         ResourceItem* item,
+                         int index,
+                         int pass,
+                         BareosResource** res_head)
 {
   LexGetToken(lc, BCT_NAME);
   // Store the type both in pass 1 and pass 2
@@ -3204,7 +3212,11 @@ static void InitResourceCb(ResourceItem* item, int pass)
  * callback function for parse_config
  * See ../lib/parse_conf.c, function ParseConfig, for more generic handling.
  */
-static void ParseConfigCb(LEX* lc, ResourceItem* item, int index, int pass)
+static void ParseConfigCb(LEX* lc,
+                          ResourceItem* item,
+                          int index,
+                          int pass,
+                          BareosResource** res_head)
 {
   switch (item->type) {
     case CFG_TYPE_AUTOPASSWORD:
@@ -3223,7 +3235,7 @@ static void ParseConfigCb(LEX* lc, ResourceItem* item, int index, int pass)
       StoreAuthtype(lc, item, index, pass);
       break;
     case CFG_TYPE_DEVICE:
-      StoreDevice(lc, item, index, pass);
+      StoreDevice(lc, item, index, pass, res_head);
       break;
     case CFG_TYPE_JOBTYPE:
       StoreJobtype(lc, item, index, pass);
@@ -3244,7 +3256,7 @@ static void ParseConfigCb(LEX* lc, ResourceItem* item, int index, int pass)
       StoreRunscript(lc, item, index, pass);
       break;
     case CFG_TYPE_MIGTYPE:
-      StoreMigtype(lc, item, index, pass);
+      StoreMigtype(lc, item, index, pass, res_head);
       break;
     case CFG_TYPE_INCEXC:
       StoreInc(lc, item, index, pass);
@@ -3681,7 +3693,7 @@ ConfigurationParser* InitDirConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb,
-      PrintConfigCb, exit_code, R_NUM, resources, res_head,
+      PrintConfigCb, exit_code, R_NUM, resources,
       default_config_filename.c_str(), "bareos-dir.d", ConfigBeforeCallback,
       ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
   if (config) { config->r_own_ = R_DIRECTOR; }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -4006,8 +4006,7 @@ static void FreeResource(BareosResource* res, int type)
  */
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type;
-  BareosResource* allocated_resource = *resources[rindex].allocated_resource_;
+  BareosResource* allocated_resource = *resources[type].allocated_resource_;
 
   switch (type) {
     case R_DIRECTOR: {
@@ -4037,7 +4036,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
         if (!BitIsSet(0, allocated_resource->item_present_)) {
           Emsg2(M_ERROR, 0,
                 _("%s item is required in %s resource, but not found.\n"),
-                items[0].name, resources[rindex].name);
+                items[0].name, resources[type].name);
           return false;
         }
       }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2575,11 +2575,7 @@ static void StoreDevice(LEX* lc,
 }
 
 // Store Migration/Copy type
-static void StoreMigtype(LEX* lc,
-                         ResourceItem* item,
-                         int index,
-                         int pass,
-                         BareosResource** configuration_resources)
+static void StoreMigtype(LEX* lc, ResourceItem* item, int index)
 {
   LexGetToken(lc, BCT_NAME);
   // Store the type both in pass 1 and pass 2
@@ -3255,7 +3251,7 @@ static void ParseConfigCb(LEX* lc,
       StoreRunscript(lc, item, index, pass);
       break;
     case CFG_TYPE_MIGTYPE:
-      StoreMigtype(lc, item, index, pass, configuration_resources);
+      StoreMigtype(lc, item, index);
       break;
     case CFG_TYPE_INCEXC:
       StoreInc(lc, item, index, pass);

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -47,7 +47,7 @@ static std::string default_config_filename("bareos-dir.conf");
 // Resource codes -- they must be sequential for indexing
 enum
 {
-  R_DIRECTOR = 1001,
+  R_DIRECTOR = 0,
   R_CLIENT,
   R_JOBDEFS,
   R_JOB,
@@ -62,14 +62,13 @@ enum
   R_CONSOLE,
   R_DEVICE,
   R_USER,
-  R_FIRST = R_DIRECTOR,
-  R_LAST = R_USER /* keep this updated */
+  R_NUM /* Number of entries */
 };
 
 // Some resource attributes
 enum
 {
-  R_NAME = 1020,
+  R_NAME = 0,
   R_ADDRESS,
   R_PASSWORD,
   R_TYPE,

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -31,7 +31,7 @@
 
 typedef struct s_tree_root TREE_ROOT;
 
-class ResHeadContainer;
+class ConfigResourcesContainer;
 
 namespace directordaemon {
 class JobResource;
@@ -96,14 +96,14 @@ struct Resources {
 };
 
 struct JobControlRecordPrivate {
-  JobControlRecordPrivate( std::shared_ptr<ResHeadContainer> configuration_resources_container) {
+  JobControlRecordPrivate( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) {
     job_config_resources_container_ = configuration_resources_container;
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
   ~JobControlRecordPrivate() {
     job_config_resources_container_ = nullptr;
   }
-  std::shared_ptr<ResHeadContainer> job_config_resources_container_;
+  std::shared_ptr<ConfigResourcesContainer> job_config_resources_container_;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */
   pthread_cond_t term_wait = PTHREAD_COND_INITIALIZER;      /**< Wait for job termination */

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -96,8 +96,7 @@ struct Resources {
 };
 
 struct JobControlRecordPrivate {
-  JobControlRecordPrivate( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) {
-    job_config_resources_container_ = configuration_resources_container;
+  JobControlRecordPrivate( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) : job_config_resources_container_(configuration_resources_container) {
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
   ~JobControlRecordPrivate() {

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -24,7 +24,6 @@
 #ifndef BAREOS_DIRD_JCR_PRIVATE_H_
 #define BAREOS_DIRD_JCR_PRIVATE_H_
 
-#include <iostream>
 #include "cats/cats.h"
 #include "dird/client_connection_handshake_mode.h"
 #include "dird/job_trigger.h"

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -24,11 +24,14 @@
 #ifndef BAREOS_DIRD_JCR_PRIVATE_H_
 #define BAREOS_DIRD_JCR_PRIVATE_H_
 
+#include <iostream>
 #include "cats/cats.h"
 #include "dird/client_connection_handshake_mode.h"
 #include "dird/job_trigger.h"
 
 typedef struct s_tree_root TREE_ROOT;
+
+class ResHeadContainer;
 
 namespace directordaemon {
 class JobResource;
@@ -93,9 +96,14 @@ struct Resources {
 };
 
 struct JobControlRecordPrivate {
-  JobControlRecordPrivate() {
+  JobControlRecordPrivate( std::shared_ptr<ResHeadContainer> res_head_container) {
+    job_res_head_container_ = res_head_container;
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
+  ~JobControlRecordPrivate() {
+    job_res_head_container_ = nullptr;
+  }
+  std::shared_ptr<ResHeadContainer> job_res_head_container_;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */
   pthread_cond_t term_wait = PTHREAD_COND_INITIALIZER;      /**< Wait for job termination */

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -96,14 +96,14 @@ struct Resources {
 };
 
 struct JobControlRecordPrivate {
-  JobControlRecordPrivate( std::shared_ptr<ResHeadContainer> res_head_container) {
-    job_res_head_container_ = res_head_container;
+  JobControlRecordPrivate( std::shared_ptr<ResHeadContainer> configuration_resources_container) {
+    job_config_resources_container_ = configuration_resources_container;
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
   ~JobControlRecordPrivate() {
-    job_res_head_container_ = nullptr;
+    job_config_resources_container_ = nullptr;
   }
-  std::shared_ptr<ResHeadContainer> job_res_head_container_;
+  std::shared_ptr<ResHeadContainer> job_config_resources_container_;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */
   pthread_cond_t term_wait = PTHREAD_COND_INITIALIZER;      /**< Wait for job termination */

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -99,9 +99,6 @@ struct JobControlRecordPrivate {
   JobControlRecordPrivate( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) : job_config_resources_container_(configuration_resources_container) {
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
-  ~JobControlRecordPrivate() {
-    job_config_resources_container_ = nullptr;
-  }
   std::shared_ptr<ConfigResourcesContainer> job_config_resources_container_;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */

--- a/core/src/dird/jcr_private.h
+++ b/core/src/dird/jcr_private.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1628,8 +1628,9 @@ JobControlRecord* NewDirectorJcr()
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
   jcr->impl = new JobControlRecordPrivate(my_config->res_head_container_);
-  Dmsg1(10, "NewDirectorJcr(): res_head_ is at %p\n",
-        my_config->res_head_container_->res_head_);
+  Dmsg1(10, "NewDirectorJcr(): res_head_ is at %p %s\n",
+        my_config->res_head_container_->res_head_,
+        my_config->res_head_container_->TimeStampAsString().c_str());
   return jcr;
 }
 

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1627,7 +1627,7 @@ void GetJobStorage(UnifiedStorageResource* store,
 JobControlRecord* NewDirectorJcr()
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
-  jcr->impl = new JobControlRecordPrivate;
+  jcr->impl = new JobControlRecordPrivate(my_config->res_head_container_);
   return jcr;
 }
 

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1628,6 +1628,8 @@ JobControlRecord* NewDirectorJcr()
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
   jcr->impl = new JobControlRecordPrivate(my_config->res_head_container_);
+  Dmsg1(10, "NewDirectorJcr(): res_head_ is at %p\n",
+        my_config->res_head_container_->res_head_);
   return jcr;
 }
 

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1627,10 +1627,11 @@ void GetJobStorage(UnifiedStorageResource* store,
 JobControlRecord* NewDirectorJcr()
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
-  jcr->impl = new JobControlRecordPrivate(my_config->res_head_container_);
-  Dmsg1(10, "NewDirectorJcr(): res_head_ is at %p %s\n",
-        my_config->res_head_container_->res_head_,
-        my_config->res_head_container_->TimeStampAsString().c_str());
+  jcr->impl
+      = new JobControlRecordPrivate(my_config->config_resources_container_);
+  Dmsg1(10, "NewDirectorJcr(): configuration_resources_ is at %p %s\n",
+        my_config->config_resources_container_->configuration_resources_,
+        my_config->config_resources_container_->TimeStampAsString().c_str());
   return jcr;
 }
 

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -178,16 +178,15 @@ static void ShowDisabledSchedules(UaContext* ua)
 // Enter with Resources locked
 static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
 {
-  for (int j = my_config->r_first_; j <= my_config->r_last_; j++) {
+  for (int j = 0; j <= my_config->r_num_ - 1; j++) {
     switch (j) {
       case R_DEVICE:
         // Skip R_DEVICE since it is really not used or updated
         continue;
       default:
-        if (my_config->res_head_[j - my_config->r_first_]) {
-          my_config->DumpResourceCb_(
-              j, my_config->res_head_[j - my_config->r_first_], bsendmsg, ua,
-              hide_sensitive_data, verbose);
+        if (my_config->res_head_[j]) {
+          my_config->DumpResourceCb_(j, my_config->res_head_[j], bsendmsg, ua,
+                                     hide_sensitive_data, verbose);
         }
         break;
     }
@@ -264,7 +263,7 @@ bool show_cmd(UaContext* ua, const char* cmd)
                          len)) {
           type = show_cmd_available_resources[j].type;
           if (type > 0) {
-            res = my_config->res_head_[type - my_config->r_first_];
+            res = my_config->res_head_[type];
           } else {
             res = NULL;
           }

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -184,9 +184,10 @@ static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
         // Skip R_DEVICE since it is really not used or updated
         continue;
       default:
-        if (my_config->res_head_[j]) {
-          my_config->DumpResourceCb_(j, my_config->res_head_[j], bsendmsg, ua,
-                                     hide_sensitive_data, verbose);
+        if (my_config->res_head_container_->res_head_[j]) {
+          my_config->DumpResourceCb_(
+              j, my_config->res_head_container_->res_head_[j], bsendmsg, ua,
+              hide_sensitive_data, verbose);
         }
         break;
     }
@@ -263,7 +264,7 @@ bool show_cmd(UaContext* ua, const char* cmd)
                          len)) {
           type = show_cmd_available_resources[j].type;
           if (type > 0) {
-            res = my_config->res_head_[type];
+            res = my_config->res_head_container_->res_head_[type];
           } else {
             res = NULL;
           }

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -184,10 +184,13 @@ static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
         // Skip R_DEVICE since it is really not used or updated
         continue;
       default:
-        if (my_config->res_head_container_->res_head_[j]) {
-          my_config->DumpResourceCb_(
-              j, my_config->res_head_container_->res_head_[j], bsendmsg, ua,
-              hide_sensitive_data, verbose);
+        if (my_config->config_resources_container_
+                ->configuration_resources_[j]) {
+          my_config->DumpResourceCb_(j,
+                                     my_config->config_resources_container_
+                                         ->configuration_resources_[j],
+                                     bsendmsg, ua, hide_sensitive_data,
+                                     verbose);
         }
         break;
     }
@@ -264,7 +267,8 @@ bool show_cmd(UaContext* ua, const char* cmd)
                          len)) {
           type = show_cmd_available_resources[j].type;
           if (type > 0) {
-            res = my_config->res_head_container_->res_head_[type];
+            res = my_config->config_resources_container_
+                      ->configuration_resources_[type];
           } else {
             res = NULL;
           }

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -56,7 +56,9 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
   jcr = NewDirectorJcr();
 
   // exclude JT_SYSTEM job from shared config counting
-  if (job_type == JT_SYSTEM) { jcr->impl->job_res_head_container_ = nullptr; }
+  if (job_type == JT_SYSTEM) {
+    jcr->impl->job_config_resources_container_ = nullptr;
+  }
 
   /* The job and defaults are not really used, but we set them up to ensure that
    * everything is correctly initialized. */

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -53,13 +53,13 @@ namespace directordaemon {
 JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 {
   JobControlRecord* jcr;
-
   jcr = NewDirectorJcr();
 
-  /*
-   * The job and defaults are not really used, but we set them up to ensure that
-   * everything is correctly initialized.
-   */
+  // exclude JT_SYSTEM job from shared config counting
+  if (job_type == JT_SYSTEM) { jcr->impl->job_res_head_container_ = nullptr; }
+
+  /* The job and defaults are not really used, but we set them up to ensure that
+   * everything is correctly initialized. */
   LockRes(my_config);
   jcr->impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
   SetJcrDefaults(jcr, jcr->impl->res.job);

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -754,15 +754,10 @@ start_again:
 static void DoDirectorStatus(UaContext* ua)
 {
   ListDirStatusHeader(ua);
-
   ListScheduledJobs(ua);
-
   ListRunningJobs(ua);
-
   ListTerminatedJobs(ua);
-
   ListConnectedClients(ua);
-
   ua->SendMsg("====\n");
 }
 

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -347,9 +347,8 @@ void ListDirStatusHeader(UaContext* ua)
               kBareosVersionStrings.GetOsInfo());
   bstrftime_nc(dt, sizeof(dt), daemon_start_time);
   ua->SendMsg(_("Daemon started %s. Jobs: run=%d, running=%d db:postgresql, %s "
-                "binary %d shared_count\n"),
-              dt, num_jobs_run, JobCount(), kBareosVersionStrings.BinaryInfo,
-              my_config->res_head_container_.use_count());
+                "binary\n"),
+              dt, num_jobs_run, JobCount(), kBareosVersionStrings.BinaryInfo);
 
   if (me->secure_erase_cmdline) {
     ua->SendMsg(_(" secure erase command='%s'\n"), me->secure_erase_cmdline);

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -347,8 +347,9 @@ void ListDirStatusHeader(UaContext* ua)
               kBareosVersionStrings.GetOsInfo());
   bstrftime_nc(dt, sizeof(dt), daemon_start_time);
   ua->SendMsg(_("Daemon started %s. Jobs: run=%d, running=%d db:postgresql, %s "
-                "binary\n"),
-              dt, num_jobs_run, JobCount(), kBareosVersionStrings.BinaryInfo);
+                "binary %d shared_count\n"),
+              dt, num_jobs_run, JobCount(), kBareosVersionStrings.BinaryInfo,
+              my_config->res_head_container_.use_count());
 
   if (me->secure_erase_cmdline) {
     ua->SendMsg(_(" secure erase command='%s'\n"), me->secure_erase_cmdline);

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -755,13 +755,10 @@ static void DoDirectorStatus(UaContext* ua)
 {
   ListDirStatusHeader(ua);
 
-  // List scheduled Jobs
   ListScheduledJobs(ua);
 
-  // List running jobs
   ListRunningJobs(ua);
 
-  // List terminated jobs
   ListTerminatedJobs(ua);
 
   ListConnectedClients(ua);

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -56,8 +56,8 @@
 
 namespace filedaemon {
 
-static BareosResource* sres_head[R_NUM];
-static BareosResource** res_head = sres_head;
+/* static BareosResource* sres_head[R_NUM]; */
+/* static BareosResource** res_head = sres_head; */
 
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
@@ -228,7 +228,11 @@ static void InitResourceCb(ResourceItem* item, int pass)
  * callback function for parse_config
  * See ../lib/parse_conf.c, function ParseConfig, for more generic handling.
  */
-static void ParseConfigCb(LEX* lc, ResourceItem* item, int index, int pass)
+static void ParseConfigCb(LEX* lc,
+                          ResourceItem* item,
+                          int index,
+                          int pass,
+                          BareosResource** res_head)
 {
   switch (item->type) {
     case CFG_TYPE_CIPHER:
@@ -255,7 +259,7 @@ ConfigurationParser* InitFdConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_NUM, resources, res_head, default_config_filename.c_str(),
+      exit_code, R_NUM, resources, default_config_filename.c_str(),
       "bareos-fd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
       DumpResource, FreeResource);
   if (config) { config->r_own_ = R_CLIENT; }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -56,9 +56,6 @@
 
 namespace filedaemon {
 
-/* static BareosResource* sres_head[R_NUM]; */
-/* static BareosResource** res_head = sres_head; */
-
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
 static void DumpResource(int type,
@@ -232,7 +229,7 @@ static void ParseConfigCb(LEX* lc,
                           ResourceItem* item,
                           int index,
                           int pass,
-                          BareosResource** res_head)
+                          BareosResource** configuration_resources)
 {
   switch (item->type) {
     case CFG_TYPE_CIPHER:

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -56,7 +56,7 @@
 
 namespace filedaemon {
 
-static BareosResource* sres_head[R_LAST - R_FIRST + 1];
+static BareosResource* sres_head[R_NUM];
 static BareosResource** res_head = sres_head;
 
 static bool SaveResource(int type, ResourceItem* items, int pass);
@@ -255,9 +255,9 @@ ConfigurationParser* InitFdConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_FIRST, R_LAST, resources, res_head,
-      default_config_filename.c_str(), "bareos-fd.d", ConfigBeforeCallback,
-      ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
+      exit_code, R_NUM, resources, res_head, default_config_filename.c_str(),
+      "bareos-fd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
+      DumpResource, FreeResource);
   if (config) { config->r_own_ = R_CLIENT; }
   return config;
 }
@@ -266,7 +266,7 @@ ConfigurationParser* InitFdConfig(const char* configfile, int exit_code)
 #ifdef HAVE_JANSSON
 bool PrintConfigSchemaJson(PoolMem& buffer)
 {
-  ResourceTable* resources = my_config->resources_;
+  ResourceTable* resources = my_config->resource_definitions_;
 
   json_t* json = json_object();
   json_object_set_new(json, "format-version", json_integer(2));
@@ -280,7 +280,7 @@ bool PrintConfigSchemaJson(PoolMem& buffer)
   json_object_set(resource, "bareos-fd", bareos_fd);
 
   for (int r = 0; resources[r].name; r++) {
-    ResourceTable resource = my_config->resources_[r];
+    ResourceTable resource = my_config->resource_definitions_[r];
     json_object_set(bareos_fd, resource.name, json_items(resource.items));
   }
 
@@ -421,7 +421,7 @@ static void FreeResource(BareosResource* res, int type)
  */
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type - R_FIRST;
+  int rindex = type;
   int i;
   int error = 0;
 

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -422,7 +422,6 @@ static void FreeResource(BareosResource* res, int type)
  */
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type;
   int i;
   int error = 0;
 
@@ -432,7 +431,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
         Emsg2(M_ABORT, 0,
               _("%s item is required in %s resource, but not found.\n"),
-              items[i].name, resources[rindex].name);
+              items[i].name, resources[type].name);
       }
     }
   }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -229,7 +229,7 @@ static void ParseConfigCb(LEX* lc,
                           ResourceItem* item,
                           int index,
                           int pass,
-                          BareosResource** configuration_resources)
+                          BareosResource**)
 {
   switch (item->type) {
     case CFG_TYPE_CIPHER:

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,19 +44,18 @@ static const std::string default_config_filename("bareos-fd.conf");
 // Resource codes -- they must be sequential for indexing
 enum
 {
-  R_DIRECTOR = 1001,
+  R_DIRECTOR = 0,
   R_CLIENT,
   R_MSGS,
   R_STORAGE,
   R_JOB,
-  R_FIRST = R_DIRECTOR,
-  R_LAST = R_JOB /* keep this updated */
+  R_NUM /* number of entires */
 };
 
 // Some resource attributes
 enum
 {
-  R_NAME = 1020,
+  R_NAME = 0,
   R_ADDRESS,
   R_PASSWORD,
   R_TYPE

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -523,7 +523,7 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
 // when last job owning is done
 void ConfigurationParser::ReleasePreviousResourceTable()
 {
-  Dmsg1(0, "ConfigurationParser::ReleasePreviousResourceTable: %p\n",
+  Dmsg1(10, "ConfigurationParser::ReleasePreviousResourceTable: %p\n",
         res_head_container_previous_->res_head_);
   res_head_container_previous_ = nullptr;
 }
@@ -551,10 +551,10 @@ void ConfigurationParser::ClearResourceTables()
 bool ConfigurationParser::RestoreResourceTable()
 {
   std::swap(res_head_container_, res_head_container_previous_);
-  Dmsg1(0, "ConfigurationParser::RestoreResourceTable: %p -> %p\n",
+  Dmsg1(10, "ConfigurationParser::RestoreResourceTable: %p -> %p\n",
         res_head_container_previous_->res_head_,
         res_head_container_->res_head_);
-  Dmsg1(0, "ConfigurationParser::RestoreResourceTable: release %p\n",
+  Dmsg1(10, "ConfigurationParser::RestoreResourceTable: release %p\n",
         res_head_container_previous_->res_head_);
   res_head_container_previous_ = nullptr;
   return true;

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -136,7 +136,7 @@ ConfigurationParser::ConfigurationParser(
   err_type_ = err_type;
   r_num_ = r_num;
   resource_definitions_ = resource_definitions;
-  config_resources_container_.reset(new ResHeadContainer(this));
+  config_resources_container_.reset(new ConfigResourcesContainer(this));
   config_default_filename_
       = config_default_filename == nullptr ? "" : config_default_filename;
   config_include_dir_ = config_include_dir == nullptr ? "" : config_include_dir;
@@ -527,7 +527,7 @@ void ConfigurationParser::RestoreResourceTable()
 void ConfigurationParser::BackupResourceTable()
 {
   std::swap(config_resources_container_, config_resources_container_backup_);
-  config_resources_container_.reset(new ResHeadContainer(this));
+  config_resources_container_.reset(new ConfigResourcesContainer(this));
 }
 
 bool ConfigurationParser::RemoveResource(int rcode, const char* name)

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -150,16 +150,19 @@ ConfigurationParser::ConfigurationParser(
   SaveResourceCb_ = SaveResourceCb;
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
+  res_head_container_.reset(new ResHeadContainer(this, res_head_));
 }
 
 ConfigurationParser::~ConfigurationParser()
 {
+#if 0
   if (res_head_) {
     for (int i = 0; i <= r_num_ - 1; i++) {
       if (res_head_[i]) { FreeResourceCb_(res_head_[i], i); }
       res_head_[i] = nullptr;
     }
   }
+#endif
 }
 
 void ConfigurationParser::InitializeQualifiedResourceNameTypeConverter(

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -207,6 +207,9 @@ bool ConfigurationParser::ParseConfig()
   bool success = ParseConfigFile(config_path.c_str(), nullptr, scan_error_,
                                  scan_warning_);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
+
+  res_head_container_->timestamp_ = std::chrono::system_clock::now();
+
   return success;
 }
 
@@ -518,8 +521,6 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
 // when last job also owning finishes
 void ConfigurationParser::ReleasePreviousResourceTable()
 {
-  Dmsg1(10, "ConfigurationParser::ReleasePreviousResourceTable: %p\n",
-        res_head_container_backup_->res_head_);
   res_head_container_backup_ = nullptr;
 }
 
@@ -528,10 +529,6 @@ void ConfigurationParser::ReleasePreviousResourceTable()
 void ConfigurationParser::RestoreResourceTable()
 {
   std::swap(res_head_container_, res_head_container_backup_);
-  Dmsg1(10, "ConfigurationParser::RestoreResourceTable: %p -> %p\n",
-        res_head_container_backup_->res_head_, res_head_container_->res_head_);
-  Dmsg1(10, "ConfigurationParser::RestoreResourceTable: release %p\n",
-        res_head_container_backup_->res_head_);
   res_head_container_backup_ = nullptr;
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -84,27 +84,8 @@ bool PrintMessage(void* sock, const char* fmt, ...)
   return true;
 }
 
-ConfigurationParser::ConfigurationParser()
-    : scan_error_(nullptr)
-    , scan_warning_(nullptr)
-    , init_res_(nullptr)
-    , store_res_(nullptr)
-    , print_res_(nullptr)
-    , err_type_(0)
-    , omit_defaults_(false)
-    , r_num_(0)
-    , r_own_(0)
-    , own_resource_(nullptr)
-    , resource_definitions_(0)
-    , SaveResourceCb_(nullptr)
-    , DumpResourceCb_(nullptr)
-    , FreeResourceCb_(nullptr)
-    , use_config_include_dir_(false)
-    , ParseConfigReadyCb_(nullptr)
-    , parser_first_run_(true)
-{
-  return;
-}
+ConfigurationParser::ConfigurationParser() = default;
+ConfigurationParser::~ConfigurationParser() = default;
 
 ConfigurationParser::ConfigurationParser(
     const char* cf,

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -96,8 +96,6 @@ ConfigurationParser::ConfigurationParser()
     , r_own_(0)
     , own_resource_(nullptr)
     , resource_definitions_(0)
-    /* , res_head_(nullptr) */
-    /* , res_head_backup_(nullptr) */
     , SaveResourceCb_(nullptr)
     , DumpResourceCb_(nullptr)
     , FreeResourceCb_(nullptr)
@@ -138,7 +136,7 @@ ConfigurationParser::ConfigurationParser(
   err_type_ = err_type;
   r_num_ = r_num;
   resource_definitions_ = resource_definitions;
-  res_head_container_.reset(new ResHeadContainer(this));
+  config_resources_container_.reset(new ResHeadContainer(this));
   config_default_filename_
       = config_default_filename == nullptr ? "" : config_default_filename;
   config_include_dir_ = config_include_dir == nullptr ? "" : config_include_dir;
@@ -151,17 +149,7 @@ ConfigurationParser::ConfigurationParser(
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
 }
-ConfigurationParser::~ConfigurationParser()
-{
-#if 0
-  if (res_head_) {
-    for (int i = 0; i <= r_num_ - 1; i++) {
-      if (res_head_[i]) { FreeResourceCb_(res_head_[i], i); }
-      res_head_[i] = nullptr;
-    }
-  }
-#endif
-}
+ConfigurationParser::~ConfigurationParser() {}
 
 void ConfigurationParser::InitializeQualifiedResourceNameTypeConverter(
     const std::map<int, std::string>& map)
@@ -208,7 +196,7 @@ bool ConfigurationParser::ParseConfig()
                                  scan_warning_);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
 
-  res_head_container_->timestamp_ = std::chrono::system_clock::now();
+  config_resources_container_->timestamp_ = std::chrono::system_clock::now();
 
   return success;
 }
@@ -290,13 +278,15 @@ bool ConfigurationParser::AppendToResourcesChain(BareosResource* new_resource,
     return false;
   }
 
-  if (!res_head_container_->res_head_[rindex]) {
-    res_head_container_->res_head_[rindex] = new_resource;
+  if (!config_resources_container_->configuration_resources_[rindex]) {
+    config_resources_container_->configuration_resources_[rindex]
+        = new_resource;
     Dmsg3(900, "Inserting first %s res: %s index=%d\n", ResToStr(rcode),
           new_resource->resource_name_, rindex);
   } else {  // append
     BareosResource* last = nullptr;
-    BareosResource* current = res_head_container_->res_head_[rindex];
+    BareosResource* current
+        = config_resources_container_->configuration_resources_[rindex];
     do {
       if (bstrcmp(current->resource_name_, new_resource->resource_name_)) {
         Emsg2(M_ERROR, 0,
@@ -521,23 +511,23 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
 // when last job also owning finishes
 void ConfigurationParser::ReleasePreviousResourceTable()
 {
-  res_head_container_backup_ = nullptr;
+  config_resources_container_backup_ = nullptr;
 }
 
-// swap the previously saved res_head_previous_ with res_head_
-// and release the res_head_previous_
+// swap the previously saved configuration_resources_previous_ with
+// configuration_resources_ and release the configuration_resources_previous_
 void ConfigurationParser::RestoreResourceTable()
 {
-  std::swap(res_head_container_, res_head_container_backup_);
-  res_head_container_backup_ = nullptr;
+  std::swap(config_resources_container_, config_resources_container_backup_);
+  config_resources_container_backup_ = nullptr;
 }
 
-// copy the current resource table to res_head_backup_
-// and create a new empty res_head_container_
+// copy the current resource table to configuration_resources_backup_
+// and create a new empty config_resources_container_
 void ConfigurationParser::BackupResourceTable()
 {
-  std::swap(res_head_container_, res_head_container_backup_);
-  res_head_container_.reset(new ResHeadContainer(this));
+  std::swap(config_resources_container_, config_resources_container_backup_);
+  config_resources_container_.reset(new ResHeadContainer(this));
 }
 
 bool ConfigurationParser::RemoveResource(int rcode, const char* name)
@@ -554,14 +544,16 @@ bool ConfigurationParser::RemoveResource(int rcode, const char* name)
    * resource_definitions must be added. If it is referenced, don't remove it.
    */
   last = nullptr;
-  for (BareosResource* res = res_head_container_->res_head_[rindex]; res;
-       res = res->next_) {
+  for (BareosResource* res
+       = config_resources_container_->configuration_resources_[rindex];
+       res; res = res->next_) {
     if (bstrcmp(res->resource_name_, name)) {
       if (!last) {
         Dmsg2(900,
               _("removing resource %s, name=%s (first resource in list)\n"),
               ResToStr(rcode), name);
-        res_head_container_->res_head_[rindex] = res->next_;
+        config_resources_container_->configuration_resources_[rindex]
+            = res->next_;
       } else {
         Dmsg2(900, _("removing resource %s, name=%s\n"), ResToStr(rcode), name);
         last->next_ = res->next_;
@@ -615,9 +607,10 @@ void ConfigurationParser::DumpResources(bool sendit(void* sock,
                                         bool hide_sensitive_data)
 {
   for (int i = 0; i <= r_num_ - 1; i++) {
-    if (res_head_container_->res_head_[i]) {
-      DumpResourceCb_(i, res_head_container_->res_head_[i], sendit, sock,
-                      hide_sensitive_data, false);
+    if (config_resources_container_->configuration_resources_[i]) {
+      DumpResourceCb_(i,
+                      config_resources_container_->configuration_resources_[i],
+                      sendit, sock, hide_sensitive_data, false);
     }
   }
 }

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -149,7 +149,6 @@ ConfigurationParser::ConfigurationParser(
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
 }
-ConfigurationParser::~ConfigurationParser() {}
 
 void ConfigurationParser::InitializeQualifiedResourceNameTypeConverter(
     const std::map<int, std::string>& map)

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -526,8 +526,8 @@ void ConfigurationParser::RestoreResourceTable()
 // and create a new empty config_resources_container_
 void ConfigurationParser::BackupResourceTable()
 {
-  std::swap(config_resources_container_, config_resources_container_backup_);
-  config_resources_container_.reset(new ConfigResourcesContainer(this));
+  config_resources_container_backup_ = config_resources_container_;
+  config_resources_container_ = make_shared<ConfigResourcesContainer>(this);
 }
 
 bool ConfigurationParser::RemoveResource(int rcode, const char* name)

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -176,7 +176,7 @@ bool ConfigurationParser::ParseConfig()
                                  scan_warning_);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
 
-  config_resources_container_->timestamp_ = std::chrono::system_clock::now();
+  config_resources_container_->SetTimestampToNow();
 
   return success;
 }

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -151,20 +151,6 @@ ConfigurationParser::ConfigurationParser(
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
 }
-
-// remove our shared pointer to previous configuration so that it will be freed
-// when last job owning is done
-void ConfigurationParser::ResetResHeadContainerPrevious()
-{
-  // res_head_container_previous_ = nullptr;
-}
-
-void ConfigurationParser::RestorePreviousConfig()
-{
-  // res_head_container_ = std::move(res_head_container_previous_);
-}
-
-
 ConfigurationParser::~ConfigurationParser()
 {
 #if 0
@@ -533,6 +519,24 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
 }
 
 
+// remove our shared pointer to previous configuration so that it will be freed
+// when last job owning is done
+void ConfigurationParser::ReleasePreviousResourceTable()
+{
+  Dmsg1(0, "ConfigurationParser::ReleasePreviousResourceTable: %p\n",
+        res_head_container_previous_->res_head_);
+  res_head_container_previous_ = nullptr;
+}
+
+#if 0
+void ConfigurationParser::RestorePreviousConfig()
+{
+  //  res_head_container_ = std::move(res_head_container_previous_);
+}
+
+#endif
+
+#if 0
 void ConfigurationParser::ClearResourceTables()
 {
   /* int num = r_num_; */
@@ -541,13 +545,26 @@ void ConfigurationParser::ClearResourceTables()
   /*   res_head_[i] = nullptr; */
   /* } */
 }
+#endif
 
 // restore the previously saved  res_head_backup_ to res_head_
-bool ConfigurationParser::RestoreResourceTable() { return true; }
+bool ConfigurationParser::RestoreResourceTable()
+{
+  std::swap(res_head_container_, res_head_container_previous_);
+  Dmsg1(0, "ConfigurationParser::RestoreResourceTable: %p -> %p\n",
+        res_head_container_previous_->res_head_,
+        res_head_container_->res_head_);
+  Dmsg1(0, "ConfigurationParser::RestoreResourceTable: release %p\n",
+        res_head_container_previous_->res_head_);
+  res_head_container_previous_ = nullptr;
+  return true;
+}
 // copy the current resource table to res_head_backup_
+// and create a new res_head_container_
 bool ConfigurationParser::BackupResourceTable()
 {
-  // res_head_container_previous_.reset(res_head_container_.get());
+  std::swap(res_head_container_, res_head_container_previous_);
+  res_head_container_.reset(new ResHeadContainer(this));
   return true;
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -527,7 +527,8 @@ void ConfigurationParser::RestoreResourceTable()
 void ConfigurationParser::BackupResourceTable()
 {
   config_resources_container_backup_ = config_resources_container_;
-  config_resources_container_ = make_shared<ConfigResourcesContainer>(this);
+  config_resources_container_
+      = std::make_shared<ConfigResourcesContainer>(this);
 }
 
 bool ConfigurationParser::RemoveResource(int rcode, const char* name)

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -41,7 +41,7 @@
 struct ResourceItem;
 class ConfigParserStateMachine;
 class ConfigurationParser;
-class ResHeadContainer;
+class ConfigResourcesContainer;
 /* For storing name_addr items in res_items table */
 
 /* using offsetof on non-standard-layout types is conditionally supported. As
@@ -219,8 +219,8 @@ class ConfigurationParser {
   BareosResource* own_resource_; /* Pointer to own resource */
   ResourceTable*
       resource_definitions_; /* Pointer to table of permitted resources */
-  std::shared_ptr<ResHeadContainer> config_resources_container_;
-  std::shared_ptr<ResHeadContainer> config_resources_container_backup_;
+  std::shared_ptr<ConfigResourcesContainer> config_resources_container_;
+  std::shared_ptr<ConfigResourcesContainer> config_resources_container_backup_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
@@ -430,13 +430,13 @@ static std::string TPAsString(const std::chrono::system_clock::time_point& tp)
   return ts;
 }
 
-class ResHeadContainer {
+class ConfigResourcesContainer {
  public:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
   BareosResource** configuration_resources_ = nullptr;
   ConfigurationParser* config_ = nullptr;
 
-  ResHeadContainer(ConfigurationParser* config)
+  ConfigResourcesContainer(ConfigurationParser* config)
   {
     config_ = config;
     int num = config_->r_num_;
@@ -444,14 +444,14 @@ class ResHeadContainer {
         = (BareosResource**)malloc(num * sizeof(BareosResource*));
 
     for (int i = 0; i < num; i++) { configuration_resources_[i] = nullptr; }
-    Dmsg1(10, "ResHeadContainer: new configuration_resources_ %p\n",
+    Dmsg1(10, "ConfigResourcesContainer: new configuration_resources_ %p\n",
           configuration_resources_);
   }
 
-  ~ResHeadContainer()
+  ~ConfigResourcesContainer()
   {
-    Dmsg1(10, "ResHeadContainer freeing %p %s\n", configuration_resources_,
-          TPAsString(timestamp_).c_str());
+    Dmsg1(10, "ConfigResourcesContainer freeing %p %s\n",
+          configuration_resources_, TPAsString(timestamp_).c_str());
     int num = config_->r_num_;
     for (int j = 0; j < num; j++) {
       config_->FreeResourceCb_(configuration_resources_[j], j);

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -423,8 +423,8 @@ struct ResHeadContainer {
   {
     res_head_ = res_head;
     config_ = config;
-    printf("ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
-           res_head_);
+    Dmsg1(100, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
+          res_head_);
   }
 
   ~ResHeadContainer()
@@ -434,13 +434,8 @@ struct ResHeadContainer {
       config_->FreeResourceCb_(res_head_[j], j);
       res_head_[j] = nullptr;
     }
-    printf("ResHeadContainer::~ResHeadContainer : feeing restable  at %p\n",
-           res_head_);
-    // free(res_head_);
-    printf("ResHeadContainer::~ResHeadContainer : freed restable  at %p\n",
-           res_head_);
-    // Dmsg0(100, "ResHeadContainer::~ResHeadContainer : freed restable  at
-    // %p\n", res_head_);
+    Dmsg1(100, "ResHeadContainer::~ResHeadContainer : freed restable  at %p\n",
+          res_head_);
   }
 };
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -184,7 +184,8 @@ typedef void(INIT_RES_HANDLER)(ResourceItem* item, int pass);
 typedef void(STORE_RES_HANDLER)(LEX* lc,
                                 ResourceItem* item,
                                 int index,
-                                int pass);
+                                int pass,
+                                BareosResource** res_head);
 typedef void(PRINT_RES_HANDLER)(ResourceItem& item,
                                 OutputFormatterResource& send,
                                 bool hide_sensitive_data,
@@ -218,10 +219,8 @@ class ConfigurationParser {
   BareosResource* own_resource_; /* Pointer to own resource */
   ResourceTable*
       resource_definitions_; /* Pointer to table of permitted resources */
- private:
-  BareosResource** res_head_; /* Pointer to defined resources */
- public:
   std::shared_ptr<ResHeadContainer> res_head_container_;
+  //  std::shared_ptr<ResHeadContainer> res_head_container_previous_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
@@ -238,7 +237,6 @@ class ConfigurationParser {
                       int32_t err_type,
                       int32_t r_num,
                       ResourceTable* resources,
-                      BareosResource** res_head,
                       const char* config_default_filename,
                       const char* config_include_dir,
                       void (*ParseConfigBeforeCb)(ConfigurationParser&),
@@ -248,7 +246,9 @@ class ConfigurationParser {
                       FreeResourceCb_t FreeResourceCb);
 
   ~ConfigurationParser();
-  void ResetResHeadContainer();
+  void ResetResHeadContainerPrevious();
+  void RestorePreviousConfig();
+  void ClearResourceTables();
 
   bool IsUsingConfigIncludeDir() const { return use_config_include_dir_; }
   bool ParseConfig();
@@ -258,7 +258,8 @@ class ConfigurationParser {
                        LEX_WARNING_HANDLER* scan_warning = nullptr);
   const std::string& get_base_config_path() const { return used_config_path_; }
   void FreeResources();
-  BareosResource** CopyResourceTable();
+  bool BackupResourceTable();
+  bool RestoreResourceTable();
   void InitResource(int rcode,
                     ResourceItem items[],
                     int pass,
@@ -420,10 +421,14 @@ class ConfigurationParser {
 struct ResHeadContainer {
   BareosResource** res_head_;
   ConfigurationParser* config_;
-  ResHeadContainer(ConfigurationParser* config, BareosResource** res_head)
+
+  ResHeadContainer(ConfigurationParser* config)
   {
-    res_head_ = res_head;
     config_ = config;
+    int num = config_->r_num_;
+    res_head_ = (BareosResource**)malloc(num * sizeof(BareosResource*));
+
+    for (int i = 0; i < num; i++) { res_head_[i] = nullptr; }
     Dmsg1(100, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
           res_head_);
   }
@@ -437,6 +442,7 @@ struct ResHeadContainer {
     }
     Dmsg1(100, "ResHeadContainer::~ResHeadContainer : freed restable  at %p\n",
           res_head_);
+    free(res_head_);
   }
 };
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -423,7 +423,8 @@ static std::string TPAsString(const std::chrono::system_clock::time_point& tp)
 {
   std::time_t t = std::chrono::system_clock::to_time_t(tp);
   char str[100];
-  if (!std::strftime(str, sizeof(str), "%F_%H:%M:%S", std::localtime(&t))) {
+  if (!std::strftime(str, sizeof(str), "%Y-%m-%d_%H:%M:%S",
+                     std::localtime(&t))) {
     return std::string("strftime error");
   }
   std::string ts = str;

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -419,7 +419,8 @@ class ConfigurationParser {
   void SetResourceDefaultsParserPass2(ResourceItem* item);
 };
 
-struct ResHeadContainer {
+class ResHeadContainer {
+ public:
   BareosResource** res_head_ = nullptr;
   ConfigurationParser* config_ = nullptr;
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -248,6 +248,7 @@ class ConfigurationParser {
                       FreeResourceCb_t FreeResourceCb);
 
   ~ConfigurationParser();
+  void ResetResHeadContainer();
 
   bool IsUsingConfigIncludeDir() const { return use_config_include_dir_; }
   bool ParseConfig();

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -209,19 +209,17 @@ class ConfigurationParser {
   PRINT_RES_HANDLER*
       print_res_; /* Print resource handler for non default types if non-null */
 
-  int32_t err_type_; /* The way to Terminate on failure */
-  // void* res_all_;        /* Pointer to res_all buffer */
-  // int32_t res_all_size_; /* Length of buffer */
+  int32_t err_type_;   /* The way to Terminate on failure */
   bool omit_defaults_; /* Omit config variables with default values when dumping
                           the config */
 
-  int32_t r_first_;              /* First daemon resource type */
-  int32_t r_last_;               /* Last daemon resource type */
+  int32_t r_num_;                /* number of daemon resource types */
   int32_t r_own_;                /* own resource type */
   BareosResource* own_resource_; /* Pointer to own resource */
-  ResourceTable* resources_;     /* Pointer to table of permitted resources */
-  BareosResource** res_head_;    /* Pointer to defined resources */
-  mutable brwlock_t res_lock_;   /* Resource lock */
+  ResourceTable*
+      resource_definitions_;   /* Pointer to table of permitted resources */
+  BareosResource** res_head_;  /* Pointer to defined resources */
+  mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
   DumpResourceCb_t DumpResourceCb_;
@@ -235,8 +233,7 @@ class ConfigurationParser {
                       STORE_RES_HANDLER* StoreRes,
                       PRINT_RES_HANDLER* print_res,
                       int32_t err_type,
-                      int32_t r_first,
-                      int32_t r_last,
+                      int32_t r_num,
                       ResourceTable* resources,
                       BareosResource** res_head,
                       const char* config_default_filename,
@@ -257,7 +254,7 @@ class ConfigurationParser {
                        LEX_WARNING_HANDLER* scan_warning = nullptr);
   const std::string& get_base_config_path() const { return used_config_path_; }
   void FreeResources();
-  BareosResource** SaveResources();
+  BareosResource** CopyResourceTable();
   void InitResource(int rcode,
                     ResourceItem items[],
                     int pass,

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -431,13 +431,13 @@ class ResHeadContainer {
     res_head_ = (BareosResource**)malloc(num * sizeof(BareosResource*));
 
     for (int i = 0; i < num; i++) { res_head_[i] = nullptr; }
-    Dmsg1(0, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
+    Dmsg1(10, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
           res_head_);
   }
 
   ~ResHeadContainer()
   {
-    Dmsg1(0, "ResHeadContainer::~ResHeadContainer : freeing res_head at %p\n",
+    Dmsg1(10, "ResHeadContainer::~ResHeadContainer : freeing res_head at %p\n",
           res_head_);
     int num = config_->r_num_;
     for (int j = 0; j < num; j++) {

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -220,7 +220,7 @@ class ConfigurationParser {
   ResourceTable*
       resource_definitions_; /* Pointer to table of permitted resources */
   std::shared_ptr<ResHeadContainer> res_head_container_;
-  std::shared_ptr<ResHeadContainer> res_head_container_previous_;
+  std::shared_ptr<ResHeadContainer> res_head_container_backup_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
@@ -257,9 +257,8 @@ class ConfigurationParser {
   void FreeResources();
 
   void ReleasePreviousResourceTable();
-  void RestorePreviousConfig();
-  bool BackupResourceTable();
-  bool RestoreResourceTable();
+  void BackupResourceTable();
+  void RestoreResourceTable();
 
   void InitResource(int rcode,
                     ResourceItem items[],

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -220,7 +220,7 @@ class ConfigurationParser {
   ResourceTable*
       resource_definitions_; /* Pointer to table of permitted resources */
   std::shared_ptr<ResHeadContainer> res_head_container_;
-  //  std::shared_ptr<ResHeadContainer> res_head_container_previous_;
+  std::shared_ptr<ResHeadContainer> res_head_container_previous_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
@@ -246,9 +246,6 @@ class ConfigurationParser {
                       FreeResourceCb_t FreeResourceCb);
 
   ~ConfigurationParser();
-  void ResetResHeadContainerPrevious();
-  void RestorePreviousConfig();
-  void ClearResourceTables();
 
   bool IsUsingConfigIncludeDir() const { return use_config_include_dir_; }
   bool ParseConfig();
@@ -258,8 +255,12 @@ class ConfigurationParser {
                        LEX_WARNING_HANDLER* scan_warning = nullptr);
   const std::string& get_base_config_path() const { return used_config_path_; }
   void FreeResources();
+
+  void ReleasePreviousResourceTable();
+  void RestorePreviousConfig();
   bool BackupResourceTable();
   bool RestoreResourceTable();
+
   void InitResource(int rcode,
                     ResourceItem items[],
                     int pass,
@@ -419,8 +420,8 @@ class ConfigurationParser {
 };
 
 struct ResHeadContainer {
-  BareosResource** res_head_;
-  ConfigurationParser* config_;
+  BareosResource** res_head_ = nullptr;
+  ConfigurationParser* config_ = nullptr;
 
   ResHeadContainer(ConfigurationParser* config)
   {
@@ -429,20 +430,21 @@ struct ResHeadContainer {
     res_head_ = (BareosResource**)malloc(num * sizeof(BareosResource*));
 
     for (int i = 0; i < num; i++) { res_head_[i] = nullptr; }
-    Dmsg1(100, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
+    Dmsg1(0, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
           res_head_);
   }
 
   ~ResHeadContainer()
   {
+    Dmsg1(0, "ResHeadContainer::~ResHeadContainer : freeing res_head at %p\n",
+          res_head_);
     int num = config_->r_num_;
     for (int j = 0; j < num; j++) {
       config_->FreeResourceCb_(res_head_[j], j);
       res_head_[j] = nullptr;
     }
-    Dmsg1(100, "ResHeadContainer::~ResHeadContainer : freed restable  at %p\n",
-          res_head_);
     free(res_head_);
+    res_head_ = nullptr;
   }
 };
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -200,32 +200,32 @@ class ConfigurationParser {
   friend class ConfigParserStateMachine;
 
  public:
-  std::string cf_;                    /* Config file parameter */
-  LEX_ERROR_HANDLER* scan_error_;     /* Error handler if non-null */
-  LEX_WARNING_HANDLER* scan_warning_; /* Warning handler if non-null */
-  INIT_RES_HANDLER*
-      init_res_; /* Init resource handler for non default types if non-null */
-  STORE_RES_HANDLER*
-      store_res_; /* Store resource handler for non default types if non-null */
-  PRINT_RES_HANDLER*
-      print_res_; /* Print resource handler for non default types if non-null */
+  std::string cf_;                             /* Config file parameter */
+  LEX_ERROR_HANDLER* scan_error_{nullptr};     /* Error handler if non-null */
+  LEX_WARNING_HANDLER* scan_warning_{nullptr}; /* Warning handler if non-null */
+  INIT_RES_HANDLER* init_res_{
+      nullptr}; /* Init resource handler for non default types if non-null */
+  STORE_RES_HANDLER* store_res_{
+      nullptr}; /* Store resource handler for non default types if non-null */
+  PRINT_RES_HANDLER* print_res_{
+      nullptr}; /* Print resource handler for non default types if non-null */
 
-  int32_t err_type_;   /* The way to Terminate on failure */
-  bool omit_defaults_; /* Omit config variables with default values when dumping
-                          the config */
+  int32_t err_type_{0};       /* The way to Terminate on failure */
+  bool omit_defaults_{false}; /* Omit config variables with default values when
+                          dumping the config */
 
-  int32_t r_num_;                /* number of daemon resource types */
-  int32_t r_own_;                /* own resource type */
-  BareosResource* own_resource_; /* Pointer to own resource */
-  ResourceTable*
-      resource_definitions_; /* Pointer to table of permitted resources */
+  int32_t r_num_{0};                      /* number of daemon resource types */
+  int32_t r_own_{0};                      /* own resource type */
+  BareosResource* own_resource_{nullptr}; /* Pointer to own resource */
+  ResourceTable* resource_definitions_{
+      0}; /* Pointer to table of permitted resources */
   std::shared_ptr<ConfigResourcesContainer> config_resources_container_;
   std::shared_ptr<ConfigResourcesContainer> config_resources_container_backup_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
-  SaveResourceCb_t SaveResourceCb_;
-  DumpResourceCb_t DumpResourceCb_;
-  FreeResourceCb_t FreeResourceCb_;
+  SaveResourceCb_t SaveResourceCb_{nullptr};
+  DumpResourceCb_t DumpResourceCb_{nullptr};
+  FreeResourceCb_t FreeResourceCb_{nullptr};
 
   ConfigurationParser();
   ConfigurationParser(const char* cf,
@@ -340,17 +340,17 @@ class ConfigurationParser {
                                            used, if no filename is given */
   std::string config_dir_; /* base directory of configuration files */
   std::string
-      config_include_dir_;      /* rel. path to the config include directory
-                                    (bareos-dir.d, bareos-sd.d, bareos-fd.d, ...) */
-  bool use_config_include_dir_; /* Use the config include directory */
+      config_include_dir_; /* rel. path to the config include directory
+                               (bareos-dir.d, bareos-sd.d, bareos-fd.d, ...) */
+  bool use_config_include_dir_{false}; /* Use the config include directory */
   std::string config_include_naming_format_; /* Format string for file paths of
                                                 resources */
   std::string used_config_path_;             /* Config file that is used. */
   std::unique_ptr<QualifiedResourceNameTypeConverter>
       qualified_resource_name_type_converter_;
-  ParseConfigBeforeCb_t ParseConfigBeforeCb_;
-  ParseConfigReadyCb_t ParseConfigReadyCb_;
-  bool parser_first_run_;
+  ParseConfigBeforeCb_t ParseConfigBeforeCb_{nullptr};
+  ParseConfigReadyCb_t ParseConfigReadyCb_{nullptr};
+  bool parser_first_run_{true};
   BStringList warnings_;
 
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -421,11 +421,12 @@ class ConfigurationParser {
 
 
 class ConfigResourcesContainer {
- public:
+ private:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
-  BareosResource** configuration_resources_ = nullptr;
   ConfigurationParser* config_ = nullptr;
 
+ public:
+  BareosResource** configuration_resources_ = nullptr;
   ConfigResourcesContainer(ConfigurationParser* config)
   {
     config_ = config;
@@ -450,7 +451,7 @@ class ConfigResourcesContainer {
     free(configuration_resources_);
     configuration_resources_ = nullptr;
   }
-
+  void SetTimestampToNow() { timestamp_ = std::chrono::system_clock::now(); }
   std::string TimeStampAsString() { return TPAsString(timestamp_); }
 };
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -418,8 +418,21 @@ class ConfigurationParser {
   void SetResourceDefaultsParserPass2(ResourceItem* item);
 };
 
+
+static std::string TPAsString(const std::chrono::system_clock::time_point& tp)
+{
+  std::time_t t = std::chrono::system_clock::to_time_t(tp);
+  char str[100];
+  if (!std::strftime(str, sizeof(str), "%F_%H:%M:%S", std::localtime(&t))) {
+    return std::string("strftime error");
+  }
+  std::string ts = str;
+  return ts;
+}
+
 class ResHeadContainer {
  public:
+  std::chrono::time_point<std::chrono::system_clock> timestamp_{};
   BareosResource** res_head_ = nullptr;
   ConfigurationParser* config_ = nullptr;
 
@@ -430,14 +443,13 @@ class ResHeadContainer {
     res_head_ = (BareosResource**)malloc(num * sizeof(BareosResource*));
 
     for (int i = 0; i < num; i++) { res_head_[i] = nullptr; }
-    Dmsg1(10, "ResHeadContainer::ResHeadContainer : res_head_ is at %p\n",
-          res_head_);
+    Dmsg1(10, "ResHeadContainer: new res_head_ %p\n", res_head_);
   }
 
   ~ResHeadContainer()
   {
-    Dmsg1(10, "ResHeadContainer::~ResHeadContainer : freeing res_head at %p\n",
-          res_head_);
+    Dmsg1(10, "ResHeadContainer freeing %p %s\n", res_head_,
+          TPAsString(timestamp_).c_str());
     int num = config_->r_num_;
     for (int j = 0; j < num; j++) {
       config_->FreeResourceCb_(res_head_[j], j);
@@ -446,6 +458,8 @@ class ResHeadContainer {
     free(res_head_);
     res_head_ = nullptr;
   }
+
+  std::string TimeStampAsString() { return TPAsString(timestamp_); }
 };
 
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -221,7 +221,6 @@ class ConfigurationParser {
   ResourceTable* resource_definitions_{
       0}; /* Pointer to table of permitted resources */
   std::shared_ptr<ConfigResourcesContainer> config_resources_container_;
-  std::shared_ptr<ConfigResourcesContainer> config_resources_container_backup_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_{nullptr};
@@ -257,9 +256,8 @@ class ConfigurationParser {
   const std::string& get_base_config_path() const { return used_config_path_; }
   void FreeResources();
 
-  void ReleasePreviousResourceTable();
-  void BackupResourceTable();
-  void RestoreResourceTable();
+  std::shared_ptr<ConfigResourcesContainer> BackupResourceTable();
+  void RestoreResourceTable(std::shared_ptr<ConfigResourcesContainer>&&);
 
   void InitResource(int rcode,
                     ResourceItem items[],

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -185,7 +185,7 @@ typedef void(STORE_RES_HANDLER)(LEX* lc,
                                 ResourceItem* item,
                                 int index,
                                 int pass,
-                                BareosResource** res_head);
+                                BareosResource** configuration_resources);
 typedef void(PRINT_RES_HANDLER)(ResourceItem& item,
                                 OutputFormatterResource& send,
                                 bool hide_sensitive_data,
@@ -219,8 +219,8 @@ class ConfigurationParser {
   BareosResource* own_resource_; /* Pointer to own resource */
   ResourceTable*
       resource_definitions_; /* Pointer to table of permitted resources */
-  std::shared_ptr<ResHeadContainer> res_head_container_;
-  std::shared_ptr<ResHeadContainer> res_head_container_backup_;
+  std::shared_ptr<ResHeadContainer> config_resources_container_;
+  std::shared_ptr<ResHeadContainer> config_resources_container_backup_;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_;
@@ -433,30 +433,32 @@ static std::string TPAsString(const std::chrono::system_clock::time_point& tp)
 class ResHeadContainer {
  public:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
-  BareosResource** res_head_ = nullptr;
+  BareosResource** configuration_resources_ = nullptr;
   ConfigurationParser* config_ = nullptr;
 
   ResHeadContainer(ConfigurationParser* config)
   {
     config_ = config;
     int num = config_->r_num_;
-    res_head_ = (BareosResource**)malloc(num * sizeof(BareosResource*));
+    configuration_resources_
+        = (BareosResource**)malloc(num * sizeof(BareosResource*));
 
-    for (int i = 0; i < num; i++) { res_head_[i] = nullptr; }
-    Dmsg1(10, "ResHeadContainer: new res_head_ %p\n", res_head_);
+    for (int i = 0; i < num; i++) { configuration_resources_[i] = nullptr; }
+    Dmsg1(10, "ResHeadContainer: new configuration_resources_ %p\n",
+          configuration_resources_);
   }
 
   ~ResHeadContainer()
   {
-    Dmsg1(10, "ResHeadContainer freeing %p %s\n", res_head_,
+    Dmsg1(10, "ResHeadContainer freeing %p %s\n", configuration_resources_,
           TPAsString(timestamp_).c_str());
     int num = config_->r_num_;
     for (int j = 0; j < num; j++) {
-      config_->FreeResourceCb_(res_head_[j], j);
-      res_head_[j] = nullptr;
+      config_->FreeResourceCb_(configuration_resources_[j], j);
+      configuration_resources_[j] = nullptr;
     }
-    free(res_head_);
-    res_head_ = nullptr;
+    free(configuration_resources_);
+    configuration_resources_ = nullptr;
   }
 
   std::string TimeStampAsString() { return TPAsString(timestamp_); }

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -34,6 +34,7 @@
 #include "lib/parse_conf.h"
 #include "lib/keyword_table_s.h"
 #include "lib/message_destination_info.h"
+#include "lib/util.h"
 
 #include <functional>
 #include <memory>
@@ -418,18 +419,6 @@ class ConfigurationParser {
   void SetResourceDefaultsParserPass2(ResourceItem* item);
 };
 
-
-static std::string TPAsString(const std::chrono::system_clock::time_point& tp)
-{
-  std::time_t t = std::chrono::system_clock::to_time_t(tp);
-  char str[100];
-  if (!std::strftime(str, sizeof(str), "%Y-%m-%d_%H:%M:%S",
-                     std::localtime(&t))) {
-    return std::string("strftime error");
-  }
-  std::string ts = str;
-  return ts;
-}
 
 class ConfigResourcesContainer {
  public:

--- a/core/src/lib/parse_conf_init_resource.cc
+++ b/core/src/lib/parse_conf_init_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -209,7 +209,7 @@ void ConfigurationParser::SetAllResourceDefaultsIterateOverItems(
 
     if (res_item_index >= MAX_RES_ITEMS) {
       Emsg1(M_ERROR_TERM, 0, _("Too many items in %s resource\n"),
-            resources_[rcode - r_first_].name);
+            resource_definitions_[rcode].name);
     }
   }
 }

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -279,10 +279,9 @@ bool ConfigParserStateMachine::InitParserPass()
 void ConfigParserStateMachine::DumpResourcesAfterSecondPass()
 {
   if (debug_level >= 900 && parser_pass_number_ == 2) {
-    for (int i = my_config_.r_first_; i <= my_config_.r_last_; i++) {
-      my_config_.DumpResourceCb_(i,
-                                 my_config_.res_head_[i - my_config_.r_first_],
-                                 PrintMessage, nullptr, false, false);
+    for (int i = 0; i <= my_config_.r_num_ - 1; i++) {
+      my_config_.DumpResourceCb_(i, my_config_.res_head_[i], PrintMessage,
+                                 nullptr, false, false);
     }
   }
 }

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -144,7 +144,8 @@ ConfigParserStateMachine::ScanResource(int token)
                                       parser_pass_number_)) {
           if (my_config_.store_res_) {
             my_config_.store_res_(lexical_parser_, item, resource_item_index,
-                                  parser_pass_number_);
+                                  parser_pass_number_,
+                                  my_config_.res_head_container_->res_head_);
           }
         }
       } else {
@@ -280,8 +281,9 @@ void ConfigParserStateMachine::DumpResourcesAfterSecondPass()
 {
   if (debug_level >= 900 && parser_pass_number_ == 2) {
     for (int i = 0; i <= my_config_.r_num_ - 1; i++) {
-      my_config_.DumpResourceCb_(i, my_config_.res_head_[i], PrintMessage,
-                                 nullptr, false, false);
+      my_config_.DumpResourceCb_(i,
+                                 my_config_.res_head_container_->res_head_[i],
+                                 PrintMessage, nullptr, false, false);
     }
   }
 }

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -145,7 +145,8 @@ ConfigParserStateMachine::ScanResource(int token)
           if (my_config_.store_res_) {
             my_config_.store_res_(lexical_parser_, item, resource_item_index,
                                   parser_pass_number_,
-                                  my_config_.res_head_container_->res_head_);
+                                  my_config_.config_resources_container_
+                                      ->configuration_resources_);
           }
         }
       } else {
@@ -281,9 +282,10 @@ void ConfigParserStateMachine::DumpResourcesAfterSecondPass()
 {
   if (debug_level >= 900 && parser_pass_number_ == 2) {
     for (int i = 0; i <= my_config_.r_num_ - 1; i++) {
-      my_config_.DumpResourceCb_(i,
-                                 my_config_.res_head_container_->res_head_[i],
-                                 PrintMessage, nullptr, false, false);
+      my_config_.DumpResourceCb_(
+          i,
+          my_config_.config_resources_container_->configuration_resources_[i],
+          PrintMessage, nullptr, false, false);
     }
   }
 }

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,7 +92,7 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
                                                     bool lock) const
 {
   BareosResource* res;
-  int rindex = rcode - r_first_;
+  int rindex = rcode;
 
   if (lock) { LockRes(this); }
 
@@ -116,7 +116,7 @@ BareosResource* ConfigurationParser::GetNextRes(int rcode,
                                                 BareosResource* res) const
 {
   BareosResource* nres;
-  int rindex = rcode - r_first_;
+  int rindex = rcode;
 
   if (res == NULL) {
     nres = res_head_[rindex];
@@ -129,19 +129,19 @@ BareosResource* ConfigurationParser::GetNextRes(int rcode,
 
 const char* ConfigurationParser::ResToStr(int rcode) const
 {
-  if (rcode < r_first_ || rcode > r_last_) {
+  if (rcode < 0 || rcode > r_num_ - 1) {
     return _("***UNKNOWN***");
   } else {
-    return resources_[rcode - r_first_].name;
+    return resource_definitions_[rcode].name;
   }
 }
 
 const char* ConfigurationParser::ResGroupToStr(int rcode) const
 {
-  if (rcode < r_first_ || rcode > r_last_) {
+  if (rcode < 0 || rcode > r_num_ - 1) {
     return _("***UNKNOWN***");
   } else {
-    return resources_[rcode - r_first_].groupname;
+    return resource_definitions_[rcode].groupname;
   }
 }
 
@@ -2034,17 +2034,16 @@ bool BareosResource::PrintConfig(OutputFormatterResource& send,
   int rindex;
 
   // If entry is not used, then there is nothing to print.
-  if (rcode_ < (uint32_t)my_config.r_first_ || refcnt_ <= 0) { return true; }
-
-  rindex = rcode_ - my_config.r_first_;
+  if (rcode_ < 0 || refcnt_ <= 0) { return true; }
+  rindex = rcode_;
 
   // don't dump internal resources.
   if ((internal_) && (!verbose)) { return true; }
   // Make sure the resource class has any items.
-  if (!my_config.resources_[rindex].items) { return true; }
-  items = my_config.resources_[rindex].items;
+  if (!my_config.resource_definitions_[rindex].items) { return true; }
+  items = my_config.resource_definitions_[rindex].items;
 
-  *my_config.resources_[rindex].allocated_resource_ = this;
+  *my_config.resource_definitions_[rindex].allocated_resource_ = this;
 
   send.ResourceStart(my_config.ResGroupToStr(rcode_),
                      my_config.ResToStr(rcode_), resource_name_, internal_);

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -96,7 +96,7 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
 
   if (lock) { LockRes(this); }
 
-  res = res_head_[rindex];
+  res = res_head_container_->res_head_[rindex];
   while (res) {
     if (bstrcmp(res->resource_name_, name)) { break; }
     res = res->next_;
@@ -119,7 +119,7 @@ BareosResource* ConfigurationParser::GetNextRes(int rcode,
   int rindex = rcode;
 
   if (res == NULL) {
-    nres = res_head_[rindex];
+    nres = res_head_container_->res_head_[rindex];
   } else {
     nres = res->next_;
   }

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -96,7 +96,7 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
 
   if (lock) { LockRes(this); }
 
-  res = res_head_container_->res_head_[rindex];
+  res = config_resources_container_->configuration_resources_[rindex];
   while (res) {
     if (bstrcmp(res->resource_name_, name)) { break; }
     res = res->next_;
@@ -119,7 +119,7 @@ BareosResource* ConfigurationParser::GetNextRes(int rcode,
   int rindex = rcode;
 
   if (res == NULL) {
-    nres = res_head_container_->res_head_[rindex];
+    nres = config_resources_container_->configuration_resources_[rindex];
   } else {
     nres = res->next_;
   }

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -1156,3 +1156,15 @@ std::string CreateDelimitedStringForSqlQueries(
   }
   return empty_list;
 }
+
+std::string TPAsString(const std::chrono::system_clock::time_point& tp)
+{
+  std::time_t t = std::chrono::system_clock::to_time_t(tp);
+  char str[100];
+  if (!std::strftime(str, sizeof(str), "%Y-%m-%d_%H:%M:%S",
+                     std::localtime(&t))) {
+    return std::string("strftime error");
+  }
+  std::string ts = str;
+  return ts;
+}

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -22,6 +22,7 @@
 #define BAREOS_LIB_UTIL_H_
 
 #include <sys/stat.h>
+#include <chrono>
 
 #include "lib/ascii_control_characters.h"
 #include "lib/message.h"
@@ -81,5 +82,7 @@ std::vector<std::string> split_string(const std::string& str, char delim);
 std::string CreateDelimitedStringForSqlQueries(
     const std::vector<char>& elements,
     char delim);
+
+std::string TPAsString(const std::chrono::system_clock::time_point& tp);
 
 #endif  // BAREOS_LIB_UTIL_H_

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -55,9 +55,6 @@
 
 static const std::string default_config_filename("tray-monitor.conf");
 
-/* static BareosResource* sres_head[R_NUM]; */
-/* static BareosResource** res_head = sres_head; */
-
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
 static void DumpResource(int type,
@@ -166,7 +163,7 @@ static ResourceItem con_font_items[] = {
  * NOTE!!! keep it in the same order as the R_codes
  *   or eliminate all resource_definitions[rindex].name
  *
- *  name items rcode res_head
+ *  name items rcode configuration_resources
  */
 static ResourceTable resource_definitions[] = {
   {"Monitor", "Monitors", mon_items, R_MONITOR, sizeof(MonitorResource),

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -55,8 +55,8 @@
 
 static const std::string default_config_filename("tray-monitor.conf");
 
-static BareosResource* sres_head[R_NUM];
-static BareosResource** res_head = sres_head;
+/* static BareosResource* sres_head[R_NUM]; */
+/* static BareosResource** res_head = sres_head; */
 
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void FreeResource(BareosResource* sres, int type);
@@ -385,9 +385,9 @@ ConfigurationParser* InitTmonConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code, R_NUM,
-      resource_definitions, res_head, default_config_filename.c_str(),
-      "tray-monitor.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
-      DumpResource, FreeResource);
+      resource_definitions, default_config_filename.c_str(), "tray-monitor.d",
+      ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
+      FreeResource);
   if (config) { config->r_own_ = R_MONITOR; }
   return config;
 }

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -272,7 +272,6 @@ static void FreeResource(BareosResource* res, int type)
  */
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type;
   int i;
   int error = 0;
 
@@ -282,13 +281,13 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
         Emsg2(M_ERROR_TERM, 0,
               _("%s item is required in %s resource, but not found.\n"),
-              items[i].name, resource_definitions[rindex].name);
+              items[i].name, resource_definitions[type].name);
       }
     }
     /* If this triggers, take a look at lib/parse_conf.h */
     if (i >= MAX_RES_ITEMS) {
       Emsg1(M_ERROR_TERM, 0, _("Too many items in %s resource\n"),
-            resource_definitions[rindex].name);
+            resource_definitions[type].name);
     }
   }
 

--- a/core/src/qt-tray-monitor/tray_conf.h
+++ b/core/src/qt-tray-monitor/tray_conf.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -40,21 +40,20 @@ extern ConfigurationParser* my_config;
 
 enum Rescode
 {
-  R_UNKNOWN = 0,
-  R_MONITOR = 1001,
+  R_MONITOR = 0,
   R_DIRECTOR,
   R_CLIENT,
   R_STORAGE,
   R_CONSOLE,
   R_CONSOLE_FONT,
-  R_FIRST = R_MONITOR,
-  R_LAST = R_CONSOLE_FONT /* keep this updated */
+  R_NUM, /* keep this updated */
+  R_UNKNOWN = 0xff
 };
 
 // Some resource attributes
 enum
 {
-  R_NAME = 1020,
+  R_NAME = 0,
   R_ADDRESS,
   R_PASSWORD,
   R_TYPE,

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -48,9 +48,6 @@
 
 namespace storagedaemon {
 
-/* static BareosResource* sres_head[R_NUM]; */
-/* static BareosResource** res_head = sres_head; */
-
 static void FreeResource(BareosResource* sres, int type);
 static bool SaveResource(int type, ResourceItem* items, int pass);
 static void DumpResource(int type,
@@ -446,7 +443,7 @@ static void ParseConfigCb(LEX* lc,
                           ResourceItem* item,
                           int index,
                           int pass,
-                          BareosResource** res_head)
+                          BareosResource** configuration_resources)
 {
   switch (item->type) {
     case CFG_TYPE_AUTOPASSWORD:

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -48,8 +48,8 @@
 
 namespace storagedaemon {
 
-static BareosResource* sres_head[R_NUM];
-static BareosResource** res_head = sres_head;
+/* static BareosResource* sres_head[R_NUM]; */
+/* static BareosResource** res_head = sres_head; */
 
 static void FreeResource(BareosResource* sres, int type);
 static bool SaveResource(int type, ResourceItem* items, int pass);
@@ -442,7 +442,11 @@ static void InitResourceCb(ResourceItem* item, int pass)
   }
 }
 
-static void ParseConfigCb(LEX* lc, ResourceItem* item, int index, int pass)
+static void ParseConfigCb(LEX* lc,
+                          ResourceItem* item,
+                          int index,
+                          int pass,
+                          BareosResource** res_head)
 {
   switch (item->type) {
     case CFG_TYPE_AUTOPASSWORD:
@@ -562,7 +566,7 @@ ConfigurationParser* InitSdConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_NUM, resources, res_head, default_config_filename.c_str(),
+      exit_code, R_NUM, resources, default_config_filename.c_str(),
       "bareos-sd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
       DumpResource, FreeResource);
   if (config) { config->r_own_ = R_STORAGE; }

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -48,7 +48,7 @@
 
 namespace storagedaemon {
 
-static BareosResource* sres_head[R_LAST - R_FIRST + 1];
+static BareosResource* sres_head[R_NUM];
 static BareosResource** res_head = sres_head;
 
 static void FreeResource(BareosResource* sres, int type);
@@ -562,9 +562,9 @@ ConfigurationParser* InitSdConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
       configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_FIRST, R_LAST, resources, res_head,
-      default_config_filename.c_str(), "bareos-sd.d", ConfigBeforeCallback,
-      ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
+      exit_code, R_NUM, resources, res_head, default_config_filename.c_str(),
+      "bareos-sd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
+      DumpResource, FreeResource);
   if (config) { config->r_own_ = R_STORAGE; }
   return config;
 }
@@ -597,7 +597,7 @@ bool ParseSdConfig(const char* configfile, int exit_code)
 #ifdef HAVE_JANSSON
 bool PrintConfigSchemaJson(PoolMem& buffer)
 {
-  ResourceTable* resources = my_config->resources_;
+  ResourceTable* resources = my_config->resource_definitions_;
 
   json_t* json = json_object();
   json_object_set_new(json, "format-version", json_integer(2));
@@ -611,7 +611,7 @@ bool PrintConfigSchemaJson(PoolMem& buffer)
   json_object_set(resource, "bareos-sd", bareos_sd);
 
   for (int r = 0; resources[r].name; r++) {
-    ResourceTable resource = my_config->resources_[r];
+    ResourceTable resource = my_config->resource_definitions_[r];
     json_object_set(bareos_sd, resource.name, json_items(resource.items));
   }
 
@@ -708,7 +708,7 @@ static void DumpResource(int type,
 
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type - R_FIRST;
+  int rindex = type;
   int i;
   int error = 0;
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -709,11 +709,10 @@ static void DumpResource(int type,
 
 static bool SaveResource(int type, ResourceItem* items, int pass)
 {
-  int rindex = type;
   int i;
   int error = 0;
 
-  BareosResource* allocated_resource = *resources[rindex].allocated_resource_;
+  BareosResource* allocated_resource = *resources[type].allocated_resource_;
   if (pass == 2 && !allocated_resource->Validate()) { return false; }
 
   // Ensure that all required items are present
@@ -722,13 +721,13 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
         Emsg2(M_ERROR_TERM, 0,
               _("\"%s\" item is required in \"%s\" resource, but not found.\n"),
-              items[i].name, resources[rindex].name);
+              items[i].name, resources[type].name);
       }
     }
 
     if (i >= MAX_RES_ITEMS) {
       Emsg1(M_ERROR_TERM, 0, _("Too many items in \"%s\" resource\n"),
-            resources[rindex].name);
+            resources[type].name);
     }
   }
 
@@ -821,7 +820,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
 
   if (!error) {
     BareosResource* new_resource = nullptr;
-    switch (resources[rindex].rcode) {
+    switch (resources[type].rcode) {
       case R_DIRECTOR:
         new_resource = res_dir;
         res_dir = nullptr;

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -46,21 +46,20 @@ static const std::string default_config_filename("bareos-sd.conf");
 // Resource codes -- they must be sequential for indexing
 enum
 {
-  R_DIRECTOR = 3001,
+  R_DIRECTOR = 0,
   R_NDMP,
   R_STORAGE,
   R_DEVICE,
   R_MSGS,
   R_AUTOCHANGER,
-  R_JOB, /* needed for Job name conversion */
-  R_FIRST = R_DIRECTOR,
-  R_LAST = R_JOB,  /* keep this updated */
+  R_JOB,           // needed for Job name conversion
+  R_NUM,           // number of entires
   R_CLIENT = 0xff  // dummy for bsock printing
 };
 
 enum
 {
-  R_NAME = 3020,
+  R_NAME = 0,
   R_ADDRESS,
   R_PASSWORD,
   R_TYPE,

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -34,6 +34,11 @@
 #include "include/job_types.h"
 #include "lib/output_formatter.h"
 
+#include "lib/parse_conf.h"
+#include "dird/dird_globals.h"
+#include "dird/dird_conf.h"
+
+
 #include <array>
 
 namespace directordaemon {
@@ -60,6 +65,11 @@ static bool sprintit(void* ctx, const char* fmt, ...)
 
 TEST(setdevice, scan_command_line)
 {
+  OSDependentInit();
+  std::string path_to_config_file = std::string(
+      RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
+  my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
+
   std::unique_ptr<JobControlRecord, decltype(&Test_FreeJcr)> jcr(
       NewDirectorJcr(), &Test_FreeJcr);
 

--- a/core/src/tests/show_cmd_available_resources_equals_config_resources.cc
+++ b/core/src/tests/show_cmd_available_resources_equals_config_resources.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,18 +43,18 @@ TEST(available_resources_equals_config_resources, check_contents)
 
   std::set<uint32_t> set_of_config_resources;
 
-  for (int i = 0; my_config->resources_[i].name; i++) {
-    if (my_config->resources_[i].rcode != R_DEVICE) {
+  for (int i = 0; my_config->resource_definitions_[i].name; i++) {
+    if (my_config->resource_definitions_[i].rcode != R_DEVICE) {
       /* skip R_DEVICE, as these are special resources, not shown by the show
        * command. */
-      set_of_config_resources.insert(my_config->resources_[i].rcode);
+      set_of_config_resources.insert(my_config->resource_definitions_[i].rcode);
     }
   }
 
   std::set<uint32_t> set_of_show_cmd_resources;
 
   for (int i = 0; show_cmd_available_resources[i].res_name; i++) {
-    if (show_cmd_available_resources[i].type > 0) {
+    if (show_cmd_available_resources[i].type >= 0) {
       set_of_show_cmd_resources.insert(show_cmd_available_resources[i].type);
     }
   }

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -41,13 +41,13 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   my_config->ParseConfig();
   my_config->DumpResources(PrintMessage, NULL);
 
-  ASSERT_EQ(true, my_config->BackupResourceTable());
+  my_config->BackupResourceTable();
 
   my_config->ParseConfig();
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
   my_config->own_resource_ = me;
   ASSERT_NE(nullptr, me);
-  ASSERT_EQ(true, my_config->RestoreResourceTable());
+  my_config->RestoreResourceTable();
   ASSERT_NE(nullptr, me);
   my_config->ParseConfig();
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -45,7 +45,6 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
 
   delete my_config;
 }
-
 TEST(ConfigParser_Dir, runscript_test)
 {
   OSDependentInit();
@@ -233,6 +232,5 @@ TEST(ConfigParser_Dir, CFG_TYPE_TIME)
 {
   test_config_directive_type(test_CFG_TYPE_TIME);
 }
-
 
 }  // namespace directordaemon

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -40,11 +40,32 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
   my_config->ParseConfig();
-
   my_config->DumpResources(PrintMessage, NULL);
+
+  ASSERT_EQ(true, my_config->BackupResourceTable());
+  my_config->ParseConfig();
+  me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+  my_config->own_resource_ = me;
+
+  ASSERT_NE(nullptr, me);
+  my_config->DumpResources(PrintMessage, NULL);
+  ASSERT_NE(nullptr, me);
+
+  ASSERT_EQ(true, my_config->RestoreResourceTable());
+  ASSERT_NE(nullptr, me);
+  my_config->ParseConfig();
+  me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+  my_config->own_resource_ = me;
+  assert(me);
+
+  ASSERT_NE(nullptr, me);
+  my_config->DumpResources(PrintMessage, NULL);
+  ASSERT_NE(nullptr, me);
 
   delete my_config;
 }
+
+#if 0
 TEST(ConfigParser_Dir, runscript_test)
 {
   OSDependentInit();
@@ -138,9 +159,9 @@ void test_CFG_TYPE_STR_VECTOR_OF_DIRS(DirectorResource* me)
    *  but this is later overwritten in the Director Daemon with ".".
    *  Therefore we skip this test.
    */
-#if !defined(HAVE_WIN32)
+#  if !defined(HAVE_WIN32)
   EXPECT_EQ(me->backend_directories.at(0), PATH_BAREOS_BACKENDDIR);
-#endif
+#  endif
 }
 
 TEST(ConfigParser_Dir, CFG_TYPE_STR_VECTOR_OF_DIRS)
@@ -232,5 +253,5 @@ TEST(ConfigParser_Dir, CFG_TYPE_TIME)
 {
   test_config_directive_type(test_CFG_TYPE_TIME);
 }
-
+#endif
 }  // namespace directordaemon

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -35,7 +35,6 @@ namespace directordaemon {
 TEST(ConfigParser_Dir, bareos_configparser_tests)
 {
   OSDependentInit();
-
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -43,14 +42,11 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   my_config->DumpResources(PrintMessage, NULL);
 
   ASSERT_EQ(true, my_config->BackupResourceTable());
+
   my_config->ParseConfig();
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
   my_config->own_resource_ = me;
-
   ASSERT_NE(nullptr, me);
-  my_config->DumpResources(PrintMessage, NULL);
-  ASSERT_NE(nullptr, me);
-
   ASSERT_EQ(true, my_config->RestoreResourceTable());
   ASSERT_NE(nullptr, me);
   my_config->ParseConfig();
@@ -61,11 +57,9 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   ASSERT_NE(nullptr, me);
   my_config->DumpResources(PrintMessage, NULL);
   ASSERT_NE(nullptr, me);
-
   delete my_config;
 }
 
-#if 0
 TEST(ConfigParser_Dir, runscript_test)
 {
   OSDependentInit();
@@ -159,9 +153,9 @@ void test_CFG_TYPE_STR_VECTOR_OF_DIRS(DirectorResource* me)
    *  but this is later overwritten in the Director Daemon with ".".
    *  Therefore we skip this test.
    */
-#  if !defined(HAVE_WIN32)
+#if !defined(HAVE_WIN32)
   EXPECT_EQ(me->backend_directories.at(0), PATH_BAREOS_BACKENDDIR);
-#  endif
+#endif
 }
 
 TEST(ConfigParser_Dir, CFG_TYPE_STR_VECTOR_OF_DIRS)
@@ -253,5 +247,4 @@ TEST(ConfigParser_Dir, CFG_TYPE_TIME)
 {
   test_config_directive_type(test_CFG_TYPE_TIME);
 }
-#endif
 }  // namespace directordaemon

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -41,13 +41,13 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   my_config->ParseConfig();
   my_config->DumpResources(PrintMessage, NULL);
 
-  my_config->BackupResourceTable();
+  auto backup = my_config->BackupResourceTable();
 
   my_config->ParseConfig();
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
   my_config->own_resource_ = me;
   ASSERT_NE(nullptr, me);
-  my_config->RestoreResourceTable();
+  my_config->RestoreResourceTable(std::move(backup));
   ASSERT_NE(nullptr, me);
   my_config->ParseConfig();
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -42,14 +42,20 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   my_config->DumpResources(PrintMessage, NULL);
 
   auto backup = my_config->BackupResourceTable();
-
   my_config->ParseConfig();
+
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
   my_config->own_resource_ = me;
   ASSERT_NE(nullptr, me);
   my_config->RestoreResourceTable(std::move(backup));
   ASSERT_NE(nullptr, me);
+
+  // If a config already exists, BackupResourceTable() needs to be called before
+  // ParseConfig(), otherwise memory of the existing config is not freed
+  // completely
+  auto backup2 = my_config->BackupResourceTable();
   my_config->ParseConfig();
+
   me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
   my_config->own_resource_ = me;
   assert(me);

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -18,7 +18,7 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 1010,
+          "code": 9,
           "equals": true
         },
         "DirPort": {
@@ -391,7 +391,7 @@
         },
         "Catalog": {
           "datatype": "RES",
-          "code": 1006,
+          "code": 5,
           "equals": true
         },
         "Passive": {
@@ -632,81 +632,81 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 1010,
+          "code": 9,
           "equals": true,
           "required": true
         },
         "Storage": {
           "datatype": "RESOURCE_LIST",
-          "code": 1005,
+          "code": 4,
           "equals": true
         },
         "Pool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true,
           "required": true
         },
         "FullBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "VirtualFullBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "IncrementalBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "DifferentialBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "NextPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "Client": {
           "datatype": "RES",
-          "code": 1002,
+          "code": 1,
           "equals": true
         },
         "FileSet": {
           "datatype": "RES",
-          "code": 1008,
+          "code": 7,
           "equals": true
         },
         "Schedule": {
           "datatype": "RES",
-          "code": 1007,
+          "code": 6,
           "equals": true
         },
         "VerifyJob": {
           "datatype": "RES",
-          "code": 1004,
+          "code": 3,
           "alias": true,
           "equals": true
         },
         "JobToVerify": {
           "datatype": "RES",
-          "code": 1004,
+          "code": 3,
           "equals": true
         },
         "Catalog": {
           "datatype": "RES",
-          "code": 1006,
+          "code": 5,
           "equals": true,
           "versions": "13.4.0-"
         },
         "JobDefs": {
           "datatype": "RES",
-          "code": 1003,
+          "code": 2,
           "equals": true
         },
         "Run": {
@@ -1025,7 +1025,7 @@
         },
         "Base": {
           "datatype": "RESOURCE_LIST",
-          "code": 1004,
+          "code": 3,
           "equals": true
         },
         "MaxConcurrentCopies": {
@@ -1120,81 +1120,81 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 1010,
+          "code": 9,
           "equals": true,
           "required": true
         },
         "Storage": {
           "datatype": "RESOURCE_LIST",
-          "code": 1005,
+          "code": 4,
           "equals": true
         },
         "Pool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true,
           "required": true
         },
         "FullBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "VirtualFullBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "IncrementalBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "DifferentialBackupPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "NextPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "Client": {
           "datatype": "RES",
-          "code": 1002,
+          "code": 1,
           "equals": true
         },
         "FileSet": {
           "datatype": "RES",
-          "code": 1008,
+          "code": 7,
           "equals": true
         },
         "Schedule": {
           "datatype": "RES",
-          "code": 1007,
+          "code": 6,
           "equals": true
         },
         "VerifyJob": {
           "datatype": "RES",
-          "code": 1004,
+          "code": 3,
           "alias": true,
           "equals": true
         },
         "JobToVerify": {
           "datatype": "RES",
-          "code": 1004,
+          "code": 3,
           "equals": true
         },
         "Catalog": {
           "datatype": "RES",
-          "code": 1006,
+          "code": 5,
           "equals": true,
           "versions": "13.4.0-"
         },
         "JobDefs": {
           "datatype": "RES",
-          "code": 1003,
+          "code": 2,
           "equals": true
         },
         "Run": {
@@ -1513,7 +1513,7 @@
         },
         "Base": {
           "datatype": "RESOURCE_LIST",
-          "code": 1004,
+          "code": 3,
           "equals": true
         },
         "MaxConcurrentCopies": {
@@ -1649,7 +1649,7 @@
         },
         "Device": {
           "datatype": "DEVICE",
-          "code": 1014,
+          "code": 13,
           "equals": true,
           "required": true
         },
@@ -1704,7 +1704,7 @@
         },
         "PairedStorage": {
           "datatype": "RES",
-          "code": 1005,
+          "code": 4,
           "equals": true
         },
         "MaximumBandwidthPerJob": {
@@ -2123,12 +2123,12 @@
         },
         "NextPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "Storage": {
           "datatype": "RESOURCE_LIST",
-          "code": 1005,
+          "code": 4,
           "equals": true
         },
         "AutoPrune": {
@@ -2145,17 +2145,17 @@
         },
         "RecyclePool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "ScratchPool": {
           "datatype": "RES",
-          "code": 1009,
+          "code": 8,
           "equals": true
         },
         "Catalog": {
           "datatype": "RES",
-          "code": 1006,
+          "code": 5,
           "equals": true
         },
         "FileRetention": {
@@ -2294,12 +2294,12 @@
         },
         "WrapCounter": {
           "datatype": "RES",
-          "code": 1011,
+          "code": 10,
           "equals": true
         },
         "Catalog": {
           "datatype": "RES",
-          "code": 1006,
+          "code": 5,
           "equals": true
         }
       },
@@ -2458,7 +2458,7 @@
         },
         "Profile": {
           "datatype": "RESOURCE_LIST",
-          "code": 1012,
+          "code": 11,
           "equals": true,
           "versions": "14.2.3-",
           "description": "Profiles can be assigned to a Console. ACL are checked until either a deny ACL is found or an allow ACL. First the console ACL is checked then any profile the console is linked to."
@@ -2632,7 +2632,7 @@
         },
         "Profile": {
           "datatype": "RESOURCE_LIST",
-          "code": 1012,
+          "code": 11,
           "equals": true,
           "versions": "14.2.3-",
           "description": "Profiles can be assigned to a Console. ACL are checked until either a deny ACL is found or an allow ACL. First the console ACL is checked then any profile the console is linked to."

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -238,7 +238,7 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 1003,
+          "code": 2,
           "equals": true
         },
         "SdConnectTimeout": {
@@ -524,7 +524,7 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 1003,
+          "code": 2,
           "equals": true
         },
         "SdConnectTimeout": {

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -245,7 +245,7 @@
         },
         "Messages": {
           "datatype": "RES",
-          "code": 3005,
+          "code": 4,
           "equals": true
         },
         "SdConnectTimeout": {
@@ -946,7 +946,7 @@
         },
         "Device": {
           "datatype": "RESOURCE_LIST",
-          "code": 3004,
+          "code": 3,
           "equals": true,
           "required": true
         },

--- a/systemtests/tests/always-incremental-consolidate/testrunner
+++ b/systemtests/tests/always-incremental-consolidate/testrunner
@@ -5,7 +5,7 @@
 # the last incremental is kept 
 # (job->AlwaysIncrementalKeepNumber default is 1)
 #
-# Run a batch of 3 incrementals with no files 
+# Run a batch of 3 incrementals with no files
 # Run consolidation : jobid with no files will get purged
 #
 # Run a batch of 3 incrementals the second with no files

--- a/systemtests/tests/commandline-options/testrunner
+++ b/systemtests/tests/commandline-options/testrunner
@@ -25,8 +25,17 @@ jobname=backup-bareos-fd
 start_test
 
 #Testing that -u and -g do not cause problems
-"${rscripts}"/bareos-ctl-dir start "-u randomuser -g randomgroup -d 100"
+usergroup_dir_log="${tmp}"/usergroup_dir_log.out
+"${rscripts}"/bareos-ctl-dir start "-u randomuser -g randomgroup -d 100" > "$usergroup_dir_log"
 "${rscripts}"/bareos-ctl-dir stop
+
+usergroup_fd_log="${tmp}"/usergroup_fd_log.out
+"${rscripts}"/bareos-ctl-fd start "-u randomuser -g randomgroup -d 100" > "$usergroup_fd_log"
+"${rscripts}"/bareos-ctl-fd stop
+
+usergroup_sd_log="${tmp}"/usergroup_sd_log.out
+"${rscripts}"/bareos-ctl-sd start "-u randomuser -g randomgroup -d 100" > "$usergroup_sd_log"
+"${rscripts}"/bareos-ctl-sd stop
 
 
 #Testing the creation and deletion of pid files with -p
@@ -78,6 +87,33 @@ fi
 if [ -s "${pid_file}" ]; then
     echo "Pid file was not removed."
     estat=6
+fi
+
+if [ "$(whoami)" != "root" ]; then
+    expect_grep "The commandline options indicate to run as specified user/group" \
+                "$usergroup_dir_log" \
+                "Error parsing user or group options in director daemon."
+
+    expect_grep "The commandline options indicate to run as specified user/group" \
+                "$usergroup_fd_log" \
+                "Error parsing user or group options in file daemon."
+
+    expect_grep "The commandline options indicate to run as specified user/group" \
+                "$usergroup_sd_log" \
+                "Error parsing user or group options in storage daemon."
+
+else
+    expect_grep "Could not find userid=randomuser" \
+                "$usergroup_dir_log" \
+                "Error parsing user or group options in director daemon with root privileges."
+
+    expect_grep "Could not find userid=randomuser" \
+                "$usergroup_fd_log" \
+                "Error parsing user or group options in file daemon with root privileges."
+
+    expect_grep "Could not find userid=randomuser" \
+                "$usergroup_sd_log" \
+                "Error parsing user or group options in storage daemon with root privileges."
 fi
 
 end_test

--- a/systemtests/tests/reload/reload_test_functions
+++ b/systemtests/tests/reload/reload_test_functions
@@ -36,6 +36,7 @@ create_console_command_file() {
   if [ ! -f "$bconsole_command_file" ]; then
   cat > "$bconsole_command_file" <<EOF
 @$out "$console_logfile"
+setdebug director level=10 trace=1
 reload
 messages
 EOF


### PR DESCRIPTION
The original way of handling the reload mechanism used callbacks that were registerd on every job start with internal job counters that would free the used configuration resources when no job is using it anymore.

Now the new mechanism simply uses shared pointers that own the configuration resources. On every job start, each job becomes shared owner of the resources, and on successfull reload the prevous confiugration resources are released by the director itself, so that only currently using jobs own the resource. When the last job using the configuration resources ends the resources are automatically freed. 

The definitions of resources have been simplified by starting the resource definitons now with `0` in all daemons instead of having a number for start and end.

In addition, the formerly used static global definitions of the resources now have been converted to be dynamic.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
~~- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
