### PR TITLE
dird: console: enable `rerun` command to work with comma separated list of jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - systemtest py3plug-fd-contrib-mysql_dump [PR #768]
 - systemtest py*plug-fd-contrib-bareos_tasks_mysql [PR #768]
 - webui: introduce rerun of multiple jobs at once [PR #1109]
+- dird: console: add the ability to rerun multiple commas separated jobids [PR #1170]
 
 ### Fixed
 - NDMP_BAREOS: support autoxflate plugin [PR #1013]

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -259,19 +259,19 @@ bool reRunCmd(UaContext* ua, const char* cmd)
 
   if (j < 0 && !timeframe && !since_jobid_given) {
     ua->SendMsg("Please specify jobid, since_jobid, hours or days\n");
-    goto bail_out;
+    return false;
   }
 
   if (j >= 0 && since_jobid_given) {
     ua->SendMsg(
         "Please specify either jobid or since_jobid (and optionally "
         "until_jobid)\n");
-    goto bail_out;
+    return false;
   }
 
   if (j >= 0 && timeframe) {
     ua->SendMsg("Please specify either jobid or timeframe\n");
-    goto bail_out;
+    return false;
   }
 
   if (timeframe || since_jobid_given) {
@@ -323,24 +323,21 @@ bool reRunCmd(UaContext* ua, const char* cmd)
     if (!yes
         && (!GetYesno(ua, _("rerun these jobids? (yes/no): "))
             || !ua->pint32_val)) {
-      goto bail_out;
+      return false;
     }
     // Job Query End
 
     // Loop over all selected JobIds.
     for (i = 0; i < ids.num_ids; i++) {
       JobId = ids.DBId[i];
-      if (!reRunJob(ua, JobId, yes, now)) { goto bail_out; }
+      if (!reRunJob(ua, JobId, yes, now)) { return false; }
     }
   } else {
     JobId = str_to_int64(ua->argv[j]);
-    if (!reRunJob(ua, JobId, yes, now)) { goto bail_out; }
+    if (!reRunJob(ua, JobId, yes, now)) { return false; }
   }
 
   return true;
-
-bail_out:
-  return false;
 }
 
 /**

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -260,21 +260,22 @@ RerunArguments GetRerunCmdlineArguments(UaContext* ua)
   return rerunarguments;
 }
 
+static time_t ConvertDaysHoursToSecs(const RerunArguments& rerunargs,
+                                     utime_t now)
+{
+  const int secs_in_day = 86400;
+  const int secs_in_hour = 3600;
+  time_t schedtime
+      = now - (rerunargs.days * secs_in_day + rerunargs.hours * secs_in_hour);
+  return schedtime;
+}
+
 static std::string PrepareRerunSqlQuery(UaContext* ua,
-                                        RerunArguments rerunargs,
+                                        const RerunArguments& rerunargs,
                                         utime_t now)
 {
-  time_t schedtime = now;
-  if (rerunargs.days > 0) {
-    const int secs_in_day = 86400;
-    schedtime = now - secs_in_day * rerunargs.days; /* Days in the past */
-  }
-  if (rerunargs.hours > 0) {
-    const int secs_in_hour = 3600;
-    schedtime = now - secs_in_hour * rerunargs.hours; /* Hours in the past */
-  }
-
   char dt[MAX_TIME_LENGTH];
+  time_t schedtime = ConvertDaysHoursToSecs(rerunargs, now);
   bstrutime(dt, sizeof(dt), schedtime);
 
   std::string select{"SELECT JobId FROM Job WHERE JobStatus = 'f'"};

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -215,21 +215,13 @@ bool reRunCmd(UaContext* ua, const char* cmd)
   if (!OpenClientDb(ua)) { return true; }
   // Determine what cmdline arguments are given.
 
-  bool since_jobid_given = false; /* Was since_jobid given? */
   int s = FindArgWithValue(ua, NT_("since_jobid"));
   int since_jobid = 0;
-  if (s > 0) {
-    since_jobid = str_to_int64(ua->argv[s]);
-    since_jobid_given = true;
-  }
+  if (s > 0) { since_jobid = str_to_int64(ua->argv[s]); }
 
-  bool until_jobid_given = false; /* Was until_jobid given? */
   int u = FindArgWithValue(ua, NT_("until_jobid"));
   int until_jobid = 0;
-  if (u > 0) {
-    until_jobid = str_to_int64(ua->argv[u]);
-    until_jobid_given = true;
-  }
+  if (u > 0) { until_jobid = str_to_int64(ua->argv[u]); }
 
   bool timeframe = false; /* Should the selection happen based on timeframe? */
   int d = FindArgWithValue(ua, NT_("days"));
@@ -240,12 +232,12 @@ bool reRunCmd(UaContext* ua, const char* cmd)
   if (FindArg(ua, NT_("yes")) > 0) { yes = true; }
 
   int j = FindArgWithValue(ua, NT_("jobid"));
-  if (j < 0 && !timeframe && !since_jobid_given) {
+  if (j < 0 && !timeframe && !since_jobid) {
     ua->SendMsg("Please specify jobid, since_jobid, hours or days\n");
     return false;
   }
 
-  if (j >= 0 && since_jobid_given) {
+  if (j >= 0 && since_jobid) {
     ua->SendMsg(
         "Please specify either jobid or since_jobid (and optionally "
         "until_jobid)\n");
@@ -262,7 +254,7 @@ bool reRunCmd(UaContext* ua, const char* cmd)
   int hours = 0;
   JobId_t JobId;
   time_t schedtime;
-  if (timeframe || since_jobid_given) {
+  if (timeframe || since_jobid) {
     schedtime = now;
     if (d > 0) {
       const int secs_in_day = 86400;
@@ -279,8 +271,8 @@ bool reRunCmd(UaContext* ua, const char* cmd)
     bstrutime(dt, sizeof(dt), schedtime);
 
     std::string select{"SELECT JobId FROM Job WHERE JobStatus = 'f'"};
-    if (since_jobid_given) {
-      if (until_jobid_given) {
+    if (since_jobid) {
+      if (until_jobid) {
         select += " AND JobId >= " + std::to_string(since_jobid)
                   + " AND JobId <= " + std::to_string(until_jobid);
       } else {

--- a/core/src/dird/ua_run.h
+++ b/core/src/dird/ua_run.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,17 @@
 
 namespace directordaemon {
 
+struct RerunArguments {
+  int since_jobid = 0;
+  int until_jobid = 0;
+  int days = 0;
+  int hours = 0;
+  bool yes = false;
+  std::vector<JobId_t> JobIds;
+  bool parsingerror = false;
+};
+
+RerunArguments GetRerunCmdlineArguments(UaContext* ua);
 bool reRunCmd(UaContext* ua, const char* cmd);
 bool RunCmd(UaContext* ua, const char* cmd);
 int DoRunCmd(UaContext* ua, const char* cmd);

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -427,3 +427,5 @@ bareos_add_test(
 bareos_add_test(
   version_strings LINK_LIBRARIES bareos GTest::gtest_main
 )
+
+  bareos_add_test(runjob LINK_LIBRARIES dird_objects bareosfind bareossql GTest::gtest_main)

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -129,7 +129,6 @@ add_library(testing_common STATIC ${COMMON_SRC})
 
 target_link_libraries(testing_common PRIVATE ${LINK_LIBRARIES})
 
-
 if(HAVE_BIG_ENDIAN)
   set_tests_properties(gtest:statefile.read PROPERTIES DISABLED TRUE)
   set_tests_properties(gtest:statefile.write PROPERTIES DISABLED TRUE)
@@ -144,7 +143,7 @@ if(HAVE_BIG_ENDIAN)
   )
 endif()
 
-#Keep alphabetically ordered
+# Keep alphabetically ordered
 if(NOT client-only)
   bareos_add_test(
     addresses_and_ports
@@ -156,9 +155,7 @@ if(NOT client-only)
     LINK_LIBRARIES bareos dird_objects bareosfind bareossql
                    $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}> GTest::gtest_main
   )
-  bareos_add_test(
-    bool_string LINK_LIBRARIES bareos GTest::gtest_main
-  )
+  bareos_add_test(bool_string LINK_LIBRARIES bareos GTest::gtest_main)
   bareos_add_test(
     bsock_test_connection_setup
     ADDITIONAL_SOURCES ${SSL_UNIT_TEST_FILES}
@@ -206,14 +203,17 @@ if(NOT client-only)
     LINK_LIBRARIES bareos dird_objects bareosfind bareossql
                    $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}> GTest::gtest_main
   )
-  bareos_add_test(
-    multiplied_device_test LINK_LIBRARIES ${LINK_LIBRARIES}
-  )
+  bareos_add_test(multiplied_device_test LINK_LIBRARIES ${LINK_LIBRARIES})
   bareos_add_test(
     ndmp_address_translate_test
     ADDITIONAL_SOURCES ../dird/ndmp_slot2elemaddr.cc
     LINK_LIBRARIES ${LINK_LIBRARIES}
   )
+
+  bareos_add_test(
+    runjob LINK_LIBRARIES dird_objects bareosfind bareossql GTest::gtest_main
+  )
+
   bareos_add_test(
     run_on_incoming_connect_interval
     LINK_LIBRARIES dird_objects bareos bareosfind bareossql
@@ -232,9 +232,7 @@ if(NOT client-only)
     scheduler_job_item_queue LINK_LIBRARIES dird_objects bareos bareosfind
                                             bareossql GTest::gtest_main
   )
-  bareos_add_test(
-    sd_backend LINK_LIBRARIES ${LINK_LIBRARIES}
-  )
+  bareos_add_test(sd_backend LINK_LIBRARIES ${LINK_LIBRARIES})
   if(TARGET droplet)
     target_compile_definitions(sd_backend PRIVATE HAVE_DROPLET)
   endif()
@@ -263,9 +261,7 @@ if(NOT client-only)
     LINK_LIBRARIES bareos dird_objects bareosfind bareossql
                    $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}> GTest::gtest_main
   )
-  bareos_add_test(
-    sort_stringvector LINK_LIBRARIES bareos GTest::gtest_main
-  )
+  bareos_add_test(sort_stringvector LINK_LIBRARIES bareos GTest::gtest_main)
   bareos_add_test(
     test_config_parser_dir LINK_LIBRARIES dird_objects bareos bareosfind
                                           bareossql GTest::gtest_main
@@ -320,9 +316,7 @@ if(HAVE_EXECINFO_H
    AND HAVE_BACKTRACE
    AND HAVE_BACKTRACE_SYMBOLS
 )
-  bareos_add_test(
-    test_backtrace LINK_LIBRARIES bareos GTest::gtest_main
-  )
+  bareos_add_test(test_backtrace LINK_LIBRARIES bareos GTest::gtest_main)
   # Backtrace doesn't work correctly when ASan is enabled, do we shouldn't test
   # in that case
   if(CMAKE_CXX_FLAGS MATCHES "-fsanitize=address")
@@ -342,9 +336,7 @@ if(NOT HAVE_WIN32 AND NOT client-only)
     LINK_LIBRARIES ${LINK_LIBRARIES}
     COMPILE_DEFINITIONS -DCERTDIR=\"${CERTDIR}\"
   )
-  bareos_add_test(
-    watchdog_timer LINK_LIBRARIES bareos GTest::gtest_main
-  )
+  bareos_add_test(watchdog_timer LINK_LIBRARIES bareos GTest::gtest_main)
 endif() # NOT HAVE_WIN32 AND NOT client-only
 
 if(ENABLE_BCONSOLE)
@@ -354,34 +346,25 @@ if(ENABLE_BCONSOLE)
   )
 endif()
 
-#Keep alphabetically ordered
+# Keep alphabetically ordered
 bareos_add_test(
   cram_md5
   LINK_LIBRARIES bareos Threads::Threads GTest::gtest_main
   ADDITIONAL_SOURCES bareos_test_sockets.cc
 )
 
-bareos_add_test(
-  job_control_record LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(job_control_record LINK_LIBRARIES bareos GTest::gtest_main)
 
-bareos_add_test(
-  test_acl_entry_syntax LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(test_acl_entry_syntax LINK_LIBRARIES bareos GTest::gtest_main)
 
-bareos_add_test(
-  test_bsnprintf LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(test_bsnprintf LINK_LIBRARIES bareos GTest::gtest_main)
 
 bareos_add_test(
   test_config_parser_fd LINK_LIBRARIES fd_objects bareos bareosfind
                                        GTest::gtest_main
 )
 
-
-bareos_add_test(
-  test_edit LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(test_edit LINK_LIBRARIES bareos GTest::gtest_main)
 
 bareos_add_test(
   test_fd_plugins
@@ -390,17 +373,11 @@ bareos_add_test(
   LINK_LIBRARIES bareos bareosfind GTest::gtest_main
 )
 
-bareos_add_test(
-  test_is_name_valid LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(test_is_name_valid LINK_LIBRARIES bareos GTest::gtest_main)
 
-bareos_add_test(
-  test_poolmem LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(test_poolmem LINK_LIBRARIES bareos GTest::gtest_main)
 
-bareos_add_test(
-  test_output_formatter LINK_LIBRARIES GTest::gtest_main bareos
-)
+bareos_add_test(test_output_formatter LINK_LIBRARIES GTest::gtest_main bareos)
 
 bareos_add_test(
   statefile
@@ -409,9 +386,7 @@ bareos_add_test(
                       TEST_ORIGINAL_FILE_DIR=\"${TEST_ORIGINAL_FILE_DIR}\"
 )
 
-bareos_add_test(
-  thread_list LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(thread_list LINK_LIBRARIES bareos GTest::gtest_main)
 set_tests_properties(
   gtest:thread_list.thread_list_startup_and_shutdown PROPERTIES LABELS broken
 )
@@ -420,12 +395,6 @@ bareos_add_test(
   thread_specific_data LINK_LIBRARIES bareos Threads::Threads GTest::gtest_main
 )
 
-bareos_add_test(
-  timer_thread LINK_LIBRARIES bareos GTest::gtest_main
-)
+bareos_add_test(timer_thread LINK_LIBRARIES bareos GTest::gtest_main)
 
-bareos_add_test(
-  version_strings LINK_LIBRARIES bareos GTest::gtest_main
-)
-
-  bareos_add_test(runjob LINK_LIBRARIES dird_objects bareosfind bareossql GTest::gtest_main)
+bareos_add_test(version_strings LINK_LIBRARIES bareos GTest::gtest_main)

--- a/core/src/tests/runjob.cc
+++ b/core/src/tests/runjob.cc
@@ -1,0 +1,173 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#  include "gtest/gtest.h"
+#else
+#  include "gtest/gtest.h"
+#  include "include/bareos.h"
+#endif
+
+#include "dird/ua.h"
+#include "include/jcr.h"
+#include "dird/ua_run.h"
+
+namespace directordaemon {
+bool DoReloadConfig() { return false; }
+}  // namespace directordaemon
+
+void FakeCmd(directordaemon::UaContext* ua, std::string cmd)
+{
+  std::string command = cmd;
+  PmStrcpy(ua->cmd, command.c_str());
+  ParseArgs(ua->cmd, ua->args, &ua->argc, ua->argk, ua->argv, MAX_CMD_ARGS);
+}
+
+class RerunArgumentsParsing : public testing::Test {
+ protected:
+  void SetUp() override { ua = directordaemon::new_ua_context(&jcr); }
+
+  void TearDown() override { FreeUaContext(ua); }
+
+  void FakeRerunCommand(std::string arguments)
+  {
+    FakeCmd(ua, "rerun " + arguments);
+  }
+
+  JobControlRecord jcr{};
+  directordaemon::UaContext* ua{nullptr};
+};
+
+TEST_F(RerunArgumentsParsing, NothingHappensWhenNoArgumentSpecified)
+{
+  FakeRerunCommand("");
+  EXPECT_TRUE(GetRerunCmdlineArguments(ua).parsingerror);
+}
+
+TEST_F(RerunArgumentsParsing, SingleJobId)
+{
+  FakeRerunCommand("jobid=1");
+  std::vector<JobId_t> expected_jobids{1};
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.JobIds, expected_jobids);
+}
+
+TEST_F(RerunArgumentsParsing, WrongJobId)
+{
+  FakeRerunCommand("jobid=jsahd");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_TRUE(rereunargs.parsingerror);
+}
+
+TEST_F(RerunArgumentsParsing, MultipleJobids)
+{
+  FakeRerunCommand("jobid=1,2,3,5,1342134");
+  std::vector<JobId_t> expected_jobids{1, 2, 3, 5, 1342134};
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.JobIds, expected_jobids);
+}
+
+TEST_F(RerunArgumentsParsing, MultipleJobidsWithOneWrongId)
+{
+  FakeRerunCommand("jobid=1,2,3,5,aaaa");
+  std::vector<JobId_t> expected_jobids{};
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_TRUE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.JobIds, expected_jobids);
+}
+
+TEST_F(RerunArgumentsParsing, Days)
+{
+  FakeRerunCommand("Days=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.days, 12);
+}
+
+TEST_F(RerunArgumentsParsing, Hours)
+{
+  FakeRerunCommand("hours=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.hours, 12);
+}
+
+TEST_F(RerunArgumentsParsing, Since_jobid)
+{
+  FakeRerunCommand("since_jobid=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.since_jobid, 12);
+}
+
+TEST_F(RerunArgumentsParsing, Until_jobid)
+{
+  FakeRerunCommand("until_jobid=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_TRUE(rereunargs.parsingerror);
+}
+
+TEST_F(RerunArgumentsParsing, Since_jobid_Until_jobid)
+{
+  FakeRerunCommand("since_jobid=1 until_jobid=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.since_jobid, 1);
+  EXPECT_EQ(rereunargs.until_jobid, 12);
+}
+
+TEST_F(RerunArgumentsParsing, Days_hours)
+{
+  FakeRerunCommand("days=1 hours=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_FALSE(rereunargs.parsingerror);
+  EXPECT_EQ(rereunargs.days, 1);
+  EXPECT_EQ(rereunargs.hours, 12);
+}
+
+TEST_F(RerunArgumentsParsing, Jobid_Days_hours)
+{
+  FakeRerunCommand("jobid=1 days=1 hours=12");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_TRUE(rereunargs.parsingerror);
+}
+
+TEST_F(RerunArgumentsParsing, Jobid_Since)
+{
+  FakeRerunCommand("jobid=1 since_jobid=1");
+  directordaemon::RerunArguments rereunargs = GetRerunCmdlineArguments(ua);
+
+  EXPECT_TRUE(rereunargs.parsingerror);
+}

--- a/systemtests/tests/bareos/testrunner-rerun-jobs
+++ b/systemtests/tests/bareos/testrunner-rerun-jobs
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+rerun_log=$tmp/rerun.out
+JobName=backup-bareos-fd
+
+rm -f $rerun_log
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $rerun_log
+setdebug level=100 storage=File
+run job=$JobName yes
+run job=$JobName yes
+wait
+rerun jobid=1 yes
+wait
+rerun jobid=2,3 yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+expect_grep "rerunning jobid 1" \
+            "$rerun_log" \
+            "Job was not rerun."
+
+expect_grep "rerunning jobid 2" \
+            "$rerun_log" \
+            "Comma separated jobs were not correctly rerun."
+
+expect_grep "rerunning jobid 3" \
+            "$rerun_log" \
+            "Comma separated jobs were not correctly rerun."
+
+
+end_test


### PR DESCRIPTION
#### Description

The `rerun` command used to process only one jobid. This PR enables the `rerun` command to handle multiple comma separated jobids at once.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
