### PR TITLE
dird: fix odd even weeks parsing bug in schedule [Backport 1210]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - fix systemtests daemon control scripts [PR #762]
 - SQL: queries: fix sql queries to handle negative job duration value [PR #1201]
 - dird: fix TLS-PSK credential not found error with very long job names [PR #1208]
+- dird: fix odd-even weeks parsing bug in schedule [PR #1232]
 
 ### Added
 - plugin: added mariabackup python plugin, added systemtest for mariabackup and updated systemtest for percona-xtrabackup [PR #967]
@@ -588,4 +589,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1208]: https://github.com/bareos/bareos/pull/1208
 [PR #1212]: https://github.com/bareos/bareos/pull/1212
 [PR #1214]: https://github.com/bareos/bareos/pull/1214
+[PR #1220]: https://github.com/bareos/bareos/pull/1220
+[PR #1222]: https://github.com/bareos/bareos/pull/1222
+[PR #1232]: https://github.com/bareos/bareos/pull/1232
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -550,9 +550,9 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             have_woy = true;
           }
           // Set the bits according to the modulo specification.
-          for (i = 0; i < 54; i++) {
+          for (i = 0; i < 53; i++) {
             if (i % code2 == 0) {
-              SetBit(i + code - 1, res_run->date_time_bitfield.woy);
+              SetBit(i + code, res_run->date_time_bitfield.woy);
             }
           }
         } else {

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/EvenWeeks.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/EvenWeeks.conf
@@ -1,0 +1,4 @@
+Schedule {
+  Name = "Even Weeks"
+  Run = w00/w02 fri at 23:10
+}

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/OddWeeks.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/schedule/OddWeeks.conf
@@ -1,0 +1,4 @@
+Schedule {
+  Name = "Odd Weeks"
+  Run = w01/w02 sun at 23:10
+}


### PR DESCRIPTION
This PR is a Backport of PR #1210 to bareos-21.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
