### PR TITLE
dird: missing quotes around name when using configure export 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - webui: get volume and pool params from query instead of route [PR #1144]
 - FreeBSD packages: add missing ddl/update 2171_2192 and 2192_2210 files [PR #1148]
+- [Issue #1445] adding quotes to director name when using `configure export`[PR #1173]
 
 ### Changed
 - cats: include only jobtypes in list jobtotals that write data to volumes [PR #1136]

--- a/core/src/dird/ua_configure.cc
+++ b/core/src/dird/ua_configure.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -232,7 +232,9 @@ static inline bool ConfigureCreateFdResourceString(UaContext* ua,
   password = &client->password_;
 
   resource.strcat("Director {\n");
-  config_add_directive(NULL, NULL, "Name", me->resource_name_, resource);
+
+  Mmsg(temp, "\"%s\"", me->resource_name_);
+  config_add_directive(NULL, NULL, "Name", temp.c_str(), resource);
 
   switch (password->encoding) {
     case p_encoding_clear:


### PR DESCRIPTION
**Backport of PR#1171 to bareos-21**

#### Description

This is a fix for issue 1445.
configure export would export name without quotes. This PR fixes the issue.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests
