### PR TITLE
webui: fix pool link in job details formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - devtools/dist-tarball.sh: fix name if version contains "~pre" [PR #1220]
 - dird: fix crash in .jobstatus [PR #1286]
 - winbareos.nsi: fix working directory in configure.sed [PR #1289]
+- webui: fix pool link in job details formatter [PR #1303] [BUG #1489]
 
 ### Documentation
 - Univention Corporate Server (UCS) >= 5: same support as for other Linux distributions, but no extended integration as for UCS < 5 [PR #1245]
@@ -48,7 +49,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Documentation
 - doc: backport FIPS section in security [PR #1212]
-
 
 ## [21.1.3] - 2022-05-09
 
@@ -214,6 +214,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - SQL: queries: fix sql queries to handle negative job duration value [PR #1201]
 - dird: fix TLS-PSK credential not found error with very long job names [PR #1208]
 - dird: fix odd-even weeks parsing bug in schedule [PR #1232]
+
 
 ### Added
 - plugin: added mariabackup python plugin, added systemtest for mariabackup and updated systemtest for percona-xtrabackup [PR #967]

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link   https://github.com/bareos/bareos for the canonical source repository
- * @copyright   Copyright (C) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright   Copyright (C) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -154,7 +154,7 @@ $this->headTitle($title);
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Pool")); ?></th>');
-      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/'; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
+      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/?pool='; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Scheduled")); ?></th>');

--- a/webui/module/Job/view/job/job/index.phtml
+++ b/webui/module/Job/view/job/job/index.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (C) 2013-2021 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2013-2022 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify
@@ -309,7 +309,7 @@ $this->headTitle($title);
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Pool")); ?></th>');
-      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/'; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
+      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/?pool='; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Scheduled")); ?></th>');


### PR DESCRIPTION
**Backport of PR #1302 to bareos-21**

Adds missing query parameter.

Fixes #1489: broken storage pool link

(cherry picked from commit e2fdc8e9882d81f2212959e946ab277170dad9a3)


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

