### PR TITLE
docs: Fix broken links with sphinx linkchecker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - clarifies Sphinx bareos-extension parallel_read_safe status to False [PR #1037]
 - fix incorrect link in contrib PythonFdPlugin [BUG #1450] [PR #1065]
 - clarifies CheckFileChanges option not intended to be used with plugin [BUG #1452][PR #1180]
+- Fix broken links with sphinx linkcheck [PR #1200]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768

--- a/docs/manuals/CMakeLists.txt
+++ b/docs/manuals/CMakeLists.txt
@@ -135,6 +135,14 @@ if(${docs-only})
   set(DOCS_ALL ALL) # this enables "make docs" by just typing "make"
 endif()
 
+add_custom_target(
+  docs-check-urls
+  COMMAND ${SPHINX_COMMAND} -M linkcheck "${SPHINX_SOURCE_DIR}" "${SPHINX_BUILDDIR}"
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+  COMMENT
+    "Check if the URLs used in the documentation are still valid targets."
+)
+
 # target: docs ######
 add_custom_target(
   docs

--- a/docs/manuals/source/Appendix/OperatingSystems.rst
+++ b/docs/manuals/source/Appendix/OperatingSystems.rst
@@ -18,7 +18,7 @@ Additionally, the following table gives an overview on the available package ver
    CentOS, current, v12.4, v12.4, v12.4
    Debian, current, v12.4, v12.4, v12.4
    Fedora, current, v12.4, v12.4, v12.4
-   Gentoo :index:`\ <single: Platform; Gentoo>`\ , `X <https://packages.gentoo.org/package/app-backup/bareos>`__,     `X <https://packages.gentoo.org/package/app-backup/bareos>`__, `X <https://packages.gentoo.org/package/app-backup/bareos>`__
+   Gentoo :index:`\ <single: Platform; Gentoo>`\ , `X <https://packages.gentoo.org/packages/app-backup/bareos>`__,     `X <https://packages.gentoo.org/packages/app-backup/bareos>`__, `X <https://packages.gentoo.org/packages/app-backup/bareos>`__
    openSUSE, current, v12.4, v12.4, v12.4
    RHEL,     current, v12.4, v12.4, v12.4
    SLES,     current, v12.4, v12.4, v12.4
@@ -126,7 +126,7 @@ The Bareos version for the Univention App Center integraties into the Univention
 Preamble
 ^^^^^^^^
 
-The `Univention Corporate Server <http://www.univention.de/>`_ is an enterprise Linux distribution based on Debian. It consists of an integrated management system for the centralised administration of servers, computer workplaces, users and their rights as well as a wide range of server applications. It also includes an Unvention App Center for the easy installation and management of extensions and appliances.
+The `Univention Corporate Server <https://www.univention.de/>`_ is an enterprise Linux distribution based on Debian. It consists of an integrated management system for the centralised administration of servers, computer workplaces, users and their rights as well as a wide range of server applications. It also includes an Unvention App Center for the easy installation and management of extensions and appliances.
 
 Bareos is part of the `App Center <https://www.univention.de/produkte/univention-app-center/app-katalog/bareos/>`_ and therefore an Univention environment can easily be extended to provide backup functionality for the Univention servers as well as for the connected client systems. Using the Univention Management Console (UMC), you can also create backup jobs for client computers (Windows or Linux systems), without the need of editing configuration files.
 
@@ -383,7 +383,7 @@ Alternatively you can also set those UCR variables via commandline.
    File: /etc/bareos/...
    [ ok ] Reloading Bareos Director: bareos-dir.
 
-When your login credentials are set, you can login into Bareos Webui by following the entry in your Administration UCS Overview or directly via https://<UCS_SERVER>/bareos-webui/.
+When your login credentials are set, you can login into Bareos Webui by following the entry in your Administration UCS Overview or directly via https://UCS_SERVER/bareos-webui/.
 
 .. image:: /include/images/univention-ucs-overview-administration.*
    :width: 80.0%

--- a/docs/manuals/source/Appendix/ReleaseNotes.rst
+++ b/docs/manuals/source/Appendix/ReleaseNotes.rst
@@ -7,7 +7,7 @@ Release Notes
 
 .. warning::
 
-      While all the source code is published on `GitHub <https://github.com/bareos/bareos>`_, the releases of packages on http://download.bareos.org is limited to the initial versions of a major release. Later maintenance releases are only published on https://download.bareos.com.
+      While all the source code is published on `GitHub <https://github.com/bareos/bareos/>`_, the releases of packages on https://download.bareos.org/ is limited to the initial versions of a major release. Later maintenance releases are only published on https://download.bareos.com/.
 
 
 This information is also available as ``CHANGELOG.md`` in the corresponding branch of the `Bareos GitHub project`_

--- a/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/HintsForBuildingBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/HintsForBuildingBareos.rst
@@ -15,7 +15,7 @@ For the test-environment, we use the minimal defines required to run the tests.
 When interested in the cmake defines for the Bareos production packages,
 please refer to the corresponding build descriptions:
 
-  * Debian Packages: `debian/rules <https://github.com/bareos/bareos/blob/master/core/debian/rules>`__
+  * Debian Packages: `debian/rules <https://github.com/bareos/bareos/blob/master/debian/rules>`__
   * RPM Packages: `core/platforms/packaging/bareos.spec <https://github.com/bareos/bareos/blob/master/core/platforms/packaging/bareos.spec>`__
 
 

--- a/docs/manuals/source/DeveloperGuide/PythonBareos.rst
+++ b/docs/manuals/source/DeveloperGuide/PythonBareos.rst
@@ -25,7 +25,7 @@ Example:
    >>> print(directorconsole.call('help').decode("utf-8"))
 
 If you want to create a command line tool, the examples in
-https://github.com/bareos/bareos/blob/master/python-bareos/bin/ might be useful.
+https://github.com/bareos/bareos/tree/master/python-bareos/bin might be useful.
 
 
 

--- a/docs/manuals/source/DeveloperGuide/api.rst
+++ b/docs/manuals/source/DeveloperGuide/api.rst
@@ -232,7 +232,7 @@ differs from API mode 1 in several aspects:
 
 -  JSON output
 -  The JSON output is in the format of JSON-RPC 2.0 responce objects
-   (http://www.jsonrpc.org/specification#response_object). This should
+   (https://www.jsonrpc.org/specification#response_object). This should
    make it easier to implement a full JSON-RPC service later.
 -  No user interaction inside a command (meaning: if not all parameters
    are given to a :bcommand:`run` command, the command fails).
@@ -405,7 +405,7 @@ Example of a JSON-RPC Error Response
 ''''''''''''''''''''''''''''''''''''
 
 Example of a JSON-RPC Error Response
-(http://www.jsonrpc.org/specification#error_object):
+(https://www.jsonrpc.org/specification#error_object):
 
 .. code-block:: bconsole
 

--- a/docs/manuals/source/DeveloperGuide/generaldevel.rst
+++ b/docs/manuals/source/DeveloperGuide/generaldevel.rst
@@ -45,7 +45,7 @@ Also, include the Bareos copyright notice that can be found in every source file
 Bug Database
 ------------
 
-We have a bug database which is at https://bugs.bareos.org.
+We have a bug database which is at https://bugs.bareos.org/.
 
 The first thing is if you want to take over a bug, rather than just make
 a note, you should assign the bug to yourself. This helps other
@@ -83,7 +83,7 @@ If the user has not properly filled in most of the important fields (platform, O
 The same applies to a support request (we answer only bugs), you might give the user a tip, but please politely refer him to the manual, the `bareos-users`_ mailing list and maybe the `commercial support`_.
 
 .. _bareos-users:       https://groups.google.com/forum/#!forum/bareos-users
-.. _commercial support: https://www.bareos.com/en/Support.html
+.. _commercial support: https://www.bareos.com/product/support/
 
 Reporting security issues
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/manuals/source/DeveloperGuide/gitworkflow.rst
+++ b/docs/manuals/source/DeveloperGuide/gitworkflow.rst
@@ -14,7 +14,7 @@ Basically this means we want you to create pull requests against our master bran
 We will then build and review the code, request changes as required and eventually merge the pull request.
 You may need to rebase and force-push during the review-phase as master is a moving target.
 
-.. _Github Flow: https://help.github.com/en/articles/github-flow
+.. _Github Flow: https://docs.github.com/en/get-started/quickstart/github-flow
 
 Releases and Backporting
 ------------------------

--- a/docs/manuals/source/DeveloperGuide/tests.rst
+++ b/docs/manuals/source/DeveloperGuide/tests.rst
@@ -13,7 +13,7 @@ Adding a new C++ Test
 ~~~~~~~~~~~~~~~~~~~~~
 To add a new test, you create your sourcefiles in ``core/src/tests`` and register the test in ``CMakeLists.txt`` in that directory. The easiest way is to copy an existing test sourcefile and the related lines in ``core/src/CMakeLists.txt``.
 
-For general advice on how to use the Google Test framework see this documentation: `Googletest Primer <https://github.com/google/googletest/blob/master/docs/primer.md>`_
+For general advice on how to use the Google Test framework see this documentation: `Googletest Primer <https://github.com/google/googletest/blob/main/docs/primer.md>`_
 
 Adding tests in general
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/Issue.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/BareosSpecificFormatting/Issue.rst
@@ -4,7 +4,7 @@ Issues tracked on Mantis
 bugs.bareos.org
 ---------------
 
-If you want to reference an issue that is tracked on https://bugs.bareos.org, the following formatting should be used:
+If you want to reference an issue that is tracked on https://bugs.bareos.org/, the following formatting should be used:
 
 .. literalinclude:: /DocumentationStyleGuide/example/mantis-issue.rst.inc
    :language: none

--- a/docs/manuals/source/DocumentationStyleGuide/Gotchas.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/Gotchas.rst
@@ -74,6 +74,6 @@ toctree
 ------------
 
 Don't use the ``:options:`` role, as this tries to refers to a option definition, which we don't have.
-Also, as we document different programs, using option would require to prefix it with the program name, see https://www.sphinx-doc.org/en/1.7/domains.html#directive-program.
+Also, as we document different programs, using option would require to prefix it with the program name, see https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#directive-program.
 
 This only applies to ``:options:`` without domain. We do you ``:config:option:`` in :ref:`DocumentationStyleGuide/BareosSpecificFormatting/BareosConfiguration:Bareos Configuration`.

--- a/docs/manuals/source/DocumentationStyleGuide/RestOverview.rst
+++ b/docs/manuals/source/DocumentationStyleGuide/RestOverview.rst
@@ -228,7 +228,7 @@ Valid values for the highlighting language are:
   * ``rest``
   * ``c``
   * ... and any other `lexer alias that Pygments supports
-    <http://pygments.org/docs/lexers/>`_.
+    <https://pygments.org/docs/lexers/>`_.
 
 If the text resides in a seperate file, use::
 
@@ -658,7 +658,7 @@ In general, images should be stored as SVG.
 Table
 -----
 
-Sphinx offers multiple methods to create tables, see https://www.sphinx-doc.org/en/2.0/usage/restructuredtext/basics.html#tables\ .
+Sphinx offers multiple methods to create tables, see https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables\ .
 
 Choose whatever sucks least.
 

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareos.rst
@@ -36,7 +36,7 @@ This will start a very basic Bareos installation which will regularly backup a d
 Decide about the Bareos release to use
 --------------------------------------
 
-You’ll find Bareos binary package repositories at https://download.bareos.org/. The stable releases are available at https://download.bareos.org/bareos/release/.
+You’ll find Bareos binary package repositories at https://download.bareos.org/bareos/. The stable releases are available at https://download.bareos.org/bareos/release/.
 
 The public key to verify the repository is also in repository directory (:file:`Release.key` for Debian based distributions, :file:`repodata/repomd.xml.key` for RPM based distributions).
 

--- a/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
@@ -14,9 +14,9 @@ In technical terms, it is a network Client/Server based backup program. Bareos i
 History
 -------
 
-Bareos is a `fork <http://www.bareos.org/en/faq/why_fork.html>`_ of the open source project `Bacula <http://www.bacula.org>`_ version 5.2. In 2010 the Bacula community developer Marco van Wieringen started to collect rejected or neglected community contributions in his own branch. This branch was later on the base of Bareos and since then was enriched by a lot of new features.
+Bareos is a fork of the open source project `Bacula <https://www.bacula.org>`_ version 5.2. In 2010 the Bacula community developer Marco van Wieringen started to collect rejected or neglected community contributions in his own branch. This branch was later on the base of Bareos and since then was enriched by a lot of new features.
 
-This documentation also bases on the `original Bacula documentation <http://www.bacula.org/5.2.x-manuals/en/main/main/>`_, it is technically also a fork of the documenation created following the rules of the GNU Free Documentation License.
+This documentation also bases on the `original Bacula documentation <https://www.bacula.org/5.2.x-manuals/en/main/main/>`_, it is technically also a fork of the documenation created following the rules of the GNU Free Documentation License.
 
 Original author of Bacula and its documentation is Kern Sibbald. We thank Kern and all contributors to Bacula and it’s documentation. We maintain a list of contributors to Bacula (until the time we’ve started the fork) and Bareos in our `AUTHORS <https://github.com/bareos/bareos/blob/master/AUTHORS>`_ file.
 

--- a/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
+++ b/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
@@ -505,7 +505,7 @@ Tapespeed and blocksizes
 :index:`\ <single: Tape; speed>`
 :index:`\ <single: Blocksize; optimize>`
 
-The `Bareos Whitepaper Tape Speed Tuning <http://www.bareos.org/en/Whitepapers/articles/Speed_Tuning_of_Tape_Drives.html>`_ shows that the two parameters :strong:`Maximum File Size`\  and :strong:`Maximum Block Size`\  of the device have significant influence on the tape speed.
+The `Bareos Whitepaper Tape Speed Tuning <https://www.bareos.com/whitepapers/optimizing-the-tape-speed.pdf>`_ shows that the two parameters :strong:`Maximum File Size`\  and :strong:`Maximum Block Size`\  of the device have significant influence on the tape speed.
 
 While it is no problem to change the :config:option:`sd/device/MaximumFileSize`\  parameter, unfortunately it is not possible to change the :config:option:`sd/device/MaximumBlockSize`\  parameter, because the previously written tapes would become unreadable in the new setup. It would require that the :config:option:`sd/device/MaximumBlockSize`\  parameter is switched back to the old value to be able to read the old volumes, but of
 course then the new volumes would be unreadable.

--- a/docs/manuals/source/TasksAndConcepts/CatalogMaintenance.rst
+++ b/docs/manuals/source/TasksAndConcepts/CatalogMaintenance.rst
@@ -138,7 +138,7 @@ If this works on your system can be verified by
    su - postgres
    psql
 
-If your database is configured to require a password, this must be defined in the file `:file:`~/.pgpass` <https://postgresql.org/docs/current/static/libpq-pgpass.html>`_ in the following syntax: :strong:`HOST:PORT:DATABASE:USER:PASSWORD`, e.g.
+If your database is configured to require a password, this must be defined in the file `:file:`~/.pgpass` <https://www.postgresql.org/docs/current/libpq-pgpass.html>`_ in the following syntax: :strong:`HOST:PORT:DATABASE:USER:PASSWORD`, e.g.
 
 .. code-block:: cfg
    :caption: PostgreSQL access credentials
@@ -476,7 +476,7 @@ Depending on the size of your database, this will take more or less time and a f
 
 Except from special cases PostgreSQL does not need to be dumped/restored to keep the database efficient. A normal process of vacuuming will prevent the database from getting too large. If you want to fine-tweak the database storage, commands such as VACUUM, VACUUM FULL, REINDEX, and CLUSTER exist specifically to keep you from having to do a dump/restore.
 
-More details on this subject can be found in the PostgreSQL documentation. The page https://www.postgresql.org/docs/ contains links to the documentation for all PostgreSQL versions. The section *Routine Vacuuming* explains how VACUUM works and why it is required, see http://www.postgresql.org/docs/current/static/routine-vacuuming.html for the current PostgreSQL version.
+More details on this subject can be found in the PostgreSQL documentation. The page https://www.postgresql.org/docs/ contains links to the documentation for all PostgreSQL versions. The section *Routine Vacuuming* explains how VACUUM works and why it is required, see https://www.postgresql.org/docs/current/routine-vacuuming.html for the current PostgreSQL version.
 
 .. _PostgresSize:
 
@@ -498,7 +498,7 @@ The reason for autovacuuming not being triggered is then probably the default se
 
 In essence, this means that a VACUUM is only triggered when 20% of table size are obsolete. Consequently, the larger the table is, the less frequently VACUUM will be triggered by autovacuum. This make sense because vacuuming has a performance impact. While it is possible to override the autovacuum parameters on a table-by-table basis, it can then still be triggered at any time.
 
-To learn more details about autovacuum see https://www.postgresql.org/docs/current/static/routine-vacuuming.html#AUTOVACUUM
+To learn more details about autovacuum see https://www.postgresql.org/docs/current/routine-vacuuming.html#AUTOVACUUM
 
 The following example shows how to configure running VACUUM on the file table by using an admin-job in Bareos. The job will be scheduled to run at a time that should not run in parallel with normal backup jobs, here by scheduling it to run after the BackupCatalog job.
 

--- a/docs/manuals/source/TasksAndConcepts/NdmpBackupsWithBareos.rst
+++ b/docs/manuals/source/TasksAndConcepts/NdmpBackupsWithBareos.rst
@@ -14,7 +14,7 @@ NDMP
 
 -  is widely used by storage product vendors and OS vendors like NetApp, Isilon, EMC, Oracle.
 
--  information is available at http://www.ndmp.org/.
+-  information is available at https://www.snia.org/ndmp.
 
 -  version is currently (2016) NDMP Version 4.
 
@@ -529,7 +529,7 @@ UPDATE
 Example NDMP Fileset to backup a subset of a NDMP filesystem
 ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''
 
-The following fileset is intended to backup all files and directories matching :file:`/ifs/home/users/a*`. It has been tested against Isilon OneFS 7.2.0.1. See `Isilon OneFS 7.2.0 CLI Administration Guide <https://www.emc.com/collateral/TechnicalDocument/docu56048.pdf>`_, section quote{NDMP environment variables} for details about the supported NDMP environment variables. Excludes are not used in this example.
+The following fileset is intended to backup all files and directories matching :file:`/ifs/home/users/a*`. It has been tested against Isilon OneFS 7.2.0.1. See `Isilon OneFS Administration Guide <https://www.delltechnologies.com/asset/en-us/products/storage/technical-support/isilon-quick-reference-guide-for-administrators.pdf>`_, section quote{NDMP environment variables} for details about the supported NDMP environment variables. Excludes are not used in this example.
 
 .. code-block:: bareosconfig
    :caption: NDMP Fileset Isilon Include/Exclude

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/OVirtPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/OVirtPlugin.rst.inc
@@ -472,5 +472,5 @@ following Plugin Option must be entered:
 Anything else from the restore dialogue is the same.
 
 This will create disk image files that could be examined for example by using
-the **guestfish** tool (see http://libguestfs.org/guestfish.1.html). This tool
+the **guestfish** tool (see https://libguestfs.org/guestfish.1.html). This tool
 can also be used to extract single files from the disk image.

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PerconaXtraBackupPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PerconaXtraBackupPlugin.rst.inc
@@ -30,7 +30,7 @@ Incremental backups only work for INNODB tables, when using MYISAM, only full ba
 Prerequisites of percona XtraBackup Plugin
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Install the XtraBackup tool from Percona. Documentation and packages are available here: https://www.percona.com/software/mysql-database/percona-XtraBackup. The plugin was successfully tested with XtraBackup versions 2.3.5 and 2.4.4.
+Install the XtraBackup tool from Percona. Documentation and packages are available here: https://www.percona.com/software/mysql-database/percona-xtrabackup. The plugin was successfully tested with XtraBackup versions 2.3.5 and 2.4.4.
 
 For authentication the :file:`.mycnf` file of the user running the |fd| is used. Before proceeding, make sure that XtraBackup can connect to the database and create backups.
 
@@ -110,7 +110,7 @@ This example shows the restore tree for restore job with ID 351. First subdirect
 
 Next line is the first incremental job with ID 335, starting at LSN 10129154 until 10142295. The third line is the 2nd incremental job with ID 338.
 
-To further prepare the restored files, use the :command:`XtraBackup --prepare` command. Read https://www.percona.com/doc/percona-xtrabackup/2.4/backup_scenarios/incremental_backup.html for more information.
+To further prepare the restored files, use the :command:`XtraBackup --prepare` command. For more information read https://docs.percona.com/percona-xtrabackup/2.4/backup_scenarios/incremental_backup.html.
 
 
 Troubleshooting

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -51,7 +51,7 @@ Requirements
 
 As the Plugin is based on the |vsphere| Storage APIs for Data Protection, which requires at least a |vsphere| Essentials License. It is tested against |vsphere| Storage APIs for Data Protection of |vmware| 7.0.1. It does not work with standalone unlicensed |vmware| ESXi\ |trade|.
 
-Since Bareos :sinceVersion:`21.0.0: VMware Plugin: VDDK 7.0.1` the plugin is using the Virtual Disk Development Kit (VDDK) 7.0.1, as of the VDDK 7.0 release notes, it should be compatible with vSphere 7.0 and the next major release (except new features) and backward compatible with vSphere 6.5 and 6.7, see VDDK release notes at https://code.vmware.com/web/sdk/7.0/vddk for details.
+Since Bareos :sinceVersion:`21.0.0: VMware Plugin: VDDK 7.0.1` the plugin is using the Virtual Disk Development Kit (VDDK) 7.0.1, as of the VDDK 7.0 release notes, it should be compatible with vSphere 7.0 and the next major release (except new features) and backward compatible with vSphere 6.5 and 6.7, see VDDK release notes at https://developer.vmware.com/web/sdk/7.0/vddk for details.
 
 This plugin requires the pyVmomi module. Since Bareos :sinceVersion:`21.0.0: VMware Plugin: pyVmomi` the package **bareos-vmware-plugin** no longer includes a dependency on a pyVmomi package, because some Linux distributions don't provide current versions. Consequently, pyVmomi must be either installed by using :command:`pip install pyvmomi` or by manually installing a distribution provided pyVmomi package.
 
@@ -69,9 +69,9 @@ When using the vCenter appliance with embedded SSO, a user account usually has t
 
 For more details regarding users and permissions in vSphere see
 
--  http://pubs.vmware.com/vsphere-55/topic/com.vmware.vsphere.security.doc/GUID-72BFF98C-C530-4C50-BF31-B5779D2A4BBB.html and
+-  https://pubs.vmware.com/vsphere-55/topic/com.vmware.vsphere.security.doc/GUID-72BFF98C-C530-4C50-BF31-B5779D2A4BBB.html and
 
--  http://pubs.vmware.com/vsphere-55/topic/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html
+-  https://pubs.vmware.com/vsphere-55/topic/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html
 
 Make sure to add or enable the following settings in your |fd| configuration:
 
@@ -174,7 +174,7 @@ For ease of use (but less secure) when the :command:`vcthumbprint` is not given,
 
 Also since :sinceVersion:`17.2.4: VMware Plugin: transport=nbdssl` another optional plugin option has been added that can be used for trying to force a given transport method. Normally, when no transport method is given, VDDK will negotiate available transport methods and select the best one. For a description of transport methods, see
 
-https://code.vmware.com/doc/preview?id=4076#/doc/vddkDataStruct.5.5.html
+https://developer.vmware.com/docs/4076/virtual-disk-development-kit-programming-guide/doc/vddkDataStruct.5.5.html
 
 When the plugin runs in a VMware virtual machine which has access to datastore where the virtual disks to be backed up reside, VDDK will use the hotadd transport method. On a physical server without SAN access, it will use the NBD transport method, hotadd transport is not available in this case.
 
@@ -307,7 +307,7 @@ Backup
 
 Before running the first backup, CBT (Changed Block Tracking) must be enabled for the VMs to be backed up.
 
-As of http://kb.vmware.com/kb/2075984 manually enabling CBT is currently not working properly. The API however works properly. To enable CBT use the Script :command:`vmware_cbt_tool.py`, it is packaged in the bareos-vmware-plugin package:
+As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently not working properly. The API however works properly. To enable CBT use the Script :command:`vmware_cbt_tool.py`, it is packaged in the bareos-vmware-plugin package:
 
 .. code-block:: shell-session
    :caption: usage of vmware\_cbt\_tool.py

--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -333,7 +333,7 @@ GFAPI Storage Backend
 
 **GFAPI** (GlusterFS)
 
-A GlusterFS Storage can be used as Storage backend of Bareos. Prerequistes are a working GlusterFS storage system and the package **bareos-storage-glusterfs**. See http://www.gluster.org/ for more information regarding GlusterFS installation and configuration and specifically `https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/ <https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/>`__ for Bareos integration. You can use following snippet to
+A GlusterFS Storage can be used as Storage backend of Bareos. Prerequistes are a working GlusterFS storage system and the package **bareos-storage-glusterfs**. See https://www.gluster.org/ for more information regarding GlusterFS installation and configuration and specifically `https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/ <https://docs.gluster.org/en/latest/Administrator-Guide/Bareos/>`__ for Bareos integration. You can use following snippet to
 configure it as storage device:
 
 
@@ -356,7 +356,7 @@ Rados Storage Backend
 
 **Rados** (Ceph Object Store)
 
-Here you configure the Ceph object store, which is accessed by the SD using the Rados library. Prerequistes are a working Ceph object store and the package **bareos-storage-ceph**. See http://ceph.com for more information regarding Ceph installation and configuration. Assuming that you have an object store with name :file:`poolname` and your Ceph access is configured in :file:`/etc/ceph/ceph.conf`, you can use following snippet to configure it as
+Here you configure the Ceph object store, which is accessed by the SD using the Rados library. Prerequistes are a working Ceph object store and the package **bareos-storage-ceph**. See https://ceph.com/en/ for more information regarding Ceph installation and configuration. Assuming that you have an object store with name :file:`poolname` and your Ceph access is configured in :file:`/etc/ceph/ceph.conf`, you can use following snippet to configure it as
 storage device:
 
 .. literalinclude:: /include/config/SdDeviceDeviceOptionsRados1.conf

--- a/docs/manuals/source/TasksAndConcepts/TheWindowsVersionOfBareos.rst
+++ b/docs/manuals/source/TasksAndConcepts/TheWindowsVersionOfBareos.rst
@@ -24,7 +24,7 @@ Windows Installation
 :index:`\ <single: Installation; Windows>`
 :index:`\ <single: Windows; File Daemon; Installation>`
 
-Normally, you will install the Windows version of Bareos from the binaries. The **winbareos** binary packages are provided under http://download.bareos.org/bareos/release/latest/windows. Additionally, there are `OPSI <http://www.opsi.org>`_ packages available under http://download.bareos.org/bareos/release/latest/windows/opsi.
+Normally, you will install the Windows version of Bareos from the binaries. The **winbareos** binary packages are provided in the :file:`windows` directory of the current Bareos release directory. For Bareos 21 it is https://download.bareos.org/bareos/release/21/windows/. Additionally, there are `OPSI <https://www.opsi.org>`_ packages available in the :file:`windows/opsi/` directory (Bareos 21: https://download.bareos.org/bareos/release/21/windows/opsi/).
 
 This install is standard Windows .exe that runs an install wizard using the NSIS Free Software installer, so if you have already installed Windows software, it should be very familiar to you. Providing you do not already have Bareos installed, the installer installs the binaries and dlls in :file:`C:\\Program Files\\Bareos` and the configuration files in :file:`C:\\ProgramData\\Bareos` (for Windows XP and older:
 :file:`C:\\Documents and Settings\\All Users\\Application Data\\Bareos`).
@@ -161,7 +161,7 @@ Antivirus Program
 If you are not using the portable option, and you have :config:option:`dir/fileset/EnableVss`\  (Volume Shadow Copy) enabled in the |dir| and you experience problems with Bareos not being able to open files, it is most likely that you are running an antivirus program that blocks Bareos from doing certain operations. In this case, disable the antivirus program and try another backup. If it succeeds, either get a different (better) antivirus program or use
 something like :config:option:`dir/job/ClientRunBeforeJob`\ /:config:option:`dir/job/ClientRunBeforeJob`\  to turn off the antivirus program while the backup is running.
 
-If turning off anti-virus software does not resolve your VSS problems, you might have to turn on VSS debugging. The following link describes how to do this: http://support.microsoft.com/kb/887013/en-us.
+If turning off anti-virus software does not resolve your VSS problems, you might have to turn on VSS debugging. The following link describes how to do this: https://docs.microsoft.com/en-US/troubleshoot/windows-server/backup-and-storage/enable-debug-tracing-features-vss.
 
 Enable Debuggging
 ~~~~~~~~~~~~~~~~~
@@ -334,7 +334,7 @@ The JobLog will then show the following informational line:
 
    Fileset has autoexclude disabled, ignoring FilesNotToBackup Registry key
 
-For more details about the Windows registry key see http://msdn.microsoft.com/en-us/library/windows/desktop/bb891959%28v=vs.85%29.aspx#filesnottobackup.
+For more details about the Windows registry key see https://docs.microsoft.com/en-us/windows/win32/backup/registry-keys-for-backup-and-restore?#filesnottobackup.
 
 Windows dedup support
 ~~~~~~~~~~~~~~~~~~~~~
@@ -551,7 +551,7 @@ Windows Ownership and Permissions Problems
 :index:`\ <single: Windows; Ownership and Permissions Problems>`
 
 If you restore files backed up from Windows to an alternate directory, Bareos may need to create some higher level directories that were not saved (or restored). In this case, the File daemon will create them under the SYSTEM account because that is the account that Bareos runs under as a service and with full access permission. However, there may be cases where you have problems accessing those files even if you run as administrator. In principle, Microsoft supplies you with the way to cease
-the ownership of those files and thus change the permissions. However, a much better solution to working with and changing Win32 permissions is the program SetACL, which can be found at `http://setacl.sourceforge.net/ <http://setacl.sourceforge.net/>`_.
+the ownership of those files and thus change the permissions. However, a much better solution to working with and changing Win32 permissions is the program SetACL, which can be found at `https://helgeklein.com/setacl/ <https://helgeklein.com/setacl/>`_.
 
 If you have not installed Bareos while running as Administrator and if Bareos is not running as a Process with the userid (User Name) SYSTEM, then it is very unlikely that it will have sufficient permission to access all your files.
 

--- a/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
@@ -78,7 +78,7 @@ To get a trusted certificate (CA or Certificate Authority signed certificate), y
 
 Bareos is known to work well with RSA certificates.
 
-You can use programs like `xca <http://xca.sourceforge.net/>`_ or TinyCA to easily manage your own CA with a Graphical User Interface.
+You can use programs like `xca <https://github.com/chris2511/xca/>`_ or TinyCA to easily manage your own CA with a Graphical User Interface.
 
 Example TLS Configuration Files
 -------------------------------

--- a/docs/manuals/source/conf.py
+++ b/docs/manuals/source/conf.py
@@ -180,7 +180,7 @@ author = "Bareos GmbH & Co. KG"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -298,6 +298,55 @@ latex_documents = [
     )
 ]
 
+# -- Options for the linkcheck builder ------------------------------------
+
+linkcheck_allowed_redirects = {
+    # All HTTP redirections from the source URI to the canonical URI will be treated as "working".
+    r'https://bareos\.org/.*': r'https://bareos\.com/.*',
+    r'http://www\.bareos\.org': r'https://www\.bareos\.com/.*',
+    r'http://www\.bareos\.org/.*': r'https://www\.bareos\.com/.*',
+    r'https://www\.bareos\.org/.*': r'https://www\.bareos\.com/.*',
+    r'https://www\.bareos\.com/whitepapers/.*': r'https://www\.bareos\.com/.*',
+    r'https://bugs\.bareos\.org/.*': r'https://bugs\.bareos\.org/my_view_page\.php',
+    r'https://download\.bareos\.org': r'https://download\.bareos\.org/bareos',
+    r'https://download\.bareos\.com': r'https://download\.bareos\.com/bareos',
+}
+linkcheck_request_headers = {
+#    "https://www.sphinx-doc.org/": {
+#        "Accept": "text/html",
+#        "Accept-Encoding": "utf-8",
+#    },
+    "*": {
+        "Accept": "text/html,application/xhtml+xml",
+    }
+}
+linkcheck_retries = 2   # default 1
+linkcheck_timeout = 10  # default 300
+linkcheck_workers = 2   # default 5
+linkcheck_anchors = True
+linkcheck_ignore = [
+    r'\.\./*',
+    r'http://localhost:*/',
+    r'https://\w+:\d+/bareos-webui/',
+    'https://UCS_SERVER/bareos-webui/',
+    'http://HOSTNAME/bareos-webui',
+    'http://localhost:9100',
+    'http://bareos:9100',
+    'http://bucket.s3_server/object',
+    'http://127.0.0.1:8000/docs',
+    'http://127.0.0.1:8000/redoc',
+    'https://pubs.vmware.com/vsphere-55/topic/com.vmware.vsphere.security.doc/*',
+    r'https://github\.com/bareos/bareos/pull/\d+', 
+    'https://www.glusterfs.org',                     #failing too often
+    'https://www.sphinx-doc.org/en/1.7/intro.html#',
+]
+#linkcheck_auth = [
+#  ('https://foo\.yourcompany\.com/.+', ('johndoe', 'secret')),
+#  ('https://.+\.yourcompany\.com/.+', HTTPDigestAuth(...)),
+#]
+linkcheck_rate_limit_timeout = 300.00
+# ignore all links in documents located in a subfolder named 'legacy'
+#linkcheck_exclude_documents = [r'.*/legacy/.*']
 
 # -- Options for manual page output ---------------------------------------
 


### PR DESCRIPTION
Documentation use sphinx linkcheck to fix broken links

- Adding linkcheck options to conf.py
- Fix all broken link in documentation

 Sphinx linkcheck can be used during documentation build

```
sphinx-build -M linkcheck docs/manuals/source docs/BareosMainReference -j2
```

The automatic usage during documentation build, still need to be discussed.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- ~~[ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
