### PR TITLE
dird: fix odd-even weeks parsing bug in schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: fix TLS-PSK credential not found error with very long job names [PR #1204]
 - dird: Add missing newline to job message for TLS handshake [PR #1209]
 - devtools/dist-tarball.sh: fix name if version contains "~pre" [PR #1221]
+- dird: fix odd-even weeks parsing bug in schedule [PR #1210]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -547,9 +547,9 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             have_woy = true;
           }
           // Set the bits according to the modulo specification.
-          for (i = 0; i < 54; i++) {
+          for (i = 0; i < 53; i++) {
             if (i % code2 == 0) {
-              SetBit(i + code - 1, res_run.date_time_bitfield.woy);
+              SetBit(i + code, res_run.date_time_bitfield.woy);
             }
           }
         } else {

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/EvenWeeks.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/EvenWeeks.conf
@@ -1,0 +1,4 @@
+Schedule {
+  Name = "Even Weeks"
+  Run = w00/w02 fri at 23:10
+}

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/OddWeeks.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/OddWeeks.conf
@@ -1,0 +1,4 @@
+Schedule {
+  Name = "Odd Weeks"
+  Run = w01/w02 sun at 23:10
+}


### PR DESCRIPTION
### Description

There is a bug where the config parser is not performing as expected when it comes to scheduling odd/even weeks

#### config files
```
Schedule {
  Name = "Odd Weeks"
  Run = w01/w02 sun at 23:10
}

Schedule {
  Name = "Even Weeks"
  Run = w00/w02 fri at 23:10
}
```

#### parsed schedule
```
show schedules
Schedule {
 Name = "Odd Weeks"
 Run = Sun w00,w02,w04,w06,w08,w10,w12,w14,w16,w18,w20,w22,w24,w26,w28,w30,w32,w34,w36,w38,w40,w42,w44,w46,w48,w50,w52 at 23:10
}

Schedule {
 Name = "Even Weeks"
 Run = Fri w01,w03,w05,w07,w09,w11,w13,w15,w17,w19,w21,w23,w25,w27,w29,w31,w33,w35,w37,w39,w41,w43,w45,w47,w49,w51 at 23:10
}
```
the odd and even weeks are flipped

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- ~~[ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
