### PR TITLE
doc: Add Security FIPS section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix incorrect link in contrib PythonFdPlugin [BUG #1450] [PR #1065]
 - clarifies CheckFileChanges option not intended to be used with plugin [BUG #1452][PR #1180]
 - Fix broken links with sphinx linkcheck [PR #1200]
+- add Security FIPS section [PR #1181]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768


### PR DESCRIPTION
This PR add a section to explain how to setup and check FIPS enabled computer.
backport should be limited to 21 version as only newer enterprise OS are concerned.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
