### PR TITLE
dird: bconsole: add support for comma separated jobstatus values in list jobs command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - jstreegrid: remove handling of IE < 8 using navigator interface to avoid warnings in chrome [PR #1140]
 - `bvfs_update` now uses `unordered_map` instead of `htable` for the pathid cache [PR #1138]
 - cats: filtered zero file jobs list is now sorted [PR #1172]
+- dird: console: changed list jobs jobstatus argument to accept comma separated value [PR #1169]
 
 ### Deprecated
 

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -789,7 +789,7 @@ class BareosDb : public BareosDbQueryEnum {
                       JobDbRecord* jr,
                       const char* range,
                       const char* clientname,
-                      int jobstatus,
+                      std::vector<char> jobstatusarray,
                       int joblevel,
                       std::vector<char> jobtypes,
                       const char* volumename,

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -507,7 +507,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
                               JobDbRecord* jr,
                               const char* range,
                               const char* clientname,
-                              int jobstatus,
+                              std::vector<char> jobstatuslist,
                               int joblevel,
                               std::vector<char> jobtypes,
                               const char* volumename,
@@ -539,8 +539,10 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
     PmStrcat(selection, temp.c_str());
   }
 
-  if (jobstatus) {
-    temp.bsprintf("AND Job.JobStatus = '%c' ", jobstatus);
+  if (!jobstatuslist.empty()) {
+    std::string jobStatuses
+        = CreateDelimitedStringForSqlQueries(jobstatuslist, ',');
+    temp.bsprintf("AND Job.JobStatus in (%s) ", jobStatuses.c_str());
     PmStrcat(selection, temp.c_str());
   }
 

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -676,9 +676,9 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
   }
 
 
-  // jobstatus=X
-  int jobstatus = 0;
-  if (!GetUserJobStatusSelection(ua, &jobstatus)) {
+  // jobstatus=X,Y,Z....
+  std::vector<char> jobstatuslist;
+  if (!GetUserJobStatusSelection(ua, jobstatuslist)) {
     ua->ErrorMsg(_("invalid jobstatus parameter\n"));
     return false;
   }
@@ -756,9 +756,9 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     SetQueryRange(query_range, ua, &jr);
 
     ua->db->ListJobRecords(ua->jcr, &jr, query_range.c_str(), clientname,
-                           jobstatus, joblevel, jobtypes, volumename, poolname,
-                           schedtime, optionslist.last, optionslist.count,
-                           ua->send, llist);
+                           jobstatuslist, joblevel, jobtypes, volumename,
+                           poolname, schedtime, optionslist.last,
+                           optionslist.count, ua->send, llist);
   } else if (Bstrcasecmp(ua->argk[1], NT_("jobtotals"))) {
     // List JOBTOTALS
     ua->db->ListJobTotals(ua->jcr, &jr, ua->send);
@@ -807,7 +807,7 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
         SetQueryRange(query_range, ua, &jr);
 
         ua->db->ListJobRecords(ua->jcr, &jr, query_range.c_str(), clientname,
-                               jobstatus, joblevel, jobtypes, volumename,
+                               jobstatuslist, joblevel, jobtypes, volumename,
                                poolname, schedtime, optionslist.last,
                                optionslist.count, ua->send, llist);
       }

--- a/core/src/dird/ua_select.h
+++ b/core/src/dird/ua_select.h
@@ -92,7 +92,7 @@ bool GetUserSlotList(UaContext* ua,
 bool GetUserJobTypeListSelection(UaContext* ua,
                                  std::vector<char>& passed_jobtypes,
                                  bool ask_user);
-bool GetUserJobStatusSelection(UaContext* ua, int* jobstatus);
+bool GetUserJobStatusSelection(UaContext* ua, std::vector<char>& jobstatus);
 bool GetUserJobLevelSelection(UaContext* ua, int* joblevel);
 
 int FindArgKeyword(UaContext* ua, const char** list);

--- a/systemtests/tests/python-bareos/test_list_command.py
+++ b/systemtests/tests/python-bareos/test_list_command.py
@@ -239,6 +239,15 @@ class PythonBareosListCommandTest(bareos_unittest.Base):
         for job in result["jobs"]:
             self.assertTrue(job["jobstatus"], "T")
 
+        # run RestoreFiles with a non existant jobId so it fails
+        director.call("run job=RestoreFiles jobid=999999 yes")
+
+        # list jobs jobstatus=X,Y,z
+        result = director.call("list jobs jobstatus=T,f")
+        self.assertTrue(result["jobs"])
+        for job in result["jobs"]:
+            self.assertTrue(job["jobstatus"] == "T" or job["jobstatus"] == "f")
+
         result = director.call("list jobs jobstatus=R")
         self.assertFalse(result["jobs"])
 


### PR DESCRIPTION
#### Description: 
Changed the list jobs command to accept multiple values for jobstatus argument instead of one
exp : list jobs jobstatus=terminated,E,f
#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
