### PR TITLE
daemons: deprecate `Maximum Connections` configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
 - marked config directive `Compatible` as deprecated [PR #1284]
+- deprecated `Maximum Connections` directive from all daemons and removed all uses in code. Directive has no effect anymore [PR #1285]
 
 ### Removed
 - removed the `-r` run job option. [PR #1206]
@@ -334,4 +335,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1277]: https://github.com/bareos/bareos/pull/1277
 [PR #1278]: https://github.com/bareos/bareos/pull/1278
 [PR #1284]: https://github.com/bareos/bareos/pull/1284
+[PR #1285]: https://github.com/bareos/bareos/pull/1285
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -133,7 +133,7 @@ static ResourceItem dir_items[] = {
 #endif
   { "Subscriptions", CFG_TYPE_PINT32, ITEM(res_dir, subscriptions), 0, CFG_ITEM_DEFAULT, "0", "12.4.4-", NULL },
   { "MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dir, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL },
-  { "MaximumConnections", CFG_TYPE_PINT32, ITEM(res_dir, MaxConnections), 0, CFG_ITEM_DEFAULT, "30", NULL, NULL },
+  { "MaximumConnections", CFG_TYPE_PINT32, ITEM(res_dir, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "30", NULL, NULL },
   { "MaximumConsoleConnections", CFG_TYPE_PINT32, ITEM(res_dir, MaxConsoleConnections), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL },
   { "Password", CFG_TYPE_AUTOPASSWORD, ITEM(res_dir, password_), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL },
   { "FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_dir, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "180" /* 3 minutes */, NULL, NULL },

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1058,7 +1058,9 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
+            foreach_alist (str, orig_list) {
+              (*new_list)->append(strdup(str));
+            }
 
             SetBit(i, dest->item_present_);
             SetBit(i, dest->inherit_content_);
@@ -1080,7 +1082,9 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<BareosResource*>(10, not_owned_by_alist);
             }
 
-            foreach_alist (res, orig_list) { (*new_list)->append(res); }
+            foreach_alist (res, orig_list) {
+              (*new_list)->append(res);
+            }
 
             SetBit(i, dest->item_present_);
             SetBit(i, dest->inherit_content_);
@@ -1104,7 +1108,9 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
+            foreach_alist (str, orig_list) {
+              (*new_list)->append(strdup(str));
+            }
 
             SetBit(i, dest->item_present_);
             SetBit(i, dest->inherit_content_);
@@ -2474,7 +2480,9 @@ static bool PopulateJobdefaults()
   bool retval = true;
 
   // Propagate the content of a JobDefs to another.
-  foreach_res (jobdefs, R_JOBDEFS) { PropagateJobdefs(R_JOBDEFS, jobdefs); }
+  foreach_res (jobdefs, R_JOBDEFS) {
+    PropagateJobdefs(R_JOBDEFS, jobdefs);
+  }
 
   // Propagate the content of the JobDefs to the actual Job.
   foreach_res (job, R_JOB) {

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -51,11 +51,6 @@ bool CheckResources()
     OK = false;
     goto bail_out;
   } else {
-    // Sanity check.
-    if (me->MaxConsoleConnections > me->MaxConnections) {
-      me->MaxConnections = me->MaxConsoleConnections + 10;
-    }
-
     my_config->omit_defaults_ = true;
     SetWorkingDirectory(me->working_directory);
 

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -134,12 +134,10 @@ extern "C" void* connect_thread(void* arg)
 {
   SetJcrInThreadSpecificData(nullptr);
 
-  // Permit MaxConnections connections.
   sock_fds = new alist<s_sockfd*>(10, not_owned_by_alist);
-  BnetThreadServerTcp((dlist<IPADDR>*)arg, me->MaxConnections, sock_fds,
-                      thread_list, HandleConnectionRequest, my_config,
-                      &server_state, UserAgentShutdownCallback,
-                      CleanupConnectionPool);
+  BnetThreadServerTcp((dlist<IPADDR>*)arg, sock_fds, thread_list,
+                      HandleConnectionRequest, my_config, &server_state,
+                      UserAgentShutdownCallback, CleanupConnectionPool);
 
   return NULL;
 }

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -318,11 +318,6 @@ static bool CheckResources()
           configfile.c_str());
     OK = false;
   } else {
-    // Sanity check.
-    if (me->MaxConnections < (2 * me->MaxConcurrentJobs)) {
-      me->MaxConnections = (2 * me->MaxConcurrentJobs) + 2;
-    }
-
     if (my_config->GetNextRes(R_CLIENT, (BareosResource*)me) != nullptr) {
       Emsg1(M_FATAL, 0, _("Only one Client resource permitted in %s\n"),
             configfile.c_str());

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -93,7 +93,7 @@ static ResourceItem cli_items[] = {
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_client, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_client, scripts_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_client, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL},
-  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_client, MaxConnections), 0, CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
+  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_client, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
   {"Messages", CFG_TYPE_RES, ITEM(res_client, messages), R_MSGS, 0, NULL, NULL, NULL},
   {"SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_client, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
   {"HeartbeatInterval", CFG_TYPE_TIME, ITEM(res_client, heartbeat_interval), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL},
@@ -381,9 +381,7 @@ static void FreeResource(BareosResource* res, int type)
       if (p->pki_signing_key_files) { delete p->pki_signing_key_files; }
       if (p->pki_signers) {
         X509_KEYPAIR* keypair = nullptr;
-        foreach_alist (keypair, p->pki_signers) {
-          CryptoKeypairFree(keypair);
-        }
+        foreach_alist (keypair, p->pki_signers) { CryptoKeypairFree(keypair); }
         delete p->pki_signers;
       }
       if (p->pki_master_key_files) { delete p->pki_master_key_files; }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -381,7 +381,9 @@ static void FreeResource(BareosResource* res, int type)
       if (p->pki_signing_key_files) { delete p->pki_signing_key_files; }
       if (p->pki_signers) {
         X509_KEYPAIR* keypair = nullptr;
-        foreach_alist (keypair, p->pki_signers) { CryptoKeypairFree(keypair); }
+        foreach_alist (keypair, p->pki_signers) {
+          CryptoKeypairFree(keypair);
+        }
         delete p->pki_signers;
       }
       if (p->pki_master_key_files) { delete p->pki_master_key_files; }

--- a/core/src/filed/socket_server.cc
+++ b/core/src/filed/socket_server.cc
@@ -122,11 +122,9 @@ void StartSocketServer(dlist<IPADDR>* addrs)
     Dmsg1(10, "filed: listening on port %d\n", p->GetPortHostOrder());
   }
 
-  // Permit MaxConnections connections.
   sock_fds = new alist<s_sockfd*>(10, not_owned_by_alist);
-  BnetThreadServerTcp(addrs, me->MaxConnections, sock_fds, thread_list,
-                      HandleConnectionRequest, my_config, nullptr,
-                      UserAgentShutdownCallback);
+  BnetThreadServerTcp(addrs, sock_fds, thread_list, HandleConnectionRequest,
+                      my_config, nullptr, UserAgentShutdownCallback);
 }
 
 void StopSocketServer(bool wait)

--- a/core/src/filed/socket_server.cc
+++ b/core/src/filed/socket_server.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -244,7 +244,6 @@ int OpenSocketAndBind(IPADDR* ipaddr,
  */
 void BnetThreadServerTcp(
     dlist<IPADDR>* addr_list,
-    int max_clients,
     alist<s_sockfd*>* sockfds,
     ThreadList& thread_list,
     std::function<void*(ConfigurationParser* config, void* bsock)>
@@ -298,8 +297,7 @@ void BnetThreadServerTcp(
 #endif
   }
 
-  thread_list.Init(max_clients, HandleConnectionRequest,
-                   UserAgentShutdownCallback);
+  thread_list.Init(HandleConnectionRequest, UserAgentShutdownCallback);
 
 #ifdef HAVE_POLL
   struct pollfd* pfds = (struct pollfd*)alloca(sizeof(struct pollfd)

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -44,9 +44,7 @@ struct s_sockfd {
   int port;
 };
 
-void BnetThreadServerTcp(
-    dlist<IPADDR>* addr_list,
-    int max_clients,
+void BnetThreadServerTcp(dlist<IPADDR>* addr_list,
     alist<s_sockfd*>* sockfds,
     ThreadList& thread_list,
     std::function<void*(ConfigurationParser* config, void* bsock)>

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,7 +44,8 @@ struct s_sockfd {
   int port;
 };
 
-void BnetThreadServerTcp(dlist<IPADDR>* addr_list,
+void BnetThreadServerTcp(
+    dlist<IPADDR>* addr_list,
     alist<s_sockfd*>* sockfds,
     ThreadList& thread_list,
     std::function<void*(ConfigurationParser* config, void* bsock)>

--- a/core/src/lib/thread_list.cc
+++ b/core/src/lib/thread_list.cc
@@ -51,8 +51,6 @@ class ThreadListPrivate {
   friend class ThreadGuard;
 
  private:
-  std::size_t maximum_thread_count_{};
-
   std::shared_ptr<ThreadListContainer> l{
       std::make_shared<ThreadListContainer>()};
 
@@ -67,12 +65,10 @@ class ThreadListPrivate {
 ThreadList::ThreadList() : impl_(std::make_unique<ThreadListPrivate>()) {}
 ThreadList::~ThreadList() = default;
 
-void ThreadList::Init(int maximum_thread_count,
-                      ThreadHandler ThreadInvokedHandler,
+void ThreadList::Init(ThreadHandler ThreadInvokedHandler,
                       ShutdownCallback ShutdownCallback)
 {
   if (!impl_->l->thread_list_.empty()) { return; }
-  impl_->maximum_thread_count_ = maximum_thread_count;
   impl_->ThreadInvokedHandler_ = std::move(ThreadInvokedHandler);
   impl_->ShutdownCallback_ = std::move(ShutdownCallback);
 }
@@ -209,12 +205,6 @@ static void WorkerThread(
 bool ThreadList::CreateAndAddNewThread(ConfigurationParser* config, void* data)
 {
   std::lock_guard<std::mutex> lg(impl_->l->thread_list_mutex_);
-
-  if (impl_->l->thread_list_.size() >= impl_->maximum_thread_count_) {
-    Dmsg1(debuglevel, "Number of maximum threads exceeded: %d\n",
-          impl_->maximum_thread_count_);
-    return false;
-  }
 
   auto run_condition = std::make_shared<IsRunningCondition>();
   bool success{false};

--- a/core/src/lib/thread_list.h
+++ b/core/src/lib/thread_list.h
@@ -39,8 +39,7 @@ class ThreadList {
       = std::function<void*(ConfigurationParser* config, void* data)>;
   using ShutdownCallback = std::function<void*(void* data)>;
 
-  void Init(int maximum_thread_count,
-            ThreadHandler ThreadInvokedHandler,
+  void Init(ThreadHandler ThreadInvokedHandler,
             ShutdownCallback ShutdownCallback = nullptr);
 
   bool CreateAndAddNewThread(ConfigurationParser* config, void* data);

--- a/core/src/lib/thread_list.h
+++ b/core/src/lib/thread_list.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -89,7 +89,6 @@ namespace storagedaemon {
  */
 struct ndmp_thread_server_args {
   dlist<IPADDR>* addr_list;
-  int max_clients;
   ThreadList* thread_list;
 };
 
@@ -1173,7 +1172,7 @@ extern "C" void* ndmp_thread_server(void* arg)
 #  endif
   }
 
-  ntsa->thread_list->Init(ntsa->max_clients, HandleNdmpConnectionRequest);
+  ntsa->thread_list->Init(HandleNdmpConnectionRequest);
 
 #  ifdef HAVE_POLL
   // Allocate on stack from -- no need to free
@@ -1277,12 +1276,11 @@ extern "C" void* ndmp_thread_server(void* arg)
   return NULL;
 }
 
-int StartNdmpThreadServer(dlist<IPADDR>* addr_list, int max_clients)
+int StartNdmpThreadServer(dlist<IPADDR>* addr_list)
 {
   int status;
 
   ndmp_thread_server_args.addr_list = addr_list;
-  ndmp_thread_server_args.max_clients = max_clients;
   ndmp_thread_server_args.thread_list = &thread_list;
 
   if ((status = pthread_create(&ndmp_tid, NULL, ndmp_thread_server,

--- a/core/src/stored/ndmp_tape.h
+++ b/core/src/stored/ndmp_tape.h
@@ -27,7 +27,7 @@ namespace storagedaemon {
 
 void EndOfNdmpBackup(JobControlRecord* jcr);
 void EndOfNdmpRestore(JobControlRecord* jcr);
-int StartNdmpThreadServer(dlist<IPADDR>* addr_list, int max_clients);
+int StartNdmpThreadServer(dlist<IPADDR>* addr_list);
 void StopNdmpThreadServer();
 
 } /* namespace storagedaemon */

--- a/core/src/stored/ndmp_tape.h
+++ b/core/src/stored/ndmp_tape.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/socket_server.cc
+++ b/core/src/stored/socket_server.cc
@@ -137,9 +137,8 @@ void StartSocketServer(dlist<IPADDR>* addrs)
   }
 
   sock_fds = new alist<s_sockfd*>(10, not_owned_by_alist);
-  BnetThreadServerTcp(addrs, me->MaxConnections, sock_fds, thread_list,
-                      HandleConnectionRequest, my_config, nullptr,
-                      UserAgentShutdownCallback);
+  BnetThreadServerTcp(addrs, sock_fds, thread_list, HandleConnectionRequest,
+                      my_config, nullptr, UserAgentShutdownCallback);
 }
 
 void StopSocketServer()

--- a/core/src/stored/socket_server.cc
+++ b/core/src/stored/socket_server.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -307,9 +307,7 @@ int main(int argc, char* argv[])
 
 #if HAVE_NDMP
   // Separate thread that handles NDMP connections
-  if (me->ndmp_enable) {
-    StartNdmpThreadServer(me->NDMPaddrs, me->MaxConnections);
-  }
+  if (me->ndmp_enable) { StartNdmpThreadServer(me->NDMPaddrs); }
 #endif
 
   // Single server used for Director/Storage and File daemon
@@ -345,11 +343,6 @@ static int CheckResources()
           _("No Device resource defined in %s. Cannot continue.\n"),
           configfile.c_str());
     OK = false;
-  }
-
-  // Sanity check.
-  if (me->MaxConnections < ((2 * me->MaxConcurrentJobs) + 2)) {
-    me->MaxConnections = (2 * me->MaxConcurrentJobs) + 2;
   }
 
   if (!me->messages) {

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -777,7 +777,9 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
           p->device_resources = res_changer->device_resources;
 
           DeviceResource* q = nullptr;
-          foreach_alist (q, p->device_resources) { q->changer_res = p; }
+          foreach_alist (q, p->device_resources) {
+            q->changer_res = p;
+          }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -87,7 +87,7 @@ static ResourceItem store_items[] = {
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_store, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_store, scripts_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_store, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL},
-  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_store, MaxConnections), 0, CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
+  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_store, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
   {"Messages", CFG_TYPE_RES, ITEM(res_store, messages), R_MSGS, 0, NULL, NULL, NULL},
   {"SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
   {"FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
@@ -777,9 +777,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
           p->device_resources = res_changer->device_resources;
 
           DeviceResource* q = nullptr;
-          foreach_alist (q, p->device_resources) {
-            q->changer_res = p;
-          }
+          foreach_alist (q, p->device_resources) { q->changer_res = p; }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/core/src/tests/thread_list.cc
+++ b/core/src/tests/thread_list.cc
@@ -94,7 +94,7 @@ TEST(thread_list, thread_list_startup_and_shutdown)
 {
   std::unique_ptr<ThreadList> t(std::make_unique<ThreadList>());
 
-  t->Init(maximum_allowed_thread_count, ThreadHandler, ShutdownCallback);
+  t->Init(ThreadHandler, ShutdownCallback);
 
   for (int i = 0; i < try_to_start_thread_count; i++) {
     auto wc(std::make_unique<WaitCondition>());
@@ -128,7 +128,7 @@ TEST(thread_list, thread_random_shutdown)
 {
   std::unique_ptr<ThreadList> t(std::make_unique<ThreadList>());
 
-  t->Init(maximum_allowed_thread_count, ThreadHandlerSleepRandomTime, nullptr);
+  t->Init(ThreadHandlerSleepRandomTime, nullptr);
 
   thread_counter = 0;
   for (int i = 0; i < maximum_allowed_thread_count; i++) {

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -108,6 +108,7 @@
           "datatype": "PINT32",
           "code": 0,
           "default_value": "30",
+          "deprecated": true,
           "equals": true
         },
         "MaximumConsoleConnections": {

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -233,6 +233,7 @@
           "datatype": "PINT32",
           "code": 0,
           "default_value": "42",
+          "deprecated": true,
           "equals": true,
           "versions": "15.2.3-"
         },
@@ -520,6 +521,7 @@
           "datatype": "PINT32",
           "code": 0,
           "default_value": "42",
+          "deprecated": true,
           "equals": true,
           "versions": "15.2.3-"
         },

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -240,6 +240,7 @@
           "datatype": "PINT32",
           "code": 0,
           "default_value": "42",
+          "deprecated": true,
           "equals": true,
           "versions": "15.2.3-"
         },

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-director-MaximumConnections.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-director-MaximumConnections.rst.inc
@@ -1,0 +1,1 @@
+This directive has been deprecated and has no effect.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumConnections.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumConnections.rst.inc
@@ -1,0 +1,1 @@
+This directive has been deprecated and has no effect.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-storage-MaximumConnections.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-storage-MaximumConnections.rst.inc
@@ -1,0 +1,1 @@
+This directive has been deprecated and has no effect.


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR deprecates the `Maximum Connections` configuration option and removes all related checks in the code.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems