### PR TITLE
webui: switch from  mod_php to php-fpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
     - packages bareos-storage-ceph and bareos-filedaemon-ceph-plugin if previously installed need to be removed manually.
 - Bareos 22 removes bareos-webui support for RHEL 7 and CentOS 7
 - Bareos 22 uses the VMware VDDK 8.0.0 for the VMware Plugin. [PR #1295]. VDDK 8.0.0 supports vSphere 8 and is backward compatible with vSphere 6.7 and 7. **vSphere 6.5 is not supported anymore**.
+- Bareos 22 bareos-webui now uses php_fpm instead of mod_php. [PR #1287]. Update should run smoothly, for details check the "Installing Bareos Webui" chapter in the docs.
 
 ### Added
 - dird: add command line feature to print specific resources [PR #1153]
@@ -162,6 +163,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: do device reservation as late as possible, i.e. after run before job scripts [PR #1273]
 - ndmp_tape.cc: do not log current rctx->rec in joblog [PR #1324]
 - dird: stored: set statistics collection as deprecated [PR #1320]
+- webui: switch from mod_php to php-fpm [PR #1287]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -676,8 +676,11 @@ This package contains the GlusterFS plugin for the file daemon
 Summary:       Bareos Web User Interface
 Group:         Productivity/Archiving/Backup
 
-Requires: php >= 7.0.0
+BuildRequires: httpd
+BuildRequires: httpd-devel
 
+Requires: php >= 7.0.0
+Requires: php-fpm
 Requires: php-bz2
 Requires: php-ctype
 Requires: php-curl
@@ -691,11 +694,6 @@ Requires: php-hash
 Requires: php-iconv
 Requires: php-intl
 Requires: php-json
-
-%if !0%{?suse_version}
-Requires: php-libxml
-%endif
-
 Requires: php-mbstring
 Requires: php-openssl
 Requires: php-pcre
@@ -708,29 +706,27 @@ Requires: php-xmlreader
 Requires: php-xmlwriter
 Requires: php-zip
 
-%if 0%{?suse_version} || 0%{?sle_version}
-BuildRequires: apache2
-# /usr/sbin/apxs2
-BuildRequires: apache2-devel
-BuildRequires: mod_php_any
-%define _apache_conf_dir /etc/apache2/conf.d/
-%define www_daemon_user  wwwrun
-%define www_daemon_group www
-Requires: apache
-Recommends: mod_php_any
-%else
-BuildRequires: httpd
-# apxs2
-BuildRequires: httpd-devel
-%define _apache_conf_dir /etc/httpd/conf.d/
-%define www_daemon_user  apache
-%define www_daemon_group apache
-%if 0%{?fedora_version} >= 33 || 0%{?rhel_version} >= 900
-Requires:   php-fpm
-%else
-Requires:   mod_php
+%if !0%{?suse_version}
+Requires: php-libxml
 %endif
-Requires:   httpd
+
+%if 0%{?centos_version} || 0%{?rhel_version} || 0%{?fedora}
+Requires: httpd
+%define _apache_conf_dir /etc/httpd/conf.d/
+%define www_daemon_user apache
+%define www_daemon_group apache
+%endif
+
+%if 0%{?suse_version} || 0%{?sle_version}
+%if 0%{?sle_version} == 120500
+Requires: apache2
+%else
+Requires: apache2-event
+%endif
+Requires: apache2-mod_fcgid
+%define _apache_conf_dir /etc/apache2/conf.d/
+%define www_daemon_user wwwrun
+%define www_daemon_group www
 %endif
 
 %description webui
@@ -1765,22 +1761,11 @@ fi\
 
 %if 0%{?webui}
 %post webui
-%if 0%{?suse_version} >= 1110
-a2enmod setenv &> /dev/null || true
+%if 0%{?suse_version}
 a2enmod rewrite &> /dev/null || true
-%endif
-
-%if 0%{?suse_version} >= 1315
-# 1315:
-#   SLES12 (PHP 7)
-#   openSUSE Leap 42.1 (PHP 5)
-if php -v | grep -q "PHP 7"; then
-  a2enmod php7 &> /dev/null || true
-else
-  a2enmod php5 &> /dev/null || true
-fi
-%else
-a2enmod php5 &> /dev/null || true
+a2enmod proxy &> /dev/null || true
+a2enmod proxy_fcgi &> /dev/null || true
+a2enmod fcgid &> /dev/null || true
 %endif
 %endif
 

--- a/debian/bareos-webui.postinst
+++ b/debian/bareos-webui.postinst
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-which a2enmod >/dev/null && a2enmod rewrite setenv php7 2> /dev/null || true
+which a2enmod >/dev/null && a2enmod rewrite proxy_fcgi 2> /dev/null || true
 which a2enconf >/dev/null && a2enconf bareos-webui || true

--- a/debian/control
+++ b/debian/control
@@ -511,7 +511,8 @@ Description: Backup Archiving Recovery Open Sourced - tray monitor
 Package: bareos-webui
 Architecture: all
 Depends: apache2 | httpd,
-   libapache2-mod-php (>= 7.0),
+   libapache2-mod-fcgid,
+   php-fpm (>= 7.0),
    php-date,
    php-intl,
    php-json,

--- a/debian/control.bareos-webui
+++ b/debian/control.bareos-webui
@@ -1,7 +1,8 @@
 Package: bareos-webui
 Architecture: all
 Depends: apache2 | httpd,
-   libapache2-mod-php (>= 7.0),
+   libapache2-mod-fcgid,
+   php-fpm (>= 7.0),
    php-date,
    php-intl,
    php-json,

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -62,9 +62,9 @@ System Requirements
 
 -  The |webui| can be installed on any host. It does not have to be installed on the same as the |dir|.
 
--  The default installation uses an Apache webserver with mod-rewrite, mod-php and mod-setenv.
+-  PHP-FPM with Apache HTTP webserver having mod-rewrite enabled.
 
--  PHP 5.3.23 or newer, PHP 7 recommended
+-  PHP 7 or newer is recommended.
 
 -  On SUSE Linux Enterprise 12 you need the additional SUSE Linux Enterprise Module for Web Scripting 12.
 

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -449,31 +449,30 @@ As an alternative to the method above the Bvfs cache can be updated after each j
 
    We do provide a specific JobId in the *JobId* command argument in this example. Only the *JobId* given by the placeholder %i will be computed into the cache.
 
-Upgrade from 21.x.x to 22.x.x
------------------------------
+Upgrade from Bareos 21 or lower to Bareos 22
+--------------------------------------------
 
-|webui| now requires PHP-FPM instead of Apache2 mod-php. Due to this change there are some manual steps to consider
-before and after upgrading. Please have a look at the following remarks according to your operating system of choice.
+|webui| now requires **php-fpm** instead of Apache **mod-php**.
+
+Usually this should be automatically handled by the packagemanager while updating.
+
+Please consider the following remarks below according to your operating system of choice
+if auto upgrading does not work for you.
+
+If the |webui| is not reachable after upgrading, make sure that:
+
+- Apache **mod-php** is disabled or has been removed
+
+- **php-fpm*** usage is configured properly in Apache
+
+- **php-fpm** service is enabled and has been restarted
+
+- Apache service has been restarted
 
 Debian, Ubuntu, Univention
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Before upgrading
-^^^^^^^^^^^^^^^^
-
-- Disable or remove any PHP module in Apache2
-
-After upgrading
-^^^^^^^^^^^^^^^
-
-- Enable PHP-FPM Apache2 configuration (e.g. `a2enconf php7.3-fpm`, `a2enconf php7.4-fpm` or `a2enconf php8.1-fpm`)
-
-- Restart Apache2 and PHP-FPM
-
-.. code-block:: bareosconfig
-
-   systemctl restart php8.1-fpm
-   systemctl restart apache2
+Please use `apt` instead of `apt-get` to upgrade automatically.
 
 SUSE Linux Enterprise Server (SLES), openSUSE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -507,10 +506,9 @@ A minimal example may look like following.
 
 - Restart Apache2 and PHP-FPM
 
-.. code-block:: bareosconfig
+.. code-block:: shell-session
 
-   systemctl restart apache2
-   systemctl restart php-fpm
+   systemctl restart apache2 php-fpm
 
 Upgrade from 18.2.6 to 18.2.7
 -----------------------------

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -62,7 +62,7 @@ System Requirements
 
 -  The |webui| can be installed on any host. It does not have to be installed on the same as the |dir|.
 
--  PHP-FPM with Apache HTTP webserver having mod-rewrite enabled.
+-  The default installation uses PHP-FPM with Apache HTTP webserver having mod-rewrite enabled.
 
 -  PHP 7 or newer is recommended.
 

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -227,7 +227,7 @@ Configure your Apache Webserver
 
 The package **bareos-webui** provides a default configuration for Apache. Depending on your distribution, it is installed at :file:`/etc/apache2/conf.d/bareos-webui.conf`, :file:`/etc/httpd/conf.d/bareos-webui.conf`, :file:`/etc/apache2/available-conf/bareos-webui.conf` or similar.
 
-The required Apache modules, :strong:`setenv`, :strong:`rewrite` and :strong:`php` are enabled via package postinstall script. However, after installing the **bareos-webui** package, you need to restart your Apache webserver manually.
+The required Apache modules, :strong:`fcgid` and :strong:`rewrite` are enabled via package postinstall script. However, after installing the **bareos-webui** package, you need to restart your Apache webserver manually.
 
 
 .. _section-webui-configuration-files:

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareosWebui.rst
@@ -62,7 +62,7 @@ System Requirements
 
 -  The |webui| can be installed on any host. It does not have to be installed on the same as the |dir|.
 
--  The default installation uses PHP-FPM with Apache HTTP webserver having mod-rewrite enabled.
+-  The default installation uses PHP-FPM with Apache HTTP webserver having mod-rewrite and mod-fcgid enabled.
 
 -  PHP 7 or newer is recommended.
 
@@ -448,6 +448,69 @@ As an alternative to the method above the Bvfs cache can be updated after each j
 .. note::
 
    We do provide a specific JobId in the *JobId* command argument in this example. Only the *JobId* given by the placeholder %i will be computed into the cache.
+
+Upgrade from 21.x.x to 22.x.x
+-----------------------------
+
+|webui| now requires PHP-FPM instead of Apache2 mod-php. Due to this change there are some manual steps to consider
+before and after upgrading. Please have a look at the following remarks according to your operating system of choice.
+
+Debian, Ubuntu, Univention
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before upgrading
+^^^^^^^^^^^^^^^^
+
+- Disable or remove any PHP module in Apache2
+
+After upgrading
+^^^^^^^^^^^^^^^
+
+- Enable PHP-FPM Apache2 configuration (e.g. `a2enconf php7.3-fpm`, `a2enconf php7.4-fpm` or `a2enconf php8.1-fpm`)
+
+- Restart Apache2 and PHP-FPM
+
+.. code-block:: bareosconfig
+
+   systemctl restart php8.1-fpm
+   systemctl restart apache2
+
+SUSE Linux Enterprise Server (SLES), openSUSE
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before upgrading
+^^^^^^^^^^^^^^^^
+
+- Disable or remove any PHP module in Apache2
+
+After upgrading
+^^^^^^^^^^^^^^^
+
+- Ensure a php.ini file is in place (e.g. `/etc/php7/fpm/php.ini` or `/etc/php8/fpm/php.ini`)
+
+- Configure PHP-FPM to your needs (e.g. `/etc/php7/fpm/php-fpm.conf` and `/etc/php7/fpm/php-fpm.d/www.conf`)
+
+- Configure mod_fcgid to your needs `/etc/apache2/conf.d/mod_fcgid.conf`
+
+A minimal example may look like following.
+
+.. code-block:: bareosconfig
+   :caption: /etc/apache2/conf.d/mod_fcgid.conf
+
+   <IfModule fcgid_module>
+        DirectoryIndex index.php
+        <FilesMatch "\.php$">
+                SetHandler "proxy:fcgi://127.0.0.1:9000/"
+                #CGIPassAuth on
+        </FilesMatch>
+   </IfModule>
+
+- Restart Apache2 and PHP-FPM
+
+.. code-block:: bareosconfig
+
+   systemctl restart apache2
+   systemctl restart php-fpm
 
 Upgrade from 18.2.6 to 18.2.7
 -----------------------------


### PR DESCRIPTION
Replace mod_php requirement with php-fpm.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.
- [x] CHANGELOG.md "breakin changes" entry with info that mod_php has been changed to php_fpm, and link to what needs to be done when upgrading.
- [x] Merge corresponding PR in git.bareos.com/ci-scripts

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

