### PR TITLE
build: enable compiling on ARM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: fix config reload and unit tests dependency issue [PR #1161]
 - pruning: `prune jobs` doesn't ask for jobtypes anymore, and prunes all jobtypes except Archives (`A`) [PR #1215]
 - dird: cats: remove copy and migration jobs with no data from catalog [PR #1262]
+- build: enable compiling on ARM [PR #1270]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/src/droplet/libdroplet/src/backend/posix/backend.c
+++ b/core/src/droplet/libdroplet/src/backend/posix/backend.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+ * Copyright (C) 2020-2022 Bareos GmbH & Co. KG
  * Copyright (C) 2010 SCALITY SA. All rights reserved.
  * http://www.scality.com
  *
@@ -144,7 +144,7 @@ dpl_status_t dpl_posix_head_raw(dpl_ctx_t* ctx,
     goto end;
   }
 
-  snprintf(buf, sizeof(buf), "%ld", st.st_nlink);
+  snprintf(buf, sizeof(buf), "%lu", (unsigned long)(st.st_nlink));
   ret2 = dpl_dict_add(metadata, "nlink", buf, 0);
   if (DPL_SUCCESS != ret2) {
     ret = ret2;
@@ -179,7 +179,7 @@ dpl_status_t dpl_posix_head_raw(dpl_ctx_t* ctx,
     goto end;
   }
 
-  snprintf(buf, sizeof(buf), "%lu", st.st_blksize);
+  snprintf(buf, sizeof(buf), "%ld", (long int)(st.st_blksize));
   ret2 = dpl_dict_add(metadata, "blksize", buf, 0);
   if (DPL_SUCCESS != ret2) {
     ret = ret2;

--- a/systemtests/tests/reload/reload_test_functions
+++ b/systemtests/tests/reload/reload_test_functions
@@ -18,16 +18,7 @@ stop_director() {
 
 start_director() {
   "${rscripts}/bareos-ctl-dir" start "$director_debug_level"
-  case $(uname -s) in
-    SunOS)
-      director_pid=$(pgrep -f ${BAREOS_DIRECTOR_BINARY}) ;;
-    FreeBSD)
-      director_pid=$(pidof ${BAREOS_DIRECTOR_BINARY});;
-    *)
-      director_pid=$(pidof $(basename ${BAREOS_DIRECTOR_BINARY}));;
-  esac
-
-  if [ -z "$director_pid" ]; then
+  if ! "${rscripts}/bareos-ctl-dir" status; then
     exit_with_error "Bareos director could not be started"
   fi
 }


### PR DESCRIPTION
While trying to compile and test (ctest) Bareos on ARM (using qemu), I had to do 2 small changes to make it work.


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

