### PR TITLE
build: adapt github action to build only on special branch names

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,22 +2,9 @@ name: Build Bareos Client on MacOS
 
 on:
   workflow_dispatch:
-    inputs:
-      jenkins_id:
-        description: 'Id on the Jenkins server'
-        type: string
-        required: true
-        default: 'jid'
-      bareos_version:
-        description: 'Bareos version to build'
-        type: string
-        required: true
-  # Push is only required initially,
-  # otherwise the workflow is unknown and not callable by the REST API.
   push:
-    paths:
-      - .github/workflows/build-macos.yml
-
+    branches:
+      - macbuild-of*
 env:
   target_dir: "${{ github.workspace }}/BUILD_RESULTS/MacOS"
 
@@ -27,12 +14,6 @@ jobs:
     runs-on: macos-12
 
     steps:
-    - name: Check input variables
-      run: |
-        if [ -z "${{ inputs.bareos_version }}" ]; then
-            echo "::error ::Missing parameter 'bareos_version'"
-            exit 1
-        fi
 
     - name: "Checkout source"
       uses: actions/checkout@v2
@@ -52,7 +33,7 @@ jobs:
         mkdir cmake-build
         cd cmake-build
         export CXXFLAGS="-I/usr/local/include"
-        cmake .. -Dclient-only=yes -DVERSION_STRING="${{ inputs.bareos_version }}"
+        cmake .. -Dclient-only=yes
         make package VERBOSE=1
         ls -la ./*.pkg
         mkdir -p "${{ env.target_dir }}"

--- a/systemtests/tests/webui-common/testrunner.in
+++ b/systemtests/tests/webui-common/testrunner.in
@@ -49,7 +49,7 @@ echo "test with ${BAREOS_WEBUI_PROFILE} profile:" >"$tmp/selenium.out" 2>&1
 #@PYTHON@ @CMAKE_SOURCE_DIR@/webui/tests/selenium/webui-selenium-test.py -v "SeleniumTest.test_${BAREOS_WEBUI_TESTNAME}" | tee "$tmp/selenium.out" 2>&1
 if ! @PYTHON@ @CMAKE_SOURCE_DIR@/webui/tests/selenium/webui-selenium-test.py -v "SeleniumTest.test_${BAREOS_WEBUI_TESTNAME}" >>"$tmp/selenium.out" 2>&1; then
 
-    set_error "$(cat "$tmp/selenium.out")"
+    set_error "$(cat "$tmp/selenium.out" "$tmp/php.out")"
 
 fi
 


### PR DESCRIPTION
This Branch enables the integration of building the mac packages via github actions controlled by our CD environment.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [ ] Commit descriptions are understandable and well formatted
- [ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems
- [ ] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
