### PR TITLE
cats: make `bvfs_update` take archive jobs into consideration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: get volume and pool params from query instead of route [PR #1139]
 - FreeBSD packages: add missing ddl/update 2171_2192 and 2192_2210 files [PR #1147]
 - Fix director connects to client while `Connection From Director To Client` is disabled. [PR #1099]
+- cats: make `.bvfs_update` and `.bvfs_versions` take archive jobs into consideration [PR #1152]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -524,9 +524,9 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
         client);
 
   if (see_copies) {
-    Mmsg(filter, " AND Job.Type IN ('C', 'B') ");
+    Mmsg(filter, " AND Job.Type IN ('C', 'B', 'A', 'a') ");
   } else {
-    Mmsg(filter, " AND Job.Type = 'B' ");
+    Mmsg(filter, " AND Job.Type IN ('B', 'A', 'a') ");
   }
 
   db->EscapeString(jcr, fname_esc, fname, strlen(fname));

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -277,7 +277,7 @@ void BareosDb::BvfsUpdateCache(JobControlRecord* jcr)
   Mmsg(cmd,
        "SELECT JobId from Job "
        "WHERE HasCache = 0 "
-       "AND Type IN ('B') AND JobStatus IN ('T', 'W', 'f', 'A') "
+       "AND Type IN ('B','A','a') AND JobStatus IN ('T', 'W', 'f', 'A') "
        "ORDER BY JobId");
   SqlQuery(cmd, DbListHandler, &jobids_list);
 

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/virtualfull.conf.in
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/job/virtualfull.conf.in
@@ -1,0 +1,17 @@
+Job {
+  Name = "VirtualLongtermFull"
+  Client = bareos-fd
+  FileSet = SelfTest
+  Type = Backup
+  Level = VirtualFull
+  Pool = AI-Consolidated
+  Messages = Standard
+
+  Priority = 13                 # run after  Consolidate
+  Run Script {
+        console = "update jobid=%i jobtype=A"
+        Runs When = After
+        Runs On Client = No
+        Runs On Failure = No
+  }
+}

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Longterm.conf
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/etc/bareos/bareos-dir.d/pool/AI-Longterm.conf
@@ -1,12 +1,11 @@
 Pool {
-  Name = AI-Consolidated
+  Name = AI-Longterm
   Pool Type = Backup
   Recycle = yes                       # Bareos can automatically recycle Volumes
   Auto Prune = yes                    # Prune expired volumes
-  Volume Retention = 360 days         # How long should jobs be kept?
+  Volume Retention = 1 days         # How long should jobs be kept?
   Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
-  Label Format = "AI-Consolidated-"
+  Label Format = "AI-Longterm-"
   Volume Use Duration = 23h
   Storage = File
-  Next Pool = AI-Longterm
 }

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
@@ -33,6 +33,8 @@ setup_data
 
 start_test
 
+start_bareos
+
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
@@ -51,7 +53,7 @@ run job=$JobName level=Incremental yes
 wait
 messages
 END_OF_DATA
-run_bareos "$@"
+run_bconsole
 
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out $tmp/log1.out
@@ -66,7 +68,7 @@ messages
 wait
 quit
 END_OF_DATA
-run_bareos "$@"
+run_bconsole
 
 # Consolidating zero-file incremental backups
 
@@ -86,7 +88,7 @@ wait
 messages
 quit
 END_OF_DATA
-run_bareos "$@"
+run_bconsole
 
 # Consolidating a zero-file job in the middle of incremental backups
 
@@ -116,7 +118,32 @@ END_OF_DATA
 
 run_bconsole
 
-stop_bareos
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+wait
+@$out $tmp/virtualfull.out
+run job=VirtualLongtermFull yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-13'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-14'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-15'"
+run job=$JobName level=Incremental yes
+wait
+messages
+.bvfs_lsdirs jobid=16 path=
+.bvfs_update
+.bvfs_lsdirs jobid=16 path=
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
 
 check_job_canceled
 
@@ -135,5 +162,9 @@ expect_grep "purging empty jobids 12" \
 expect_grep "purged JobIds 6,4,11 as they were consolidated into Job 15" \
             "$tmp"/log3.out \
             "consolidation of expected jobs did not happen."
+
+expect_grep "0	0	A A A A A A A A A A A A A A	/" \
+            "$tmp"/virtualfull.out \
+            "bvfs_update did not take into consideration VirtualFull Archive."
 
 end_test

--- a/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
+++ b/systemtests/tests/ai-consolidate-ignore-duplicate-job/testrunner
@@ -138,6 +138,7 @@ messages
 .bvfs_lsdirs jobid=16 path=
 .bvfs_update
 .bvfs_lsdirs jobid=16 path=
+.bvfs_versions jobid=16 path=${tmp}/data/weird-files/ client=bareos-fd fname=normalfile
 wait
 messages
 quit
@@ -166,5 +167,9 @@ expect_grep "purged JobIds 6,4,11 as they were consolidated into Job 15" \
 expect_grep "0	0	A A A A A A A A A A A A A A	/" \
             "$tmp"/virtualfull.out \
             "bvfs_update did not take into consideration VirtualFull Archive."
+
+expect_grep "43xzp14Dk2Gvm+cKgszDNQ	AI-Longterm" \
+            "$tmp"/virtualfull.out \
+            ".bvfs_versions did not find a file backup up by a VirtualFull Archive."
 
 end_test


### PR DESCRIPTION
#### Description:

When using `.bvfs_update` in `bconsole`, Virtual Full Archive jobs are not taken in consideration, and thus their paths are not updated and cannot be restored as a consequence. This PR makes sure `.bvfs_update` takes into consideration archive jobs when running.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
