### PR TITLE
backup.cc: fail backup when `Write Bootstrap` to pipe fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: systemtests: docs: checkpoints improvements [PR #1277]
 - winbareos.nsi: fix working directory in configure.sed [PR #1288]
 - core: BareosDb::FindLastJobStartTimeForJobAndClient: take into account Running job [PR #1265] [BUG #1466]
+- backup.cc: fail backup when `Write Bootstrap` to pipe fails [PR #1296]
 
 ### Changed
 - contrib: rename Python modules to satisfy PEP8 [PR #768]

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -852,10 +852,11 @@ void UpdateBootstrapFile(JobControlRecord* jcr)
         int status = CloseBpipe(bpipe);
         if (status) {
           BErrNo err;
-          Jmsg(jcr, M_FATAL, 0,
-               _("Piping went wrong when updating bootstrap file: "
+          Jmsg(jcr, M_ERROR, 0,
+               _("Error running program when updating bootstrap file: "
                  "%s: ERR=%s\n"),
                fname, err.bstrerror(status));
+          jcr->setJobStatus(JS_ErrorTerminated);
         }
       } else {
         fclose(fd);

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -849,7 +849,14 @@ void UpdateBootstrapFile(JobControlRecord* jcr)
       }
       if (VolParams) { free(VolParams); }
       if (got_pipe) {
-        CloseBpipe(bpipe);
+        int status = CloseBpipe(bpipe);
+        if (status) {
+          BErrNo err;
+          Jmsg(jcr, M_FATAL, 0,
+               _("Piping went wrong when updating bootstrap file: "
+                 "%s: ERR=%s\n"),
+               fname, err.bstrerror(status));
+        }
       } else {
         fclose(fd);
       }

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -404,10 +404,6 @@ bareos_add_test(
 
 bareos_add_test(thread_list LINK_LIBRARIES bareos GTest::gtest_main)
 
-set_tests_properties(
-  gtest:thread_list.thread_list_startup_and_shutdown PROPERTIES LABELS broken
-)
-
 bareos_add_test(
   thread_specific_data LINK_LIBRARIES bareos Threads::Threads GTest::gtest_main
 )

--- a/core/src/tests/thread_list.cc
+++ b/core/src/tests/thread_list.cc
@@ -87,8 +87,7 @@ static void* ShutdownCallback(void* data)
   return nullptr;
 }
 
-static constexpr int maximum_allowed_thread_count = 10;
-static constexpr int try_to_start_thread_count = 11;
+static constexpr int maximum_thread_count = 10;
 
 TEST(thread_list, thread_list_startup_and_shutdown)
 {
@@ -96,7 +95,7 @@ TEST(thread_list, thread_list_startup_and_shutdown)
 
   t->Init(ThreadHandler, ShutdownCallback);
 
-  for (int i = 0; i < try_to_start_thread_count; i++) {
+  for (int i = 0; i < maximum_thread_count; i++) {
     auto wc(std::make_unique<WaitCondition>());
     if (t->CreateAndAddNewThread(nullptr, wc.get())) {
       list_of_wait_conditions.push_back(std::move(wc));
@@ -110,7 +109,7 @@ TEST(thread_list, thread_list_startup_and_shutdown)
     EXPECT_EQ(c.get()->GetStatus(), WaitCondition::Status::kSuccess);
   }
 
-  EXPECT_EQ(thread_counter, maximum_allowed_thread_count);
+  EXPECT_EQ(thread_counter, maximum_thread_count);
 }
 
 static void* ThreadHandlerSleepRandomTime(ConfigurationParser*, void* data)
@@ -131,7 +130,7 @@ TEST(thread_list, thread_random_shutdown)
   t->Init(ThreadHandlerSleepRandomTime, nullptr);
 
   thread_counter = 0;
-  for (int i = 0; i < maximum_allowed_thread_count; i++) {
+  for (int i = 0; i < maximum_thread_count; i++) {
     t->CreateAndAddNewThread(nullptr, nullptr);
   }
 
@@ -139,5 +138,5 @@ TEST(thread_list, thread_random_shutdown)
   t->ShutdownAndWaitForThreadsToFinish();
 
   EXPECT_EQ(t->Size(), 0);
-  EXPECT_EQ(thread_counter, maximum_allowed_thread_count);
+  EXPECT_EQ(thread_counter, maximum_thread_count);
 }

--- a/systemtests/tests/bareos/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
+++ b/systemtests/tests/bareos/etc/bareos/bareos-dir.d/job/BackupCatalog.conf.in
@@ -13,8 +13,5 @@ Job {
   # This deletes the copy of the catalog
   RunAfterJob  = "@scriptdir@/delete_catalog_backup MyCatalog"
 
-  # This sends the bootstrap via mail for disaster recovery.
-  # Should be sent to another system, please change recipient accordingly
-  Write Bootstrap = "|@bindir@/bsmtp -h @smtp_host@ -f \"\(Bareos\) \" -s \"Bootstrap for Job %j\" @job_email@" # (#01)
   Priority = 11                   # run after main backup
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

When using a pipe in the `Write Bootstrap` directive, if the given command after the pipe fails, the job still is successful. 
This PR checks for the return value of the pipe and makes the job fail in case of errors.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
