### PR TITLE
docs: mssql: after PITR restore, a full backup is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - update Appendix/HardwareSizing DB size with new numbers and formulas [BUG #1477][PR #1231]
 - add description to fileset signature sha256 and sha512 parameter [PR #1230]
 - improve troubleshooting and debugging chapter [PR #1233]
+- mssql: after PITR restore, a full backup is required [PR #1235]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,6 +157,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - add description to fileset signature sha256 and sha512 parameter [PR #1230]
 - improve troubleshooting and debugging chapter [PR #1233]
 - mssql: after PITR restore, a full backup is required [PR #1235]
+- mssql add a warning in case of pitr to run another backup full or diff afterwards [PR #1235]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768
@@ -258,6 +259,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1227]: https://github.com/bareos/bareos/pull/1227
 [PR #1228]: https://github.com/bareos/bareos/pull/1228
 [PR #1229]: https://github.com/bareos/bareos/pull/1229
+[PR #1231]: https://github.com/bareos/bareos/pull/1231
+[PR #1235]: https://github.com/bareos/bareos/pull/1235
 [PR #1236]: https://github.com/bareos/bareos/pull/1236
 [PR #1237]: https://github.com/bareos/bareos/pull/1237
 [PR #1216]: https://github.com/bareos/bareos/pull/1216

--- a/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
@@ -3,8 +3,9 @@
 Backup Of Third Party Databases
 -------------------------------
 
-:index:`\ <single: Backup; of Third Party Databases>`
-:index:`\ <single: Database; Backup Of Third Party>`
+.. index::
+   single: Backup; of Third Party Databases
+   single: Database; Backup Of Third Party
 
 If you are running a database in production mode on your machine, Bareos will happily backup the files, but if the database is in use while Bareos is reading it, you may back it up in an unstable state.
 
@@ -53,6 +54,13 @@ If you like to use the MSSQL-Plugin to backing up your Databases you need to con
       | The user have to be a backupoperator and dbowner of the database which you like to backup.
 
 There is no difference for the rights and roles between using a systemaccount (trusted security method) or a extra backup user (standard security method). Please keep in mind if you use the trusted security method you have to use the same system account like the bareos-filedeamon runs on.
+
+-  PITR Point in time restore
+
+   .. warning::
+
+      Doing a PITR (Point In Time Restore) will break the backup chain. After the restore a Full job **must be** run afterwards to obtain a clean backup chain.
+
 
 .. _MssqlPluginInstallation:
 


### PR DESCRIPTION
This PR will improve the appendix/howto 3rd database MSSQL.
In case of PITR the backup chain is broken, so a new full or diff backup is needed afterwards.

OP#4943

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
