### PR TITLE
spool.cc: set BlockSizeBoundaries in SetupNewDcrDevice()

### DIFF
--- a/core/src/stored/spool.cc
+++ b/core/src/stored/spool.cc
@@ -26,6 +26,7 @@
  */
 
 #include "include/bareos.h"
+#include "stored/blocksize_boundaries.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/acquire.h"
@@ -298,7 +299,10 @@ static bool DespoolData(DeviceControlRecord* dcr, bool commit)
   rdev->min_block_size = dcr->dev->min_block_size;
   rdev->device_resource = dcr->dev->device_resource;
   rdcr = dcr->get_new_spooling_dcr();
-  SetupNewDcrDevice(jcr, rdcr, rdev.get(), NULL);
+  struct BlockSizeBoundaries devboundries {
+    dcr->dev->max_block_size, dcr->dev->min_block_size
+  };
+  SetupNewDcrDevice(jcr, rdcr, rdev.get(), &devboundries);
   rdcr->spool_fd = dcr->spool_fd;
   block = dcr->block;       /* save block */
   dcr->block = rdcr->block; /* make read and write block the same */


### PR DESCRIPTION
During despooling in DespoolData(), the blocksize boundaries were not transferred to SetupNewDcrDevice().

This patch fixes this problem.
Fatal error: stored/spool.cc:478 Spool block too big. Max 64512 bytes, got 1048576

OP #5274 #5284

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
