### PR TITLE
winbareos.nsi: fix working directory in configure.sed 

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -32,31 +32,6 @@ OS:
            - libfastlz
            - python-bareos
 
-    "16.04":
-      TYPE: deb
-      IMAGE: "ubuntu16.04"
-      BUILD_FOR_VERSIONS:
-        - bareos-20
-        - bareos-19.2
-        - bareos-19.1
-        - bareos-18.2
-        - bareos-17.2
-      ARCH:
-        - i586
-        - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-vmware
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-        i586:
-           - bareos
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-
   openSUSE:
     "Leap_15.3":
       TYPE: rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Documentation
 - Adapt VMware plugin documentation for update to VDDK 8 [PR #1292]
 
+### Fixed
+- winbareos.nsi: fix working directory in configure.sed [PR #1290]
+
+### Removed
+- packaging: do not build for EOL Ubuntu 16.04 anymore [PR #1290]
+
 ## [20.0.7] - 2022-08-05
 
 ### Changed
@@ -22,6 +28,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
   - webui is NOT affected
   - webui does NOT use the npm server
   - webui does NOT use a user-provided locale string to directly switch moment locale
+
 
 ## [20.0.6] - 2022-03-14
 

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -580,7 +580,7 @@ SectionIn 1 2 3 4
   File libpcre-1.dll
   File libbz2-1.dll
   File libssp-0.dll
-
+  File libintl-8.dll
 
   # for password generation
   File "openssl.exe"
@@ -2167,6 +2167,7 @@ ConfDeleteSkip:
   Delete "$INSTDIR\libpcre-1.dll"
   Delete "$INSTDIR\libbz2-1.dll"
   Delete "$INSTDIR\libssp-0.dll"
+  Delete "$INSTDIR\libintl-8.dll"
 
   RMDir /r "$INSTDIR\platforms"
 

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -612,7 +612,7 @@ SectionIn 1 2 3 4
   #File "bpipe-fd.dll"
   #File "mssqlvdi-fd.dll"
   #File "python-fd.dll"
-  File "*fd*"
+  File "*-fd.dll"
 
   File "Plugins\BareosFd*.py"
   File "Plugins\bareos-fd*.py"
@@ -675,7 +675,7 @@ SectionIn 2 3
   SetShellVarContext all
   SetOutPath "$INSTDIR\Plugins"
   SetOverwrite ifnewer
-  File "*sd*"
+  File "*-sd.dll"
   File "Plugins\BareosSd*.py"
   File "Plugins\bareos-sd*.py"
 SectionEnd
@@ -888,7 +888,7 @@ SectionIn 2 3
   SetOverwrite ifnewer
 
   #File "python-dir.dll"
-  File "*dir*"
+  File "*-dir.dll"
   File "Plugins\BareosDir*.py"
   File "Plugins\bareos-dir*.py"
 SectionEnd

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1211,6 +1211,9 @@ Section -ConfigureConfiguration
 #  Archive directory:            /usr/i686-w64-mingw32/sys-root/mingw/var/lib/bareos/storage
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/lib/bareos/storage#C:/bareos-storage#g$\r$\n"
 
+#  Working directory:            /usr/i686-w64-mingw32/sys-root/mingw/var/lib/bareos
+  FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/lib/bareos#$BareosAppdata/working#g$\r$\n"
+
 # Log directory:                /usr/i686-w64-mingw32/sys-root/mingw/var/log/bareos
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/var/log/bareos#$BareosAppdata/logs#g$\r$\n"
 
@@ -1225,9 +1228,6 @@ Section -ConfigureConfiguration
 
 #  Scripts directory:            /usr/x86_64-w64-mingw32/sys-root/mingw/lib/bareos/scripts
   FileWrite $R1 "s#/usr/.*mingw.*/sys-root/mingw/lib/bareos/scripts#$BareosAppdata/scripts#g$\r$\n"
-
-#  Working directory:            /var/lib/bareos
-  FileWrite $R1 "s#/var/lib/bareos#$BareosAppdata/working#g$\r$\n"
 
   FileWrite $R1 "s#dbpassword = .*#dbpassword = $DbPassword#g$\r$\n"
 


### PR DESCRIPTION
This PR fix the working directory syntax and order in configure.sed
We also improve the installed plugins directory content.
Ubuntu 16.04 has been disabled (EOL since 2019)

**Backport of PR #1288 to bareos-20**

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

