### PR TITLE
libcloud plugin: libcloud storage provider config

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -135,6 +135,7 @@ Martin Simmons
 Martin Skuta
 Matt Richards
 Matthew Ife
+Matthias Kneer
 Max Meyer
 Meno Abels
 Michael -buk- Scherer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: Add support for Ubuntu 22.04, Fedora 36, EL 9, openSUSE 15.4 [PR #1179]
 - tests: skip mysql tests if root [PR #1197]
 - build: Add support for SLE_15_SP4 [PR #1205]
-- libcloud plugin: allow to configure the storage provider [PR #1174]
+- libcloud plugin: allow to configure the storage provider [PR #1226]
 
 ### Fixed
 - dird: RunScript fixes [PR #1217]
@@ -203,6 +203,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1140]: https://github.com/bareos/bareos/pull/1140
 [PR #1147]: https://github.com/bareos/bareos/pull/1147
 [PR #1149]: https://github.com/bareos/bareos/pull/1149
+[PR #1151]: https://github.com/bareos/bareos/pull/1151
 [PR #1152]: https://github.com/bareos/bareos/pull/1152
 [PR #1153]: https://github.com/bareos/bareos/pull/1153
 [PR #1154]: https://github.com/bareos/bareos/pull/1154
@@ -221,6 +222,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1183]: https://github.com/bareos/bareos/pull/1183
 [PR #1185]: https://github.com/bareos/bareos/pull/1185
 [PR #1187]: https://github.com/bareos/bareos/pull/1187
+[PR #1188]: https://github.com/bareos/bareos/pull/1188
 [PR #1189]: https://github.com/bareos/bareos/pull/1189
 [PR #1192]: https://github.com/bareos/bareos/pull/1192
 [PR #1193]: https://github.com/bareos/bareos/pull/1193
@@ -232,4 +234,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1206]: https://github.com/bareos/bareos/pull/1206
 [PR #1209]: https://github.com/bareos/bareos/pull/1209
 [PR #1217]: https://github.com/bareos/bareos/pull/1217
+[PR #1218]: https://github.com/bareos/bareos/pull/1218
+[PR #1221]: https://github.com/bareos/bareos/pull/1221
+[PR #1226]: https://github.com/bareos/bareos/pull/1226
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,10 +39,11 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: Add support for Ubuntu 22.04, Fedora 36, EL 9, openSUSE 15.4 [PR #1179]
 - tests: skip mysql tests if root [PR #1197]
 - build: Add support for SLE_15_SP4 [PR #1205]
+- libcloud plugin: allow to configure the storage provider [PR #1174]
 
 ### Fixed
 - dird: RunScript fixes [PR #1217]
-  - fix show command output for RunScript RunsOnClient 
+  - fix show command output for RunScript RunsOnClient
   - fix show verbose for RunScripts
   - execute console runscripts only on the Director
 - python plugins: store architecture specific modules in sitearch (instead of sitelib) [PR #698]

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
@@ -34,6 +34,11 @@ options = {
 def get_driver(options):
     driver_opt = dict(options)
 
+    try:
+        provider_opt = driver_opt.get("provider")
+    except KeyError:
+        provider_opt = "S3"
+
     # remove unknown options
     for opt in (
         "buckets_exclude",
@@ -50,7 +55,7 @@ def get_driver(options):
 
     driver = None
 
-    provider = getattr(libcloud.storage.types.Provider, "S3")
+    provider = getattr(libcloud.storage.types.Provider, provider_opt)
     driver = libcloud.storage.providers.get_driver(provider)(**driver_opt)
 
     try:

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/get_libcloud_driver.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/ApacheLibcloudPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/ApacheLibcloudPlugin.rst.inc
@@ -125,7 +125,7 @@ tls
    Use Transport encryption, if supported by the backend
 
 provider
-   The provider string, currently only 'S3'
+   The provider string, 'S3' being the default if not specified
 
 username
    The username to use for backups


### PR DESCRIPTION
Is a port of PR #1174 to master

Right now S3 is hardcoded within the provider type
for the apache libcloud plugin. Any other value, in
the config_file parameter for "provider" will not
be respected.

With this change the option will be actually used.

(cherry picked from commit ae36762ef56ac24c8e0f9a42586029f1cb3554c4)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
