### PR TITLE
winbareos.nsi: fix working directory in configure.sed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: fix crash in .jobstatus [PR #1278]
 - testfind: remove unnecessary libraries and fix systemtest [PR #1250]
 - stored: systemtests: docs: checkpoints improvements [PR #1277]
+- winbareos.nsi: fix working directory in configure.sed [PR #1288]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1148,6 +1148,9 @@ Section -ConfigureConfiguration
 #  Archive directory:            /usr/i686-w64-mingw32/sys-root/mingw/var/lib/bareos/storage
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/lib/bareos/storage#C:/bareos-storage#g$\r$\n"
 
+#  Working directory:            /usr/i686-w64-mingw32/sys-root/mingw/var/lib/bareos
+  FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/lib/bareos#$BareosAppdata/working#g$\r$\n"
+
 # Log directory:                /usr/i686-w64-mingw32/sys-root/mingw/var/log/bareos
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/log/bareos#$BareosAppdata/logs#g$\r$\n"
 
@@ -1162,9 +1165,6 @@ Section -ConfigureConfiguration
 
 #  Scripts directory:            /usr/x86_64-w64-mingw32/sys-root/mingw/lib/bareos/scripts
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/lib/bareos/scripts#$BareosAppdata/scripts#g$\r$\n"
-
-#  Working directory:            /var/lib/bareos
-  FileWrite $R1 "s#/var/lib/bareos#$BareosAppdata/working#g$\r$\n"
 
   FileWrite $R1 "s#dbpassword = .*#dbpassword = $DbPassword#g$\r$\n"
 

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -567,7 +567,7 @@ SectionIn 1 2 3 4
   File libpcre-1.dll
   File libbz2-1.dll
   File libssp-0.dll
-
+  File libintl-8.dll
 
   # for password generation
   File "openssl.exe"
@@ -2072,6 +2072,7 @@ ConfDeleteSkip:
   Delete "$INSTDIR\libpcre-1.dll"
   Delete "$INSTDIR\libbz2-1.dll"
   Delete "$INSTDIR\libssp-0.dll"
+  Delete "$INSTDIR\libintl-8.dll"
 
   RMDir /r "$INSTDIR\platforms"
 

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -599,7 +599,7 @@ SectionIn 1 2 3 4
   #File "bpipe-fd.dll"
   #File "mssqlvdi-fd.dll"
   #File "python-fd.dll"
-  File "*fd*"
+  File "*-fd.dll"
 
   File "Plugins\BareosFd*.py"
   File "Plugins\bareos-fd*.py"
@@ -662,7 +662,7 @@ SectionIn 2 3
   SetShellVarContext all
   SetOutPath "$INSTDIR\Plugins"
   SetOverwrite ifnewer
-  File "*sd*"
+  File "*-sd.dll"
   File "Plugins\BareosSd*.py"
   File "Plugins\bareos-sd*.py"
 SectionEnd
@@ -824,7 +824,7 @@ SectionIn 2 3
   SetOverwrite ifnewer
 
   #File "python-dir.dll"
-  File "*dir*"
+  File "*-dir.dll"
   File "Plugins\BareosDir*.py"
   File "Plugins\bareos-dir*.py"
 SectionEnd


### PR DESCRIPTION
This PR fix the working directory syntax and order in configure.sed
We also improve the installed plugins directory content

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

Manually checked.