### PR TITLE
py3plug-fd-postgres systemtest: remove "BROKEN" label

### DIFF
--- a/systemtests/tests/py2plug-fd-postgres/CMakeLists.txt
+++ b/systemtests/tests/py2plug-fd-postgres/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -33,10 +33,6 @@ if(TARGET python3-fd)
      AND (${Python3_VERSION_MINOR} LESS 10)
   )
     create_systemtest(${SYSTEMTEST_PREFIX} "py3plug-fd-postgres")
-    # fails because of psycopg2
-    set_tests_properties(
-      "${SYSTEMTEST_PREFIX}py3plug-fd-postgres" PROPERTIES LABELS "broken"
-    )
   else()
     create_systemtest(${SYSTEMTEST_PREFIX} "py3plug-fd-postgres" DISABLED)
   endif()


### PR DESCRIPTION
The test was marked broken when the plugin was using psycopg2, but now
we use pg8000 so we want to enable it again if all requirements are met.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

