### PR TITLE
libcloud plugin: storage provider config

### DIFF
--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
@@ -34,6 +34,11 @@ options = {
 def get_driver(options):
     driver_opt = dict(options)
 
+    try:
+        provider_opt = driver_opt.get("provider")
+    except KeyError:
+        provider_opt = "S3"
+
     # remove unknown options
     for opt in (
         "buckets_exclude",
@@ -50,7 +55,7 @@ def get_driver(options):
 
     driver = None
 
-    provider = getattr(libcloud.storage.types.Provider, "S3")
+    provider = getattr(libcloud.storage.types.Provider, provider_opt)
     driver = libcloud.storage.providers.get_driver(provider)(**driver_opt)
 
     try:


### PR DESCRIPTION
Right now S3 is hardcoded within the provider type
for the apache libcloud plugin. Any other value, in
the config_file parameter for "provider" will not
be respected.

With this change the option will be actually used.

We were able to successfully test this change with S3 and S3_RGW providers.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
