### PR TITLE
 Debian: fix Debian package dependencies for webui and Ceph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+- debian: fix package dependencies for webui and Ceph [PR #1184]
+
+### Changed
+
+### Security
+
+### Documentation
+
+
+
 ## [21.1.3] - 2022-05-09
 
 ### Fixed
@@ -550,4 +561,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1167]: https://github.com/bareos/bareos/pull/1167
 [PR #1173]: https://github.com/bareos/bareos/pull/1173
 [PR #1175]: https://github.com/bareos/bareos/pull/1175
+[PR #1184]: https://github.com/bareos/bareos/pull/1184
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/debian/control
+++ b/debian/control
@@ -46,13 +46,15 @@ Build-Depends: acl-dev,
  zlib1g-dev,
  systemd,
  dh-systemd <buster> <stretch> <xenial> <bionic>,
- librados-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- libradosstriper-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- libcephfs-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- glusterfs-common <bullseye> <buster> <stretch> <xenial> <bionic>,
+ librados-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+ libradosstriper-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+ libcephfs-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
  ucslint <univention>,
  univention-config-dev <univention>,
  wget <univention>
+# required for bareos-storage-glusterfs and bareos-filedaemon-glusterfs-plugin
+# glusterfs-common <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+# libglusterfs-dev <bullseye> <buster> <focal> <jammy>,
 Build-Conflicts: python2.2-dev, python2.3, python2.4, qt3-dev-tools, libqt4-dev
 Standards-Version: 3.9.6
 Vcs-Git: git://github.com/bareos/bareos.git -b master
@@ -275,7 +277,7 @@ Package:        bareos-director-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin
@@ -290,7 +292,7 @@ Package:        bareos-director-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin
@@ -328,7 +330,7 @@ Package:        bareos-filedaemon-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, bareos-filedaemon-python-plugins-common
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin
@@ -344,7 +346,7 @@ Package:        bareos-filedaemon-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}, bareos-filedaemon-python-plugins-common
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python3-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin
@@ -453,7 +455,7 @@ Package:        bareos-storage-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin
@@ -468,7 +470,7 @@ Package:        bareos-storage-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin
@@ -510,15 +512,14 @@ Description: Backup Archiving Recovery Open Sourced - tray monitor
 
 Package: bareos-webui
 Architecture: all
-Depends: apache2 | httpd, libapache2-mod-php | libapache2-mod-php5 | libapache2-mod-php7 | php | php5 | php7 | php-cgi,
-   php-common | php5-common | php7-common,
-   php-date | php5-date | php7-date,
-   php-intl | php5-intl | php7-intl,
-   php-json | php5-json | php7-json,
-   php-curl | php5-curl | php7-curl,
-   php-gettext | php5-gettext | php7-gettext | php7.4-gettext,
+Depends: apache2 | httpd,
+   libapache2-mod-php,
+   php-date,
+   php-intl,
+   php-json,
+   php-curl,
    ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - webui
- This package contains the webui.
+ This package contains the Bareos WebUI.
 
 

--- a/debian/control.bareos-webui
+++ b/debian/control.bareos-webui
@@ -1,12 +1,11 @@
 Package: bareos-webui
 Architecture: all
-Depends: apache2 | httpd, libapache2-mod-php | libapache2-mod-php5 | libapache2-mod-php7 | php | php5 | php7 | php-cgi,
-   php-common | php5-common | php7-common,
-   php-date | php5-date | php7-date,
-   php-intl | php5-intl | php7-intl,
-   php-json | php5-json | php7-json,
-   php-curl | php5-curl | php7-curl,
-   php-gettext | php5-gettext | php7-gettext | php7.4-gettext,
+Depends: apache2 | httpd,
+   libapache2-mod-php,
+   php-date,
+   php-intl,
+   php-json,
+   php-curl,
    ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - webui
- This package contains the webui.
+ This package contains the Bareos WebUI.

--- a/debian/control.src
+++ b/debian/control.src
@@ -38,13 +38,15 @@ Build-Depends: acl-dev,
  zlib1g-dev,
  systemd,
  dh-systemd <buster> <stretch> <xenial> <bionic>,
- librados-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- libradosstriper-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- libcephfs-dev <bullseye> <buster> <stretch> <xenial> <bionic>,
- glusterfs-common <bullseye> <buster> <stretch> <xenial> <bionic>,
+ librados-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+ libradosstriper-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+ libcephfs-dev <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
  ucslint <univention>,
  univention-config-dev <univention>,
  wget <univention>
+# required for bareos-storage-glusterfs and bareos-filedaemon-glusterfs-plugin
+# glusterfs-common <bullseye> <buster> <stretch> <xenial> <bionic> <focal> <jammy>,
+# libglusterfs-dev <bullseye> <buster> <focal> <jammy>,
 Build-Conflicts: python2.2-dev, python2.3, python2.4, qt3-dev-tools, libqt4-dev
 Standards-Version: 3.9.6
 Vcs-Git: git://github.com/bareos/bareos.git -b master


### PR DESCRIPTION
Fixes some dependencies for bareos-webui on Debian based distributions
and also cleaning up a bit.
Required at least for installing Debian 10 packages on UCS 5.

Backport of PR #1183 to bareos-21

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
