### PR TITLE
Cats: make bvfs_update take archive jobs into consideration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: add timeline chart by jobs [PR #1063]
 - webui: analytics module: show stored data per jobname in treemap [PR #1116]
 - webui: add pool column to volume lists [PR #1125]
+- cats: make `.bvfs_update` and `.bvfs_versions` take archive jobs into consideration [PR #1164]
 
 ### Changed
 - webui: add timeline chart by jobs [PR #1063]

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -278,7 +278,7 @@ void BareosDb::BvfsUpdateCache(JobControlRecord* jcr)
   Mmsg(cmd,
        "SELECT JobId from Job "
        "WHERE HasCache = 0 "
-       "AND Type IN ('B') AND JobStatus IN ('T', 'W', 'f', 'A') "
+       "AND Type IN ('B','A','a') AND JobStatus IN ('T', 'W', 'f', 'A') "
        "ORDER BY JobId");
   SqlQuery(cmd, DbListHandler, &jobids_list);
 

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -531,9 +531,9 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
         client);
 
   if (see_copies) {
-    Mmsg(filter, " AND Job.Type IN ('C', 'B') ");
+    Mmsg(filter, " AND Job.Type IN ('C', 'B', 'A', 'a') ");
   } else {
-    Mmsg(filter, " AND Job.Type = 'B' ");
+    Mmsg(filter, " AND Job.Type IN ('B', 'A', 'a') ");
   }
 
   db->EscapeString(jcr, fname_esc, fname, strlen(fname));


### PR DESCRIPTION
### Description
Backport of PR #1152 

When using .bvfs_update in bconsole, Virtual Full Archive jobs are not taken in consideration, and thus their paths are not updated and cannot be restored as a consequence. This PR makes sure .bvfs_update takes into consideration archive jobs when running.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [X] Decision taken that backporting test will not be done due to other changes in master
