### PR TITLE
core: BareosDb::FindLastJobStartTimeForJobAndClient:  take into account Running job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - testfind: remove unnecessary libraries and fix systemtest [PR #1250]
 - stored: systemtests: docs: checkpoints improvements [PR #1277]
 - winbareos.nsi: fix working directory in configure.sed [PR #1288]
+- core: BareosDb::FindLastJobStartTimeForJobAndClient: take into account Running job [PR #1265] [BUG #1466]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]
@@ -328,6 +329,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1255]: https://github.com/bareos/bareos/pull/1255
 [PR #1260]: https://github.com/bareos/bareos/pull/1260
 [PR #1262]: https://github.com/bareos/bareos/pull/1262
+[PR #1265]: https://github.com/bareos/bareos/pull/1265
 [PR #1266]: https://github.com/bareos/bareos/pull/1266
 [PR #1267]: https://github.com/bareos/bareos/pull/1267
 [PR #1268]: https://github.com/bareos/bareos/pull/1268

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -142,17 +142,17 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
 }
 
 /**
- * Find the last job start time for specified job and client
- * used in RunOnIncomingConnectInterval.
+ * Find the last job start time for specified job and client.
+ * Used in RunOnIncomingConnectInterval.
  *
- * The tricky part is that we can have an actual job in state C not yet started
- * this will return a starttime NULL due to following PostgreSQL rules.
+ * The tricky part is that we can have a job in state 'C' not yet started
+ * having a starttime of NULL.
  *
- * By default, null values sort as if larger than any non-null value; that is,
- * NULLS FIRST is the default for DESC order, and NULLS LAST otherwise.
+ * As NULL values are regarded as greater than any non-null value on sorting,
+ * the job with the NULL value starttime would be returned by the query below.
  *
- * To avoid this we use now()::timestamp. Casting is mandatory otherwise
- * value has a DST.
+ * To avoid this, we use NOW()::timestamp so that a valid timestamp is returned
+ * for jobs with NULL timestamp. Casting is required to remove the DST.
  */
 BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
     JobControlRecord* jcr,


### PR DESCRIPTION
- Adding Running jobs to the query will avoid the start of a second backup job for the same client while starttime is overdue.
- The build binaries have been tested by community members, and the problem hasn't been since then.

Fix [BUG #1466] 
[OP #5251]

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

