### PR TITLE
Add missing newline to job message for TLS handshake.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -162,6 +162,7 @@ Philipp Storz
 Philippe Chauvat
 Preben Guldberg
 Radosław Korzeniewski
+Rainer Jung
 Renout Gerrits
 Riccardo Ghetta
 Richard Mortimer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Windows Installer: made 'Director PotsgreSQL Backend Support' checked by default if 'Full PostgreSQL' installation selected. [PR #1185]
 - SQL: queries: fix sql queries to handle negative job duration value [PR #1198]
 - dird: fix TLS-PSK credential not found error with very long job names [PR #1204]
+- dird: Add missing newline to job message for TLS handshake [PR #1209]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]
@@ -215,4 +216,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1198]: https://github.com/bareos/bareos/pull/1198
 [PR #1200]: https://github.com/bareos/bareos/pull/1200
 [PR #1204]: https://github.com/bareos/bareos/pull/1204
+[PR #1205]: https://github.com/bareos/bareos/pull/1205
+[PR #1209]: https://github.com/bareos/bareos/pull/1209
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -197,7 +197,6 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
   switch (jcr->impl->connection_handshake_try_) {
     case ClientConnectionHandshakeMode::kTlsFirst:
       m += " Handshake: Immediate TLS,";
-      add_newline_in_joblog = true;
       break;
     case ClientConnectionHandshakeMode::kCleartextFirst:
       m += " Handshake: Cleartext,";
@@ -212,7 +211,7 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
     std::replace(m1.begin(), m1.end(), '\r', ' ');
     std::replace(m1.begin(), m1.end(), '\v', ' ');
     std::replace(m1.begin(), m1.end(), ',', ' ');
-    m1 += std::string("\n"); 
+    m1 += std::string("\n");
     Jmsg(jcr, M_INFO, 0, m1.c_str());
   }
   if (ua) { /* only whith console connection */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -198,6 +198,7 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
   switch (jcr->impl->connection_handshake_try_) {
     case ClientConnectionHandshakeMode::kTlsFirst:
       m += " Handshake: Immediate TLS,";
+      add_newline_in_joblog = true;
       break;
     case ClientConnectionHandshakeMode::kCleartextFirst:
       m += " Handshake: Cleartext,";

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -194,7 +194,6 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
       == ClientConnectionHandshakeMode::kUndefined) {
     m += "\r\v";
   }
-  bool add_newline_in_joblog = false;
   switch (jcr->impl->connection_handshake_try_) {
     case ClientConnectionHandshakeMode::kTlsFirst:
       m += " Handshake: Immediate TLS,";
@@ -202,10 +201,9 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
       break;
     case ClientConnectionHandshakeMode::kCleartextFirst:
       m += " Handshake: Cleartext,";
-      add_newline_in_joblog = true;
       break;
     default:
-      m += " unknown mode\n";
+      m += " Handshake: Unknown mode";
       break;
   }
 
@@ -214,7 +212,7 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
     std::replace(m1.begin(), m1.end(), '\r', ' ');
     std::replace(m1.begin(), m1.end(), '\v', ' ');
     std::replace(m1.begin(), m1.end(), ',', ' ');
-    if (add_newline_in_joblog) { m1 += std::string("\n"); }
+    m1 += std::string("\n"); 
     Jmsg(jcr, M_INFO, 0, m1.c_str());
   }
   if (ua) { /* only whith console connection */


### PR DESCRIPTION
Add missing newline to job message for TLS handshake. 
This PR will fix the missing new line in job log as seen like
```
07-Jul 23:00 bareos-dir JobId 15390:  Handshake: Immediate TLS 07-Jul 23:00 bareos-dir JobId 15391:  Handshake: Immediate TLS 07-Jul 23:00 bareos-bie JobId 15390:  Encryption: PSK-AES256-CBC-SHA TLSv1/SSLv3
```
instead expected result
```
07-Jul 23:00 bareos-bie JobId 15391:  Handshake: Immediate TLS 
07-Jul 23:00 bareos-bie JobId 15390:  Encryption: PSK-AES256-CBC-SHA TLSv1/SSLv3
```
- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
