### PR TITLE
systemtests: skip mysql tests if root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
   - bareos-contrib-director-python-plugins
   - bareos-contrib-filedaemon-python-plugins
   - bareos-contrib-tools
-- systemtest py3plug-fd-contrib-mysql_dump [PR #768]
-- systemtest py*plug-fd-contrib-bareos_tasks_mysql [PR #768]
+- tests: py3plug-fd-contrib-mysql_dump [PR #768]
+- tests: py*plug-fd-contrib-bareos_tasks_mysql [PR #768]
 - webui: introduce rerun of multiple jobs at once [PR #1109]
 - dird: console: add the ability to rerun multiple commas separated jobids [PR #1170]
 - build: Add support for Ubuntu 22.04, Fedora 36, EL 9, openSUSE 15.4 [PR #1179]
+- tests: skip mysql tests if root [PR #1197]
 
 ### Fixed
 - python plugins: store architecture specific modules in sitearch (instead of sitelib) [PR #698]

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -1036,6 +1036,16 @@ if ! grep -q "${expected_result}" "${target_file}"; then
 fi
 }
 
+# Used by mysqltest 
+skip_if_root()
+{
+USER=$(whoami)
+if [ "$USER" == "root"  ]; then
+ echo "${TestName} test skipped: test cannot be run as user root."
+ exit 77;
+fi
+}
+
 REGRESS_DEBUG=${REGRESS_DEBUG:-0}
 if test "x${REGRESS_DEBUG}" = "x1"; then
    set_debug 1

--- a/systemtests/tests/py2plug-fd-contrib-bareos_tasks_mysql/testrunner
+++ b/systemtests/tests/py2plug-fd-contrib-bareos_tasks_mysql/testrunner
@@ -9,11 +9,6 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-if [ "$USER" == "root"  ]; then
- echo "This test cannot be run as user root."
- exit 1;
-fi
-
 #shellcheck source=../environment.in
 . ./environment
 
@@ -23,6 +18,9 @@ RESTORE_DIR="$tmp/bareos-restores/@MYSQL/"
 
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+
+skip_if_root
+
 #shellcheck source=../scripts/mysql.sh
 . "${rscripts}"/mysql.sh
 "${rscripts}"/cleanup

--- a/systemtests/tests/py2plug-fd-mariabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-mariabackup/testrunner
@@ -10,15 +10,12 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-if [ "$USER" == "root"  ]; then
- echo "This test cannot be run as user root."
- exit 1;
-fi
-
 #shellcheck source=../environment.in
 . ./environment
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+
+skip_if_root
 
 JobName=backup-bareos-fd
 MARIABACKUP="${MARIABACKUP_BINARY} --defaults-file=mysqldefaults"

--- a/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
@@ -10,11 +10,6 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-if [ "$USER" == "root"  ]; then
- echo "This test cannot be run as user root."
- exit 1;
-fi
-
 JobName=backup-bareos-fd
 #shellcheck source=../environment.in
 . ./environment
@@ -23,6 +18,8 @@ MYSQL_CLIENT="${MYSQL_CLIENT_BINARY} --defaults-file=mysqldefaults"
 JobName=backup-bareos-fd
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+skip_if_root
+
 #shellcheck source=../scripts/mysql.sh
 . "${rscripts}"/mysql.sh
 "${rscripts}"/cleanup

--- a/systemtests/tests/py3plug-fd-contrib-mysql_dump/testrunner
+++ b/systemtests/tests/py3plug-fd-contrib-mysql_dump/testrunner
@@ -9,11 +9,6 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-if [ "$USER" == "root"  ]; then
- echo "This test cannot be run as user root."
- exit 1;
-fi
-
 #shellcheck source=../environment.in
 . ./environment
 
@@ -23,6 +18,8 @@ RESTORE_DIR="$tmp/bareos-restores/@mysqlbackup@/"
 
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+skip_if_root
+
 #shellcheck source=../scripts/mysql.sh
 . "${rscripts}"/mysql.sh
 "${rscripts}"/cleanup


### PR DESCRIPTION
Actually every build and test in container with podman will result with at least
```
326 - system:py2plug-fd-contrib-bareos_tasks_mysql (Failed)
327 - system:py3plug-fd-contrib-bareos_tasks_mysql (Failed)
335 - system:py2plug-fd-mariabackup (Failed)
336 - system:py3plug-fd-mariabackup (Failed)
347 - system:py3plug-fd-contrib-mysql_dump (Failed)
```
As prepared in task 5147, we will skip mysql test if run as root.

This PR introduce a function in function skip_if_root in systemtests/scripts/functions and call it in every mysql test.

Resulting in 
```
Start 345: system:py3plug-fd-contrib-mysql_dump
Test #345: system:py3plug-fd-contrib-mysql_dump ....***Skipped   0.02 sec
```
#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
~~- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
