### PR TITLE
doc: clarifies checkfilechanges option use case (not intended for plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - improve Mysql - PostgreSQL howto [PR #1093] fixing [BUG #1429]
 - clarifies Sphinx bareos-extension parallel_read_safe status to False [PR #1037]
 - fix incorrect link in contrib PythonFdPlugin [BUG #1450] [PR #1065]
+- clarifies CheckFileChanges option not intended to be used with plugin [BUG #1452][PR #1180]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768

--- a/docs/manuals/source/Configuration/Director.rst
+++ b/docs/manuals/source/Configuration/Director.rst
@@ -1073,6 +1073,7 @@ The directives within an Options resource may be one of the following:
 .. config:option:: dir/fileset/include/options/MtimeOnly
 
    :type: yes|no
+   :default: no
 
    If enabled, tells the Client that the selection of files during
    Incremental and Differential backups should based only on the st\_mtime
@@ -1105,6 +1106,8 @@ The directives within an Options resource may be one of the following:
 .. config:option:: dir/fileset/include/options/CheckFileChanges
 
    :type: yes|no
+   :default: no
+
 
    If enabled, the Client will check size, age of each file after
    their backup to see if they have changed during backup. If time
@@ -1115,7 +1118,11 @@ The directives within an Options resource may be one of the following:
 
       zog-fd: Client1.2007-03-31_09.46.21 Error: /tmp/test mtime changed during backup.
 
-   In general, it is recommended to use this option.
+   
+   .. note::
+
+      This option is intended to be used :config:option:`dir/fileset/include/File` resources. 
+      Using it with :config:option:`dir/fileset/include/Plugin` filesets will generate warnings during backup.
 
 .. config:option:: dir/fileset/include/options/HardLinks
 


### PR DESCRIPTION
This PR is about clarifying the option CheckFileChanges usage in documentation.
It will clearly state this option is reserved for File= resource type, and has to not be used with Plugin=

Referenced in [bug #1452](https://bugs.bareos.org/view.php?id=1452) and [bug #1449](https://bugs.bareos.org/view.php?id=1449)

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
