### PR TITLE
lib: make foreach_res() reload-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: enable compiling on ARM [PR #1270]
 - core and webui: adapt binary info messages to new wording [PR #1298]
 - build: enable -Wextra warning level and apply required changes [PR #1261]
+- lib: make foreach_res() reload-safe [PR #1279]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -210,7 +210,7 @@ class ProfileResource : public BareosResource {
 struct UserAcl {
   BareosResource* corresponding_resource = nullptr;
   alist<const char*>* ACL_lists[Num_ACL] = {0}; /**< Pointers to ACLs */
-  alist<const char*>* profiles = nullptr; /**< Pointers to profile resources */
+  alist<ProfileResource*>* profiles = nullptr; /**< Pointers to profile resources */
 };
 
 // Console Resource
@@ -340,7 +340,7 @@ class StorageResource
   char* media_type = nullptr; /**< Media Type provided by this Storage */
   char* ndmp_changer_device = nullptr; /**< If DIR controls storage directly
                                 (NDMP_NATIVE) changer device used */
-  alist<const char*>* device
+  alist<DeviceResource*>* device
       = nullptr;                     /**< Alternate devices for this Storage */
   int32_t MaxConcurrentJobs = 0;     /**< Maximum concurrent jobs */
   int32_t MaxConcurrentReadJobs = 0; /**< Maximum concurrent jobs reading */
@@ -475,7 +475,7 @@ class JobResource : public BareosResource {
   alist<const char*>* FdPluginOptions = nullptr; /**< Generic FD plugin options used by this Job */
   alist<const char*>* SdPluginOptions = nullptr; /**< Generic SD plugin options used by this Job */
   alist<const char*>* DirPluginOptions = nullptr;           /**< Generic DIR plugin options used by this Job */
-  alist<const char*>* base = nullptr; /**< Base jobs */
+  alist<JobResource*>* base = nullptr; /**< Base jobs */
 
   bool allow_mixed_priority = false; /**< Allow jobs with higher priority concurrently with this */
   bool where_use_regexp = false;  /**< true if RestoreWhere is a BareosRegex */

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -210,7 +210,8 @@ class ProfileResource : public BareosResource {
 struct UserAcl {
   BareosResource* corresponding_resource = nullptr;
   alist<const char*>* ACL_lists[Num_ACL] = {0}; /**< Pointers to ACLs */
-  alist<ProfileResource*>* profiles = nullptr; /**< Pointers to profile resources */
+  alist<ProfileResource*>* profiles
+      = nullptr; /**< Pointers to profile resources */
 };
 
 // Console Resource

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1755,7 +1755,7 @@ void CreateClones(JobControlRecord* jcr)
   Dmsg2(900, "cloned=%d run_cmds=%p\n", jcr->impl->cloned,
         jcr->impl->res.job->run_cmds);
   if (!jcr->impl->cloned && jcr->impl->res.job->run_cmds) {
-    char* runcmd = nullptr;
+    const char* runcmd = nullptr;
     JobId_t jobid;
     JobResource* job = jcr->impl->res.job;
     POOLMEM* cmd = GetPoolMemory(PM_FNAME);

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -273,7 +273,7 @@ static bool ValidateCommand(JobControlRecord* jcr,
                             const char* cmd,
                             alist<const char*>* allowed_job_cmds)
 {
-  char* allowed_job_cmd = nullptr;
+  const char* allowed_job_cmd = nullptr;
   bool allowed = false;
 
   // If there is no explicit list of allowed cmds allow all cmds.

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -354,7 +354,7 @@ static bool CheckResources()
 
     /* If everything is well, attempt to initialize our public/private keys */
     if (OK && (me->pki_encrypt || me->pki_sign)) {
-      char* filepath = nullptr;
+      const char* filepath = nullptr;
       /* Load our keypair */
       me->pki_keypair = crypto_keypair_new();
       if (!me->pki_keypair) {

--- a/core/src/findlib/attribs.cc
+++ b/core/src/findlib/attribs.cc
@@ -600,12 +600,10 @@ int encode_attribsEx(JobControlRecord* jcr,
 }
 
 // Do casting according to unknown type to keep compiler happy
-#  ifdef HAVE_TYPEOF
-#    define plug(st, val) st = (typeof st)val
-#  else
-// Use templates to do the casting
-template <class T> void plug(T& st, uint64_t val) { st = static_cast<T>(val); }
-#  endif
+template <typename T> static void plug(T& st, uint64_t val)
+{
+  st = static_cast<T>(val);
+}
 
 /**
  * Set Extended File Attributes for Win32

--- a/core/src/include/config.h.in
+++ b/core/src/include/config.h.in
@@ -487,9 +487,6 @@ extern char win_os[];
 // Define to 1 if TLS support should be enabled
 #cmakedefine HAVE_TLS @HAVE_TLS@
 
-// Define to 1 if compiler has typeof
-#cmakedefine HAVE_TYPEOF @HAVE_TYPEOF@
-
 // Define to 1 if you have the <ucontext.h> header file
 #cmakedefine HAVE_UCONTEXT_H @HAVE_UCONTEXT_H@
 

--- a/core/src/lib/alist.h
+++ b/core/src/lib/alist.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,23 +35,18 @@
  * Loop var through each member of list using an increasing index.
  * Loop var through each member of list using an decreasing index.
  */
-#define foreach_alist(var, list)                                 \
-  for ((var) = list ? (list)->first() : 0; (var); \
-       (var) = (list)->next())
+#define foreach_alist(var, list) \
+  for ((var) = list ? (list)->first() : 0; (var); (var) = (list)->next())
 
-#define foreach_alist_null(var, list)                                  \
-  for ((var) = list ? (list)->first() : nullptr; (var); \
-       (var) = (list)->next())
+#define foreach_alist_null(var, list) \
+  for ((var) = list ? (list)->first() : nullptr; (var); (var) = (list)->next())
 
-#define foreach_alist_index(inx, var, list)                                 \
-  for ((inx) = 0;                                                           \
-       (list != nullptr) ? ((var) = (list)->get((inx))) : 0; \
-       (inx)++)
+#define foreach_alist_index(inx, var, list) \
+  for ((inx) = 0; (list != nullptr) ? ((var) = (list)->get((inx))) : 0; (inx)++)
 
-#define foreach_alist_rindex(inx, var, list)                                \
-  for ((list != nullptr) ? (inx) = ((list)->size() - 1) : 0;                \
-       (list != nullptr) ? ((var) = (list)->get((inx))) : 0; \
-       (inx)--)
+#define foreach_alist_rindex(inx, var, list)                 \
+  for ((list != nullptr) ? (inx) = ((list)->size() - 1) : 0; \
+       (list != nullptr) ? ((var) = (list)->get((inx))) : 0; (inx)--)
 
 
 #include <string>

--- a/core/src/lib/alist.h
+++ b/core/src/lib/alist.h
@@ -35,48 +35,23 @@
  * Loop var through each member of list using an increasing index.
  * Loop var through each member of list using an decreasing index.
  */
-#ifdef HAVE_TYPEOF
-#  define foreach_alist(var, list)                                 \
-    for ((var) = list ? (typeof((var)))(list)->first() : 0; (var); \
-         (var) = (typeof(var))(list)->next())
+#define foreach_alist(var, list)                                 \
+  for ((var) = list ? (list)->first() : 0; (var); \
+       (var) = (list)->next())
 
-#  define foreach_alist_null(var, list)                                  \
-    for ((var) = list ? (typeof((var)))(list)->first() : nullptr; (var); \
-         (var) = (typeof(var))(list)->next())
+#define foreach_alist_null(var, list)                                  \
+  for ((var) = list ? (list)->first() : nullptr; (var); \
+       (var) = (list)->next())
 
-#  define foreach_alist_index(inx, var, list)                                 \
-    for ((inx) = 0;                                                           \
-         (list != nullptr) ? ((var) = (typeof((var)))(list)->get((inx))) : 0; \
-         (inx)++)
+#define foreach_alist_index(inx, var, list)                                 \
+  for ((inx) = 0;                                                           \
+       (list != nullptr) ? ((var) = (list)->get((inx))) : 0; \
+       (inx)++)
 
-#  define foreach_alist_rindex(inx, var, list)                                \
-    for ((list != nullptr) ? (inx) = ((list)->size() - 1) : 0;                \
-         (list != nullptr) ? ((var) = (typeof((var)))(list)->get((inx))) : 0; \
-         (inx)--)
-
-#else
-#  define foreach_alist(var, list)                                          \
-    for ((void)(list ? (*((void**)&(var)) = (void*)((list)->first())) : 0); \
-         (var); (*((void**)&(var)) = (void*)((list)->next())))
-
-#  define foreach_alist_null(var, list)                               \
-    for ((void)(list ? (*((void**)&(var)) = (void*)((list)->first())) \
-                     : nullptr);                                      \
-         (var); (*((void**)&(var)) = (void*)((list)->next())))
-
-#  define foreach_alist_index(inx, var, list)                                 \
-    for ((inx) = 0; (list != nullptr)                                         \
-                        ? ((*((void**)&(var)) = (void*)((list)->get((inx))))) \
-                        : 0;                                                  \
-         (inx)++)
-
-#  define foreach_alist_rindex(inx, var, list)                     \
-    for ((list != nullptr) ? (inx) = ((list)->size() - 1) : 0;     \
-         (list != nullptr)                                         \
-             ? ((*((void**)&(var)) = (void*)((list)->get((inx))))) \
-             : 0;                                                  \
-         (inx)--)
-#endif
+#define foreach_alist_rindex(inx, var, list)                                \
+  for ((list != nullptr) ? (inx) = ((list)->size() - 1) : 0;                \
+       (list != nullptr) ? ((var) = (list)->get((inx))) : 0; \
+       (inx)--)
 
 
 #include <string>

--- a/core/src/lib/attribs.cc
+++ b/core/src/lib/attribs.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/attribs.cc
+++ b/core/src/lib/attribs.cc
@@ -107,23 +107,10 @@ void EncodeStat(char* buf,
 }
 
 /* Do casting according to unknown type to keep compiler happy */
-#ifdef HAVE_TYPEOF
-#  define plug(st, val) st = (typeof st)val
-#else
-#  if !HAVE_GCC & HAVE_SUN_OS
-/* Sun compiler does not handle templates correctly */
-#    define plug(st, val) st = val
-#  elif __sgi
-#    define plug(st, val) st = val
-#  else
-/* Use templates to do the casting */
-template <class T>
-void plug(T& st, uint64_t val)
+template <typename T> static void plug(T& st, uint64_t val)
 {
   st = static_cast<T>(val);
 }
-#  endif
-#endif
 
 // Decode a stat packet from base64 characters
 int DecodeStat(char* buf, struct stat* statp, int stat_size, int32_t* LinkFI)

--- a/core/src/lib/bareos_resource.cc
+++ b/core/src/lib/bareos_resource.cc
@@ -23,9 +23,9 @@
 
 #include "lib/bareos_resource.h"
 
-const char* GetResourceName(void* resource)
+const char* GetResourceName(const void* resource)
 {
-  return ((BareosResource*)resource)->resource_name_;
+  return static_cast<const BareosResource*>(resource)->resource_name_;
 }
 
 BareosResource::BareosResource()

--- a/core/src/lib/bareos_resource.cc
+++ b/core/src/lib/bareos_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/bareos_resource.h
+++ b/core/src/lib/bareos_resource.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/bareos_resource.h
+++ b/core/src/lib/bareos_resource.h
@@ -64,6 +64,6 @@ class BareosResource {
                                  bool verbose);
 };
 
-const char* GetResourceName(void* resource);
+const char* GetResourceName(const void* resource);
 
 #endif  // BAREOS_LIB_BAREOS_RESOURCE_H_

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -34,24 +34,10 @@
 #include "lib/message.h"
 #include "lib/message_severity.h"
 
-/**
- * There is a lot of extra casting here to work around the fact
- * that some compilers (Sun and Visual C++) do not accept
- * (void *) as an lvalue on the left side of an equal.
- *
- * Loop var through each member of list
- */
-#ifdef HAVE_TYPEOF
-#  define foreach_dlist(var, list)                                   \
+#define foreach_dlist(var, list) \
     for ((var) = nullptr;                                            \
-         (list ? ((var) = (typeof(var))(list)->next(var)) : nullptr) \
+         (list ? ((var) = (list)->next(var)) : nullptr) \
          != nullptr;)
-#else
-#  define foreach_dlist(var, list)                                           \
-    for ((var) = nullptr;                                                    \
-         (list ? (*((void**)&(var)) = (void*)((list)->next(var))) : nullptr) \
-         != nullptr;)
-#endif
 
 template <typename T> class dlist {
   T* head{nullptr};

--- a/core/src/lib/dlist.h
+++ b/core/src/lib/dlist.h
@@ -35,9 +35,8 @@
 #include "lib/message_severity.h"
 
 #define foreach_dlist(var, list) \
-    for ((var) = nullptr;                                            \
-         (list ? ((var) = (list)->next(var)) : nullptr) \
-         != nullptr;)
+  for ((var) = nullptr;          \
+       (list ? ((var) = (list)->next(var)) : nullptr) != nullptr;)
 
 template <typename T> class dlist {
   T* head{nullptr};

--- a/core/src/lib/htable.h
+++ b/core/src/lib/htable.h
@@ -28,17 +28,8 @@
 #ifndef BAREOS_LIB_HTABLE_H_
 #define BAREOS_LIB_HTABLE_H_
 
-// Loop var through each member of table
-#ifdef HAVE_TYPEOF
-#  define foreach_htable(var, tbl)                     \
-    for ((var) = (typeof(var))((tbl)->first()); (var); \
-         (var) = (typeof(var))((tbl)->next()))
-#else
-#  define foreach_htable(var, tbl)                             \
-    for ((*((void**)&(var)) = (void*)((tbl)->first())); (var); \
-         (*((void**)&(var)) = (void*)((tbl)->next())))
-#endif
-
+#define foreach_htable(var, tbl) \
+  for ((var) = (tbl)->first(); (var); (var) = (tbl)->next())
 
 #include "include/config.h"
 #include "monotonic_buffer.h"

--- a/core/src/lib/output_formatter_resource.cc
+++ b/core/src/lib/output_formatter_resource.cc
@@ -26,7 +26,7 @@
 #include "lib/util.h"
 #include "lib/output_formatter_resource.h"
 
-const char* GetAsCString(void* item) { return (const char*)item; }
+const char* GetAsCString(const void* item) { return (const char*)item; }
 
 OutputFormatterResource::OutputFormatterResource(OutputFormatter* send,
                                                  int indent_level)
@@ -199,13 +199,13 @@ void OutputFormatterResource::KeyUnquotedString(const char* name,
 void OutputFormatterResource::KeyMultipleStringsInOneLine(
     const char* key,
     alist<const char*>* list,
-    std::function<const char*(void* item)> GetValue,
+    std::function<const char*(const void* item)> GetValue,
     bool as_comment,
     bool quoted_strings)
 {
   // Each member of the list is comma-separated
   int cnt = 0;
-  char* item = nullptr;
+  const char* item = nullptr;
   std::string format = "%s";
   if (quoted_strings) { format = "\"%s\""; }
 
@@ -255,13 +255,13 @@ void OutputFormatterResource::KeyMultipleStringsOnePerLineAddItem(
 void OutputFormatterResource::KeyMultipleStringsOnePerLine(
     const char* key,
     alist<const char*>* list,
-    std::function<const char*(void* item)> GetValue,
+    std::function<const char*(const void* item)> GetValue,
     bool as_comment,
     bool quoted_strings,
     bool escape_strings)
 {
   // One line for each member of the list
-  char* item = nullptr;
+  const char* item = nullptr;
 
   if ((list == NULL) or (list->empty())) {
     if (as_comment) {

--- a/core/src/lib/output_formatter_resource.h
+++ b/core/src/lib/output_formatter_resource.h
@@ -107,7 +107,7 @@ class OutputFormatterResource {
   void KeyMultipleStringsInOneLine(
       const char* key,
       alist<const char*>* list,
-      std::function<const char*(void* item)> GetValue,
+      std::function<const char*(const void* item)> GetValue,
       bool as_comment = false,
       bool quoted_strings = true);
 
@@ -119,7 +119,7 @@ class OutputFormatterResource {
 
   void KeyMultipleStringsOnePerLine(const char* key,
                                     alist<const char*>* list,
-                                    std::function<const char*(void*)> GetValue,
+                                    std::function<const char*(const void*)> GetValue,
                                     bool as_comment = false,
                                     bool quoted_strings = true,
                                     bool escape_strings = false);

--- a/core/src/lib/output_formatter_resource.h
+++ b/core/src/lib/output_formatter_resource.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -117,12 +117,13 @@ class OutputFormatterResource {
                                     bool quoted_strings = true,
                                     bool escape_strings = false);
 
-  void KeyMultipleStringsOnePerLine(const char* key,
-                                    alist<const char*>* list,
-                                    std::function<const char*(const void*)> GetValue,
-                                    bool as_comment = false,
-                                    bool quoted_strings = true,
-                                    bool escape_strings = false);
+  void KeyMultipleStringsOnePerLine(
+      const char* key,
+      alist<const char*>* list,
+      std::function<const char*(const void*)> GetValue,
+      bool as_comment = false,
+      bool quoted_strings = true,
+      bool escape_strings = false);
 
   void KeyMultipleStringsOnePerLine(const char* key,
                                     const std::vector<std::string>&,

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -475,16 +475,22 @@ void IndentConfigItem(PoolMem& cfg_str,
                       const char* config_item,
                       bool inherited = false);
 
+/* this function is used as an initializer in foreach_res, so we can null
+ * the pointer passed into and also get a reference to the configuration that
+ * we then keep for the lifetime of the loop.
+ */
+inline std::shared_ptr<ConfigResourcesContainer> _init_foreach_res_(
+    ConfigurationParser* my_config,
+    void* var)
+{
+  memset(var, 0, sizeof(void*));
+  return my_config->GetResourcesContainer();
+}
 // Loop through each resource of type, returning in var
-#ifdef HAVE_TYPEOF
-#  define foreach_res(var, type)                                    \
-    for ((var) = NULL; ((var) = (typeof(var))my_config->GetNextRes( \
-                            (type), (BareosResource*)var));)
-#else
-#  define foreach_res(var, type)                                        \
-    for (var = NULL; (*((void**)&(var)) = (void*)my_config->GetNextRes( \
-                          (type), (BareosResource*)var));)
-#endif
+#define foreach_res(var, type)                                    \
+  for (auto _config_table_ = _init_foreach_res_(my_config, &var); \
+       ((var)                                                      \
+       = static_cast<decltype(var)>(my_config->GetNextRes((type), var)));)
 
 #define LockRes(x) (x)->b_LockRes(__FILE__, __LINE__)
 #define UnlockRes(x) (x)->b_UnlockRes(__FILE__, __LINE__)

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -489,8 +489,8 @@ inline std::shared_ptr<ConfigResourcesContainer> _init_foreach_res_(
 // Loop through each resource of type, returning in var
 #define foreach_res(var, type)                                    \
   for (auto _config_table_ = _init_foreach_res_(my_config, &var); \
-       ((var)                                                      \
-       = static_cast<decltype(var)>(my_config->GetNextRes((type), var)));)
+       ((var)                                                     \
+        = static_cast<decltype(var)>(my_config->GetNextRes((type), var)));)
 
 #define LockRes(x) (x)->b_LockRes(__FILE__, __LINE__)
 #define UnlockRes(x) (x)->b_UnlockRes(__FILE__, __LINE__)

--- a/core/src/lib/plugins.cc
+++ b/core/src/lib/plugins.cc
@@ -215,7 +215,7 @@ bool LoadPlugins(void* bareos_plugin_interface_version,
    * type.
    */
   if (plugin_names && plugin_names->size()) {
-    char* name = nullptr;
+    const char* name = nullptr;
     PoolMem plugin_name(PM_FNAME);
 
     foreach_alist (name, plugin_names) {

--- a/core/src/lib/plugins.cc
+++ b/core/src/lib/plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/rblist.h
+++ b/core/src/lib/rblist.h
@@ -30,22 +30,9 @@
 
 #define M_ABORT 1
 
-/**
- * There is a lot of extra casting here to work around the fact
- * that some compilers (Sun and Visual C++) do not accept
- * (bnode *) as an lvalue on the left side of an equal.
- *
- * Loop var through each member of list
- */
-#ifdef HAVE_TYPEOF
-#  define foreach_rblist(var, tree)                     \
-    for (((var) = (typeof(var))(tree)->first()); (var); \
-         ((var) = (typeof(var))(tree)->next(var)))
-#else
-#  define foreach_rblist(var, tree)                             \
-    for ((*((void**)&(var)) = (void*)((tree)->first())); (var); \
-         (*((void**)&(var)) = (void*)((tree)->next(var))))
-#endif
+#define foreach_rblist(var, tree)                                    \
+  for (((var) = static_cast<decltype(var)>((tree)->first())); (var); \
+       ((var) = static_cast<decltype(var)>((tree)->next(var))))
 
 struct rblink {
   void* parent = nullptr;

--- a/core/src/lib/rblist.h
+++ b/core/src/lib/rblist.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -61,7 +61,7 @@ static bool ScriptDirAllowed(JobControlRecord*,
                              RunScript* script,
                              alist<const char*>* allowed_script_dirs)
 {
-  char *bp, *allowed_script_dir = nullptr;
+  const char* allowed_script_dir = nullptr;
   bool allowed = false;
   PoolMem script_dir(PM_FNAME);
 
@@ -70,7 +70,9 @@ static bool ScriptDirAllowed(JobControlRecord*,
 
   // Determine the dir the script is in.
   PmStrcpy(script_dir, script->command.c_str());
-  if ((bp = strrchr(script_dir.c_str(), '/'))) { *bp = '\0'; }
+  if (char* bp = strrchr(script_dir.c_str(), '/'); bp != nullptr) {
+    *bp = '\0';
+  }
 
   /*
    * Make sure there are no relative path elements in script dir by which the

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -405,7 +405,7 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
 {
   bool ok = false;
   DirectorStorage* store = nullptr;
-  char* device_name = nullptr;
+  const char* device_name = nullptr;
   alist<DirectorStorage*>* dirstore;
   DeviceControlRecord* dcr = jcr->impl->dcr;
 

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/reserve.h
+++ b/core/src/stored/reserve.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/reserve.h
+++ b/core/src/stored/reserve.h
@@ -56,7 +56,7 @@ class DirectorStorage {
 class ReserveContext {
  public:
   JobControlRecord* jcr;
-  char* device_name;
+  const char* device_name;
   DirectorStorage* store;
   DeviceResource* device_resource;
   Device* low_use_drive;            /**< Low use drive candidate */

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -66,7 +66,7 @@ void AlistFill(alist<const char*>* list, int max)
 // we expect, that the list is filled with strings of numbers from 0 to n.
 void TestForeachAlist(alist<const char*>* list)
 {
-  char* str = NULL;
+  const char* str = NULL;
   char buf[30];
   int i = 0;
 

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -235,7 +235,7 @@ void test_config_directive_type(
 
 void test_CFG_TYPE_AUDIT(DirectorResource* me)
 {
-  char* val = nullptr;
+  const char* val = nullptr;
   foreach_alist (val, me->audit_events) {
     printf("AuditEvents = %s\n", val);
   }
@@ -250,7 +250,7 @@ TEST(ConfigParser_Dir, CFG_TYPE_AUDIT)
 
 void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* me)
 {
-  char* val = nullptr;
+  const char* val = nullptr;
   foreach_alist (val, me->plugin_names) {
     printf("PluginNames = %s\n", val);
   }

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -31,6 +31,11 @@
 #include "dird/dird_conf.h"
 #include "lib/output_formatter_resource.h"
 
+#include <thread>
+#include <condition_variable>
+#include <chrono>
+using namespace std::chrono_literals;
+
 namespace directordaemon {
 
 static std::string sprintoutput{};
@@ -127,6 +132,63 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   }
   delete my_config;
 }
+
+TEST(ConfigParser_Dir, foreach_res_and_reload)
+{
+  OSDependentInit();
+  std::string path_to_config_file = std::string(
+      RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
+  my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
+  my_config->ParseConfig();
+
+  [[maybe_unused]] auto do_reload = [](bool keep_config) {
+    auto backup = my_config->BackupResourcesContainer();
+    my_config->ParseConfig();
+
+    me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+    my_config->own_resource_ = me;
+    ASSERT_NE(nullptr, me);
+    if (!keep_config) {
+      my_config->RestoreResourcesContainer(std::move(backup));
+      ASSERT_NE(nullptr, me);
+    }
+  };
+
+  std::mutex cv_m;
+  std::condition_variable cv;
+  bool done = false;
+
+  auto do_foreach_res = [&]() {
+    std::unique_lock lk(cv_m);
+    BareosResource* client;
+    client = (BareosResource*)0xfefe;
+    // auto handle = my_config->GetResourcesContainer();
+    foreach_res (client, R_CLIENT) {
+      cv.wait(lk);
+      printf("%p %s\n", client->resource_name_, client->resource_name_);
+    }
+    done = true;
+    return;
+  };
+
+  auto reload_loop = [&]() {
+    std::unique_lock<std::mutex> lk(cv_m);
+    while (!done) {
+      lk.unlock();
+      printf("Config reload\n");
+      do_reload(true);
+      cv.notify_one();
+      std::this_thread::sleep_for(10ms);
+      lk.lock();
+    }
+  };
+
+  std::thread t1{do_foreach_res}, t2{reload_loop};
+  t1.join();
+  t2.join();
+
+  delete my_config;
+}  // namespace directordaemon
 
 TEST(ConfigParser_Dir, runscript_test)
 {


### PR DESCRIPTION
Keep a reference to the config while looping over configuration resources with `foreach_res()`.

The PR also removes uses of the GCC extension `typeof()` which are mostly not needed anymore and can be replaced with `decltype()` where still required.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
