### PR TITLE
webui: fix pool link in job details formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - webui: get volume and pool params from query instead of route [PR #1145]
+- webui: fix pool link in job details formatter [PR #1304] [BUG #1489]
 
 ## [20.0.6] - 2022-03-14
 

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -153,7 +153,7 @@ $this->headTitle($title);
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Pool")); ?></th>');
-      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/'; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
+      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/?pool='; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Scheduled")); ?></th>');

--- a/webui/module/Job/view/job/job/index.phtml
+++ b/webui/module/Job/view/job/job/index.phtml
@@ -301,7 +301,7 @@ $this->headTitle($title);
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Pool")); ?></th>');
-      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/'; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
+      html.push('<td><a href="<?php echo $this->basePath() . '/pool/details/?pool='; ?>' + row.poolname + '">' + row.poolname + '</a></td>');
       html.push('</tr>');
       html.push('<tr>');
       html.push('<th><?php echo addslashes($this->translate("Scheduled")); ?></th>');


### PR DESCRIPTION
Adds missing query parameter.

Fixes #1489: broken storage pool link

(cherry picked from commit e2fdc8e9882d81f2212959e946ab277170dad9a3)

**Backport of PR #1302 to bareos-20**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- ~`bareos-check-sources --since-merge` does not report any problems~
