### PR TITLE
build: switch from FreeBSD 13.0 to 13.1

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -216,7 +216,7 @@ OS:
       PROJECTPACKAGES:
         amd64:
            - bareos-freebsd
-    "13.0":
+    "13.1":
       TYPE: freebsd
       ARCH:
         - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: Added `FS Type = vfat` in LinuxAll.conf for UEFI partition [PR #1236]
 - bareos tools: reintegrate testfind binary [PR #1176]
 - fd: add support for role switching on PostgreSQL add-on [BUG #4607] [PR #1178]
+- build: switch from FreeBSD 13.0 to 13.1 [PR #1253]
 
 ### Fixed
 - dird: RunScript fixes [PR #1217]

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -339,6 +339,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   include_directories(/usr/local/include)
   link_directories(/usr/local/lib)
   link_libraries(intl)
+  check_cxx_compiler_flag(-Wunused-but-set-variable compiler_will_warn_of_unused_but_set_variable)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -126,6 +126,11 @@ endif()
 set(DBCHKSRCS dbcheck.cc dbcheck_utils.cc dird_conf.cc dird_globals.cc
               ua_acl.cc ua_audit.cc run_conf.cc inc_conf.cc
 )
+
+if(compiler_will_warn_of_unused_but_set_variable)
+  set_source_files_properties(catreq.cc PROPERTIES COMPILE_FLAGS -Wno-unused-but-set-variable)
+endif()
+
 if(HAVE_WIN32)
   list(APPEND DBCHKSRCS ../win32/dird/dbcheckres.rc)
 endif()

--- a/core/src/ndmp/CMakeLists.txt
+++ b/core/src/ndmp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -32,6 +32,10 @@ if(${HAVE_LINUX_OS})
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_LINUX_OS")
 elseif(${HAVE_SUN_OS})
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DHAVE_SUN_OS")
+endif()
+
+if(compiler_will_warn_of_unused_but_set_variable)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-but-set-variable")
 endif()
 
 set(RPC_GEN_FILES


### PR DESCRIPTION
This PR switches to build for FreeBSD 13.1 and fixes build problems arising from new warnings issued by the new compiler.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Separate commit for this PR in the CHANGELOG.md, PR number referenced is same
- [x] Commit descriptions are understandable and well formatted
- ~~[ ] If backport: add original PR number and target branch at top of this file: **Backport of PR#000 to bareos-2x**~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
- [x] `git status` should not report modifications in the source tree after building and testing
