### PR TITLE
dird: fix crash in .jobstatus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: fix password string length limitation [Issue #1480][PR #1251]
 - systemtest: fixed issues with systemtests not succeeding on first try [PR #1186]
 - btape: dumplabel only when label is valid [PR #1266]
+- dird: fix crash in .jobstatus [PR #1278]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]
@@ -312,6 +313,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1244]: https://github.com/bareos/bareos/pull/1244
 [PR #1247]: https://github.com/bareos/bareos/pull/1247
 [PR #1248]: https://github.com/bareos/bareos/pull/1248
+[PR #1249]: https://github.com/bareos/bareos/pull/1249
 [PR #1251]: https://github.com/bareos/bareos/pull/1251
 [PR #1253]: https://github.com/bareos/bareos/pull/1253
 [PR #1254]: https://github.com/bareos/bareos/pull/1254
@@ -320,4 +322,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1266]: https://github.com/bareos/bareos/pull/1266
 [PR #1267]: https://github.com/bareos/bareos/pull/1267
 [PR #1268]: https://github.com/bareos/bareos/pull/1268
+[PR #1275]: https://github.com/bareos/bareos/pull/1275
+[PR #1278]: https://github.com/bareos/bareos/pull/1278
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -937,10 +937,10 @@ bool DotJobstatusCmd(UaContext* ua, const char* cmd)
     }
   }
 
+  if (!OpenClientDb(ua)) { return false; }
+
   ua->db->FillQuery(select, BareosDb::SQL_QUERY::get_jobstatus_details,
                     where.c_str());
-
-  if (!OpenClientDb(ua)) { return false; }
 
   ua->send->ArrayStart("jobstatus");
   retval = ua->db->ListSqlQuery(ua->jcr, select.c_str(), ua->send, HORZ_LIST,

--- a/systemtests/tests/bconsole/testrunner-dotjobstatus
+++ b/systemtests/tests/bconsole/testrunner-dotjobstatus
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+#
+# Run a simple backup
+#   then restore it.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+JobName=bconsole-dotstatus
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+rm -f "$tmp/log2.out"
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log1.out
+.jobstatus
+
+@$out $tmp/log2.out
+messages
+quit
+END_OF_DATA
+
+# Start the bareos daemons
+# and run the bconsole commands from ${tmp}/bconcmds
+# Further bconsole commands can be executed by "run_bconsole".
+run_bconsole
+
+# if log2.out has not been written, bconsole crashed or disconnected
+# after .jobstatus command
+test -f "$tmp/log2.out" || exit 2
+
+end_test


### PR DESCRIPTION
The .jobstatus command could crash the director. This PR fixes that crash and adds a test for it.

### Thank you for contributing to the Bareos Project!


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
