### PR TITLE
webui: fix password string length limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - devtools/dist-tarball.sh: fix name if version contains "~pre" [PR #1221]
 - dird: fix odd-even weeks parsing bug in schedule [PR #1210]
 - bcopy: fix crash in bcopy when using certain cli arguments [PR #1211]
+- webui: fix password string length limitation [BUG #1480][PR #1251]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]
@@ -282,4 +283,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1237]: https://github.com/bareos/bareos/pull/1237
 [PR #1238]: https://github.com/bareos/bareos/pull/1238
 [PR #1242]: https://github.com/bareos/bareos/pull/1242
+[PR #1251]: https://github.com/bareos/bareos/pull/1251
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/webui/module/Auth/src/Auth/Model/Auth.php
+++ b/webui/module/Auth/src/Auth/Model/Auth.php
@@ -72,7 +72,7 @@ class Auth implements InputFilterAwareInterface
                   'options' => array(
                      'encoding' => 'UTF-8',
                      'min' => 1,
-                     'max' => 64,
+                     'max' => 128,
                   ),
                ),
             ),
@@ -88,7 +88,6 @@ class Auth implements InputFilterAwareInterface
          'options' => array(
              'encoding' => 'UTF-8',
              'min' => 1,
-             'max' => 64,
          ),
           ),
       ),


### PR DESCRIPTION
This PR removes the max string length value from the form data input filter validator for the password input field to allow passwords longer than 64 characters.

Fixes #1480: password string length limitation

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing

##### Tests

- [X] Decision taken that a test is not required (we wont extend the existing)