### PR TITLE
testfind: remove unnecessary libraries and fix systemtest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - systemtest: fixed issues with systemtests not succeeding on first try [PR #1186]
 - btape: dumplabel only when label is valid [PR #1266]
 - dird: fix crash in .jobstatus [PR #1278]
+- testfind: remove unnecessary libraries and fix systemtest [#1250]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -47,6 +47,7 @@ set(DIRD_OBJECTS_SRCS
     getmsg.cc
     inc_conf.cc
     job.cc
+    jcr_util.cc
     jobq.cc
     job_trigger.cc
     migrate.cc
@@ -137,9 +138,7 @@ if(HAVE_WIN32)
   list(APPEND DBCHKSRCS ../win32/dird/dbcheckres.rc)
 endif()
 
-set(TSTFNDSRCS testfind.cc dird_conf.cc dird_globals.cc ua_acl.cc ua_audit.cc
-               run_conf.cc inc_conf.cc
-)
+set(TSTFNDSRCS testfind.cc)
 
 set(DIRD_RESTYPES
     catalog
@@ -201,19 +200,7 @@ target_link_libraries(
 # is not built by default
 if(NOT client-only)
   add_executable(testfind ${TSTFNDSRCS})
-  target_link_libraries(
-    testfind
-    dird_objects
-    fd_objects
-    bareos
-    bareosfind
-    bareossql
-    jansson
-    ${OPENSSL_LIBRARIES}
-    ${ACL_LIBRARIES}
-    ${CAP_LIBRARIES}
-    ${LZO_LIBRARIES}
-  )
+  target_link_libraries(testfind dird_objects bareosfind)
 endif()
 install(TARGETS bareos-dir bareos-dbcheck testfind DESTINATION "${sbindir}")
 

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -128,7 +128,9 @@ set(DBCHKSRCS dbcheck.cc dbcheck_utils.cc dird_conf.cc dird_globals.cc
 )
 
 if(compiler_will_warn_of_unused_but_set_variable)
-  set_source_files_properties(catreq.cc PROPERTIES COMPILE_FLAGS -Wno-unused-but-set-variable)
+  set_source_files_properties(
+    catreq.cc PROPERTIES COMPILE_FLAGS -Wno-unused-but-set-variable
+  )
 endif()
 
 if(HAVE_WIN32)

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -1,0 +1,41 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "dird/dird_globals.h"
+#include "dird/jcr_private.h"
+#include "lib/parse_bsr.h"
+#include "lib/parse_conf.h"
+
+
+namespace directordaemon {
+
+JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr)
+{
+  JobControlRecord* jcr = new_jcr(DirdFreeJcr);
+  jcr->impl
+      = new JobControlRecordPrivate(my_config->config_resources_container_);
+  Dmsg1(10, "NewDirectorJcr: configuration_resources_ is at %p %s\n",
+        my_config->config_resources_container_->configuration_resources_,
+        my_config->config_resources_container_->TimeStampAsString().c_str());
+  return jcr;
+}
+
+} /* namespace directordaemon */

--- a/core/src/dird/jcr_util.h
+++ b/core/src/dird/jcr_util.h
@@ -1,0 +1,32 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_DIRD_JCR_UTIL_H_
+#define BAREOS_DIRD_JCR_UTIL_H_
+
+#include "dird/jcr_private.h"
+
+namespace directordaemon {
+
+JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr);
+
+} /* namespace directordaemon */
+#endif  // BAREOS_DIRD_JCR_UTIL_H_

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1624,17 +1624,6 @@ void GetJobStorage(UnifiedStorageResource* store,
   }
 }
 
-JobControlRecord* NewDirectorJcr()
-{
-  JobControlRecord* jcr = new_jcr(DirdFreeJcr);
-  jcr->impl
-      = new JobControlRecordPrivate(my_config->config_resources_container_);
-  Dmsg1(10, "NewDirectorJcr(): configuration_resources_ is at %p %s\n",
-        my_config->config_resources_container_->configuration_resources_,
-        my_config->config_resources_container_->TimeStampAsString().c_str());
-  return jcr;
-}
-
 /**
  * Set some defaults in the JobControlRecord necessary to
  * run. These items are pulled from the job

--- a/core/src/dird/job.h
+++ b/core/src/dird/job.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,7 +32,6 @@ class UnifiedStorageResource;
 class RunResource;
 
 bool AllowDuplicateJob(JobControlRecord* jcr);
-JobControlRecord* NewDirectorJcr();
 void SetJcrDefaults(JobControlRecord* jcr, JobResource* job);
 void CreateUniqueJobName(JobControlRecord* jcr, const char* base_name);
 void UpdateJobEndRecord(JobControlRecord* jcr);

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -39,6 +39,7 @@
 #include "dird/storage.h"
 #include "lib/berrno.h"
 #include "lib/thread_specific_data.h"
+#include "dird/jcr_util.h"
 
 namespace directordaemon {
 
@@ -653,7 +654,7 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
        * appropriate fields.
        */
       jcr->setJobStatus(JS_WaitStartTime);
-      njcr = NewDirectorJcr();
+      njcr = NewDirectorJcr(DirdFreeJcr);
       SetJcrDefaults(njcr, jcr->impl->res.job);
       njcr->impl->reschedule_count = jcr->impl->reschedule_count;
       njcr->sched_time = jcr->sched_time;

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -57,6 +57,7 @@
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"
+#include "dird/jcr_util.h"
 
 #include "cats/sql.h"
 
@@ -1109,7 +1110,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
     if (!jcr->impl->spool_data) { jcr->impl->spool_data = job->spool_data; }
 
     // Create a migration jcr
-    mig_jcr = NewDirectorJcr();
+    mig_jcr = NewDirectorJcr(DirdFreeJcr);
     jcr->impl->mig_jcr = mig_jcr;
     memcpy(&mig_jcr->impl->previous_jr, &jcr->impl->previous_jr,
            sizeof(mig_jcr->impl->previous_jr));

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -30,7 +30,7 @@
 #include "dird/jcr_private.h"
 #include "dird/run_on_incoming_connect_interval.h"
 #include "dird/scheduler.h"
-
+#include "dird/jcr_util.h"
 #include <utility>
 
 namespace directordaemon {
@@ -54,7 +54,7 @@ RunOnIncomingConnectInterval::RunOnIncomingConnectInterval(
 
 time_t RunOnIncomingConnectInterval::FindLastJobStart(JobResource* job)
 {
-  JobControlRecord* jcr = NewDirectorJcr();
+  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr);
   SetJcrDefaults(jcr, job);
   auto db = db_ != nullptr ? db_ : GetDatabaseConnection(jcr);
   if (db == nullptr) {

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -35,6 +35,7 @@
 #include "dird/scheduler_time_adapter.h"
 #include "dird/storage.h"
 #include "lib/parse_conf.h"
+#include "dird/jcr_util.h"
 
 #include <chrono>
 #include <utility>
@@ -126,7 +127,7 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
 JobControlRecord* SchedulerPrivate::TryCreateJobControlRecord(
     const SchedulerJobItem& next_job)
 {
-  JobControlRecord* jcr = NewDirectorJcr();
+  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr);
   SetJcrDefaults(jcr, next_job.job);
   if (next_job.run != nullptr) {
     next_job.run->scheduled_last = time_adapter->time_source_->SystemTime();

--- a/core/src/dird/testfind.cc
+++ b/core/src/dird/testfind.cc
@@ -26,13 +26,13 @@
  */
 
 #include "include/bareos.h"
-#include "dird/dird.h"
+#include "dird/dird_conf.h"
 #include "findlib/find.h"
 #include "lib/mntent_cache.h"
 #include "include/ch.h"
 #include "filed/fd_plugins.h"
 #include "lib/parse_conf.h"
-#include "dird/job.h"
+#include "dird/jcr_util.h"
 #include "dird/dird_globals.h"
 #include "dird/dird_conf.h"
 #include "dird/jcr_private.h"
@@ -40,12 +40,27 @@
 #include "findlib/attribs.h"
 #include "filed/fileset.h"
 #include "lib/util.h"
+#include "lib/tree.h"
 
 #if defined(HAVE_WIN32)
 #  define isatty(fd) (fd == 0)
 #endif
 
+
 using namespace directordaemon;
+
+void TestfindFreeJcr(JobControlRecord* jcr)
+{
+  Dmsg0(200, "Start testfind FreeJcr\n");
+
+  if (jcr->impl) {
+    delete jcr->impl;
+    jcr->impl = nullptr;
+  }
+
+  Dmsg0(200, "End testfind FreeJcr\n");
+}
+
 
 /* Dummy functions */
 void GeneratePluginEvent(JobControlRecord* jcr,
@@ -150,7 +165,7 @@ int main(int argc, char* const* argv)
     InitMsg(NULL, msg);
   }
 
-  jcr = NewDirectorJcr();  // Ueb: null
+  jcr = NewDirectorJcr(TestfindFreeJcr);
   jcr->impl->res.fileset
       = (FilesetResource*)my_config->GetResWithName(R_FILESET, fileset_name);
 

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2014-2016 Planets Communications B.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -358,19 +358,6 @@ StorageResource* UaContext::GetStoreResWithName(const char* name,
                                                 bool lock)
 {
   return (StorageResource*)GetResWithName(R_STORAGE, name, audit_event, lock);
-}
-
-StorageResource* UaContext::GetStoreResWithId(DBId_t id,
-                                              bool audit_event,
-                                              bool lock)
-{
-  StorageDbRecord storage_dbr;
-
-  storage_dbr.StorageId = id;
-  if (db->GetStorageRecord(jcr, &storage_dbr)) {
-    return GetStoreResWithName(storage_dbr.Name, audit_event, lock);
-  }
-  return NULL;
 }
 
 ClientResource* UaContext::GetClientResWithName(const char* name,

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1995,6 +1995,19 @@ static bool time_cmd(UaContext* ua, const char* cmd)
   return true;
 }
 
+StorageResource* UaContext::GetStoreResWithId(DBId_t id,
+                                              bool audit_event,
+                                              bool lock)
+{
+  StorageDbRecord storage_dbr;
+
+  storage_dbr.StorageId = id;
+  if (db->GetStorageRecord(jcr, &storage_dbr)) {
+    return GetStoreResWithName(storage_dbr.Name, audit_event, lock);
+  }
+  return NULL;
+}
+
 
 /**
  * truncate command. Truncates volumes (volume files) on the storage daemon.

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -43,6 +43,7 @@
 #include "dird/show_cmd_available_resources.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
+#include "dird/jcr_util.h"
 
 namespace directordaemon {
 
@@ -1279,7 +1280,7 @@ static bool ListNextvol(UaContext* ua, int ndays)
     }
   }
 
-  jcr = NewDirectorJcr();
+  jcr = NewDirectorJcr(DirdFreeJcr);
   for (run = NULL; (run = find_next_run(run, job, runtime, ndays));) {
     if (!CompleteJcrForJob(jcr, job, run->pool)) {
       found = false;

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -39,6 +39,7 @@
 #include "lib/edit.h"
 #include "lib/keyword_table_s.h"
 #include "lib/util.h"
+#include "dird/jcr_util.h"
 
 namespace directordaemon {
 
@@ -387,7 +388,7 @@ int DoRunCmd(UaContext* ua, const char* cmd)
    * before returning.
    */
   if (!jcr) {
-    jcr = NewDirectorJcr();
+    jcr = NewDirectorJcr(DirdFreeJcr);
     SetJcrDefaults(jcr, rc.job);
     jcr->impl->unlink_bsr
         = ua->jcr->impl->unlink_bsr; /* copy unlink flag from caller */

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -42,6 +42,7 @@
 #include "lib/bnet.h"
 #include "lib/parse_conf.h"
 #include "lib/thread_specific_data.h"
+#include "dird/jcr_util.h"
 
 
 namespace directordaemon {
@@ -53,7 +54,7 @@ namespace directordaemon {
 JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 {
   JobControlRecord* jcr;
-  jcr = NewDirectorJcr();
+  jcr = NewDirectorJcr(DirdFreeJcr);
 
   // exclude JT_SYSTEM job from shared config counting
   if (job_type == JT_SYSTEM) {

--- a/core/src/findlib/find.h
+++ b/core/src/findlib/find.h
@@ -125,7 +125,7 @@ struct findFOPTS {
                              integer */
   int Compress_level{};     /**< Compression level */
   int StripPath{};          /**< Strip path count */
-  struct s_sz_matching* size_match; /**< Perform size matching ? */
+  struct s_sz_matching* size_match{}; /**< Perform size matching ? */
   b_fileset_shadow_type shadow_type{
       check_shadow_none};        /**< Perform fileset shadowing check ? */
   char VerifyOpts[MAX_OPTS]{};   /**< Verify options */

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -33,6 +33,7 @@
 #include "include/bareos.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"
+#include "dird/jcr_util.h"
 
 #include <string>
 #include <vector>
@@ -97,7 +98,7 @@ void CatalogTest::SetUp()
 
   // connect to database
   {
-    jcr = directordaemon::NewDirectorJcr();
+    jcr = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
     jcr->impl->res.catalog
         = (directordaemon::CatalogResource*)my_config->GetResWithName(
             directordaemon::R_CATALOG, catalog_backend_name.c_str());

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -24,6 +24,7 @@
 #include "dird/ua.h"
 #include "dird/fd_cmds.cc"
 #include "dird/job.cc"
+#include "dird/jcr_util.h"
 
 TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
 {
@@ -35,7 +36,8 @@ TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
 
 
-  JobControlRecord* jcr = directordaemon::NewDirectorJcr();
+  JobControlRecord* jcr
+      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
 
   jcr->impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,

--- a/core/src/tests/pruning.cc
+++ b/core/src/tests/pruning.cc
@@ -22,6 +22,7 @@
 #include "testing_dir_common.h"
 
 #include "include/jcr.h"
+#include "dird/jcr_util.h"
 #include "dird/job.h"
 #include "dird/ua_prune.h"
 #include "dird/ua_purge.h"
@@ -34,11 +35,14 @@ TEST(Pruning, ExcludeRunningJobsFromList)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   if (!director_config) { return; }
 
-  JobControlRecord* jcr1 = directordaemon::NewDirectorJcr();
+  JobControlRecord* jcr1
+      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
   jcr1->JobId = 1;
-  JobControlRecord* jcr2 = directordaemon::NewDirectorJcr();
+  JobControlRecord* jcr2
+      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
   jcr2->JobId = 2;
-  JobControlRecord* jcr3 = directordaemon::NewDirectorJcr();
+  JobControlRecord* jcr3
+      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
   jcr3->JobId = 3;
 
   std::vector<JobId_t> pruninglist{0, 0, 1, 2, 3, 4, 5};
@@ -58,7 +62,8 @@ TEST(Pruning, TransformJobidsTobedeleted)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   if (!director_config) { return; }
 
-  JobControlRecord* jcr1 = directordaemon::NewDirectorJcr();
+  JobControlRecord* jcr1
+      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
   jcr1->JobId = 1;
 
   directordaemon::UaContext* ua = directordaemon::new_ua_context(jcr1);

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -37,6 +37,7 @@
 #include "lib/parse_conf.h"
 #include "dird/dird_globals.h"
 #include "dird/dird_conf.h"
+#include "dird/jcr_util.h"
 
 
 #include <array>
@@ -67,7 +68,7 @@ TEST(setdevice, scan_command_line)
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
 
   std::unique_ptr<JobControlRecord, decltype(&Test_FreeJcr)> jcr(
-      NewDirectorJcr(), &Test_FreeJcr);
+      NewDirectorJcr(directordaemon::DirdFreeJcr), &Test_FreeJcr);
 
   std::unique_ptr<UaContext, decltype(&FreeUaContext)> ua(
       new_ua_context(jcr.get()), &FreeUaContext);

--- a/systemtests/tests/testfind/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/testfind/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -14,7 +14,7 @@ FileSet {
       fstype = zfs
       fstype = btrfs
     }
-   File = "@sbindir@"
+   File = "@tmpdir@/data"
    #File=<@tmpdir@/file-list
   }
 }

--- a/systemtests/tests/testfind/testrunner
+++ b/systemtests/tests/testfind/testrunner
@@ -9,23 +9,34 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
+bstat=0
+dstat=0
+estat=0
+rstat=0
+zstat=0
 
 #shellcheck source=../environment.in
 . ./environment
 
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+setup_data
 
 testfind_log=$tmp/testfind.out
 
 rm -f $testfind_log
+./sbin/testfind-testfind -c etc/bareos | tee  "$testfind_log"
 
-./sbin/testfind-testfind -c etc/bareos > $testfind_log
-
-expect_grep "Total files    : 1" \
+expect_grep "Total files    : 68" \
             "$testfind_log" \
             "Number of files is incorrect."
 
-expect_grep "Max file length: 4" \
+expect_grep "Max file length: 148" \
             "$testfind_log" \
             "Max file length is incorrect."
+
+expect_grep "Hard links     : 2" \
+            "$testfind_log" \
+            "Number of hard links is incorrect."
+
+end_test


### PR DESCRIPTION
### Description

This pr is meant to remove unnecessary libraries linked to testfind `bareossql` and fix previous issues found with the testfind systemtest

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- [x] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
