### PR TITLE
config: add `FS Type = vfat` in LinuxAll.conf for UEFI partition.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: Add support for SLE_15_SP4 [PR #1205]
 - libcloud plugin: allow to configure the storage provider [PR #1226]
 - core/platform: Adding Bareos firewalld service xml files [PR #1237]
+- dird: Added `FS Type = vfat` in LinuxAll.conf for UEFI partition [PR #1236]
 
 ### Fixed
 - dird: RunScript fixes [PR #1217]
@@ -246,10 +247,13 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1216]: https://github.com/bareos/bareos/pull/1216
 [PR #1217]: https://github.com/bareos/bareos/pull/1217
 [PR #1218]: https://github.com/bareos/bareos/pull/1218
+[PR #1219]: https://github.com/bareos/bareos/pull/1219
 [PR #1221]: https://github.com/bareos/bareos/pull/1221
 [PR #1225]: https://github.com/bareos/bareos/pull/1225
 [PR #1226]: https://github.com/bareos/bareos/pull/1226
 [PR #1227]: https://github.com/bareos/bareos/pull/1227
 [PR #1228]: https://github.com/bareos/bareos/pull/1228
 [PR #1229]: https://github.com/bareos/bareos/pull/1229
+[PR #1236]: https://github.com/bareos/bareos/pull/1236
+[PR #1237]: https://github.com/bareos/bareos/pull/1237
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/defaultconfigs/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/core/src/defaultconfigs/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/bareos-configparser-tests/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/catalog/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/catalog/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/console-director/tls_disabled/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/core/src/tests/configs/console-director/tls_disabled/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/console-director/tls_psk_default_enabled/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/core/src/tests/configs/console-director/tls_psk_default_enabled/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/run-on-incoming-connect-interval/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/run-on-incoming-connect-interval/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/scheduler-hourly/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/scheduler-hourly/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/scheduler-on-time-noday-noclient/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/scheduler-on-time-noday-noclient/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/scheduler-on-time-noday/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/scheduler-on-time-noday/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/core/src/tests/configs/scheduler-on-time/bareos-dir.d/fileset/LinuxAll.conf
+++ b/core/src/tests/configs/scheduler-on-time/bareos-dir.d/fileset/LinuxAll.conf
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }

--- a/docs/manuals/source/Configuration/Director.rst
+++ b/docs/manuals/source/Configuration/Director.rst
@@ -10,7 +10,10 @@ Of all the configuration files needed to run Bareos, the Director’s is the mos
 
 For a general discussion of configuration files and resources including the recognized data types see :ref:`ConfigureChapter`.
 
-:index:`\ <single: Types; Director Resource>`\  :index:`\ <single: Director; Resource Types>`\  :index:`\ <single: Resource Types>`\
+.. index::
+   single: Types; Director Resource
+   single: Director; Resource Types
+   single: Resource Types
 
 Everything revolves around a job and is tied to a job in one way or another.
 
@@ -1391,8 +1394,8 @@ The directives within an Options resource may be one of the following:
    This option allows you to select files and directories by the
    filesystem type.  Example filesystem-type names are:
 
-   ext2, jfs, ntfs, proc, reiserfs, xfs, usbdevfs, sysfs, smbfs,
-   iso9660.
+   btrfs, ext2, ext3, ext4, jfs, ntfs, proc, reiserfs, xfs, nfs, vfat,
+   usbdevfs, sysfs, smbfs, iso9660.
 
    You may have multiple Fstype directives, and thus permit matching
    of multiple filesystem types within a single Options resource.  If

--- a/systemtests/tests/bareos/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bareos/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -13,6 +13,7 @@ FileSet {
       fstype = xfs
       fstype = zfs
       fstype = btrfs
+      fstype = vfat
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/commandline-options/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/commandline-options/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -13,6 +13,7 @@ FileSet {
       fstype = xfs
       fstype = zfs
       fstype = btrfs
+      fstype = vfat
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -1391,6 +1391,7 @@ FileSet {
       FsType = "ext4"
       FsType = "reiserfs"
       FsType = "jfs"
+      FsType = "vfat"
       FsType = "xfs"
       FsType = "zfs"
     }

--- a/systemtests/tests/webui-common/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/bareos-dir.d/fileset/LinuxAll.conf.in
@@ -11,6 +11,7 @@ FileSet {
       FS Type = ext4
       FS Type = reiserfs
       FS Type = jfs
+      FS Type = vfat  # UEFI
       FS Type = xfs
       FS Type = zfs
     }


### PR DESCRIPTION
This PR add FS Type = vfat to LinuxAll.conf so complete linux with UEFI partition will be backup and can be restored.
Small improvements done into doc Director.rst

OP#5186

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
