### PR TITLE
VMware plugin: Fixed: Restore to local file required API connection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -182,6 +182,7 @@ Simone Caronni
 Stefan Reddig
 Stefan Warten
 Stephan Duehr
+Stephan Sedlmeier
 Stev Dubau
 Sébastien Marchal
 Thomas Duemesnil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
   - fix show command output for RunScript RunsOnClient
   - fix show verbose for RunScripts
   - execute console runscripts only on the Director
+- VMware file daemon plugin: fix restore with localvmdk=yes requires an API connection to vCenter [PR #1219]
 - python plugins: store architecture specific modules in sitearch (instead of sitelib) [PR #698]
 - debian: fix package dependencies for webui and Ceph [PR #1183]
 - Python plugins: fix handling of additional pluginoptions parameter [PR #1177]

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -223,6 +223,9 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             if "uuid" not in self.options:
                 mandatory_options += self.mandatory_options_vmname
 
+        if self.options.get("localvmdk") == "yes":
+            mandatory_options = list(set(mandatory_options) - set(["vcserver", "vcuser", "vcpass", "folder", "dc", "vmname"]))
+
         for option in mandatory_options:
             if option not in self.options:
                 bareosfd.DebugMessage(100, "Option '%s' not defined.\n" % (option))
@@ -259,7 +262,7 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                 % (option, StringCodec.encode(self.options[option])),
             )
 
-        if "vcthumbprint" not in self.options:
+        if not self.options.get("localvmdk") == "yes" and "vcthumbprint" not in self.options:
             # if vcthumbprint is not given in options, retrieve it
             if not self.vadp.retrieve_vcthumbprint():
                 return bareosfd.bRC_Error
@@ -380,7 +383,7 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         if check_option_bRC != bareosfd.bRC_OK:
             return check_option_bRC
 
-        if not self.vadp.connect_vmware():
+        if not self.options.get("localvmdk") == "yes" and not self.vadp.connect_vmware():
             return bareosfd.bRC_Error
 
         return self.vadp.prepare_vm_restore()
@@ -852,13 +855,19 @@ class BareosVADPWrapper(object):
         # the Disconnect Method does not close the tcp connection
         # is that so intentionally?
         # However, explicitly closing it works like this:
-        self.si._stub.DropConnections()
-        self.si = None
-        self.log = None
+        if self.si is not None:
+            self.si._stub.DropConnections()
+            self.si = None
+            self.log = None
 
     def keepalive(self):
         # Prevent from vSphere API timeout by calling CurrentTime() every
         # 10min (600s) to keep alive the connection and session
+
+        # ignore keepalive if there is no connection to the API
+        if self.si is None:
+            return
+
         if int(time.time()) - self.si_last_keepalive > 600:
             self.si.CurrentTime()
             self.si_last_keepalive = int(time.time())

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -224,7 +224,10 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                 mandatory_options += self.mandatory_options_vmname
 
         if self.options.get("localvmdk") == "yes":
-            mandatory_options = list(set(mandatory_options) - set(["vcserver", "vcuser", "vcpass", "folder", "dc", "vmname"]))
+            mandatory_options = list(
+                set(mandatory_options)
+                - set(["vcserver", "vcuser", "vcpass", "folder", "dc", "vmname"])
+            )
 
         for option in mandatory_options:
             if option not in self.options:
@@ -262,7 +265,10 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                 % (option, StringCodec.encode(self.options[option])),
             )
 
-        if not self.options.get("localvmdk") == "yes" and "vcthumbprint" not in self.options:
+        if (
+            not self.options.get("localvmdk") == "yes"
+            and "vcthumbprint" not in self.options
+        ):
             # if vcthumbprint is not given in options, retrieve it
             if not self.vadp.retrieve_vcthumbprint():
                 return bareosfd.bRC_Error
@@ -383,7 +389,10 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         if check_option_bRC != bareosfd.bRC_OK:
             return check_option_bRC
 
-        if not self.options.get("localvmdk") == "yes" and not self.vadp.connect_vmware():
+        if (
+            not self.options.get("localvmdk") == "yes"
+            and not self.vadp.connect_vmware()
+        ):
             return bareosfd.bRC_Error
 
         return self.vadp.prepare_vm_restore()


### PR DESCRIPTION
Restoring a VM to a local file using the VMware plugin required a valid
connection to the vSphere API.
This makes a restore in a worst-case scenario where you lose your
vCenter installation unnecessarily complicated.
This commit fixes the option check logic and does not connect to the
vCenter API when localvmdk is set to yes.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

