### PR TITLE
console: aborting job run if jobId doesn't exist in catalog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: Now use solaris 11.4-11.4.42.0.0.111.0 [PR #1189]
 - bconsole: removed commas from jobid attribute in list jobs and llist jobs outputs [PR #1126]
 - testing: matrix.yml: run multiple tests sequentially [PR #1193]
+- console: aborting job run if jobid doesn't exist in catalog [PR 1188]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -683,6 +683,7 @@ class BareosDb : public BareosDbQueryEnum {
                         POOLMEM*& stime,
                         char* job);
   bool FindLastJobid(JobControlRecord* jcr, const char* Name, JobDbRecord* jr);
+  bool FindJobById(JobControlRecord* jcr, const std::string id);
   int FindNextVolume(JobControlRecord* jcr,
                      int index,
                      bool InChanger,

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -356,6 +356,26 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
 }
 
 /**
+ * @brief BareosDb::FindJobById
+ * @param jcr
+ * @param id id of job to look for
+ * @return returns true if job exists in db, false if not
+ */
+bool BareosDb::FindJobById(JobControlRecord* jcr, std::string id)
+{
+  std::string query = "SELECT JobId FROM Job WHERE JobId=" + id;
+  Dmsg1(100, "Query: %s\n", query.c_str());
+  if (!QUERY_DB(jcr, query.c_str())) { return false; }
+  if (SqlFetchRow() == NULL) {
+    Mmsg1(errmsg, _("No Job found with id: %d.\n"), id.c_str());
+    SqlFreeResult();
+    return false;
+  } else {
+    return true;
+  }
+}
+
+/**
  * Search a comma separated list of unwanted volume names and see if given
  * VolumeName is on it.
  */

--- a/systemtests/tests/bareos/testrunner-run-non-existing-jobid
+++ b/systemtests/tests/bareos/testrunner-run-non-existing-jobid
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# Run a job with a non existing jobid
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+run_log=$tmp/run.out
+JobName=RestoreFiles
+
+rm -f $run_log
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $run_log
+setdebug level=100 storage=File
+run job=$JobName jobid=999999 yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+expect_grep "JobId 999999 not found in catalog." \
+            "$run_log" \
+            "The run command accepted a jobid that does not exist in the database."
+
+end_test

--- a/systemtests/tests/python-bareos/test_list_command.py
+++ b/systemtests/tests/python-bareos/test_list_command.py
@@ -238,15 +238,16 @@ class PythonBareosListCommandTest(bareos_unittest.Base):
         self.assertTrue(result["jobs"])
         for job in result["jobs"]:
             self.assertTrue(job["jobstatus"], "T")
-
-        # run RestoreFiles with a non existant jobId so it fails
-        director.call("run job=RestoreFiles jobid=999999 yes")
+            
+        # running a job a canceling
+        director.call("run job=backup-bareos-fd yes")
+        director.call("cancel job=backup-bareos-fd yes")
 
         # list jobs jobstatus=X,Y,z
-        result = director.call("list jobs jobstatus=T,f")
+        result = director.call("list jobs jobstatus=T,A")
         self.assertTrue(result["jobs"])
         for job in result["jobs"]:
-            self.assertTrue(job["jobstatus"] == "T" or job["jobstatus"] == "f")
+            self.assertTrue(job["jobstatus"] == "T" or job["jobstatus"] == "A")
 
         result = director.call("list jobs jobstatus=R")
         self.assertFalse(result["jobs"])

--- a/systemtests/tests/virtualfull/testrunner
+++ b/systemtests/tests/virtualfull/testrunner
@@ -133,7 +133,7 @@ if ! grep -q "Fatal error: Could not create bootstrap file" "$tmp/log4.out"; the
   estat=1
 fi
 
-if ! grep -q "Termination:.*Backup Error" "$tmp/log5.out"; then
+if ! grep -q "JobId 2 not found in catalog." "$tmp/log5.out"; then
   echo "Consolidating missing jobids did not fail as expected" >&2
   cat "$tmp/log5.out"
   estat=1


### PR DESCRIPTION
### Description

Check whether a given `jobId` exists in the database before executing the `run` command and abort if it doesn't.

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
~~- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
