### PR TITLE
dird: add command line feature to print specific resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - when using PAM Bareos will now check authorization, too. If authorization is not configured, login will fail. See [updated documentation](https://docs.bareos.org/TasksAndConcepts/PAM.html#configuration) on how to proceed [PR #1115].
 
 ### Added
+- dird: add command line feature to print specific resources [PR #1153]
 - Python plugins: add default module_path to search path [PR #1038]
 - dird: extend the list command to be able to query volumes and pools by ID [PR #1041]
 - docs: Add chapter for mariabackup db plugin [PR #1016]
@@ -151,5 +152,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1140]: https://github.com/bareos/bareos/pull/1140
 [PR #1147]: https://github.com/bareos/bareos/pull/1147
 [PR #1149]: https://github.com/bareos/bareos/pull/1149
+[PR #1152]: https://github.com/bareos/bareos/pull/1152
+[PR #1153]: https://github.com/bareos/bareos/pull/1153
 [PR #1155]: https://github.com/bareos/bareos/pull/1155
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -264,11 +264,15 @@ class ConfigurationParser {
                     std::function<void()> ResourceSpecificInitializer);
   bool AppendToResourcesChain(BareosResource* new_resource, int rcode);
   bool RemoveResource(int rcode, const char* name);
+  bool DumpResources(bool sendit(void* sock, const char* fmt, ...),
+                     void* sock,
+                     const std::string& res_type_name,
+                     const std::string& res_name,
+                     bool hide_sensitive_data = false);
   void DumpResources(bool sendit(void* sock, const char* fmt, ...),
                      void* sock,
                      bool hide_sensitive_data = false);
   int GetResourceCode(const char* resource_type);
-  ResourceTable* GetResourceTable(int resource_type);
   ResourceTable* GetResourceTable(const char* resource_type_name);
   int GetResourceItemIndex(ResourceItem* res_table, const char* item);
   ResourceItem* GetResourceItem(ResourceItem* res_table, const char* item);
@@ -354,7 +358,7 @@ class ConfigurationParser {
                      const char* config_filename);
   bool GetConfigIncludePath(PoolMem& full_path, const char* config_dir);
   bool FindConfigPath(PoolMem& full_path);
-  int GetResourceTableIndex(int resource_type);
+  int GetResourceTableIndex(const char* resource_type_name);
   void StoreMsgs(LEX* lc, ResourceItem* item, int index, int pass);
   void StoreName(LEX* lc, ResourceItem* item, int index, int pass);
   void StoreStrname(LEX* lc, ResourceItem* item, int index, int pass);

--- a/systemtests/tests/config-dump/etc/compare/Console-admin.conf
+++ b/systemtests/tests/config-dump/etc/compare/Console-admin.conf
@@ -1,0 +1,6 @@
+Console {
+  Name = "admin"
+  Password = "[md5]5ebe2294ecd0e0f08eab7690d2a6ee69"
+  Profile = "webui-admin"
+  TlsEnable = No
+}

--- a/systemtests/tests/config-dump/etc/compare/Console.conf
+++ b/systemtests/tests/config-dump/etc/compare/Console.conf
@@ -1,0 +1,14 @@
+Console {
+  Name = "bareos-mon"
+  Description = "Restricted console used by tray-monitor to get the status of the director."
+  Password = "[md5]4cf5943929b8447731b086f0f43f7f99"
+  JobAcl = "*all*"
+  CommandAcl = "status", ".status"
+}
+
+Console {
+  Name = "admin"
+  Password = "[md5]5ebe2294ecd0e0f08eab7690d2a6ee69"
+  Profile = "webui-admin"
+  TlsEnable = No
+}

--- a/systemtests/tests/config-dump/testrunner
+++ b/systemtests/tests/config-dump/testrunner
@@ -125,6 +125,50 @@ diff_files()
     fi
 }
 
+compare_export_config()
+{
+    configfile="$1"
+    comparefile="$2"
+    directorparameter="$3"
+
+    if ! [ -e "${configfile}" ]; then
+        set_error "Director config file \"${configfile}\" does not exist."
+        exit 1
+    fi
+
+    DESC="compare_export_config ${configfile} compare=${comparefile} parameter=${directorparameter}"
+    print_debug "*** start $DESC"
+
+    "${BAREOS_DIRECTOR_BINARY}" -c "${configfile}" -xc"${directorparameter}" > $tmp/bareos-dir-xc-${directorparameter}.conf
+
+    print_debug "*** end   $DESC"
+
+    diff_files "${comparefile}" "$tmp/bareos-dir-xc-${directorparameter}.conf"
+}
+
+bareos_dir_failing()
+{
+    configfile="$1"
+    directorparameter="$2"
+
+    if ! [ -e "${configfile}" ]; then
+        set_error "Director config file \"${configfile}\" does not exist."
+        exit 1
+    fi
+
+    DESC="bareos_dir_failing ${configfile} parameter=${directorparameter}"
+    print_debug "*** start $DESC"
+
+    if OUT=$("${BAREOS_DIRECTOR_BINARY}" -c "${configfile}" -xc"${directorparameter}"); then
+        echo "${OUT}"
+        set_error "Starting Director with -xc"${directorparameter}" should fail."
+        exit 1
+    fi
+
+    print_debug "$OUT"
+    print_debug "*** end   $DESC"
+}
+
 TestName="$(basename "$(pwd)")"
 export TestName
 
@@ -175,5 +219,17 @@ diff_files "${tmp}/bareos-dir-show-full1.conf" "$tmp/bareos-dir-show-full2.conf"
 
 # Compare export and re-export from bareos-dir-full.conf(verbose versions).
 diff_files "${tmp}/bareos-dir-show-verbose-full1.conf" "$tmp/bareos-dir-show-verbose-full2.conf"
+
+
+# export all resources of a type
+compare_export_config "${conf}/bareos-dir-19.2.7-xc.conf" "etc/compare/Console.conf" "console"
+# export single resource
+compare_export_config "${conf}/bareos-dir-19.2.7-xc.conf" "etc/compare/Console-admin.conf" "console=admin"
+# try export non-existing resource
+bareos_dir_failing "${conf}/bareos-dir-19.2.7-xc.conf" "console=DOESNOTEXIST"
+# try export non-existing resource type
+bareos_dir_failing "${conf}/bareos-dir-19.2.7-xc.conf" "DOESNOTEXIST"
+# export unused (empty) resource type
+bareos_dir_failing "${conf}/bareos-dir-19.2.7-xc.conf" "counter"
 
 end_test


### PR DESCRIPTION
The bareos-dir prints its configuration when called with the -xc parameter.
This change allows to print only specific resources:

  # print full configuration
  bareos-dir -xc

  # print all Job resources
  baroes-dir -xcJob

  # print the Job resource BackupCatalog
  bareos-dir -xcJob=BackupCatalog

While this feature might also be useful for other daemons, it can be applied to them in a later change.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- ~~[ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
