### PR TITLE
doc: fix bsmtp get-usage.sh call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - describe usage of the add_bareos_repositories.sh script [PR #1248]
 - Appendix/Bareos Programs improvements [PR #1255]
 - obsolete comments removed [PR #1268]
+- fix bsmtp get-usage.sh call [PR #1267]
 
 [PR #698]: https://github.com/bareos/bareos/pull/698
 [PR #768]: https://github.com/bareos/bareos/pull/768
@@ -299,13 +300,12 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1242]: https://github.com/bareos/bareos/pull/1242
 [PR #1243]: https://github.com/bareos/bareos/pull/1243
 [PR #1247]: https://github.com/bareos/bareos/pull/1247
-[PR #1251]: https://github.com/bareos/bareos/pull/1251
-[PR #1253]: https://github.com/bareos/bareos/pull/1253
-[PR #1254]: https://github.com/bareos/bareos/pull/1254
-[PR #1260]: https://github.com/bareos/bareos/pull/1260
 [PR #1248]: https://github.com/bareos/bareos/pull/1248
 [PR #1251]: https://github.com/bareos/bareos/pull/1251
 [PR #1253]: https://github.com/bareos/bareos/pull/1253
 [PR #1254]: https://github.com/bareos/bareos/pull/1254
+[PR #1255]: https://github.com/bareos/bareos/pull/1255
+[PR #1260]: https://github.com/bareos/bareos/pull/1260
 [PR #1266]: https://github.com/bareos/bareos/pull/1266
+[PR #1267]: https://github.com/bareos/bareos/pull/1267
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/CMakeLists.txt
+++ b/docs/manuals/CMakeLists.txt
@@ -200,11 +200,12 @@ if(${docs-build-json})
     DEPENDS bscan
   )
 
+  # bsmtp -? return 1 so ||: is needed
   add_custom_command(
     OUTPUT ${USAGE_DIR}/bsmtp.txt
-    COMMAND bsmtp --help >/dev/null
+    COMMAND bsmtp -? > /dev/null 2>&1 ||:
     COMMAND ${PROJECT_SOURCE_DIR}/scripts/get-usage.sh $<TARGET_FILE:bsmtp>
-            ${USAGE_DIR}
+            ${USAGE_DIR} '-? ||:' ||:
     DEPENDS bsmtp
   )
 
@@ -282,10 +283,10 @@ endif()
 
 add_custom_target(
   docs-check-urls
-  COMMAND ${SPHINX_COMMAND} -M linkcheck "${SPHINX_SOURCE_DIR}" "${SPHINX_BUILDDIR}"
+  COMMAND ${SPHINX_COMMAND} -M linkcheck "${SPHINX_SOURCE_DIR}"
+          "${SPHINX_BUILDDIR}"
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-  COMMENT
-    "Check if the URLs used in the documentation are still valid targets."
+  COMMENT "Check if the URLs used in the documentation are still valid targets."
 )
 
 # target: docs ######

--- a/docs/manuals/scripts/get-usage.sh
+++ b/docs/manuals/scripts/get-usage.sh
@@ -23,9 +23,10 @@ set -u
 
 FULLPATH="$1"
 TARGETDIR="$2"
+FLAG="${3:---help}"
 
 COMMAND=$(basename "${FULLPATH}")
 
-USAGE=$("${FULLPATH}" --help)
+USAGE=$("${FULLPATH}" "$FLAG")
 
 sed --expression='/Usage:/,$!d' --expression='s|Usage: .*/|Usage: |' <<<"${USAGE}" > "${TARGETDIR}/${COMMAND}.txt"

--- a/docs/manuals/source/include/autogenerated/usage/bsmtp.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bsmtp.txt
@@ -1,3 +1,4 @@
+
 Usage: bsmtp [-f from] [-h mailhost] [-s subject] [-c copy] [recipient ...]
        -4          forces bsmtp to use IPv4 addresses only.
        -6          forces bsmtp to use IPv6 addresses only.


### PR DESCRIPTION
This PR fix the defect introduced by PR #1255 about the get-usage.sh call for bsmtp.
(bsmtp doesn't include CLI11 call like --help)


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

