### PR TITLE
fix miscalculation when using Always Incremental Keep Number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - [BUG #1445] adding quotes to director name when using `configure export`. [PR #1171]
 - FreeBSD packages: add missing ddl/update 2171_2192 and 2192_2210 files [PR #1147]
 - Fix director connects to client while `Connection From Director To Client` is disabled. [PR #1099]
+- dir: miscalculation when using `always incremental keep number` [PR #1159]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fix `always-incremental-consolidate` systemtest sporadic fails, and rename it. [PR #1154]
 - packaging: FreeBSD place all scripts into "normal" location /usr/local/lib/bareos/scripts [PR #1163]
 - [BUG #1445] adding quotes to director name when using `configure export`. [PR #1171]
+- FreeBSD packages: add missing ddl/update 2171_2192 and 2192_2210 files [PR #1147]
+- Fix director connects to client while `Connection From Director To Client` is disabled. [PR #1099]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -432,8 +432,8 @@ class db_list_ctx : public BStringList {
   void add(const char* str) { Append(str); }
   void add(JobId_t id) { push_back(std::to_string(id)); }
 
-  std::string GetAsString() { return Join(','); }
-  uint64_t GetFrontAsInteger()
+  std::string GetAsString() const { return Join(','); }
+  uint64_t GetFrontAsInteger() const
   {
     try {
       return std::stoull(at(0));

--- a/core/src/dird/consolidate.cc
+++ b/core/src/dird/consolidate.cc
@@ -200,17 +200,17 @@ bool DoConsolidate(JobControlRecord* jcr)
        * Calculate limit for query. We specify how many incrementals should be
        * left. the limit is total number of incrementals - number required - 1
        */
-      const int32_t max_incrementals_to_consolidate
-          = incrementals_total - job->AlwaysIncrementalKeepNumber;
-
       Dmsg2(10, "Incrementals found/required. (%d/%d).\n", incrementals_total,
             job->AlwaysIncrementalKeepNumber);
-      if (max_incrementals_to_consolidate == 0) {
+      if (incrementals_total <= job->AlwaysIncrementalKeepNumber) {
         Jmsg(jcr, M_INFO, 0,
              _("%s: less incrementals than required, not consolidating\n"),
              job->resource_name_);
         continue;
       }
+
+      const int32_t max_incrementals_to_consolidate
+          = incrementals_total - job->AlwaysIncrementalKeepNumber;
 
       jcr->impl->jr.limit = max_incrementals_to_consolidate + 1;
       Dmsg3(10, "total: %d, to_consolidate: %d, limit: %d.\n",


### PR DESCRIPTION
When changing consolidation to remove zero-file-jobs, we introduced a bug by recalculating the number of existing incrementals wrong.
This PR fixes that problem and refactors the code to make it clearer so that such bugs will be less likely to occur in the future.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

