### PR TITLE
devtools/dist-tarball.sh: create correct source name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and since Bareos version 20 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Fixed
+- devtools/dist-tarball.sh: fix name if version contains "~pre" [PR #1220]
 
 ## [21.1.4] - 2022-08-05
 

--- a/devtools/dist-tarball.sh
+++ b/devtools/dist-tarball.sh
@@ -97,7 +97,7 @@ if [ -n "${changed_files}" ]; then
 fi
 
 # get version of Bareos to name tarball and directory
-version="$("$cmake" -P get_version.cmake | sed -e 's/^-- //')"
+version="$("$cmake" -P get_version.cmake | sed -e 's/^-- //' | sed -e 's/-pre/~pre/g')"
 # get timestamp of latest commit to use as mtime for all files in tarball
 timestamp="$("$git" show --quiet --date='format-local:%Y-%m-%d %H:%M:%S' --format='%cd')"
 


### PR DESCRIPTION
`devtools/dist-tarball.sh` used `-pre` instead of `~pre` in tarfile names which makes the ulc build fail.
This PR fixes the issue.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
