### PR TITLE
catalog: update fileset text in fileset record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: dird: added backup checkpoints that save backup metadata to the Catalog during the execution of the backup. [PR #1074]
 - stored: dird: add backup checkpoints that save backup metadata to the Catalog during the execution of the backup. [PR #1074]
 - build: run a build and test with sanitizers enabled [PR #1244]
+- catalog: update fileset text in fileset record [PR #1300]
 
 ### Fixed
 - webui: adapt links to new URLs after website relaunch. [PR #1275]
@@ -332,6 +333,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1254]: https://github.com/bareos/bareos/pull/1254
 [PR #1255]: https://github.com/bareos/bareos/pull/1255
 [PR #1260]: https://github.com/bareos/bareos/pull/1260
+[PR #1261]: https://github.com/bareos/bareos/pull/1261
 [PR #1262]: https://github.com/bareos/bareos/pull/1262
 [PR #1265]: https://github.com/bareos/bareos/pull/1265
 [PR #1266]: https://github.com/bareos/bareos/pull/1266
@@ -341,6 +343,11 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1275]: https://github.com/bareos/bareos/pull/1275
 [PR #1277]: https://github.com/bareos/bareos/pull/1277
 [PR #1278]: https://github.com/bareos/bareos/pull/1278
+[PR #1279]: https://github.com/bareos/bareos/pull/1279
 [PR #1284]: https://github.com/bareos/bareos/pull/1284
 [PR #1285]: https://github.com/bareos/bareos/pull/1285
+[PR #1288]: https://github.com/bareos/bareos/pull/1288
+[PR #1296]: https://github.com/bareos/bareos/pull/1296
+[PR #1298]: https://github.com/bareos/bareos/pull/1298
+[PR #1300]: https://github.com/bareos/bareos/pull/1300
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -706,7 +706,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
     num_rows = SqlNumRows();
 
     if (num_rows > 1) {
-      Mmsg1(errmsg, _("More than one FileSet!: %d\n"), num_rows);
+      Mmsg2(errmsg, _("More than one FileSet! %s: %d\n"), esc_fs, num_rows);
       Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
     }
     if (num_rows >= 1) {
@@ -734,8 +734,9 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
 
       Mmsg(cmd,
            "UPDATE FileSet SET (FileSet,MD5,CreateTime,FileSetText) "
-           "= ('%s','%s','%s','%s')",
-           esc_fs, esc_md5, fsr->cCreateTime, esc_filesettext.c_str());
+           "= ('%s','%s','%s','%s') WHERE FileSet='%s' AND MD5='%s' ",
+           esc_fs, esc_md5, fsr->cCreateTime, esc_filesettext.c_str(), esc_fs,
+           esc_md5);
       if (QUERY_DB(jcr, cmd)) {
         SqlFreeResult();
         return true;
@@ -762,7 +763,6 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
     len = strlen(fsr->FileSetText);
     esc_filesettext.check_size(len * 2 + 1);
     EscapeString(jcr, esc_filesettext.c_str(), fsr->FileSetText, len);
-
     Mmsg(cmd,
          "INSERT INTO FileSet (FileSet,MD5,CreateTime,FileSetText) "
          "VALUES ('%s','%s','%s','%s')",
@@ -925,7 +925,6 @@ bool BareosDb::CreateFileAttributesRecord(JobControlRecord* jcr,
   DbLocker _{this};
   Dmsg1(dbglevel, "Fname=%s\n", ar->fname);
   Dmsg0(dbglevel, "put_file_into_catalog\n");
-
   SplitPathAndFile(jcr, ar->fname);
 
   if (!CreatePathRecord(jcr, ar)) { return false; }

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1360,7 +1360,8 @@ bool GetOrCreateFilesetRecord(JobControlRecord* jcr)
   } else {
     Jmsg(jcr, M_WARNING, 0, _("FileSet MD5 digest not found.\n"));
   }
-  if (!jcr->impl->res.fileset->ignore_fs_changes) {
+  if (!jcr->impl->res.fileset->ignore_fs_changes
+      || !jcr->db->GetFilesetRecord(jcr, &fsr)) {
     PoolMem FileSetText(PM_MESSAGE);
     OutputFormatter output_formatter
         = OutputFormatter(pm_append, (void*)&FileSetText, nullptr, nullptr);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1352,18 +1352,15 @@ bool GetOrCreateFilesetRecord(JobControlRecord* jcr)
     unsigned char digest[16]; /* MD5 digest length */
     memcpy(&md5c, &jcr->impl->res.fileset->md5c, sizeof(md5c));
     ALLOW_DEPRECATED(MD5_Final(digest, &md5c));
-    /*
-     * Keep the flag (last arg) set to false otherwise old FileSets will
-     * get new MD5 sums and the user will get Full backups on everything
-     */
+    /* Keep the flag (last arg) set to false otherwise old FileSets will
+     * get new MD5 sums and the user will get Full backups on everything */
     BinToBase64(fsr.MD5, sizeof(fsr.MD5), (char*)digest, sizeof(digest), false);
     bstrncpy(jcr->impl->res.fileset->MD5, fsr.MD5,
              sizeof(jcr->impl->res.fileset->MD5));
   } else {
     Jmsg(jcr, M_WARNING, 0, _("FileSet MD5 digest not found.\n"));
   }
-  if (!jcr->impl->res.fileset->ignore_fs_changes
-      || !jcr->db->GetFilesetRecord(jcr, &fsr)) {
+  if (!jcr->impl->res.fileset->ignore_fs_changes) {
     PoolMem FileSetText(PM_MESSAGE);
     OutputFormatter output_formatter
         = OutputFormatter(pm_append, (void*)&FileSetText, nullptr, nullptr);

--- a/systemtests/tests/bareos/testrunner-filesettext-is-updated
+++ b/systemtests/tests/bareos/testrunner-filesettext-is-updated
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# Delete fileset text from database and check that it is readded
+# when estimate call uses the fileset
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+run_log=$tmp/run.out
+filesetwithtext=$tmp/fileset-with-filesettext
+filesetwithouttext=$tmp/fileset-without-filesettext
+JobName=backup-bareos-fd
+
+rm -f $run_log $filesetwithtext $filesetwithouttext
+
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $run_log
+@# first do an estimate to be sure the fileset db entry exists
+estimate listing job=$JobName
+
+@# remove filesettext from db entry
+sqlquery
+update fileset set filesettext='';
+
+@$out $filesetwithouttext
+@# display fileset entry (without filesettext)
+sqlquery
+select * from fileset;
+
+@# call estimate to update the fileset db entry and readd the filesettext
+estimate listing job=$JobName
+
+@#verify the fileset text is added again
+@$out $filesetwithtext
+sqlquery
+select * from fileset;
+END_OF_DATA
+
+run_bconsole
+
+run_bconsole
+
+# check that the fileset has not the fileset text after it was deleted
+expect_grep "|         1 | SelfTest | FileSet {" \
+            "$filesetwithtext" \
+            "The expected fileset text was not found."
+
+# check that the fileset has the fileset was added by the estimate call
+expect_grep "|         1 | SelfTest |             |" \
+            "$filesetwithouttext" \
+            "The expected fileset without text was not found."
+
+
+end_test


### PR DESCRIPTION
Old bareos versions did not set the fileset text in the fileset database.

As existing fileset database entries were not updated if they already exist, the fileset text was not added afterwards.

This PR fixes this so that the fileset is updated even if it already exists.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
