### PR TITLE
core: use distinct names for JobControlRecordPrivate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - lib: make foreach_res() reload-safe [PR #1279]
 - Prepare Bareos for an upgrade to the C++20 standard [PR #1271]
 - stored: refactor the SD's backend interface [PR #1272]
+- core: use distinct names for JobControlRecordPrivate [PR #1307]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.

--- a/core/src/dird/admin.cc
+++ b/core/src/dird/admin.cc
@@ -30,7 +30,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/admin.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/storage.h"
 
@@ -52,9 +52,9 @@ bool DoAdminInit(JobControlRecord* jcr)
  */
 bool do_admin(JobControlRecord* jcr)
 {
-  jcr->impl->jr.JobId = jcr->JobId;
+  jcr->dir_impl->jr.JobId = jcr->JobId;
 
-  jcr->impl->fname = (char*)GetPoolMemory(PM_FNAME);
+  jcr->dir_impl->fname = (char*)GetPoolMemory(PM_FNAME);
 
   Jmsg(jcr, M_INFO, 0, _("Start Admin JobId %d, Job=%s\n"), jcr->JobId,
        jcr->Job);
@@ -76,7 +76,7 @@ void AdminCleanup(JobControlRecord* jcr, int TermCode)
 
   UpdateJobEnd(jcr, TermCode);
 
-  if (!jcr->db->GetJobRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_WARNING, 0,
          _("Error getting Job record for Job report: ERR=%s\n"),
          jcr->db->strerror());
@@ -102,9 +102,9 @@ void AdminCleanup(JobControlRecord* jcr, int TermCode)
               jcr->getJobStatus());
       break;
   }
-  bstrftimes(schedt, sizeof(schedt), jcr->impl->jr.SchedTime);
-  bstrftimes(sdt, sizeof(sdt), jcr->impl->jr.StartTime);
-  bstrftimes(edt, sizeof(edt), jcr->impl->jr.EndTime);
+  bstrftimes(schedt, sizeof(schedt), jcr->dir_impl->jr.SchedTime);
+  bstrftimes(sdt, sizeof(sdt), jcr->dir_impl->jr.StartTime);
+  bstrftimes(edt, sizeof(edt), jcr->dir_impl->jr.EndTime);
 
   Jmsg(jcr, msg_type, 0,
        _("BAREOS %s (%s): %s\n"
@@ -117,9 +117,9 @@ void AdminCleanup(JobControlRecord* jcr, int TermCode)
          "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt,
-       jcr->impl->jr.JobId, jcr->impl->jr.Job, schedt, sdt, edt,
+       jcr->dir_impl->jr.JobId, jcr->dir_impl->jr.Job, schedt, sdt, edt,
        kBareosVersionStrings.JoblogMessage,
-       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
+       JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave AdminCleanup()\n");
 }

--- a/core/src/dird/archive.cc
+++ b/core/src/dird/archive.cc
@@ -30,7 +30,7 @@
 #include "dird.h"
 #include "dird/archive.h"
 #include "dird/job.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/storage.h"
 
 namespace directordaemon {
@@ -51,9 +51,9 @@ bool DoArchiveInit(JobControlRecord* jcr)
  */
 bool DoArchive(JobControlRecord* jcr)
 {
-  jcr->impl->jr.JobId = jcr->JobId;
+  jcr->dir_impl->jr.JobId = jcr->JobId;
 
-  jcr->impl->fname = (char*)GetPoolMemory(PM_FNAME);
+  jcr->dir_impl->fname = (char*)GetPoolMemory(PM_FNAME);
 
   Jmsg(jcr, M_INFO, 0, _("Start Archive JobId %d, Job=%s\n"), jcr->JobId,
        jcr->Job);
@@ -75,7 +75,7 @@ void ArchiveCleanup(JobControlRecord* jcr, int TermCode)
 
   UpdateJobEnd(jcr, TermCode);
 
-  if (!jcr->db->GetJobRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_WARNING, 0,
          _("Error getting Job record for Job report: ERR=%s\n"),
          jcr->db->strerror());
@@ -102,9 +102,9 @@ void ArchiveCleanup(JobControlRecord* jcr, int TermCode)
       break;
   }
 
-  bstrftimes(schedt, sizeof(schedt), jcr->impl->jr.SchedTime);
-  bstrftimes(sdt, sizeof(sdt), jcr->impl->jr.StartTime);
-  bstrftimes(edt, sizeof(edt), jcr->impl->jr.EndTime);
+  bstrftimes(schedt, sizeof(schedt), jcr->dir_impl->jr.SchedTime);
+  bstrftimes(sdt, sizeof(sdt), jcr->dir_impl->jr.StartTime);
+  bstrftimes(edt, sizeof(edt), jcr->dir_impl->jr.EndTime);
 
   Jmsg(jcr, msg_type, 0,
        _("BAREOS %s (%s): %s\n"
@@ -117,9 +117,9 @@ void ArchiveCleanup(JobControlRecord* jcr, int TermCode)
          "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt,
-       jcr->impl->jr.JobId, jcr->impl->jr.Job, schedt, sdt, edt,
+       jcr->dir_impl->jr.JobId, jcr->dir_impl->jr.Job, schedt, sdt, edt,
        kBareosVersionStrings.JoblogMessage,
-       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
+       JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave ArchiveCleanup()\n");
 }

--- a/core/src/dird/authenticate.cc
+++ b/core/src/dird/authenticate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -37,7 +37,7 @@
 #include "dird/fd_cmds.h"
 #include "dird/client_connection_handshake_mode.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "lib/bnet.h"
 #include "lib/qualified_resource_name_type_converter.h"
 #include "lib/bstringlist.h"
@@ -124,9 +124,9 @@ bool AuthenticateWithFileDaemon(JobControlRecord* jcr)
   if (jcr->authenticated) { return true; }
 
   BareosSocket* fd = jcr->file_bsock;
-  ClientResource* client = jcr->impl->res.client;
+  ClientResource* client = jcr->dir_impl->res.client;
 
-  if (jcr->impl->connection_handshake_try_
+  if (jcr->dir_impl->connection_handshake_try_
       == ClientConnectionHandshakeMode::kTlsFirst) {
     std::string qualified_resource_name;
     if (!my_config->GetQualifiedResourceNameTypeConverter()->ResourceToString(
@@ -186,9 +186,9 @@ bool AuthenticateWithFileDaemon(JobControlRecord* jcr)
   }
 
   Dmsg1(110, "<filed: %s", fd->msg);
-  jcr->impl->FDVersion = 0;
+  jcr->dir_impl->FDVersion = 0;
   if (!bstrncmp(fd->msg, FDOKhello, sizeof(FDOKhello))
-      && sscanf(fd->msg, FDOKnewHello, &jcr->impl->FDVersion) != 1) {
+      && sscanf(fd->msg, FDOKnewHello, &jcr->dir_impl->FDVersion) != 1) {
     Dmsg0(debuglevel, _("File daemon rejected Hello command\n"));
     Jmsg(jcr, M_FATAL, 0,
          _("File daemon at \"%s:%d\" rejected Hello command\n"), fd->host(),

--- a/core/src/dird/autoprune.cc
+++ b/core/src/dird/autoprune.cc
@@ -28,7 +28,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 #include "dird/ua_server.h"
 #include "dird/ua_prune.h"
@@ -49,14 +49,14 @@ void DoAutoprune(JobControlRecord* jcr)
   PoolResource* pool;
   bool pruned;
 
-  if (!jcr->impl->res.client) { /* temp -- remove me */
+  if (!jcr->dir_impl->res.client) { /* temp -- remove me */
     return;
   }
 
   ua = new_ua_context(jcr);
-  job = jcr->impl->res.job;
-  client = jcr->impl->res.client;
-  pool = jcr->impl->res.pool;
+  job = jcr->dir_impl->res.job;
+  client = jcr->dir_impl->res.client;
+  pool = jcr->dir_impl->res.pool;
 
   if (job->PruneJobs || client->AutoPrune) {
     PruneJobs(ua, client, pool);
@@ -92,8 +92,9 @@ void PruneVolumes(JobControlRecord* jcr,
   PoolMem query(PM_MESSAGE);
   char ed1[50], ed2[100], ed3[50];
 
-  Dmsg1(100, "Prune volumes PoolId=%d\n", jcr->impl->jr.PoolId);
-  if (!jcr->impl->res.job->PruneVolumes && !jcr->impl->res.pool->AutoPrune) {
+  Dmsg1(100, "Prune volumes PoolId=%d\n", jcr->dir_impl->jr.PoolId);
+  if (!jcr->dir_impl->res.job->PruneVolumes
+      && !jcr->dir_impl->res.pool->AutoPrune) {
     Dmsg0(100, "AutoPrune not set in Pool.\n");
     return;
   }

--- a/core/src/dird/consolidate.cc
+++ b/core/src/dird/consolidate.cc
@@ -31,7 +31,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/consolidate.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/storage.h"
 #include "dird/ua_input.h"
@@ -54,7 +54,7 @@ bool DoConsolidateInit(JobControlRecord* jcr)
 
 /**
  * Start a Virtual(Full) Job that creates a new virtual backup
- * containing the jobids given in jcr->impl_->vf_jobids
+ * containing the jobids given in jcr->dir_impl_->vf_jobids
  */
 static inline void StartNewConsolidationJob(JobControlRecord* jcr,
                                             char* jobname)
@@ -66,7 +66,8 @@ static inline void StartNewConsolidationJob(JobControlRecord* jcr,
   ua = new_ua_context(jcr);
   ua->batch = true;
   Mmsg(ua->cmd, "run job=\"%s\" jobid=%s level=VirtualFull %s", jobname,
-       jcr->impl->vf_jobids, jcr->accurate ? "accurate=yes" : "accurate=no");
+       jcr->dir_impl->vf_jobids,
+       jcr->accurate ? "accurate=yes" : "accurate=no");
 
   Dmsg1(debuglevel, "=============== consolidate cmd=%s\n", ua->cmd);
   ParseUaArgs(ua); /* parse command */
@@ -100,16 +101,16 @@ bool DoConsolidate(JobControlRecord* jcr)
   int32_t fullconsolidations_started = 0;
   int32_t max_full_consolidations = 0;
 
-  tmpjob = jcr->impl->res.job; /* Memorize job */
+  tmpjob = jcr->dir_impl->res.job; /* Memorize job */
 
   // Get Value for MaxFullConsolidations from Consolidation job
-  max_full_consolidations = jcr->impl->res.job->MaxFullConsolidations;
+  max_full_consolidations = jcr->dir_impl->res.job->MaxFullConsolidations;
 
-  jcr->impl->jr.JobId = jcr->JobId;
-  jcr->impl->fname = (char*)GetPoolMemory(PM_FNAME);
+  jcr->dir_impl->jr.JobId = jcr->JobId;
+  jcr->dir_impl->fname = (char*)GetPoolMemory(PM_FNAME);
 
   // do not cancel virtual fulls started by consolidation
-  jcr->impl->IgnoreDuplicateJobChecking = true;
+  jcr->dir_impl->IgnoreDuplicateJobChecking = true;
 
   // Print Job Start message
   Jmsg(jcr, M_INFO, 0, _("Start Consolidate JobId %d, Job=%s\n"), jcr->JobId,
@@ -123,12 +124,12 @@ bool DoConsolidate(JobControlRecord* jcr)
            job->resource_name_);
 
       // Fake always incremental job as job of current jcr.
-      jcr->impl->res.job = job;
-      jcr->impl->res.fileset = job->fileset;
-      jcr->impl->res.client = job->client;
-      jcr->impl->jr.JobLevel = L_INCREMENTAL;
-      jcr->impl->jr.limit = 0;
-      jcr->impl->jr.StartTime = 0;
+      jcr->dir_impl->res.job = job;
+      jcr->dir_impl->res.fileset = job->fileset;
+      jcr->dir_impl->res.client = job->client;
+      jcr->dir_impl->jr.JobLevel = L_INCREMENTAL;
+      jcr->dir_impl->jr.limit = 0;
+      jcr->dir_impl->jr.StartTime = 0;
 
       if (!GetOrCreateFilesetRecord(jcr)) {
         Jmsg(jcr, M_FATAL, 0, _("JobId=%d no FileSet\n"), (int)jcr->JobId);
@@ -144,7 +145,7 @@ bool DoConsolidate(JobControlRecord* jcr)
 
       // First determine the number of total incrementals
       db_list_ctx all_jobids_ctx;
-      jcr->db->AccurateGetJobids(jcr, &jcr->impl->jr, &all_jobids_ctx);
+      jcr->db->AccurateGetJobids(jcr, &jcr->dir_impl->jr, &all_jobids_ctx);
       Dmsg1(10, "unlimited jobids list:  %s.\n",
             all_jobids_ctx.GetAsString().c_str());
 
@@ -156,20 +157,20 @@ bool DoConsolidate(JobControlRecord* jcr)
       if (job->AlwaysIncrementalJobRetention) {
         char sdt[50];
 
-        jcr->impl->jr.StartTime = now - job->AlwaysIncrementalJobRetention;
-        bstrftimes(sdt, sizeof(sdt), jcr->impl->jr.StartTime);
+        jcr->dir_impl->jr.StartTime = now - job->AlwaysIncrementalJobRetention;
+        bstrftimes(sdt, sizeof(sdt), jcr->dir_impl->jr.StartTime);
         Jmsg(jcr, M_INFO, 0,
              _("%s: considering jobs older than %s for consolidation.\n"),
              job->resource_name_, sdt);
         Dmsg4(10,
               _("%s: considering jobs with ClientId %d and FilesetId %d older "
                 "than %s for consolidation.\n"),
-              job->resource_name_, jcr->impl->jr.ClientId,
-              jcr->impl->jr.FileSetId, sdt);
+              job->resource_name_, jcr->dir_impl->jr.ClientId,
+              jcr->dir_impl->jr.FileSetId, sdt);
       }
 
       db_list_ctx jobids_ctx;
-      jcr->db->AccurateGetJobids(jcr, &jcr->impl->jr, &jobids_ctx);
+      jcr->db->AccurateGetJobids(jcr, &jcr->dir_impl->jr, &jobids_ctx);
       Dmsg1(10, "consolidate candidates:  %s.\n",
             jobids_ctx.GetAsString().c_str());
 
@@ -212,12 +213,12 @@ bool DoConsolidate(JobControlRecord* jcr)
       const int32_t max_incrementals_to_consolidate
           = incrementals_total - job->AlwaysIncrementalKeepNumber;
 
-      jcr->impl->jr.limit = max_incrementals_to_consolidate + 1;
+      jcr->dir_impl->jr.limit = max_incrementals_to_consolidate + 1;
       Dmsg3(10, "total: %d, to_consolidate: %d, limit: %d.\n",
             incrementals_total, max_incrementals_to_consolidate,
-            jcr->impl->jr.limit);
+            jcr->dir_impl->jr.limit);
       jobids_ctx.clear();
-      jcr->db->AccurateGetJobids(jcr, &jcr->impl->jr, &jobids_ctx);
+      jcr->db->AccurateGetJobids(jcr, &jcr->dir_impl->jr, &jobids_ctx);
       const int32_t incrementals_to_consolidate = jobids_ctx.size() - 1;
       Dmsg2(10, "%d consolidate ids after limit: %s.\n", jobids_ctx.size(),
             jobids_ctx.GetAsString().c_str());
@@ -256,18 +257,18 @@ bool DoConsolidate(JobControlRecord* jcr)
         if (p) { *p = '\0'; }
 
         // Get db record of oldest jobid and check its age
-        jcr->impl->previous_jr = JobDbRecord{};
-        jcr->impl->previous_jr.JobId = str_to_int64(jobids);
+        jcr->dir_impl->previous_jr = JobDbRecord{};
+        jcr->dir_impl->previous_jr.JobId = str_to_int64(jobids);
         Dmsg1(10, "Previous JobId=%s\n", jobids);
 
-        if (!jcr->db->GetJobRecord(jcr, &jcr->impl->previous_jr)) {
+        if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->previous_jr)) {
           Jmsg(jcr, M_FATAL, 0,
                _("Error getting Job record for first Job: ERR=%s\n"),
                jcr->db->strerror());
           goto bail_out;
         }
 
-        starttime = jcr->impl->previous_jr.JobTDate;
+        starttime = jcr->dir_impl->previous_jr.JobTDate;
         oldest_allowed_starttime = now - job->AlwaysIncrementalMaxFullAge;
         bstrftimes(sdt_allowed, sizeof(sdt_allowed), oldest_allowed_starttime);
         bstrftimes(sdt_starttime, sizeof(sdt_starttime), starttime);
@@ -305,10 +306,10 @@ bool DoConsolidate(JobControlRecord* jcr)
       }
 
       // Set the virtualfull jobids to be consolidated
-      if (!jcr->impl->vf_jobids) {
-        jcr->impl->vf_jobids = GetPoolMemory(PM_MESSAGE);
+      if (!jcr->dir_impl->vf_jobids) {
+        jcr->dir_impl->vf_jobids = GetPoolMemory(PM_MESSAGE);
       }
-      PmStrcpy(jcr->impl->vf_jobids, p);
+      PmStrcpy(jcr->dir_impl->vf_jobids, p);
 
       Jmsg(jcr, M_INFO, 0, _("%s: Start new consolidation\n"),
            job->resource_name_);
@@ -318,7 +319,7 @@ bool DoConsolidate(JobControlRecord* jcr)
 
 bail_out:
   // Restore original job back to jcr.
-  jcr->impl->res.job = tmpjob;
+  jcr->dir_impl->res.job = tmpjob;
   jcr->setJobStatusWithPriorityCheck(JS_Terminated);
   ConsolidateCleanup(jcr, JS_Terminated);
 
@@ -339,7 +340,7 @@ void ConsolidateCleanup(JobControlRecord* jcr, int TermCode)
 
   UpdateJobEnd(jcr, TermCode);
 
-  if (!jcr->db->GetJobRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_WARNING, 0,
          _("Error getting Job record for Job report: ERR=%s\n"),
          jcr->db->strerror());
@@ -365,9 +366,9 @@ void ConsolidateCleanup(JobControlRecord* jcr, int TermCode)
               jcr->getJobStatus());
       break;
   }
-  bstrftimes(schedt, sizeof(schedt), jcr->impl->jr.SchedTime);
-  bstrftimes(sdt, sizeof(sdt), jcr->impl->jr.StartTime);
-  bstrftimes(edt, sizeof(edt), jcr->impl->jr.EndTime);
+  bstrftimes(schedt, sizeof(schedt), jcr->dir_impl->jr.SchedTime);
+  bstrftimes(sdt, sizeof(sdt), jcr->dir_impl->jr.StartTime);
+  bstrftimes(edt, sizeof(edt), jcr->dir_impl->jr.EndTime);
 
   Jmsg(jcr, msg_type, 0,
        _("BAREOS %s (%s): %s\n"
@@ -380,9 +381,9 @@ void ConsolidateCleanup(JobControlRecord* jcr, int TermCode)
          "  Job triggered by:       %s\n"
          "  Termination:            %s\n\n"),
        kBareosVersionStrings.Full, kBareosVersionStrings.ShortDate, edt,
-       jcr->impl->jr.JobId, jcr->impl->jr.Job, schedt, sdt, edt,
+       jcr->dir_impl->jr.JobId, jcr->dir_impl->jr.Job, schedt, sdt, edt,
        kBareosVersionStrings.JoblogMessage,
-       JobTriggerToString(jcr->impl->job_trigger).c_str(), TermMsg);
+       JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), TermMsg);
 
   Dmsg0(debuglevel, "Leave ConsolidateCleanup()\n");
 }

--- a/core/src/dird/dbcopy/database_connection.h
+++ b/core/src/dird/dbcopy/database_connection.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,7 +25,7 @@
 #include "include/bareos.h"
 #include "dird/dird_globals.h"
 #include "dird/job.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/dird_conf.h"
 #include "dird/get_database_connection.h"
 #include "dird/dbcopy/database_type.h"
@@ -47,11 +47,11 @@ class DatabaseConnection {
   {
     jcr_.reset(directordaemon::NewDirectorJcr());
 
-    jcr_->impl->res.catalog
+    jcr_->dir_impl->res.catalog
         = static_cast<directordaemon::CatalogResource*>(config->GetResWithName(
             directordaemon::R_CATALOG, catalog_resource_name.c_str()));
 
-    if (jcr_->impl->res.catalog == nullptr) {
+    if (jcr_->dir_impl->res.catalog == nullptr) {
       std::string err{"Could not find catalog resource "};
       err += catalog_resource_name;
       err += ".";
@@ -67,7 +67,7 @@ class DatabaseConnection {
       throw std::runtime_error(err);
     }
 
-    db_type = DatabaseType::Convert(jcr_->impl->res.catalog->db_driver);
+    db_type = DatabaseType::Convert(jcr_->dir_impl->res.catalog->db_driver);
   }
 
  private:

--- a/core/src/dird/dbcopy/dbcopy.cc
+++ b/core/src/dird/dbcopy/dbcopy.cc
@@ -30,7 +30,7 @@
 #include "dird/dird_conf.h"
 #include "dird/dird_globals.h"
 #include "dird/get_database_connection.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -49,7 +49,7 @@
 #include "dird.h"
 #include "dird/inc_conf.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "include/auth_protocol_types.h"
 #include "include/auth_types.h"
 #include "include/migration_selection_types.h"
@@ -3139,25 +3139,29 @@ extern "C" char* job_code_callback_director(JobControlRecord* jcr,
 
   switch (param[0]) {
     case 'f':
-      if (jcr->impl->res.fileset) {
-        return jcr->impl->res.fileset->resource_name_;
+      if (jcr->dir_impl->res.fileset) {
+        return jcr->dir_impl->res.fileset->resource_name_;
       }
       break;
     case 'h':
-      if (jcr->impl->res.client) { return jcr->impl->res.client->address; }
+      if (jcr->dir_impl->res.client) {
+        return jcr->dir_impl->res.client->address;
+      }
       break;
     case 'p':
-      if (jcr->impl->res.pool) { return jcr->impl->res.pool->resource_name_; }
+      if (jcr->dir_impl->res.pool) {
+        return jcr->dir_impl->res.pool->resource_name_;
+      }
       break;
     case 'w':
-      if (jcr->impl->res.write_storage) {
-        return jcr->impl->res.write_storage->resource_name_;
+      if (jcr->dir_impl->res.write_storage) {
+        return jcr->dir_impl->res.write_storage->resource_name_;
       }
       break;
     case 'x':
-      return jcr->impl->spool_data ? yes : no;
+      return jcr->dir_impl->spool_data ? yes : no;
     case 'C':
-      return jcr->impl->cloned ? yes : no;
+      return jcr->dir_impl->cloned ? yes : no;
     case 'D':
       return my_name;
     case 'V':
@@ -3166,7 +3170,7 @@ extern "C" char* job_code_callback_director(JobControlRecord* jcr,
          * If this is a migration/copy we need the volume name from the
          * mig_jcr.
          */
-        if (jcr->impl->mig_jcr) { jcr = jcr->impl->mig_jcr; }
+        if (jcr->dir_impl->mig_jcr) { jcr = jcr->dir_impl->mig_jcr; }
 
         if (jcr->VolumeName) {
           return jcr->VolumeName;

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -21,8 +21,8 @@
    02110-1301, USA.
 */
 
-#ifndef BAREOS_DIRD_JCR_PRIVATE_H_
-#define BAREOS_DIRD_JCR_PRIVATE_H_
+#ifndef BAREOS_DIRD_DIRECTOR_JCR_IMPL_H_
+#define BAREOS_DIRD_DIRECTOR_JCR_IMPL_H_
 
 #include "cats/cats.h"
 #include "dird/client_connection_handshake_mode.h"
@@ -55,10 +55,10 @@ struct BootStrapRecord;
        || jcr->getJobStatus() == JS_WaitClientRes                           \
        || jcr->getJobStatus() == JS_WaitMaxJobs                             \
        || jcr->getJobStatus() == JS_WaitPriority                            \
-       || jcr->impl->SDJobStatus == JS_WaitMedia                            \
-       || jcr->impl->SDJobStatus == JS_WaitMount                            \
-       || jcr->impl->SDJobStatus == JS_WaitDevice                           \
-       || jcr->impl->SDJobStatus == JS_WaitMaxJobs))
+       || jcr->dir_impl->SDJobStatus == JS_WaitMedia                        \
+       || jcr->dir_impl->SDJobStatus == JS_WaitMount                        \
+       || jcr->dir_impl->SDJobStatus == JS_WaitDevice                       \
+       || jcr->dir_impl->SDJobStatus == JS_WaitMaxJobs))
 
 /* clang-format off */
 struct Resources {
@@ -96,8 +96,8 @@ struct Resources {
   bool run_next_pool_override{};  /**< Next pool override was given on run cmdline */
 };
 
-struct JobControlRecordPrivate {
-  JobControlRecordPrivate( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) : job_config_resources_container_(configuration_resources_container) {
+struct DirectorJcrImpl {
+  DirectorJcrImpl( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) : job_config_resources_container_(configuration_resources_container) {
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
   std::shared_ptr<ConfigResourcesContainer> job_config_resources_container_;
@@ -169,4 +169,4 @@ struct JobControlRecordPrivate {
 };
 /* clang-format on */
 
-#endif  // BAREOS_DIRD_JCR_PRIVATE_H_
+#endif  // BAREOS_DIRD_DIRECTOR_JCR_IMPL_H_

--- a/core/src/dird/expand.cc
+++ b/core/src/dird/expand.cc
@@ -30,7 +30,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"
 #include "lib/output_formatter.h"
@@ -92,7 +92,7 @@ static int job_item(JobControlRecord* jcr,
 
   switch (code) {
     case 1: /* Job */
-      str = jcr->impl->res.job->resource_name_;
+      str = jcr->dir_impl->res.job->resource_name_;
       break;
     case 2: /* Director's name */
       str = my_name;
@@ -108,31 +108,31 @@ static int job_item(JobControlRecord* jcr,
       str = buf;
       break;
     case 6: /* Client */
-      str = jcr->impl->res.client->resource_name_;
+      str = jcr->dir_impl->res.client->resource_name_;
       if (!str) { str = " "; }
       break;
     case 7: /* NumVols */
-      Bsnprintf(buf, sizeof(buf), "%d", jcr->impl->NumVols);
+      Bsnprintf(buf, sizeof(buf), "%d", jcr->dir_impl->NumVols);
       str = buf;
       break;
     case 8: /* Pool */
-      str = jcr->impl->res.pool->resource_name_;
+      str = jcr->dir_impl->res.pool->resource_name_;
       break;
     case 9: /* Storage */
-      if (jcr->impl->res.write_storage) {
-        str = jcr->impl->res.write_storage->resource_name_;
+      if (jcr->dir_impl->res.write_storage) {
+        str = jcr->dir_impl->res.write_storage->resource_name_;
       } else {
-        str = jcr->impl->res.read_storage->resource_name_;
+        str = jcr->dir_impl->res.read_storage->resource_name_;
       }
       break;
     case 10: /* Catalog */
-      str = jcr->impl->res.catalog->resource_name_;
+      str = jcr->dir_impl->res.catalog->resource_name_;
       break;
     case 11: /* MediaType */
-      if (jcr->impl->res.write_storage) {
-        str = jcr->impl->res.write_storage->media_type;
+      if (jcr->dir_impl->res.write_storage) {
+        str = jcr->dir_impl->res.write_storage->media_type;
       } else {
-        str = jcr->impl->res.read_storage->media_type;
+        str = jcr->dir_impl->res.read_storage->media_type;
       }
       break;
     case 12: /* JobName */

--- a/core/src/dird/get_database_connection.cc
+++ b/core/src/dird/get_database_connection.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,7 +25,7 @@
 #include "cats/sql_pooling.h"
 #include "dird/dird_conf.h"
 #include "dird/get_database_connection.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "include/jcr.h"
 
 namespace directordaemon {
@@ -33,15 +33,16 @@ namespace directordaemon {
 BareosDb* GetDatabaseConnection(JobControlRecord* jcr)
 {
   return DbSqlGetPooledConnection(
-      jcr, jcr->impl->res.catalog->db_driver, jcr->impl->res.catalog->db_name,
-      jcr->impl->res.catalog->db_user,
-      jcr->impl->res.catalog->db_password.value,
-      jcr->impl->res.catalog->db_address, jcr->impl->res.catalog->db_port,
-      jcr->impl->res.catalog->db_socket,
-      jcr->impl->res.catalog->mult_db_connections,
-      jcr->impl->res.catalog->disable_batch_insert,
-      jcr->impl->res.catalog->try_reconnect,
-      jcr->impl->res.catalog->exit_on_fatal);
+      jcr, jcr->dir_impl->res.catalog->db_driver,
+      jcr->dir_impl->res.catalog->db_name, jcr->dir_impl->res.catalog->db_user,
+      jcr->dir_impl->res.catalog->db_password.value,
+      jcr->dir_impl->res.catalog->db_address,
+      jcr->dir_impl->res.catalog->db_port,
+      jcr->dir_impl->res.catalog->db_socket,
+      jcr->dir_impl->res.catalog->mult_db_connections,
+      jcr->dir_impl->res.catalog->disable_batch_insert,
+      jcr->dir_impl->res.catalog->try_reconnect,
+      jcr->dir_impl->res.catalog->exit_on_fatal);
 }
 
 }  // namespace directordaemon

--- a/core/src/dird/getmsg.cc
+++ b/core/src/dird/getmsg.cc
@@ -43,7 +43,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/catreq.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/msgchan.h"
 #include "lib/bnet.h"
 #include "lib/edit.h"
@@ -81,10 +81,10 @@ static void SetJcrSdJobStatus(JobControlRecord* jcr, int SDJobStatus)
     Dmsg0(800, "Setting wait_time\n");
     jcr->wait_time = time(NULL);
   }
-  jcr->impl->SDJobStatus = SDJobStatus;
+  jcr->dir_impl->SDJobStatus = SDJobStatus;
 
   // Some SD Job status setting are propagated to the controlling Job.
-  switch (jcr->impl->SDJobStatus) {
+  switch (jcr->dir_impl->SDJobStatus) {
     case JS_Incomplete:
       jcr->setJobStatusWithPriorityCheck(JS_Incomplete);
       break;

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -30,7 +30,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "findlib/match.h"
 #include "lib/parse_conf.h"
 #include "include/allow_deprecated.h"
@@ -300,9 +300,9 @@ void FindUsedCompressalgos(PoolMem* compressalgos, JobControlRecord* jcr)
   FilesetResource* fs;
   struct s_fs_opt* fs_opt;
 
-  if (!jcr->impl->res.job || !jcr->impl->res.job->fileset) { return; }
+  if (!jcr->dir_impl->res.job || !jcr->dir_impl->res.job->fileset) { return; }
 
-  fs = jcr->impl->res.job->fileset;
+  fs = jcr->dir_impl->res.job->fileset;
   for (std::size_t i = 0; i < fs->include_items.size(); i++) {
     inc = fs->include_items[i];
 

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -20,7 +20,7 @@
 */
 
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "lib/parse_bsr.h"
 #include "lib/parse_conf.h"
 
@@ -30,8 +30,7 @@ namespace directordaemon {
 JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr)
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
-  jcr->impl
-      = new JobControlRecordPrivate(my_config->config_resources_container_);
+  jcr->dir_impl = new DirectorJcrImpl(my_config->config_resources_container_);
   Dmsg1(10, "NewDirectorJcr: configuration_resources_ is at %p %s\n",
         my_config->config_resources_container_->configuration_resources_,
         my_config->config_resources_container_->TimeStampAsString().c_str());

--- a/core/src/dird/jcr_util.h
+++ b/core/src/dird/jcr_util.h
@@ -22,7 +22,7 @@
 #ifndef BAREOS_DIRD_JCR_UTIL_H_
 #define BAREOS_DIRD_JCR_UTIL_H_
 
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 
 namespace directordaemon {
 

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -37,7 +37,7 @@
 #include "dird/fd_cmds.h"
 #include "dird/get_database_connection.h"
 #include "dird/job.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/migration.h"
 #include "dird/pthread_detach_if_not_detached.h"
 #include "dird/restore.h"
@@ -144,23 +144,23 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
 
   // See if we should suppress all output.
   if (!suppress_output) {
-    InitMsg(jcr, jcr->impl->res.messages, job_code_callback_director);
+    InitMsg(jcr, jcr->dir_impl->res.messages, job_code_callback_director);
   } else {
     jcr->suppress_output = true;
   }
 
   // Initialize termination condition variable
-  if ((errstat = pthread_cond_init(&jcr->impl->term_wait, NULL)) != 0) {
+  if ((errstat = pthread_cond_init(&jcr->dir_impl->term_wait, NULL)) != 0) {
     BErrNo be;
     Jmsg1(jcr, M_FATAL, 0, _("Unable to init job cond variable: ERR=%s\n"),
           be.bstrerror(errstat));
     jcr->unlock();
     goto bail_out;
   }
-  jcr->impl->term_wait_inited = true;
+  jcr->dir_impl->term_wait_inited = true;
 
   // Initialize nextrun ready condition variable
-  if ((errstat = pthread_cond_init(&jcr->impl->nextrun_ready, NULL)) != 0) {
+  if ((errstat = pthread_cond_init(&jcr->dir_impl->nextrun_ready, NULL)) != 0) {
     BErrNo be;
     Jmsg1(jcr, M_FATAL, 0,
           _("Unable to init job nextrun cond variable: ERR=%s\n"),
@@ -168,9 +168,9 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
     jcr->unlock();
     goto bail_out;
   }
-  jcr->impl->nextrun_ready_inited = true;
+  jcr->dir_impl->nextrun_ready_inited = true;
 
-  CreateUniqueJobName(jcr, jcr->impl->res.job->resource_name_);
+  CreateUniqueJobName(jcr, jcr->dir_impl->res.job->resource_name_);
   jcr->setJobStatusWithPriorityCheck(JS_Created);
   jcr->unlock();
 
@@ -179,44 +179,45 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
   jcr->db = GetDatabaseConnection(jcr);
   if (jcr->db == NULL) {
     Jmsg(jcr, M_FATAL, 0, _("Could not open database \"%s\".\n"),
-         jcr->impl->res.catalog->db_name);
+         jcr->dir_impl->res.catalog->db_name);
     goto bail_out;
   }
   Dmsg0(150, "DB opened\n");
-  if (!jcr->impl->fname) { jcr->impl->fname = GetPoolMemory(PM_FNAME); }
+  if (!jcr->dir_impl->fname) { jcr->dir_impl->fname = GetPoolMemory(PM_FNAME); }
 
-  if (!jcr->impl->res.pool_source) {
-    jcr->impl->res.pool_source = GetPoolMemory(PM_MESSAGE);
-    PmStrcpy(jcr->impl->res.pool_source, _("unknown source"));
+  if (!jcr->dir_impl->res.pool_source) {
+    jcr->dir_impl->res.pool_source = GetPoolMemory(PM_MESSAGE);
+    PmStrcpy(jcr->dir_impl->res.pool_source, _("unknown source"));
   }
 
-  if (!jcr->impl->res.npool_source) {
-    jcr->impl->res.npool_source = GetPoolMemory(PM_MESSAGE);
-    PmStrcpy(jcr->impl->res.npool_source, _("unknown source"));
+  if (!jcr->dir_impl->res.npool_source) {
+    jcr->dir_impl->res.npool_source = GetPoolMemory(PM_MESSAGE);
+    PmStrcpy(jcr->dir_impl->res.npool_source, _("unknown source"));
   }
 
   if (jcr->JobReads()) {
-    if (!jcr->impl->res.rpool_source) {
-      jcr->impl->res.rpool_source = GetPoolMemory(PM_MESSAGE);
-      PmStrcpy(jcr->impl->res.rpool_source, _("unknown source"));
+    if (!jcr->dir_impl->res.rpool_source) {
+      jcr->dir_impl->res.rpool_source = GetPoolMemory(PM_MESSAGE);
+      PmStrcpy(jcr->dir_impl->res.rpool_source, _("unknown source"));
     }
   }
 
   // Create Job record
   InitJcrJobRecord(jcr);
 
-  if (jcr->impl->res.client) {
+  if (jcr->dir_impl->res.client) {
     if (!GetOrCreateClientRecord(jcr)) { goto bail_out; }
   }
 
-  if (!jcr->db->CreateJobRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->CreateJobRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
     goto bail_out;
   }
 
-  jcr->JobId = jcr->impl->jr.JobId;
+  jcr->JobId = jcr->dir_impl->jr.JobId;
   Dmsg4(100, "Created job record JobId=%d Name=%s Type=%c Level=%c\n",
-        jcr->JobId, jcr->Job, jcr->impl->jr.JobType, jcr->impl->jr.JobLevel);
+        jcr->JobId, jcr->Job, jcr->dir_impl->jr.JobType,
+        jcr->dir_impl->jr.JobLevel);
 
   NewPlugins(jcr); /* instantiate plugins for this jcr */
   DispatchNewPluginOptions(jcr);
@@ -224,11 +225,12 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
 
   if (JobCanceled(jcr)) { goto bail_out; }
 
-  if (jcr->JobReads() && !jcr->impl->res.read_storage_list) {
-    if (jcr->impl->res.job->storage) {
-      CopyRwstorage(jcr, jcr->impl->res.job->storage, _("Job resource"));
+  if (jcr->JobReads() && !jcr->dir_impl->res.read_storage_list) {
+    if (jcr->dir_impl->res.job->storage) {
+      CopyRwstorage(jcr, jcr->dir_impl->res.job->storage, _("Job resource"));
     } else {
-      CopyRwstorage(jcr, jcr->impl->res.job->pool->storage, _("Pool resource"));
+      CopyRwstorage(jcr, jcr->dir_impl->res.job->pool->storage,
+                    _("Pool resource"));
     }
   }
 
@@ -308,9 +310,9 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
            * Any non NDMP restore is not interested at the items
            * that were selected for restore so drop them now.
            */
-          if (jcr->impl->restore_tree_root) {
-            FreeTree(jcr->impl->restore_tree_root);
-            jcr->impl->restore_tree_root = NULL;
+          if (jcr->dir_impl->restore_tree_root) {
+            FreeTree(jcr->dir_impl->restore_tree_root);
+            jcr->dir_impl->restore_tree_root = NULL;
           }
           if (!DoNativeRestoreInit(jcr)) {
             NativeRestoreCleanup(jcr, JS_ErrorTerminated);
@@ -382,7 +384,7 @@ bool IsConnectingToClientAllowed(ClientResource* res)
 
 bool IsConnectingToClientAllowed(JobControlRecord* jcr)
 {
-  return IsConnectingToClientAllowed(jcr->impl->res.client);
+  return IsConnectingToClientAllowed(jcr->dir_impl->res.client);
 }
 
 bool IsConnectFromClientAllowed(ClientResource* res)
@@ -392,7 +394,7 @@ bool IsConnectFromClientAllowed(ClientResource* res)
 
 bool IsConnectFromClientAllowed(JobControlRecord* jcr)
 {
-  return IsConnectFromClientAllowed(jcr->impl->res.client);
+  return IsConnectFromClientAllowed(jcr->dir_impl->res.client);
 }
 
 bool UseWaitingClient(JobControlRecord* jcr, int timeout)
@@ -403,17 +405,17 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
 
   if (!IsConnectFromClientAllowed(jcr)) {
     Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
-          jcr->impl->res.client->resource_name_);
+          jcr->dir_impl->res.client->resource_name_);
   } else {
-    connection
-        = connections->remove(jcr->impl->res.client->resource_name_, timeout);
+    connection = connections->remove(jcr->dir_impl->res.client->resource_name_,
+                                     timeout);
     if (connection) {
       jcr->file_bsock = connection->bsock();
-      jcr->impl->FDVersion = connection->protocol_version();
+      jcr->dir_impl->FDVersion = connection->protocol_version();
       jcr->authenticated = connection->authenticated();
       delete (connection);
       Jmsg(jcr, M_INFO, 0, _("Using Client Initiated Connection (%s).\n"),
-           jcr->impl->res.client->resource_name_);
+           jcr->dir_impl->res.client->resource_name_);
       result = true;
     }
   }
@@ -445,13 +447,13 @@ static void* job_thread(void* arg)
   jcr->setJobStatusWithPriorityCheck(
       JS_Running);              /* this will be set only if no error */
   jcr->start_time = time(NULL); /* set the real start time */
-  jcr->impl->jr.StartTime = jcr->start_time;
+  jcr->dir_impl->jr.StartTime = jcr->start_time;
 
   // Let the statistics subsystem know a new Job was started.
   stats_job_started();
 
-  if (jcr->impl->res.job->MaxStartDelay != 0
-      && jcr->impl->res.job->MaxStartDelay
+  if (jcr->dir_impl->res.job->MaxStartDelay != 0
+      && jcr->dir_impl->res.job->MaxStartDelay
              < (utime_t)(jcr->start_time - jcr->sched_time)) {
     jcr->setJobStatusWithPriorityCheck(JS_Canceled);
     Jmsg(jcr, M_FATAL, 0,
@@ -465,18 +467,18 @@ static void* job_thread(void* arg)
   }
 
   // TODO : check if it is used somewhere
-  if (jcr->impl->res.job->RunScripts == NULL) {
+  if (jcr->dir_impl->res.job->RunScripts == NULL) {
     Dmsg0(200, "Warning, job->RunScripts is empty\n");
-    jcr->impl->res.job->RunScripts
+    jcr->dir_impl->res.job->RunScripts
         = new alist<RunScript*>(10, not_owned_by_alist);
   }
 
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
   }
 
   // Run any script BeforeJob on dird
-  RunScripts(jcr, jcr->impl->res.job->RunScripts, "BeforeJob");
+  RunScripts(jcr, jcr->dir_impl->res.job->RunScripts, "BeforeJob");
 
   /*
    * We re-update the job start record so that the start time is set after the
@@ -488,8 +490,8 @@ static void* job_thread(void* arg)
    * because in that case, their date is after the start of this run.
    */
   jcr->start_time = time(NULL);
-  jcr->impl->jr.StartTime = jcr->start_time;
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  jcr->dir_impl->jr.StartTime = jcr->start_time;
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
   }
 
@@ -643,7 +645,7 @@ static void* job_thread(void* arg)
       break;
   }
 
-  RunScripts(jcr, jcr->impl->res.job->RunScripts, "AfterJob");
+  RunScripts(jcr, jcr->dir_impl->res.job->RunScripts, "AfterJob");
 
   // Send off any queued messages
   if (jcr->msg_queue && jcr->msg_queue->size() > 0) { DequeueMessages(jcr); }
@@ -657,10 +659,10 @@ static void* job_thread(void* arg)
 void SdMsgThreadSendSignal(JobControlRecord* jcr, int sig)
 {
   jcr->lock();
-  if (!jcr->impl->sd_msg_thread_done && jcr->impl->SD_msg_chan_started
-      && !pthread_equal(jcr->impl->SD_msg_chan, pthread_self())) {
+  if (!jcr->dir_impl->sd_msg_thread_done && jcr->dir_impl->SD_msg_chan_started
+      && !pthread_equal(jcr->dir_impl->SD_msg_chan, pthread_self())) {
     Dmsg1(800, "Send kill to SD msg chan jid=%d\n", jcr->JobId);
-    pthread_kill(jcr->impl->SD_msg_chan, sig);
+    pthread_kill(jcr->dir_impl->SD_msg_chan, sig);
   }
   jcr->unlock();
 }
@@ -704,14 +706,16 @@ bool CancelJob(UaContext* ua, JobControlRecord* jcr)
       }
 
       // Cancel second Storage daemon for SD-SD replication.
-      if (jcr->impl->mig_jcr && jcr->impl->mig_jcr->store_bsock) {
-        if (!CancelStorageDaemonJob(ua, jcr->impl->mig_jcr)) { return false; }
+      if (jcr->dir_impl->mig_jcr && jcr->dir_impl->mig_jcr->store_bsock) {
+        if (!CancelStorageDaemonJob(ua, jcr->dir_impl->mig_jcr)) {
+          return false;
+        }
       }
 
       break;
   }
 
-  RunScripts(jcr, jcr->impl->res.job->RunScripts, "AfterJob");
+  RunScripts(jcr, jcr->dir_impl->res.job->RunScripts, "AfterJob");
 
   return true;
 }
@@ -734,7 +738,7 @@ static void JobMonitorWatchdog(watchdog_t* self)
   foreach_jcr (jcr) {
     bool cancel = false;
 
-    if (jcr->JobId == 0 || JobCanceled(jcr) || jcr->impl->no_maxtime) {
+    if (jcr->JobId == 0 || JobCanceled(jcr) || jcr->dir_impl->no_maxtime) {
       Dmsg2(800, "Skipping JobControlRecord=%p Job=%s\n", jcr, jcr->Job);
       continue;
     }
@@ -778,7 +782,7 @@ static void JobMonitorWatchdog(watchdog_t* self)
 static bool JobCheckMaxwaittime(JobControlRecord* jcr)
 {
   bool cancel = false;
-  JobResource* job = jcr->impl->res.job;
+  JobResource* job = jcr->dir_impl->res.job;
   utime_t current = 0;
 
   if (!JobWaiting(jcr)) { return false; }
@@ -802,7 +806,7 @@ static bool JobCheckMaxwaittime(JobControlRecord* jcr)
 static bool JobCheckMaxruntime(JobControlRecord* jcr)
 {
   bool cancel = false;
-  JobResource* job = jcr->impl->res.job;
+  JobResource* job = jcr->dir_impl->res.job;
   utime_t run_time;
 
   if (JobCanceled(jcr) || !jcr->job_started) { return false; }
@@ -841,10 +845,11 @@ static bool JobCheckMaxruntime(JobControlRecord* jcr)
  */
 static bool JobCheckMaxrunschedtime(JobControlRecord* jcr)
 {
-  if (jcr->impl->MaxRunSchedTime == 0 || JobCanceled(jcr)) { return false; }
-  if ((watchdog_time - jcr->initial_sched_time) < jcr->impl->MaxRunSchedTime) {
+  if (jcr->dir_impl->MaxRunSchedTime == 0 || JobCanceled(jcr)) { return false; }
+  if ((watchdog_time - jcr->initial_sched_time)
+      < jcr->dir_impl->MaxRunSchedTime) {
     Dmsg3(200, "Job %p (%s) with MaxRunSchedTime %d not expired\n", jcr,
-          jcr->Job, jcr->impl->MaxRunSchedTime);
+          jcr->Job, jcr->dir_impl->MaxRunSchedTime);
     return false;
   }
 
@@ -865,7 +870,7 @@ DBId_t GetOrCreatePoolRecord(JobControlRecord* jcr, char* pool_name)
 
   while (!jcr->db->GetPoolRecord(jcr, &pr)) { /* get by Name */
     /* Try to create the pool */
-    if (CreatePool(jcr, jcr->db, jcr->impl->res.pool, POOL_OP_CREATE) < 0) {
+    if (CreatePool(jcr, jcr->db, jcr->dir_impl->res.pool, POOL_OP_CREATE) < 0) {
       Jmsg(jcr, M_FATAL, 0, _("Pool \"%s\" not in database. ERR=%s"), pr.Name,
            jcr->db->strerror());
       return 0;
@@ -885,7 +890,7 @@ DBId_t GetOrCreatePoolRecord(JobControlRecord* jcr, char* pool_name)
 bool AllowDuplicateJob(JobControlRecord* jcr)
 {
   JobControlRecord* djcr; /* possible duplicate job */
-  JobResource* job = jcr->impl->res.job;
+  JobResource* job = jcr->dir_impl->res.job;
   bool cancel_dup = false;
   bool cancel_me = false;
 
@@ -893,7 +898,7 @@ bool AllowDuplicateJob(JobControlRecord* jcr)
    * See if AllowDuplicateJobs is set or
    * if duplicate checking is disabled for this job.
    */
-  if (job->AllowDuplicateJobs || jcr->impl->IgnoreDuplicateJobChecking) {
+  if (job->AllowDuplicateJobs || jcr->dir_impl->IgnoreDuplicateJobChecking) {
     return true;
   }
 
@@ -913,9 +918,9 @@ bool AllowDuplicateJob(JobControlRecord* jcr)
      * See if this Job has the IgnoreDuplicateJobChecking flag set, ignore it
      * for any checking against other jobs.
      */
-    if (djcr->impl->IgnoreDuplicateJobChecking) { continue; }
+    if (djcr->dir_impl->IgnoreDuplicateJobChecking) { continue; }
 
-    if (bstrcmp(job->resource_name_, djcr->impl->res.job->resource_name_)) {
+    if (bstrcmp(job->resource_name_, djcr->dir_impl->res.job->resource_name_)) {
       if (job->DuplicateJobProximity > 0) {
         utime_t now = (utime_t)time(NULL);
         if ((now - djcr->start_time) > job->DuplicateJobProximity) {
@@ -1021,14 +1026,15 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
   utime_t last_diff_time;
   char prev_job[MAX_NAME_LENGTH];
 
-  jcr->impl->since[0] = 0;
+  jcr->dir_impl->since[0] = 0;
 
   // If since time was given on command line use it
   if (jcr->starttime_string && jcr->starttime_string[0]) {
-    bstrncpy(jcr->impl->since, _(", since="), sizeof(jcr->impl->since));
-    bstrncat(jcr->impl->since, jcr->starttime_string, sizeof(jcr->impl->since));
+    bstrncpy(jcr->dir_impl->since, _(", since="), sizeof(jcr->dir_impl->since));
+    bstrncat(jcr->dir_impl->since, jcr->starttime_string,
+             sizeof(jcr->dir_impl->since));
     Jmsg(jcr, M_INFO, 0, "Using since time from command line %s (%s)",
-         jcr->starttime_string, jcr->impl->since);
+         jcr->starttime_string, jcr->dir_impl->since);
     return pool_updated;
   }
 
@@ -1038,7 +1044,7 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
     jcr->starttime_string = GetPoolMemory(PM_MESSAGE);
     jcr->starttime_string[0] = 0;
   }
-  jcr->impl->PrevJob[0] = 0;
+  jcr->dir_impl->PrevJob[0] = 0;
 
   /*
    * Lookup the last FULL backup job to get the time/date for a
@@ -1052,19 +1058,20 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
 
       // Look up start time of last Full job
       now = (utime_t)time(NULL);
-      jcr->impl->jr.JobId = 0; /* flag to return since time */
+      jcr->dir_impl->jr.JobId = 0; /* flag to return since time */
 
       /*
        * This is probably redundant, but some of the code below
        * uses jcr->starttime_string, so don't remove unless you are sure.
        */
-      if (!jcr->db->FindJobStartTime(jcr, &jcr->impl->jr, jcr->starttime_string,
-                                     jcr->impl->PrevJob)) {
+      if (!jcr->db->FindJobStartTime(jcr, &jcr->dir_impl->jr,
+                                     jcr->starttime_string,
+                                     jcr->dir_impl->PrevJob)) {
         do_full = true;
       }
 
-      have_full = jcr->db->FindLastJobStartTime(jcr, &jcr->impl->jr, start_time,
-                                                prev_job, L_FULL);
+      have_full = jcr->db->FindLastJobStartTime(jcr, &jcr->dir_impl->jr,
+                                                start_time, prev_job, L_FULL);
       if (have_full) {
         last_full_time = StrToUtime(start_time);
       } else {
@@ -1076,9 +1083,9 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
 
       // Make sure the last diff is recent enough
       if (have_full && JobLevel == L_INCREMENTAL
-          && jcr->impl->res.job->MaxDiffInterval > 0) {
+          && jcr->dir_impl->res.job->MaxDiffInterval > 0) {
         // Lookup last diff job
-        if (jcr->db->FindLastJobStartTime(jcr, &jcr->impl->jr, start_time,
+        if (jcr->db->FindLastJobStartTime(jcr, &jcr->dir_impl->jr, start_time,
                                           prev_job, L_DIFFERENTIAL)) {
           last_diff_time = StrToUtime(start_time);
           // If no Diff since Full, use Full time
@@ -1093,19 +1100,19 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
           Dmsg1(50, "No last_diff_time setting to full_time=%lld\n",
                 last_full_time);
         }
-        do_diff
-            = ((now - last_diff_time) >= jcr->impl->res.job->MaxDiffInterval);
+        do_diff = ((now - last_diff_time)
+                   >= jcr->dir_impl->res.job->MaxDiffInterval);
         Dmsg2(50, "do_diff=%d diffInter=%lld\n", do_diff,
-              jcr->impl->res.job->MaxDiffInterval);
+              jcr->dir_impl->res.job->MaxDiffInterval);
       }
 
       // Note, do_full takes precedence over do_vfull and do_diff
-      if (have_full && jcr->impl->res.job->MaxFullInterval > 0) {
-        do_full
-            = ((now - last_full_time) >= jcr->impl->res.job->MaxFullInterval);
-      } else if (have_full && jcr->impl->res.job->MaxVFullInterval > 0) {
-        do_vfull
-            = ((now - last_full_time) >= jcr->impl->res.job->MaxVFullInterval);
+      if (have_full && jcr->dir_impl->res.job->MaxFullInterval > 0) {
+        do_full = ((now - last_full_time)
+                   >= jcr->dir_impl->res.job->MaxFullInterval);
+      } else if (have_full && jcr->dir_impl->res.job->MaxVFullInterval > 0) {
+        do_vfull = ((now - last_full_time)
+                    >= jcr->dir_impl->res.job->MaxVFullInterval);
       }
       FreePoolMemory(start_time);
 
@@ -1115,9 +1122,9 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
         Jmsg(jcr, M_INFO, 0,
              _("No prior or suitable Full backup found in catalog. Doing FULL "
                "backup.\n"));
-        Bsnprintf(jcr->impl->since, sizeof(jcr->impl->since),
+        Bsnprintf(jcr->dir_impl->since, sizeof(jcr->dir_impl->since),
                   _(" (upgraded from %s)"), JobLevelToString(JobLevel));
-        jcr->setJobLevel(jcr->impl->jr.JobLevel = L_FULL);
+        jcr->setJobLevel(jcr->dir_impl->jr.JobLevel = L_FULL);
         pool_updated = true;
       } else if (do_vfull) {
         /*
@@ -1128,59 +1135,60 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
         Jmsg(jcr, M_INFO, 0,
              _("No prior or suitable Full backup found in catalog. Doing "
                "Virtual FULL backup.\n"));
-        Bsnprintf(jcr->impl->since, sizeof(jcr->impl->since),
+        Bsnprintf(jcr->dir_impl->since, sizeof(jcr->dir_impl->since),
                   _(" (upgraded from %s)"),
                   JobLevelToString(jcr->getJobLevel()));
-        jcr->setJobLevel(jcr->impl->jr.JobLevel = L_VIRTUAL_FULL);
+        jcr->setJobLevel(jcr->dir_impl->jr.JobLevel = L_VIRTUAL_FULL);
         pool_updated = true;
 
         /*
          * If we get upgraded to a Virtual Full we will be using a read pool so
          * make sure we have a rpool_source.
          */
-        if (!jcr->impl->res.rpool_source) {
-          jcr->impl->res.rpool_source = GetPoolMemory(PM_MESSAGE);
-          PmStrcpy(jcr->impl->res.rpool_source, _("unknown source"));
+        if (!jcr->dir_impl->res.rpool_source) {
+          jcr->dir_impl->res.rpool_source = GetPoolMemory(PM_MESSAGE);
+          PmStrcpy(jcr->dir_impl->res.rpool_source, _("unknown source"));
         }
       } else if (do_diff) {
         // No recent diff job found, so upgrade this one to Diff
         Jmsg(jcr, M_INFO, 0,
              _("No prior or suitable Differential backup found in catalog. "
                "Doing Differential backup.\n"));
-        Bsnprintf(jcr->impl->since, sizeof(jcr->impl->since),
+        Bsnprintf(jcr->dir_impl->since, sizeof(jcr->dir_impl->since),
                   _(" (upgraded from %s)"), JobLevelToString(JobLevel));
-        jcr->setJobLevel(jcr->impl->jr.JobLevel = L_DIFFERENTIAL);
+        jcr->setJobLevel(jcr->dir_impl->jr.JobLevel = L_DIFFERENTIAL);
         pool_updated = true;
       } else {
-        if (jcr->impl->res.job->rerun_failed_levels) {
-          if (jcr->db->FindFailedJobSince(jcr, &jcr->impl->jr,
+        if (jcr->dir_impl->res.job->rerun_failed_levels) {
+          if (jcr->db->FindFailedJobSince(jcr, &jcr->dir_impl->jr,
                                           jcr->starttime_string, JobLevel)) {
             Jmsg(jcr, M_INFO, 0,
                  _("Prior failed job found in catalog. Upgrading to %s.\n"),
                  JobLevelToString(JobLevel));
-            Bsnprintf(jcr->impl->since, sizeof(jcr->impl->since),
+            Bsnprintf(jcr->dir_impl->since, sizeof(jcr->dir_impl->since),
                       _(" (upgraded from %s)"), JobLevelToString(JobLevel));
-            jcr->setJobLevel(jcr->impl->jr.JobLevel = JobLevel);
-            jcr->impl->jr.JobId = jcr->JobId;
+            jcr->setJobLevel(jcr->dir_impl->jr.JobLevel = JobLevel);
+            jcr->dir_impl->jr.JobId = jcr->JobId;
             pool_updated = true;
             break;
           }
         }
 
-        bstrncpy(jcr->impl->since, _(", since="), sizeof(jcr->impl->since));
-        bstrncat(jcr->impl->since, jcr->starttime_string,
-                 sizeof(jcr->impl->since));
+        bstrncpy(jcr->dir_impl->since, _(", since="),
+                 sizeof(jcr->dir_impl->since));
+        bstrncat(jcr->dir_impl->since, jcr->starttime_string,
+                 sizeof(jcr->dir_impl->since));
       }
-      jcr->impl->jr.JobId = jcr->JobId;
+      jcr->dir_impl->jr.JobId = jcr->JobId;
 
       /*
        * Lookup the Job record of the previous Job and store it in
-       * jcr->impl_->previous_jr.
+       * jcr->dir_impl_->previous_jr.
        */
-      if (jcr->impl->PrevJob[0]) {
-        bstrncpy(jcr->impl->previous_jr.Job, jcr->impl->PrevJob,
-                 sizeof(jcr->impl->previous_jr.Job));
-        if (!jcr->db->GetJobRecord(jcr, &jcr->impl->previous_jr)) {
+      if (jcr->dir_impl->PrevJob[0]) {
+        bstrncpy(jcr->dir_impl->previous_jr.Job, jcr->dir_impl->PrevJob,
+                 sizeof(jcr->dir_impl->previous_jr.Job));
+        if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->previous_jr)) {
           Jmsg(jcr, M_FATAL, 0,
                _("Could not get job record for previous Job. ERR=%s\n"),
                jcr->db->strerror());
@@ -1191,7 +1199,7 @@ bool GetLevelSinceTime(JobControlRecord* jcr)
   }
 
   Dmsg3(100, "Level=%c last start time=%s job=%s\n", JobLevel,
-        jcr->starttime_string, jcr->impl->PrevJob);
+        jcr->starttime_string, jcr->dir_impl->PrevJob);
 
   return pool_updated;
 }
@@ -1205,86 +1213,93 @@ void ApplyPoolOverrides(JobControlRecord* jcr, bool force)
    * If a cmdline pool override is given ignore any level pool overrides.
    * Unless a force is given then we always apply any overrides.
    */
-  if (!force && jcr->impl->IgnoreLevelPoolOverrides) { return; }
+  if (!force && jcr->dir_impl->IgnoreLevelPoolOverrides) { return; }
 
   /*
    * If only a pool override and no level overrides are given in run entry
    * choose this pool
    */
-  if (jcr->impl->res.run_pool_override && !jcr->impl->res.run_full_pool_override
-      && !jcr->impl->res.run_vfull_pool_override
-      && !jcr->impl->res.run_inc_pool_override
-      && !jcr->impl->res.run_diff_pool_override) {
-    PmStrcpy(jcr->impl->res.pool_source, _("Run Pool override"));
+  if (jcr->dir_impl->res.run_pool_override
+      && !jcr->dir_impl->res.run_full_pool_override
+      && !jcr->dir_impl->res.run_vfull_pool_override
+      && !jcr->dir_impl->res.run_inc_pool_override
+      && !jcr->dir_impl->res.run_diff_pool_override) {
+    PmStrcpy(jcr->dir_impl->res.pool_source, _("Run Pool override"));
     Dmsg2(100, "Pool set to '%s' because of %s",
-          jcr->impl->res.pool->resource_name_, _("Run Pool override\n"));
+          jcr->dir_impl->res.pool->resource_name_, _("Run Pool override\n"));
   } else {
     // Apply any level related Pool selections
     switch (jcr->getJobLevel()) {
       case L_FULL:
-        if (jcr->impl->res.full_pool) {
-          jcr->impl->res.pool = jcr->impl->res.full_pool;
+        if (jcr->dir_impl->res.full_pool) {
+          jcr->dir_impl->res.pool = jcr->dir_impl->res.full_pool;
           pool_override = true;
-          if (jcr->impl->res.run_full_pool_override) {
-            PmStrcpy(jcr->impl->res.pool_source, _("Run FullPool override"));
+          if (jcr->dir_impl->res.run_full_pool_override) {
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Run FullPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.full_pool->resource_name_,
+                  jcr->dir_impl->res.full_pool->resource_name_,
                   "Run FullPool override\n");
           } else {
-            PmStrcpy(jcr->impl->res.pool_source, _("Job FullPool override"));
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Job FullPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.full_pool->resource_name_,
+                  jcr->dir_impl->res.full_pool->resource_name_,
                   "Job FullPool override\n");
           }
         }
         break;
       case L_VIRTUAL_FULL:
-        if (jcr->impl->res.vfull_pool) {
-          jcr->impl->res.pool = jcr->impl->res.vfull_pool;
+        if (jcr->dir_impl->res.vfull_pool) {
+          jcr->dir_impl->res.pool = jcr->dir_impl->res.vfull_pool;
           pool_override = true;
-          if (jcr->impl->res.run_vfull_pool_override) {
-            PmStrcpy(jcr->impl->res.pool_source, _("Run VFullPool override"));
+          if (jcr->dir_impl->res.run_vfull_pool_override) {
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Run VFullPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.vfull_pool->resource_name_,
+                  jcr->dir_impl->res.vfull_pool->resource_name_,
                   "Run VFullPool override\n");
           } else {
-            PmStrcpy(jcr->impl->res.pool_source, _("Job VFullPool override"));
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Job VFullPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.vfull_pool->resource_name_,
+                  jcr->dir_impl->res.vfull_pool->resource_name_,
                   "Job VFullPool override\n");
           }
         }
         break;
       case L_INCREMENTAL:
-        if (jcr->impl->res.inc_pool) {
-          jcr->impl->res.pool = jcr->impl->res.inc_pool;
+        if (jcr->dir_impl->res.inc_pool) {
+          jcr->dir_impl->res.pool = jcr->dir_impl->res.inc_pool;
           pool_override = true;
-          if (jcr->impl->res.run_inc_pool_override) {
-            PmStrcpy(jcr->impl->res.pool_source, _("Run IncPool override"));
+          if (jcr->dir_impl->res.run_inc_pool_override) {
+            PmStrcpy(jcr->dir_impl->res.pool_source, _("Run IncPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.inc_pool->resource_name_,
+                  jcr->dir_impl->res.inc_pool->resource_name_,
                   "Run IncPool override\n");
           } else {
-            PmStrcpy(jcr->impl->res.pool_source, _("Job IncPool override"));
+            PmStrcpy(jcr->dir_impl->res.pool_source, _("Job IncPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.inc_pool->resource_name_,
+                  jcr->dir_impl->res.inc_pool->resource_name_,
                   "Job IncPool override\n");
           }
         }
         break;
       case L_DIFFERENTIAL:
-        if (jcr->impl->res.diff_pool) {
-          jcr->impl->res.pool = jcr->impl->res.diff_pool;
+        if (jcr->dir_impl->res.diff_pool) {
+          jcr->dir_impl->res.pool = jcr->dir_impl->res.diff_pool;
           pool_override = true;
-          if (jcr->impl->res.run_diff_pool_override) {
-            PmStrcpy(jcr->impl->res.pool_source, _("Run DiffPool override"));
+          if (jcr->dir_impl->res.run_diff_pool_override) {
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Run DiffPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.diff_pool->resource_name_,
+                  jcr->dir_impl->res.diff_pool->resource_name_,
                   "Run DiffPool override\n");
           } else {
-            PmStrcpy(jcr->impl->res.pool_source, _("Job DiffPool override"));
+            PmStrcpy(jcr->dir_impl->res.pool_source,
+                     _("Job DiffPool override"));
             Dmsg2(100, "Pool set to '%s' because of %s",
-                  jcr->impl->res.diff_pool->resource_name_,
+                  jcr->dir_impl->res.diff_pool->resource_name_,
                   "Job DiffPool override\n");
           }
         }
@@ -1293,9 +1308,9 @@ void ApplyPoolOverrides(JobControlRecord* jcr, bool force)
   }
 
   // Update catalog if pool overridden
-  if (pool_override && jcr->impl->res.pool->catalog) {
-    jcr->impl->res.catalog = jcr->impl->res.pool->catalog;
-    PmStrcpy(jcr->impl->res.catalog_source, _("Pool resource"));
+  if (pool_override && jcr->dir_impl->res.pool->catalog) {
+    jcr->dir_impl->res.catalog = jcr->dir_impl->res.pool->catalog;
+    PmStrcpy(jcr->dir_impl->res.catalog_source, _("Pool resource"));
   }
 }
 
@@ -1304,40 +1319,40 @@ bool GetOrCreateClientRecord(JobControlRecord* jcr)
 {
   ClientDbRecord cr;
 
-  bstrncpy(cr.Name, jcr->impl->res.client->resource_name_, sizeof(cr.Name));
-  cr.AutoPrune = jcr->impl->res.client->AutoPrune;
-  cr.FileRetention = jcr->impl->res.client->FileRetention;
-  cr.JobRetention = jcr->impl->res.client->JobRetention;
+  bstrncpy(cr.Name, jcr->dir_impl->res.client->resource_name_, sizeof(cr.Name));
+  cr.AutoPrune = jcr->dir_impl->res.client->AutoPrune;
+  cr.FileRetention = jcr->dir_impl->res.client->FileRetention;
+  cr.JobRetention = jcr->dir_impl->res.client->JobRetention;
   if (!jcr->client_name) { jcr->client_name = GetPoolMemory(PM_NAME); }
-  PmStrcpy(jcr->client_name, jcr->impl->res.client->resource_name_);
+  PmStrcpy(jcr->client_name, jcr->dir_impl->res.client->resource_name_);
   if (!jcr->db->CreateClientRecord(jcr, &cr)) {
     Jmsg(jcr, M_FATAL, 0, _("Could not create Client record. ERR=%s\n"),
          jcr->db->strerror());
     return false;
   }
   // Only initialize quota when a Soft or Hard Limit is set.
-  if (jcr->impl->res.client->HardQuota != 0
-      || jcr->impl->res.client->SoftQuota != 0) {
+  if (jcr->dir_impl->res.client->HardQuota != 0
+      || jcr->dir_impl->res.client->SoftQuota != 0) {
     if (!jcr->db->GetQuotaRecord(jcr, &cr)) {
       if (!jcr->db->CreateQuotaRecord(jcr, &cr)) {
         Jmsg(jcr, M_FATAL, 0, _("Could not create Quota record. ERR=%s\n"),
              jcr->db->strerror());
       }
-      jcr->impl->res.client->QuotaLimit = 0;
-      jcr->impl->res.client->GraceTime = 0;
+      jcr->dir_impl->res.client->QuotaLimit = 0;
+      jcr->dir_impl->res.client->GraceTime = 0;
     }
   }
-  jcr->impl->jr.ClientId = cr.ClientId;
-  jcr->impl->res.client->QuotaLimit = cr.QuotaLimit;
-  jcr->impl->res.client->GraceTime = cr.GraceTime;
+  jcr->dir_impl->jr.ClientId = cr.ClientId;
+  jcr->dir_impl->res.client->QuotaLimit = cr.QuotaLimit;
+  jcr->dir_impl->res.client->GraceTime = cr.GraceTime;
   if (cr.Uname[0]) {
-    if (!jcr->impl->client_uname) {
-      jcr->impl->client_uname = GetPoolMemory(PM_NAME);
+    if (!jcr->dir_impl->client_uname) {
+      jcr->dir_impl->client_uname = GetPoolMemory(PM_NAME);
     }
-    PmStrcpy(jcr->impl->client_uname, cr.Uname);
+    PmStrcpy(jcr->dir_impl->client_uname, cr.Uname);
   }
   Dmsg2(100, "Created Client %s record %d\n",
-        jcr->impl->res.client->resource_name_, jcr->impl->jr.ClientId);
+        jcr->dir_impl->res.client->resource_name_, jcr->dir_impl->jr.ClientId);
   return true;
 }
 
@@ -1346,22 +1361,22 @@ bool GetOrCreateFilesetRecord(JobControlRecord* jcr)
   FileSetDbRecord fsr;
 
   // Get or Create FileSet record
-  bstrncpy(fsr.FileSet, jcr->impl->res.fileset->resource_name_,
+  bstrncpy(fsr.FileSet, jcr->dir_impl->res.fileset->resource_name_,
            sizeof(fsr.FileSet));
-  if (jcr->impl->res.fileset->have_MD5) {
+  if (jcr->dir_impl->res.fileset->have_MD5) {
     MD5_CTX md5c;
     unsigned char digest[16]; /* MD5 digest length */
-    memcpy(&md5c, &jcr->impl->res.fileset->md5c, sizeof(md5c));
+    memcpy(&md5c, &jcr->dir_impl->res.fileset->md5c, sizeof(md5c));
     ALLOW_DEPRECATED(MD5_Final(digest, &md5c));
     /* Keep the flag (last arg) set to false otherwise old FileSets will
      * get new MD5 sums and the user will get Full backups on everything */
     BinToBase64(fsr.MD5, sizeof(fsr.MD5), (char*)digest, sizeof(digest), false);
-    bstrncpy(jcr->impl->res.fileset->MD5, fsr.MD5,
-             sizeof(jcr->impl->res.fileset->MD5));
+    bstrncpy(jcr->dir_impl->res.fileset->MD5, fsr.MD5,
+             sizeof(jcr->dir_impl->res.fileset->MD5));
   } else {
     Jmsg(jcr, M_WARNING, 0, _("FileSet MD5 digest not found.\n"));
   }
-  if (!jcr->impl->res.fileset->ignore_fs_changes
+  if (!jcr->dir_impl->res.fileset->ignore_fs_changes
       || !jcr->db->GetFilesetRecord(jcr, &fsr)) {
     PoolMem FileSetText(PM_MESSAGE);
     OutputFormatter output_formatter
@@ -1369,8 +1384,8 @@ bool GetOrCreateFilesetRecord(JobControlRecord* jcr)
     OutputFormatterResource output_formatter_resource
         = OutputFormatterResource(&output_formatter);
 
-    jcr->impl->res.fileset->PrintConfig(output_formatter_resource, *my_config,
-                                        false, false);
+    jcr->dir_impl->res.fileset->PrintConfig(output_formatter_resource,
+                                            *my_config, false, false);
 
     fsr.FileSetText = FileSetText.c_str();
 
@@ -1382,46 +1397,47 @@ bool GetOrCreateFilesetRecord(JobControlRecord* jcr)
     }
   }
 
-  jcr->impl->jr.FileSetId = fsr.FileSetId;
-  bstrncpy(jcr->impl->FSCreateTime, fsr.cCreateTime,
-           sizeof(jcr->impl->FSCreateTime));
+  jcr->dir_impl->jr.FileSetId = fsr.FileSetId;
+  bstrncpy(jcr->dir_impl->FSCreateTime, fsr.cCreateTime,
+           sizeof(jcr->dir_impl->FSCreateTime));
 
   Dmsg2(119, "Created FileSet %s record %u\n",
-        jcr->impl->res.fileset->resource_name_, jcr->impl->jr.FileSetId);
+        jcr->dir_impl->res.fileset->resource_name_,
+        jcr->dir_impl->jr.FileSetId);
 
   return true;
 }
 
 void InitJcrJobRecord(JobControlRecord* jcr)
 {
-  jcr->impl->jr.SchedTime = jcr->sched_time;
-  jcr->impl->jr.StartTime = jcr->start_time;
-  jcr->impl->jr.EndTime = 0; /* perhaps rescheduled, clear it */
-  jcr->impl->jr.JobType = jcr->getJobType();
-  jcr->impl->jr.JobLevel = jcr->getJobLevel();
-  jcr->impl->jr.JobStatus = jcr->getJobStatus();
-  jcr->impl->jr.JobId = jcr->JobId;
-  jcr->impl->jr.JobSumTotalBytes = 18446744073709551615LLU;
-  bstrncpy(jcr->impl->jr.Name, jcr->impl->res.job->resource_name_,
-           sizeof(jcr->impl->jr.Name));
-  bstrncpy(jcr->impl->jr.Job, jcr->Job, sizeof(jcr->impl->jr.Job));
+  jcr->dir_impl->jr.SchedTime = jcr->sched_time;
+  jcr->dir_impl->jr.StartTime = jcr->start_time;
+  jcr->dir_impl->jr.EndTime = 0; /* perhaps rescheduled, clear it */
+  jcr->dir_impl->jr.JobType = jcr->getJobType();
+  jcr->dir_impl->jr.JobLevel = jcr->getJobLevel();
+  jcr->dir_impl->jr.JobStatus = jcr->getJobStatus();
+  jcr->dir_impl->jr.JobId = jcr->JobId;
+  jcr->dir_impl->jr.JobSumTotalBytes = 18446744073709551615LLU;
+  bstrncpy(jcr->dir_impl->jr.Name, jcr->dir_impl->res.job->resource_name_,
+           sizeof(jcr->dir_impl->jr.Name));
+  bstrncpy(jcr->dir_impl->jr.Job, jcr->Job, sizeof(jcr->dir_impl->jr.Job));
 }
 
 // Write status and such in DB
 void UpdateJobEndRecord(JobControlRecord* jcr)
 {
-  jcr->impl->jr.EndTime = time(NULL);
-  jcr->end_time = jcr->impl->jr.EndTime;
-  jcr->impl->jr.JobId = jcr->JobId;
-  jcr->impl->jr.JobStatus = jcr->getJobStatus();
-  jcr->impl->jr.JobFiles = jcr->JobFiles;
-  jcr->impl->jr.JobBytes = jcr->JobBytes;
-  jcr->impl->jr.ReadBytes = jcr->ReadBytes;
-  jcr->impl->jr.VolSessionId = jcr->VolSessionId;
-  jcr->impl->jr.VolSessionTime = jcr->VolSessionTime;
-  jcr->impl->jr.JobErrors = jcr->JobErrors;
-  jcr->impl->jr.HasBase = jcr->HasBase;
-  if (!jcr->db->UpdateJobEndRecord(jcr, &jcr->impl->jr)) {
+  jcr->dir_impl->jr.EndTime = time(NULL);
+  jcr->end_time = jcr->dir_impl->jr.EndTime;
+  jcr->dir_impl->jr.JobId = jcr->JobId;
+  jcr->dir_impl->jr.JobStatus = jcr->getJobStatus();
+  jcr->dir_impl->jr.JobFiles = jcr->JobFiles;
+  jcr->dir_impl->jr.JobBytes = jcr->JobBytes;
+  jcr->dir_impl->jr.ReadBytes = jcr->ReadBytes;
+  jcr->dir_impl->jr.VolSessionId = jcr->VolSessionId;
+  jcr->dir_impl->jr.VolSessionTime = jcr->VolSessionTime;
+  jcr->dir_impl->jr.JobErrors = jcr->JobErrors;
+  jcr->dir_impl->jr.HasBase = jcr->HasBase;
+  if (!jcr->db->UpdateJobEndRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_WARNING, 0, _("Error updating job record. %s\n"),
          jcr->db->strerror());
   }
@@ -1509,14 +1525,14 @@ void DirdFreeJcrPointers(JobControlRecord* jcr)
 
   BfreeAndNull(jcr->sd_auth_key);
   BfreeAndNull(jcr->where);
-  BfreeAndNull(jcr->impl->backup_format);
+  BfreeAndNull(jcr->dir_impl->backup_format);
   BfreeAndNull(jcr->RestoreBootstrap);
   BfreeAndNull(jcr->ar);
 
   FreeAndNullPoolMemory(jcr->JobIds);
-  FreeAndNullPoolMemory(jcr->impl->client_uname);
+  FreeAndNullPoolMemory(jcr->dir_impl->client_uname);
   FreeAndNullPoolMemory(jcr->attr);
-  FreeAndNullPoolMemory(jcr->impl->fname);
+  FreeAndNullPoolMemory(jcr->dir_impl->fname);
 }
 
 /**
@@ -1528,21 +1544,21 @@ void DirdFreeJcr(JobControlRecord* jcr)
 {
   Dmsg0(200, "Start dird FreeJcr\n");
 
-  if (jcr->impl->mig_jcr) {
-    FreeJcr(jcr->impl->mig_jcr);
-    jcr->impl->mig_jcr = NULL;
+  if (jcr->dir_impl->mig_jcr) {
+    FreeJcr(jcr->dir_impl->mig_jcr);
+    jcr->dir_impl->mig_jcr = NULL;
   }
 
   DirdFreeJcrPointers(jcr);
 
-  if (jcr->impl->term_wait_inited) {
-    pthread_cond_destroy(&jcr->impl->term_wait);
-    jcr->impl->term_wait_inited = false;
+  if (jcr->dir_impl->term_wait_inited) {
+    pthread_cond_destroy(&jcr->dir_impl->term_wait);
+    jcr->dir_impl->term_wait_inited = false;
   }
 
-  if (jcr->impl->nextrun_ready_inited) {
-    pthread_cond_destroy(&jcr->impl->nextrun_ready);
-    jcr->impl->nextrun_ready_inited = false;
+  if (jcr->dir_impl->nextrun_ready_inited) {
+    pthread_cond_destroy(&jcr->dir_impl->nextrun_ready);
+    jcr->dir_impl->nextrun_ready_inited = false;
   }
 
   if (jcr->db_batch) {
@@ -1556,24 +1572,26 @@ void DirdFreeJcr(JobControlRecord* jcr)
     jcr->db = NULL;
   }
 
-  if (jcr->impl->restore_tree_root) { FreeTree(jcr->impl->restore_tree_root); }
+  if (jcr->dir_impl->restore_tree_root) {
+    FreeTree(jcr->dir_impl->restore_tree_root);
+  }
 
-  if (jcr->impl->bsr) {
-    libbareos::FreeBsr(jcr->impl->bsr);
-    jcr->impl->bsr = NULL;
+  if (jcr->dir_impl->bsr) {
+    libbareos::FreeBsr(jcr->dir_impl->bsr);
+    jcr->dir_impl->bsr = NULL;
   }
 
   FreeAndNullPoolMemory(jcr->starttime_string);
-  FreeAndNullPoolMemory(jcr->impl->fname);
-  FreeAndNullPoolMemory(jcr->impl->res.pool_source);
-  FreeAndNullPoolMemory(jcr->impl->res.npool_source);
-  FreeAndNullPoolMemory(jcr->impl->res.rpool_source);
-  FreeAndNullPoolMemory(jcr->impl->res.wstore_source);
-  FreeAndNullPoolMemory(jcr->impl->res.rstore_source);
-  FreeAndNullPoolMemory(jcr->impl->res.catalog_source);
-  FreeAndNullPoolMemory(jcr->impl->FDSecureEraseCmd);
-  FreeAndNullPoolMemory(jcr->impl->SDSecureEraseCmd);
-  FreeAndNullPoolMemory(jcr->impl->vf_jobids);
+  FreeAndNullPoolMemory(jcr->dir_impl->fname);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.pool_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.npool_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.rpool_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.wstore_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.rstore_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->res.catalog_source);
+  FreeAndNullPoolMemory(jcr->dir_impl->FDSecureEraseCmd);
+  FreeAndNullPoolMemory(jcr->dir_impl->SDSecureEraseCmd);
+  FreeAndNullPoolMemory(jcr->dir_impl->vf_jobids);
 
   // Delete lists setup to hold storage pointers
   FreeRwstorage(jcr);
@@ -1587,9 +1605,9 @@ void DirdFreeJcr(JobControlRecord* jcr)
 
   FreePlugins(jcr); /* release instantiated plugins */
 
-  if (jcr->impl) {
-    delete jcr->impl;
-    jcr->impl = nullptr;
+  if (jcr->dir_impl) {
+    delete jcr->dir_impl;
+    jcr->dir_impl = nullptr;
   }
 
   Dmsg0(200, "End dird FreeJcr\n");
@@ -1633,7 +1651,7 @@ void GetJobStorage(UnifiedStorageResource* store,
  */
 void SetJcrDefaults(JobControlRecord* jcr, JobResource* job)
 {
-  jcr->impl->res.job = job;
+  jcr->dir_impl->res.job = job;
   jcr->setJobType(job->JobType);
   jcr->setJobProtocol(job->Protocol);
   jcr->setJobStatus(JS_Created);
@@ -1650,18 +1668,18 @@ void SetJcrDefaults(JobControlRecord* jcr, JobResource* job)
       break;
   }
 
-  if (!jcr->impl->fname) { jcr->impl->fname = GetPoolMemory(PM_FNAME); }
-  if (!jcr->impl->res.pool_source) {
-    jcr->impl->res.pool_source = GetPoolMemory(PM_MESSAGE);
-    PmStrcpy(jcr->impl->res.pool_source, _("unknown source"));
+  if (!jcr->dir_impl->fname) { jcr->dir_impl->fname = GetPoolMemory(PM_FNAME); }
+  if (!jcr->dir_impl->res.pool_source) {
+    jcr->dir_impl->res.pool_source = GetPoolMemory(PM_MESSAGE);
+    PmStrcpy(jcr->dir_impl->res.pool_source, _("unknown source"));
   }
-  if (!jcr->impl->res.npool_source) {
-    jcr->impl->res.npool_source = GetPoolMemory(PM_MESSAGE);
-    PmStrcpy(jcr->impl->res.npool_source, _("unknown source"));
+  if (!jcr->dir_impl->res.npool_source) {
+    jcr->dir_impl->res.npool_source = GetPoolMemory(PM_MESSAGE);
+    PmStrcpy(jcr->dir_impl->res.npool_source, _("unknown source"));
   }
-  if (!jcr->impl->res.catalog_source) {
-    jcr->impl->res.catalog_source = GetPoolMemory(PM_MESSAGE);
-    PmStrcpy(jcr->impl->res.catalog_source, _("unknown source"));
+  if (!jcr->dir_impl->res.catalog_source) {
+    jcr->dir_impl->res.catalog_source = GetPoolMemory(PM_MESSAGE);
+    PmStrcpy(jcr->dir_impl->res.catalog_source, _("unknown source"));
   }
 
   jcr->JobPriority = job->Priority;
@@ -1672,48 +1690,48 @@ void SetJcrDefaults(JobControlRecord* jcr, JobResource* job)
   } else if (job->pool) {
     CopyRwstorage(jcr, job->pool->storage, _("Pool resource"));
   }
-  jcr->impl->res.client = job->client;
+  jcr->dir_impl->res.client = job->client;
 
-  if (jcr->impl->res.client) {
+  if (jcr->dir_impl->res.client) {
     if (!jcr->client_name) { jcr->client_name = GetPoolMemory(PM_NAME); }
-    PmStrcpy(jcr->client_name, jcr->impl->res.client->resource_name_);
+    PmStrcpy(jcr->client_name, jcr->dir_impl->res.client->resource_name_);
   }
 
-  PmStrcpy(jcr->impl->res.pool_source, _("Job resource"));
-  jcr->impl->res.pool = job->pool;
-  jcr->impl->res.full_pool = job->full_pool;
-  jcr->impl->res.inc_pool = job->inc_pool;
-  jcr->impl->res.diff_pool = job->diff_pool;
+  PmStrcpy(jcr->dir_impl->res.pool_source, _("Job resource"));
+  jcr->dir_impl->res.pool = job->pool;
+  jcr->dir_impl->res.full_pool = job->full_pool;
+  jcr->dir_impl->res.inc_pool = job->inc_pool;
+  jcr->dir_impl->res.diff_pool = job->diff_pool;
 
   if (job->pool && job->pool->catalog) {
-    jcr->impl->res.catalog = job->pool->catalog;
-    PmStrcpy(jcr->impl->res.catalog_source, _("Pool resource"));
+    jcr->dir_impl->res.catalog = job->pool->catalog;
+    PmStrcpy(jcr->dir_impl->res.catalog_source, _("Pool resource"));
   } else {
     if (job->catalog) {
-      jcr->impl->res.catalog = job->catalog;
-      PmStrcpy(jcr->impl->res.catalog_source, _("Job resource"));
+      jcr->dir_impl->res.catalog = job->catalog;
+      PmStrcpy(jcr->dir_impl->res.catalog_source, _("Job resource"));
     } else {
       if (job->client) {
-        jcr->impl->res.catalog = job->client->catalog;
-        PmStrcpy(jcr->impl->res.catalog_source, _("Client resource"));
+        jcr->dir_impl->res.catalog = job->client->catalog;
+        PmStrcpy(jcr->dir_impl->res.catalog_source, _("Client resource"));
       } else {
-        jcr->impl->res.catalog
+        jcr->dir_impl->res.catalog
             = (CatalogResource*)my_config->GetNextRes(R_CATALOG, NULL);
-        PmStrcpy(jcr->impl->res.catalog_source, _("Default catalog"));
+        PmStrcpy(jcr->dir_impl->res.catalog_source, _("Default catalog"));
       }
     }
   }
 
-  jcr->impl->res.fileset = job->fileset;
+  jcr->dir_impl->res.fileset = job->fileset;
   jcr->accurate = job->accurate;
-  jcr->impl->res.messages = job->messages;
-  jcr->impl->spool_data = job->spool_data;
-  jcr->impl->spool_size = job->spool_size;
-  jcr->impl->IgnoreDuplicateJobChecking = job->IgnoreDuplicateJobChecking;
-  jcr->impl->MaxRunSchedTime = job->MaxRunSchedTime;
+  jcr->dir_impl->res.messages = job->messages;
+  jcr->dir_impl->spool_data = job->spool_data;
+  jcr->dir_impl->spool_size = job->spool_size;
+  jcr->dir_impl->IgnoreDuplicateJobChecking = job->IgnoreDuplicateJobChecking;
+  jcr->dir_impl->MaxRunSchedTime = job->MaxRunSchedTime;
 
-  if (jcr->impl->backup_format) { free(jcr->impl->backup_format); }
-  jcr->impl->backup_format = strdup(job->backup_format);
+  if (jcr->dir_impl->backup_format) { free(jcr->dir_impl->backup_format); }
+  jcr->dir_impl->backup_format = strdup(job->backup_format);
 
   if (jcr->RestoreBootstrap) {
     free(jcr->RestoreBootstrap);
@@ -1726,7 +1744,7 @@ void SetJcrDefaults(JobControlRecord* jcr, JobResource* job)
   }
 
   // This can be overridden by Console program
-  jcr->impl->res.verify_job = job->verify_job;
+  jcr->dir_impl->res.verify_job = job->verify_job;
 
   // If no default level given, set one
   if (jcr->getJobLevel() == 0) {
@@ -1751,12 +1769,12 @@ void SetJcrDefaults(JobControlRecord* jcr, JobResource* job)
 void CreateClones(JobControlRecord* jcr)
 {
   // Fire off any clone jobs (run directives)
-  Dmsg2(900, "cloned=%d run_cmds=%p\n", jcr->impl->cloned,
-        jcr->impl->res.job->run_cmds);
-  if (!jcr->impl->cloned && jcr->impl->res.job->run_cmds) {
+  Dmsg2(900, "cloned=%d run_cmds=%p\n", jcr->dir_impl->cloned,
+        jcr->dir_impl->res.job->run_cmds);
+  if (!jcr->dir_impl->cloned && jcr->dir_impl->res.job->run_cmds) {
     const char* runcmd = nullptr;
     JobId_t jobid;
-    JobResource* job = jcr->impl->res.job;
+    JobResource* job = jcr->dir_impl->res.job;
     POOLMEM* cmd = GetPoolMemory(PM_FNAME);
 
     UaContext* ua = new_ua_context(jcr);
@@ -1781,7 +1799,7 @@ void CreateClones(JobControlRecord* jcr)
 }
 
 /**
- * Given: a JobId in jcr->impl_->previous_jr.JobId,
+ * Given: a JobId in jcr->dir_impl_->previous_jr.JobId,
  *  this subroutine writes a bsr file to restore that job.
  * Returns: -1 on error
  *           number of files if OK
@@ -1794,24 +1812,24 @@ int CreateRestoreBootstrapFile(JobControlRecord* jcr)
 
   rx.bsr = std::make_unique<RestoreBootstrapRecord>();
   rx.JobIds = (char*)"";
-  rx.bsr->JobId = jcr->impl->previous_jr.JobId;
+  rx.bsr->JobId = jcr->dir_impl->previous_jr.JobId;
   ua = new_ua_context(jcr);
   if (!AddVolumeInformationToBsr(ua, rx.bsr.get())) {
     files = -1;
     goto bail_out;
   }
-  for (uint32_t fi = 1; fi <= jcr->impl->previous_jr.JobFiles; fi++) {
+  for (uint32_t fi = 1; fi <= jcr->dir_impl->previous_jr.JobFiles; fi++) {
     rx.bsr->fi->Add(fi);
   }
-  jcr->impl->ExpectedFiles = WriteBsrFile(ua, rx);
-  if (jcr->impl->ExpectedFiles == 0) {
+  jcr->dir_impl->ExpectedFiles = WriteBsrFile(ua, rx);
+  if (jcr->dir_impl->ExpectedFiles == 0) {
     files = 0;
     goto bail_out;
   }
   FreeUaContext(ua);
   rx.bsr.reset(nullptr);
-  jcr->impl->needs_sd = true;
-  return jcr->impl->ExpectedFiles;
+  jcr->dir_impl->needs_sd = true;
+  return jcr->dir_impl->ExpectedFiles;
 
 bail_out:
   FreeUaContext(ua);

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -33,7 +33,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/jobq.h"
 #include "dird/storage.h"
@@ -206,15 +206,15 @@ int JobqAdd(jobq_t* jq, JobControlRecord* jcr)
   pthread_t id;
   wait_pkt* sched_pkt;
 
-  if (!jcr->impl->term_wait_inited) {
+  if (!jcr->dir_impl->term_wait_inited) {
     // Initialize termination condition variable
-    if ((status = pthread_cond_init(&jcr->impl->term_wait, NULL)) != 0) {
+    if ((status = pthread_cond_init(&jcr->dir_impl->term_wait, NULL)) != 0) {
       BErrNo be;
       Jmsg1(jcr, M_FATAL, 0, _("Unable to init job cond variable: ERR=%s\n"),
             be.bstrerror(status));
       return status;
     }
-    jcr->impl->term_wait_inited = true;
+    jcr->dir_impl->term_wait_inited = true;
   }
 
   Dmsg3(2300, "JobqAdd jobid=%d jcr=0x%x UseCount=%d\n", jcr->JobId, jcr,
@@ -441,12 +441,12 @@ extern "C" void* jobq_server(void* arg)
        * been acquired for jobs canceled before they were put into the ready
        * queue.
        */
-      if (jcr->impl->acquired_resource_locks) {
+      if (jcr->dir_impl->acquired_resource_locks) {
         DecReadStore(jcr);
         DecWriteStore(jcr);
         DecClientConcurrency(jcr);
         DecJobConcurrency(jcr);
-        jcr->impl->acquired_resource_locks = false;
+        jcr->dir_impl->acquired_resource_locks = false;
       }
 
       if (RescheduleJob(jcr, jq, je)) { continue; /* go look for more work */ }
@@ -454,7 +454,7 @@ extern "C" void* jobq_server(void* arg)
       // Clean up and release old jcr
       Dmsg2(2300, "====== Termination job=%d use_cnt=%d\n", jcr->JobId,
             jcr->UseCount());
-      jcr->impl->SDJobStatus = 0;
+      jcr->dir_impl->SDJobStatus = 0;
       unlock_mutex(jq->mutex); /* release internal lock */
       FreeJcr(jcr);
       free(je);              /* release job entry */
@@ -475,10 +475,10 @@ extern "C" void* jobq_server(void* arg)
         running_allow_mix = true;
 
         for (; re;) {
-          Dmsg2(
-              2300, "JobId %d is also running with %s\n", re->jcr->JobId,
-              re->jcr->impl->res.job->allow_mixed_priority ? "mix" : "no mix");
-          if (!re->jcr->impl->res.job->allow_mixed_priority) {
+          Dmsg2(2300, "JobId %d is also running with %s\n", re->jcr->JobId,
+                re->jcr->dir_impl->res.job->allow_mixed_priority ? "mix"
+                                                                 : "no mix");
+          if (!re->jcr->dir_impl->res.job->allow_mixed_priority) {
             running_allow_mix = false;
             break;
           }
@@ -502,12 +502,12 @@ extern "C" void* jobq_server(void* arg)
 
         Dmsg4(2300, "Examining Job=%d JobPri=%d want Pri=%d (%s)\n", jcr->JobId,
               jcr->JobPriority, Priority,
-              jcr->impl->res.job->allow_mixed_priority ? "mix" : "no mix");
+              jcr->dir_impl->res.job->allow_mixed_priority ? "mix" : "no mix");
 
         // Take only jobs of correct Priority
         if (!(jcr->JobPriority == Priority
               || (jcr->JobPriority < Priority
-                  && jcr->impl->res.job->allow_mixed_priority
+                  && jcr->dir_impl->res.job->allow_mixed_priority
                   && running_allow_mix))) {
           jcr->setJobStatusWithPriorityCheck(JS_WaitPriority);
           break;
@@ -593,15 +593,16 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
   // Reschedule the job if requested and possible
 
   // Basic condition is that more reschedule times remain
-  if (jcr->impl->res.job->RescheduleTimes == 0
-      || jcr->impl->reschedule_count < jcr->impl->res.job->RescheduleTimes) {
+  if (jcr->dir_impl->res.job->RescheduleTimes == 0
+      || jcr->dir_impl->reschedule_count
+             < jcr->dir_impl->res.job->RescheduleTimes) {
     resched =
         // Check for incomplete jobs
-        (jcr->impl->res.job->RescheduleIncompleteJobs && jcr->IsIncomplete()
+        (jcr->dir_impl->res.job->RescheduleIncompleteJobs && jcr->IsIncomplete()
          && jcr->is_JobType(JT_BACKUP) && !jcr->is_JobLevel(L_BASE))
         ||
         // Check for failed jobs
-        (jcr->impl->res.job->RescheduleOnError && !jcr->IsTerminatedOk()
+        (jcr->dir_impl->res.job->RescheduleOnError && !jcr->IsTerminatedOk()
          && !jcr->is_JobStatus(JS_Canceled) && jcr->is_JobType(JT_BACKUP));
   }
 
@@ -614,19 +615,19 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
      * possible.
      */
     now = time(NULL);
-    jcr->impl->reschedule_count++;
-    jcr->sched_time = now + jcr->impl->res.job->RescheduleInterval;
+    jcr->dir_impl->reschedule_count++;
+    jcr->sched_time = now + jcr->dir_impl->res.job->RescheduleInterval;
     bstrftime(dt, sizeof(dt), now);
     bstrftime(dt2, sizeof(dt2), jcr->sched_time);
     Dmsg4(2300, "Rescheduled Job %s to re-run in %d seconds.(now=%u,then=%u)\n",
-          jcr->Job, (int)jcr->impl->res.job->RescheduleInterval, now,
+          jcr->Job, (int)jcr->dir_impl->res.job->RescheduleInterval, now,
           jcr->sched_time);
     Jmsg(jcr, M_INFO, 0,
          _("Rescheduled Job %s at %s to re-run in %d seconds (%s).\n"),
-         jcr->Job, dt, (int)jcr->impl->res.job->RescheduleInterval, dt2);
+         jcr->Job, dt, (int)jcr->dir_impl->res.job->RescheduleInterval, dt2);
     DirdFreeJcrPointers(jcr); /* partial cleanup old stuff */
     jcr->setJobStatus(-1);
-    jcr->impl->SDJobStatus = 0;
+    jcr->dir_impl->SDJobStatus = 0;
     jcr->JobErrors = 0;
     if (!AllowDuplicateJob(jcr)) { return false; }
 
@@ -638,7 +639,7 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
       UpdateJobEnd(jcr, JS_WaitStartTime);
       Dmsg2(2300, "Requeue job=%d use=%d\n", jcr->JobId, jcr->UseCount());
       unlock_mutex(jq->mutex);
-      jcr->impl->jr.RealEndTime = 0;
+      jcr->dir_impl->jr.RealEndTime = 0;
       JobqAdd(jq, jcr); /* queue the job to run again */
       lock_mutex(jq->mutex);
       FreeJcr(jcr);  /* release jcr */
@@ -655,41 +656,43 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
        */
       jcr->setJobStatusWithPriorityCheck(JS_WaitStartTime);
       njcr = NewDirectorJcr(DirdFreeJcr);
-      SetJcrDefaults(njcr, jcr->impl->res.job);
-      njcr->impl->reschedule_count = jcr->impl->reschedule_count;
+      SetJcrDefaults(njcr, jcr->dir_impl->res.job);
+      njcr->dir_impl->reschedule_count = jcr->dir_impl->reschedule_count;
       njcr->sched_time = jcr->sched_time;
       njcr->initial_sched_time = jcr->initial_sched_time;
 
       njcr->setJobLevel(jcr->getJobLevel());
-      njcr->impl->res.pool = jcr->impl->res.pool;
-      njcr->impl->res.run_pool_override = jcr->impl->res.run_pool_override;
-      njcr->impl->res.full_pool = jcr->impl->res.full_pool;
-      njcr->impl->res.run_full_pool_override
-          = jcr->impl->res.run_full_pool_override;
-      njcr->impl->res.inc_pool = jcr->impl->res.inc_pool;
-      njcr->impl->res.run_inc_pool_override
-          = jcr->impl->res.run_inc_pool_override;
-      njcr->impl->res.diff_pool = jcr->impl->res.diff_pool;
-      njcr->impl->res.run_diff_pool_override
-          = jcr->impl->res.run_diff_pool_override;
-      njcr->impl->res.next_pool = jcr->impl->res.next_pool;
-      njcr->impl->res.run_next_pool_override
-          = jcr->impl->res.run_next_pool_override;
+      njcr->dir_impl->res.pool = jcr->dir_impl->res.pool;
+      njcr->dir_impl->res.run_pool_override
+          = jcr->dir_impl->res.run_pool_override;
+      njcr->dir_impl->res.full_pool = jcr->dir_impl->res.full_pool;
+      njcr->dir_impl->res.run_full_pool_override
+          = jcr->dir_impl->res.run_full_pool_override;
+      njcr->dir_impl->res.inc_pool = jcr->dir_impl->res.inc_pool;
+      njcr->dir_impl->res.run_inc_pool_override
+          = jcr->dir_impl->res.run_inc_pool_override;
+      njcr->dir_impl->res.diff_pool = jcr->dir_impl->res.diff_pool;
+      njcr->dir_impl->res.run_diff_pool_override
+          = jcr->dir_impl->res.run_diff_pool_override;
+      njcr->dir_impl->res.next_pool = jcr->dir_impl->res.next_pool;
+      njcr->dir_impl->res.run_next_pool_override
+          = jcr->dir_impl->res.run_next_pool_override;
       njcr->setJobStatus(-1);
       njcr->setJobStatusWithPriorityCheck(jcr->getJobStatus());
-      if (jcr->impl->res.read_storage) {
-        CopyRstorage(njcr, jcr->impl->res.read_storage_list, _("previous Job"));
+      if (jcr->dir_impl->res.read_storage) {
+        CopyRstorage(njcr, jcr->dir_impl->res.read_storage_list,
+                     _("previous Job"));
       } else {
         FreeRstorage(njcr);
       }
-      if (jcr->impl->res.write_storage) {
-        CopyWstorage(njcr, jcr->impl->res.write_storage_list,
+      if (jcr->dir_impl->res.write_storage) {
+        CopyWstorage(njcr, jcr->dir_impl->res.write_storage_list,
                      _("previous Job"));
       } else {
         FreeWstorage(njcr);
       }
-      njcr->impl->res.messages = jcr->impl->res.messages;
-      njcr->impl->spool_data = jcr->impl->spool_data;
+      njcr->dir_impl->res.messages = jcr->dir_impl->res.messages;
+      njcr->dir_impl->spool_data = jcr->dir_impl->spool_data;
       Dmsg0(2300, "Call to run new job\n");
       unlock_mutex(jq->mutex);
       RunJob(njcr);  /* This creates a "new" job */
@@ -712,7 +715,7 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
 static bool AcquireResources(JobControlRecord* jcr)
 {
   // Set that we didn't acquire any resourse locks yet.
-  jcr->impl->acquired_resource_locks = false;
+  jcr->dir_impl->acquired_resource_locks = false;
 
   /*
    * Some Job Types are excluded from the client and storage concurrency
@@ -726,11 +729,11 @@ static bool AcquireResources(JobControlRecord* jcr)
        * Migration/Copy and Consolidation jobs are not counted for client
        * concurrency as they do not touch the client at all
        */
-      jcr->impl->IgnoreClientConcurrency = true;
+      jcr->dir_impl->IgnoreClientConcurrency = true;
       Dmsg1(200, "Skipping migrate/copy Job %s for client concurrency\n",
             jcr->Job);
 
-      if (jcr->impl->MigrateJobId == 0) {
+      if (jcr->dir_impl->MigrateJobId == 0) {
         /*
          * Migration/Copy control jobs are not counted for storage concurrency
          * as they do not touch the storage at all
@@ -738,14 +741,14 @@ static bool AcquireResources(JobControlRecord* jcr)
         Dmsg1(200,
               "Skipping migrate/copy Control Job %s for storage concurrency\n",
               jcr->Job);
-        jcr->impl->IgnoreStorageConcurrency = true;
+        jcr->dir_impl->IgnoreStorageConcurrency = true;
       }
       break;
     default:
       break;
   }
 
-  if (jcr->impl->res.read_storage) {
+  if (jcr->dir_impl->res.read_storage) {
     if (!IncReadStore(jcr)) {
       jcr->setJobStatusWithPriorityCheck(JS_WaitStoreRes);
 
@@ -753,7 +756,7 @@ static bool AcquireResources(JobControlRecord* jcr)
     }
   }
 
-  if (jcr->impl->res.write_storage) {
+  if (jcr->dir_impl->res.write_storage) {
     if (!IncWriteStore(jcr)) {
       DecReadStore(jcr);
       jcr->setJobStatusWithPriorityCheck(JS_WaitStoreRes);
@@ -781,23 +784,24 @@ static bool AcquireResources(JobControlRecord* jcr)
     return false;
   }
 
-  jcr->impl->acquired_resource_locks = true;
+  jcr->dir_impl->acquired_resource_locks = true;
 
   return true;
 }
 
 static bool IncClientConcurrency(JobControlRecord* jcr)
 {
-  if (!jcr->impl->res.client || jcr->impl->IgnoreClientConcurrency) {
+  if (!jcr->dir_impl->res.client || jcr->dir_impl->IgnoreClientConcurrency) {
     return true;
   }
 
   lock_mutex(mutex);
-  if (jcr->impl->res.client->rcs->NumConcurrentJobs
-      < jcr->impl->res.client->MaxConcurrentJobs) {
-    jcr->impl->res.client->rcs->NumConcurrentJobs++;
-    Dmsg2(50, "Inc Client=%s rncj=%d\n", jcr->impl->res.client->resource_name_,
-          jcr->impl->res.client->rcs->NumConcurrentJobs);
+  if (jcr->dir_impl->res.client->rcs->NumConcurrentJobs
+      < jcr->dir_impl->res.client->MaxConcurrentJobs) {
+    jcr->dir_impl->res.client->rcs->NumConcurrentJobs++;
+    Dmsg2(50, "Inc Client=%s rncj=%d\n",
+          jcr->dir_impl->res.client->resource_name_,
+          jcr->dir_impl->res.client->rcs->NumConcurrentJobs);
     unlock_mutex(mutex);
 
     return true;
@@ -810,13 +814,14 @@ static bool IncClientConcurrency(JobControlRecord* jcr)
 
 static void DecClientConcurrency(JobControlRecord* jcr)
 {
-  if (jcr->impl->IgnoreClientConcurrency) { return; }
+  if (jcr->dir_impl->IgnoreClientConcurrency) { return; }
 
   lock_mutex(mutex);
-  if (jcr->impl->res.client) {
-    jcr->impl->res.client->rcs->NumConcurrentJobs--;
-    Dmsg2(50, "Dec Client=%s rncj=%d\n", jcr->impl->res.client->resource_name_,
-          jcr->impl->res.client->rcs->NumConcurrentJobs);
+  if (jcr->dir_impl->res.client) {
+    jcr->dir_impl->res.client->rcs->NumConcurrentJobs--;
+    Dmsg2(50, "Dec Client=%s rncj=%d\n",
+          jcr->dir_impl->res.client->resource_name_,
+          jcr->dir_impl->res.client->rcs->NumConcurrentJobs);
   }
   unlock_mutex(mutex);
 }
@@ -824,11 +829,11 @@ static void DecClientConcurrency(JobControlRecord* jcr)
 static bool IncJobConcurrency(JobControlRecord* jcr)
 {
   lock_mutex(mutex);
-  if (jcr->impl->res.job->rjs->NumConcurrentJobs
-      < jcr->impl->res.job->MaxConcurrentJobs) {
-    jcr->impl->res.job->rjs->NumConcurrentJobs++;
-    Dmsg2(50, "Inc Job=%s rncj=%d\n", jcr->impl->res.job->resource_name_,
-          jcr->impl->res.job->rjs->NumConcurrentJobs);
+  if (jcr->dir_impl->res.job->rjs->NumConcurrentJobs
+      < jcr->dir_impl->res.job->MaxConcurrentJobs) {
+    jcr->dir_impl->res.job->rjs->NumConcurrentJobs++;
+    Dmsg2(50, "Inc Job=%s rncj=%d\n", jcr->dir_impl->res.job->resource_name_,
+          jcr->dir_impl->res.job->rjs->NumConcurrentJobs);
     unlock_mutex(mutex);
 
     return true;
@@ -842,9 +847,9 @@ static bool IncJobConcurrency(JobControlRecord* jcr)
 static void DecJobConcurrency(JobControlRecord* jcr)
 {
   lock_mutex(mutex);
-  jcr->impl->res.job->rjs->NumConcurrentJobs--;
-  Dmsg2(50, "Dec Job=%s rncj=%d\n", jcr->impl->res.job->resource_name_,
-        jcr->impl->res.job->rjs->NumConcurrentJobs);
+  jcr->dir_impl->res.job->rjs->NumConcurrentJobs--;
+  Dmsg2(50, "Dec Job=%s rncj=%d\n", jcr->dir_impl->res.job->resource_name_,
+        jcr->dir_impl->res.job->rjs->NumConcurrentJobs);
   unlock_mutex(mutex);
 }
 
@@ -854,18 +859,19 @@ static void DecJobConcurrency(JobControlRecord* jcr)
  */
 bool IncReadStore(JobControlRecord* jcr)
 {
-  if (jcr->impl->IgnoreStorageConcurrency) { return true; }
+  if (jcr->dir_impl->IgnoreStorageConcurrency) { return true; }
 
   lock_mutex(mutex);
-  if (jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs
-      < jcr->impl->res.read_storage->MaxConcurrentJobs) {
-    jcr->impl->res.read_storage->runtime_storage_status
+  if (jcr->dir_impl->res.read_storage->runtime_storage_status->NumConcurrentJobs
+      < jcr->dir_impl->res.read_storage->MaxConcurrentJobs) {
+    jcr->dir_impl->res.read_storage->runtime_storage_status
         ->NumConcurrentReadJobs++;
-    jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs++;
-    Dmsg2(
-        50, "Inc Rstore=%s rncj=%d\n",
-        jcr->impl->res.read_storage->resource_name_,
-        jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs);
+    jcr->dir_impl->res.read_storage->runtime_storage_status
+        ->NumConcurrentJobs++;
+    Dmsg2(50, "Inc Rstore=%s rncj=%d\n",
+          jcr->dir_impl->res.read_storage->resource_name_,
+          jcr->dir_impl->res.read_storage->runtime_storage_status
+              ->NumConcurrentJobs);
     unlock_mutex(mutex);
 
     return true;
@@ -873,38 +879,42 @@ bool IncReadStore(JobControlRecord* jcr)
   unlock_mutex(mutex);
 
   Dmsg2(50, "Fail to acquire Rstore=%s rncj=%d\n",
-        jcr->impl->res.read_storage->resource_name_,
-        jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs);
+        jcr->dir_impl->res.read_storage->resource_name_,
+        jcr->dir_impl->res.read_storage->runtime_storage_status
+            ->NumConcurrentJobs);
 
   return false;
 }
 
 void DecReadStore(JobControlRecord* jcr)
 {
-  if (jcr->impl->res.read_storage && !jcr->impl->IgnoreStorageConcurrency) {
+  if (jcr->dir_impl->res.read_storage
+      && !jcr->dir_impl->IgnoreStorageConcurrency) {
     lock_mutex(mutex);
-    jcr->impl->res.read_storage->runtime_storage_status
+    jcr->dir_impl->res.read_storage->runtime_storage_status
         ->NumConcurrentReadJobs--;
-    jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs--;
-    Dmsg2(
-        50, "Dec Rstore=%s rncj=%d\n",
-        jcr->impl->res.read_storage->resource_name_,
-        jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs);
+    jcr->dir_impl->res.read_storage->runtime_storage_status
+        ->NumConcurrentJobs--;
+    Dmsg2(50, "Dec Rstore=%s rncj=%d\n",
+          jcr->dir_impl->res.read_storage->resource_name_,
+          jcr->dir_impl->res.read_storage->runtime_storage_status
+              ->NumConcurrentJobs);
 
-    if (jcr->impl->res.read_storage->runtime_storage_status
+    if (jcr->dir_impl->res.read_storage->runtime_storage_status
             ->NumConcurrentReadJobs
         < 0) {
       Jmsg(jcr, M_FATAL, 0, _("NumConcurrentReadJobs Dec Rstore=%s rncj=%d\n"),
-           jcr->impl->res.read_storage->resource_name_,
-           jcr->impl->res.read_storage->runtime_storage_status
+           jcr->dir_impl->res.read_storage->resource_name_,
+           jcr->dir_impl->res.read_storage->runtime_storage_status
                ->NumConcurrentReadJobs);
     }
 
-    if (jcr->impl->res.read_storage->runtime_storage_status->NumConcurrentJobs
+    if (jcr->dir_impl->res.read_storage->runtime_storage_status
+            ->NumConcurrentJobs
         < 0) {
       Jmsg(jcr, M_FATAL, 0, _("NumConcurrentJobs Dec Rstore=%s rncj=%d\n"),
-           jcr->impl->res.read_storage->resource_name_,
-           jcr->impl->res.read_storage->runtime_storage_status
+           jcr->dir_impl->res.read_storage->resource_name_,
+           jcr->dir_impl->res.read_storage->runtime_storage_status
                ->NumConcurrentJobs);
     }
     unlock_mutex(mutex);
@@ -913,15 +923,17 @@ void DecReadStore(JobControlRecord* jcr)
 
 static bool IncWriteStore(JobControlRecord* jcr)
 {
-  if (jcr->impl->IgnoreStorageConcurrency) { return true; }
+  if (jcr->dir_impl->IgnoreStorageConcurrency) { return true; }
 
   lock_mutex(mutex);
-  if (jcr->impl->res.write_storage->runtime_storage_status->NumConcurrentJobs
-      < jcr->impl->res.write_storage->MaxConcurrentJobs) {
-    jcr->impl->res.write_storage->runtime_storage_status->NumConcurrentJobs++;
+  if (jcr->dir_impl->res.write_storage->runtime_storage_status
+          ->NumConcurrentJobs
+      < jcr->dir_impl->res.write_storage->MaxConcurrentJobs) {
+    jcr->dir_impl->res.write_storage->runtime_storage_status
+        ->NumConcurrentJobs++;
     Dmsg2(50, "Inc Wstore=%s wncj=%d\n",
-          jcr->impl->res.write_storage->resource_name_,
-          jcr->impl->res.write_storage->runtime_storage_status
+          jcr->dir_impl->res.write_storage->resource_name_,
+          jcr->dir_impl->res.write_storage->runtime_storage_status
               ->NumConcurrentJobs);
     unlock_mutex(mutex);
 
@@ -929,29 +941,32 @@ static bool IncWriteStore(JobControlRecord* jcr)
   }
   unlock_mutex(mutex);
 
-  Dmsg2(
-      50, "Fail to acquire Wstore=%s wncj=%d\n",
-      jcr->impl->res.write_storage->resource_name_,
-      jcr->impl->res.write_storage->runtime_storage_status->NumConcurrentJobs);
+  Dmsg2(50, "Fail to acquire Wstore=%s wncj=%d\n",
+        jcr->dir_impl->res.write_storage->resource_name_,
+        jcr->dir_impl->res.write_storage->runtime_storage_status
+            ->NumConcurrentJobs);
 
   return false;
 }
 
 static void DecWriteStore(JobControlRecord* jcr)
 {
-  if (jcr->impl->res.write_storage && !jcr->impl->IgnoreStorageConcurrency) {
+  if (jcr->dir_impl->res.write_storage
+      && !jcr->dir_impl->IgnoreStorageConcurrency) {
     lock_mutex(mutex);
-    jcr->impl->res.write_storage->runtime_storage_status->NumConcurrentJobs--;
+    jcr->dir_impl->res.write_storage->runtime_storage_status
+        ->NumConcurrentJobs--;
     Dmsg2(50, "Dec Wstore=%s wncj=%d\n",
-          jcr->impl->res.write_storage->resource_name_,
-          jcr->impl->res.write_storage->runtime_storage_status
+          jcr->dir_impl->res.write_storage->resource_name_,
+          jcr->dir_impl->res.write_storage->runtime_storage_status
               ->NumConcurrentJobs);
 
-    if (jcr->impl->res.write_storage->runtime_storage_status->NumConcurrentJobs
+    if (jcr->dir_impl->res.write_storage->runtime_storage_status
+            ->NumConcurrentJobs
         < 0) {
       Jmsg(jcr, M_FATAL, 0, _("NumConcurrentJobs Dec Wstore=%s wncj=%d\n"),
-           jcr->impl->res.write_storage->resource_name_,
-           jcr->impl->res.write_storage->runtime_storage_status
+           jcr->dir_impl->res.write_storage->resource_name_,
+           jcr->dir_impl->res.write_storage->runtime_storage_status
                ->NumConcurrentJobs);
     }
     unlock_mutex(mutex);

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -42,7 +42,7 @@
 #include "dird.h"
 #include "dird/dird_globals.h"
 #include "dird/backup.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/migration.h"
 #include "dird/msgchan.h"
@@ -250,7 +250,7 @@ static inline bool SetMigrationNextPool(JobControlRecord* jcr,
    * Get the PoolId used with the original job. Then
    * find the pool name from the database record.
    */
-  pr.PoolId = jcr->impl->jr.PoolId;
+  pr.PoolId = jcr->dir_impl->jr.PoolId;
   if (!jcr->db->GetPoolRecord(jcr, &pr)) {
     Jmsg(jcr, M_FATAL, 0, _("Pool for JobId %s not in database. ERR=%s\n"),
          edit_int64(pr.PoolId, ed1), jcr->db->strerror());
@@ -266,22 +266,24 @@ static inline bool SetMigrationNextPool(JobControlRecord* jcr,
   }
 
   // See if there is a next pool override.
-  if (jcr->impl->res.run_next_pool_override) {
-    PmStrcpy(jcr->impl->res.npool_source, _("Run NextPool override"));
-    PmStrcpy(jcr->impl->res.pool_source, _("Run NextPool override"));
+  if (jcr->dir_impl->res.run_next_pool_override) {
+    PmStrcpy(jcr->dir_impl->res.npool_source, _("Run NextPool override"));
+    PmStrcpy(jcr->dir_impl->res.pool_source, _("Run NextPool override"));
     storage_source = _("Storage from Run NextPool override");
   } else {
     // See if there is a next pool override in the Job definition.
-    if (jcr->impl->res.job->next_pool) {
-      jcr->impl->res.next_pool = jcr->impl->res.job->next_pool;
-      PmStrcpy(jcr->impl->res.npool_source, _("Job's NextPool resource"));
-      PmStrcpy(jcr->impl->res.pool_source, _("Job's NextPool resource"));
+    if (jcr->dir_impl->res.job->next_pool) {
+      jcr->dir_impl->res.next_pool = jcr->dir_impl->res.job->next_pool;
+      PmStrcpy(jcr->dir_impl->res.npool_source, _("Job's NextPool resource"));
+      PmStrcpy(jcr->dir_impl->res.pool_source, _("Job's NextPool resource"));
       storage_source = _("Storage from Job's NextPool resource");
     } else {
       // Fall back to the pool's NextPool definition.
-      jcr->impl->res.next_pool = pool->NextPool;
-      PmStrcpy(jcr->impl->res.npool_source, _("Job Pool's NextPool resource"));
-      PmStrcpy(jcr->impl->res.pool_source, _("Job Pool's NextPool resource"));
+      jcr->dir_impl->res.next_pool = pool->NextPool;
+      PmStrcpy(jcr->dir_impl->res.npool_source,
+               _("Job Pool's NextPool resource"));
+      PmStrcpy(jcr->dir_impl->res.pool_source,
+               _("Job Pool's NextPool resource"));
       storage_source = _("Storage from Pool's NextPool resource");
     }
   }
@@ -291,21 +293,21 @@ static inline bool SetMigrationNextPool(JobControlRecord* jcr,
    * record exists in the database. Note, in this case, we
    * will be migrating from pool to pool->NextPool.
    */
-  if (jcr->impl->res.next_pool) {
-    jcr->impl->jr.PoolId
-        = GetOrCreatePoolRecord(jcr, jcr->impl->res.next_pool->resource_name_);
-    if (jcr->impl->jr.PoolId == 0) { return false; }
+  if (jcr->dir_impl->res.next_pool) {
+    jcr->dir_impl->jr.PoolId = GetOrCreatePoolRecord(
+        jcr, jcr->dir_impl->res.next_pool->resource_name_);
+    if (jcr->dir_impl->jr.PoolId == 0) { return false; }
   }
 
-  if (!SetMigrationWstorage(jcr, pool, jcr->impl->res.next_pool,
+  if (!SetMigrationWstorage(jcr, pool, jcr->dir_impl->res.next_pool,
                             storage_source)) {
     return false;
   }
 
-  jcr->impl->res.pool = jcr->impl->res.next_pool;
+  jcr->dir_impl->res.pool = jcr->dir_impl->res.next_pool;
   Dmsg2(dbglevel, "Write pool=%s read rpool=%s\n",
-        jcr->impl->res.pool->resource_name_,
-        jcr->impl->res.rpool->resource_name_);
+        jcr->dir_impl->res.pool->resource_name_,
+        jcr->dir_impl->res.rpool->resource_name_);
 
   return true;
 }
@@ -315,8 +317,9 @@ static inline bool SameStorage(JobControlRecord* jcr)
 {
   StorageResource *read_store, *write_store;
 
-  read_store = (StorageResource*)jcr->impl->res.read_storage_list->first();
-  write_store = (StorageResource*)jcr->impl->res.write_storage_list->first();
+  read_store = (StorageResource*)jcr->dir_impl->res.read_storage_list->first();
+  write_store
+      = (StorageResource*)jcr->dir_impl->res.write_storage_list->first();
 
   if (!read_store->autochanger && !write_store->autochanger
       && bstrcmp(read_store->resource_name_, write_store->resource_name_)) {
@@ -336,21 +339,22 @@ static inline void StartNewMigrationJob(JobControlRecord* jcr)
   ua = new_ua_context(jcr);
   ua->batch = true;
   Mmsg(ua->cmd, "run job=\"%s\" jobid=%s ignoreduplicatecheck=yes",
-       jcr->impl->res.job->resource_name_,
-       edit_uint64(jcr->impl->MigrateJobId, ed1));
+       jcr->dir_impl->res.job->resource_name_,
+       edit_uint64(jcr->dir_impl->MigrateJobId, ed1));
 
   // Make sure we have something to compare against.
-  if (jcr->impl->res.pool) {
+  if (jcr->dir_impl->res.pool) {
     // See if there was actually a pool override.
-    if (jcr->impl->res.pool != jcr->impl->res.job->pool) {
-      Mmsg(cmd, " pool=\"%s\"", jcr->impl->res.pool->resource_name_);
+    if (jcr->dir_impl->res.pool != jcr->dir_impl->res.job->pool) {
+      Mmsg(cmd, " pool=\"%s\"", jcr->dir_impl->res.pool->resource_name_);
       PmStrcat(ua->cmd, cmd.c_str());
     }
 
     // See if there was actually a next pool override.
-    if (jcr->impl->res.next_pool
-        && jcr->impl->res.next_pool != jcr->impl->res.pool->NextPool) {
-      Mmsg(cmd, " nextpool=\"%s\"", jcr->impl->res.next_pool->resource_name_);
+    if (jcr->dir_impl->res.next_pool
+        && jcr->dir_impl->res.next_pool != jcr->dir_impl->res.pool->NextPool) {
+      Mmsg(cmd, " nextpool=\"%s\"",
+           jcr->dir_impl->res.next_pool->resource_name_);
       PmStrcat(ua->cmd, cmd.c_str());
     }
   }
@@ -532,7 +536,7 @@ static bool find_mediaid_then_jobids(JobControlRecord* jcr,
   ids->count = 0;
 
   // Basic query for MediaId
-  Mmsg(query, query1, jcr->impl->res.rpool->resource_name_);
+  Mmsg(query, query1, jcr->dir_impl->res.rpool->resource_name_);
   if (!jcr->db->SqlQuery(query.c_str(), UniqueDbidHandler, (void*)ids)) {
     Jmsg(jcr, M_FATAL, 0, _("SQL failed. ERR=%s\n"), jcr->db->strerror());
     return false;
@@ -572,9 +576,9 @@ static inline bool FindJobidsOfPoolUncopiedJobs(JobControlRecord* jcr,
   }
 
   Dmsg1(dbglevel, "copy selection pattern=%s\n",
-        jcr->impl->res.rpool->resource_name_);
+        jcr->dir_impl->res.rpool->resource_name_);
   Mmsg(query, sql_jobids_of_pool_uncopied_jobs,
-       jcr->impl->res.rpool->resource_name_);
+       jcr->dir_impl->res.rpool->resource_name_);
   Dmsg1(dbglevel, "get uncopied jobs query=%s\n", query.c_str());
   if (!jcr->db->SqlQuery(query.c_str(), UniqueDbidHandler, (void*)ids)) {
     Jmsg(jcr, M_FATAL, 0, _("SQL to get uncopied jobs failed. ERR=%s\n"),
@@ -601,16 +605,16 @@ static bool regex_find_jobids(JobControlRecord* jcr,
   PoolMem query(PM_MESSAGE);
 
   item_chain = new dlist<uitem>();
-  if (!jcr->impl->res.job->selection_pattern) {
+  if (!jcr->dir_impl->res.job->selection_pattern) {
     Jmsg(jcr, M_FATAL, 0, _("No %s %s selection pattern specified.\n"),
          jcr->get_OperationName(), type);
     goto bail_out;
   }
   Dmsg1(dbglevel, "regex-sel-pattern=%s\n",
-        jcr->impl->res.job->selection_pattern);
+        jcr->dir_impl->res.job->selection_pattern);
 
   // Basic query for names
-  Mmsg(query, query1, jcr->impl->res.rpool->resource_name_);
+  Mmsg(query, query1, jcr->dir_impl->res.rpool->resource_name_);
   Dmsg1(dbglevel, "get name query1=%s\n", query.c_str());
   if (!jcr->db->SqlQuery(query.c_str(), UniqueNameHandler, (void*)item_chain)) {
     Jmsg(jcr, M_FATAL, 0, _("SQL to get %s failed. ERR=%s\n"), type,
@@ -620,17 +624,18 @@ static bool regex_find_jobids(JobControlRecord* jcr,
   Dmsg1(dbglevel, "query1 returned %d names\n", item_chain->size());
   if (item_chain->size() == 0) {
     Jmsg(jcr, M_INFO, 0, _("Query of Pool \"%s\" returned no Jobs to %s.\n"),
-         jcr->impl->res.rpool->resource_name_, jcr->get_ActionName());
+         jcr->dir_impl->res.rpool->resource_name_, jcr->get_ActionName());
     ok = true;
     goto bail_out; /* skip regex match */
   } else {
     // Compile regex expression
-    rc = regcomp(&preg, jcr->impl->res.job->selection_pattern, REG_EXTENDED);
+    rc = regcomp(&preg, jcr->dir_impl->res.job->selection_pattern,
+                 REG_EXTENDED);
     if (rc != 0) {
       regerror(rc, &preg, prbuf, sizeof(prbuf));
       Jmsg(jcr, M_FATAL, 0,
            _("Could not compile regex pattern \"%s\" ERR=%s\n"),
-           jcr->impl->res.job->selection_pattern, prbuf);
+           jcr->dir_impl->res.job->selection_pattern, prbuf);
       goto bail_out;
     }
 
@@ -674,7 +679,7 @@ static bool regex_find_jobids(JobControlRecord* jcr,
   ids->count = 0;
   foreach_dlist (item, item_chain) {
     Dmsg2(dbglevel, "Got %s: %s\n", type, item->item);
-    Mmsg(query, query2, item->item, jcr->impl->res.rpool->resource_name_);
+    Mmsg(query, query2, item->item, jcr->dir_impl->res.rpool->resource_name_);
     Dmsg1(dbglevel, "get id from name query2=%s\n", query.c_str());
     if (!jcr->db->SqlQuery(query.c_str(), UniqueDbidHandler, (void*)ids)) {
       Jmsg(jcr, M_FATAL, 0, _("SQL failed. ERR=%s\n"), jcr->db->strerror());
@@ -729,7 +734,7 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
   mid.list = NULL;
   jids.list = NULL;
 
-  switch (jcr->impl->res.job->selection_type) {
+  switch (jcr->dir_impl->res.job->selection_type) {
     case MT_JOB:
       if (!regex_find_jobids(jcr, &ids, sql_job, sql_jobids_from_job, "Job")) {
         goto bail_out;
@@ -748,13 +753,13 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
       }
       break;
     case MT_SQLQUERY:
-      if (!jcr->impl->res.job->selection_pattern) {
+      if (!jcr->dir_impl->res.job->selection_pattern) {
         Jmsg(jcr, M_FATAL, 0, _("No %s SQL selection pattern specified.\n"),
              jcr->get_OperationName());
         goto bail_out;
       }
-      Dmsg1(dbglevel, "SQL=%s\n", jcr->impl->res.job->selection_pattern);
-      if (!jcr->db->SqlQuery(jcr->impl->res.job->selection_pattern,
+      Dmsg1(dbglevel, "SQL=%s\n", jcr->dir_impl->res.job->selection_pattern);
+      if (!jcr->db->SqlQuery(jcr->dir_impl->res.job->selection_pattern,
                              UniqueDbidHandler, (void*)&ids)) {
         Jmsg(jcr, M_FATAL, 0, _("SQL failed. ERR=%s\n"), jcr->db->strerror());
         goto bail_out;
@@ -785,7 +790,7 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
       ctx.count = 0;
 
       // Find count of bytes in pool
-      Mmsg(query, sql_pool_bytes, jcr->impl->res.rpool->resource_name_);
+      Mmsg(query, sql_pool_bytes, jcr->dir_impl->res.rpool->resource_name_);
 
       if (!jcr->db->SqlQuery(query.c_str(), db_int64_handler, (void*)&ctx)) {
         Jmsg(jcr, M_FATAL, 0, _("SQL failed. ERR=%s\n"), jcr->db->strerror());
@@ -801,9 +806,9 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
 
       pool_bytes = ctx.value;
       Dmsg2(dbglevel, "highbytes=%lld pool=%lld\n",
-            jcr->impl->res.rpool->MigrationHighBytes, pool_bytes);
+            jcr->dir_impl->res.rpool->MigrationHighBytes, pool_bytes);
 
-      if (pool_bytes < (int64_t)jcr->impl->res.rpool->MigrationHighBytes) {
+      if (pool_bytes < (int64_t)jcr->dir_impl->res.rpool->MigrationHighBytes) {
         Jmsg(jcr, M_INFO, 0, _("No Volumes found to %s.\n"),
              jcr->get_ActionName());
         retval = true;
@@ -814,7 +819,7 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
 
       ids.count = 0;
       // Find a list of MediaIds that could be migrated
-      Mmsg(query, sql_mediaids, jcr->impl->res.rpool->resource_name_);
+      Mmsg(query, sql_mediaids, jcr->dir_impl->res.rpool->resource_name_);
       Dmsg1(dbglevel, "query=%s\n", query.c_str());
 
       if (!jcr->db->SqlQuery(query.c_str(), UniqueDbidHandler, (void*)&ids)) {
@@ -864,10 +869,11 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
         Dmsg2(dbglevel, "Total %s Job bytes=%s\n", jcr->get_ActionName(),
               edit_int64_with_commas(ctx.value, ed1));
         Dmsg2(dbglevel, "lowbytes=%s poolafter=%s\n",
-              edit_int64_with_commas(jcr->impl->res.rpool->MigrationLowBytes,
-                                     ed1),
+              edit_int64_with_commas(
+                  jcr->dir_impl->res.rpool->MigrationLowBytes, ed1),
               edit_int64_with_commas(pool_bytes, ed2));
-        if (pool_bytes <= (int64_t)jcr->impl->res.rpool->MigrationLowBytes) {
+        if (pool_bytes
+            <= (int64_t)jcr->dir_impl->res.rpool->MigrationLowBytes) {
           Dmsg0(dbglevel, "We should be done.\n");
           break;
         }
@@ -883,11 +889,11 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
       time_t ttime;
       char dt[MAX_TIME_LENGTH];
 
-      ttime = time(NULL) - (time_t)jcr->impl->res.rpool->MigrationTime;
+      ttime = time(NULL) - (time_t)jcr->dir_impl->res.rpool->MigrationTime;
       bstrutime(dt, sizeof(dt), ttime);
 
       ids.count = 0;
-      Mmsg(query, sql_pool_time, jcr->impl->res.rpool->resource_name_, dt);
+      Mmsg(query, sql_pool_time, jcr->dir_impl->res.rpool->resource_name_, dt);
       Dmsg1(dbglevel, "query=%s\n", query.c_str());
 
       if (!jcr->db->SqlQuery(query.c_str(), UniqueDbidHandler, (void*)&ids)) {
@@ -927,8 +933,8 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
   Dmsg2(dbglevel, "Before loop count=%d ids=%s\n", ids.count, ids.list);
 
   // Note: to not over load the system, limit the number of new jobs started.
-  if (jcr->impl->res.job->MaxConcurrentCopies) {
-    limit = jcr->impl->res.job->MaxConcurrentCopies;
+  if (jcr->dir_impl->res.job->MaxConcurrentCopies) {
+    limit = jcr->dir_impl->res.job->MaxConcurrentCopies;
     apply_limit = true;
   }
 
@@ -946,7 +952,7 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
       retval = true;
       goto bail_out;
     }
-    jcr->impl->MigrateJobId = JobId;
+    jcr->dir_impl->MigrateJobId = JobId;
 
     if (apply_limit) {
       // Don't start any more when limit reaches zero
@@ -958,7 +964,7 @@ static inline bool getJobs_to_migrate(JobControlRecord* jcr)
     Dmsg0(dbglevel, "Back from StartNewMigrationJob\n");
   }
 
-  jcr->impl->HasSelectedJobs = true;
+  jcr->dir_impl->HasSelectedJobs = true;
   retval = true;
 
 bail_out:
@@ -992,9 +998,9 @@ bool DoMigrationInit(JobControlRecord* jcr)
 
   if (!AllowDuplicateJob(jcr)) { return false; }
 
-  jcr->impl->jr.PoolId
-      = GetOrCreatePoolRecord(jcr, jcr->impl->res.pool->resource_name_);
-  if (jcr->impl->jr.PoolId == 0) {
+  jcr->dir_impl->jr.PoolId
+      = GetOrCreatePoolRecord(jcr, jcr->dir_impl->res.pool->resource_name_);
+  if (jcr->dir_impl->jr.PoolId == 0) {
     Dmsg1(dbglevel, "JobId=%d no PoolId\n", (int)jcr->JobId);
     Jmsg(jcr, M_FATAL, 0, _("Could not get or create a Pool record.\n"));
     return false;
@@ -1006,50 +1012,53 @@ bool DoMigrationInit(JobControlRecord* jcr)
    * pool will be changed to point to the write pool,
    * which comes from pool->NextPool.
    */
-  jcr->impl->res.rpool = jcr->impl->res.pool; /* save read pool */
-  PmStrcpy(jcr->impl->res.rpool_source, jcr->impl->res.pool_source);
+  jcr->dir_impl->res.rpool = jcr->dir_impl->res.pool; /* save read pool */
+  PmStrcpy(jcr->dir_impl->res.rpool_source, jcr->dir_impl->res.pool_source);
   Dmsg2(dbglevel, "Read pool=%s (From %s)\n",
-        jcr->impl->res.rpool->resource_name_, jcr->impl->res.rpool_source);
+        jcr->dir_impl->res.rpool->resource_name_,
+        jcr->dir_impl->res.rpool_source);
 
   /*
    * See if this is a control job e.g. the one that selects the Jobs to Migrate
    * or Copy or one of the worker Jobs that do the actual Migration or Copy. If
-   * jcr->impl_->MigrateJobId is set we know that its an actual Migration or
+   * jcr->dir_impl_->MigrateJobId is set we know that its an actual Migration or
    * Copy Job.
    */
-  if (jcr->impl->MigrateJobId != 0) {
+  if (jcr->dir_impl->MigrateJobId != 0) {
     Dmsg1(dbglevel, "At Job start previous jobid=%u\n",
-          jcr->impl->MigrateJobId);
+          jcr->dir_impl->MigrateJobId);
 
-    jcr->impl->previous_jr.JobId = jcr->impl->MigrateJobId;
-    Dmsg1(dbglevel, "Previous jobid=%d\n", (int)jcr->impl->previous_jr.JobId);
+    jcr->dir_impl->previous_jr.JobId = jcr->dir_impl->MigrateJobId;
+    Dmsg1(dbglevel, "Previous jobid=%d\n",
+          (int)jcr->dir_impl->previous_jr.JobId);
 
-    if (!jcr->db->GetJobRecord(jcr, &jcr->impl->previous_jr)) {
+    if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->previous_jr)) {
       Jmsg(jcr, M_FATAL, 0,
            _("Could not get job record for JobId %s to %s. ERR=%s\n"),
-           edit_int64(jcr->impl->previous_jr.JobId, ed1), jcr->get_ActionName(),
-           jcr->db->strerror());
+           edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
+           jcr->get_ActionName(), jcr->db->strerror());
       return false;
     }
 
     Jmsg(jcr, M_INFO, 0, _("%s using JobId=%s Job=%s\n"),
          jcr->get_OperationName(),
-         edit_int64(jcr->impl->previous_jr.JobId, ed1),
-         jcr->impl->previous_jr.Job);
+         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
+         jcr->dir_impl->previous_jr.Job);
     Dmsg4(dbglevel, "%s JobId=%d  using JobId=%s Job=%s\n",
           jcr->get_OperationName(), jcr->JobId,
-          edit_int64(jcr->impl->previous_jr.JobId, ed1),
-          jcr->impl->previous_jr.Job);
+          edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
+          jcr->dir_impl->previous_jr.Job);
 
     if (CreateRestoreBootstrapFile(jcr) < 0) {
       Jmsg(jcr, M_FATAL, 0, _("Create bootstrap file failed.\n"));
       return false;
     }
 
-    if (jcr->impl->previous_jr.JobId == 0 || jcr->impl->ExpectedFiles == 0) {
+    if (jcr->dir_impl->previous_jr.JobId == 0
+        || jcr->dir_impl->ExpectedFiles == 0) {
       jcr->setJobStatusWithPriorityCheck(JS_Terminated);
       Dmsg1(dbglevel, "JobId=%d expected files == 0\n", (int)jcr->JobId);
-      if (jcr->impl->previous_jr.JobId == 0) {
+      if (jcr->dir_impl->previous_jr.JobId == 0) {
         Jmsg(jcr, M_INFO, 0, _("No previous Job found to %s.\n"),
              jcr->get_ActionName());
       } else {
@@ -1061,22 +1070,23 @@ bool DoMigrationInit(JobControlRecord* jcr)
     }
 
     Dmsg5(dbglevel, "JobId=%d: Current: Name=%s JobId=%d Type=%c Level=%c\n",
-          (int)jcr->JobId, jcr->impl->jr.Name, (int)jcr->impl->jr.JobId,
-          jcr->impl->jr.JobType, jcr->impl->jr.JobLevel);
+          (int)jcr->JobId, jcr->dir_impl->jr.Name, (int)jcr->dir_impl->jr.JobId,
+          jcr->dir_impl->jr.JobType, jcr->dir_impl->jr.JobLevel);
 
-    job = (JobResource*)my_config->GetResWithName(R_JOB, jcr->impl->jr.Name);
+    job = (JobResource*)my_config->GetResWithName(R_JOB,
+                                                  jcr->dir_impl->jr.Name);
     prev_job = (JobResource*)my_config->GetResWithName(
-        R_JOB, jcr->impl->previous_jr.Name);
+        R_JOB, jcr->dir_impl->previous_jr.Name);
 
     if (!job) {
       Jmsg(jcr, M_FATAL, 0, _("Job resource not found for \"%s\".\n"),
-           jcr->impl->jr.Name);
+           jcr->dir_impl->jr.Name);
       return false;
     }
 
     if (!prev_job) {
       Jmsg(jcr, M_FATAL, 0, _("Previous Job resource not found for \"%s\".\n"),
-           jcr->impl->previous_jr.Name);
+           jcr->dir_impl->previous_jr.Name);
       return false;
     }
 
@@ -1091,29 +1101,33 @@ bool DoMigrationInit(JobControlRecord* jcr)
      * If the current Job has no explicit client set use the client setting of
      * the previous Job.
      */
-    if (!jcr->impl->res.client && prev_job->client) {
-      jcr->impl->res.client = prev_job->client;
+    if (!jcr->dir_impl->res.client && prev_job->client) {
+      jcr->dir_impl->res.client = prev_job->client;
       if (!jcr->client_name) { jcr->client_name = GetPoolMemory(PM_NAME); }
-      PmStrcpy(jcr->client_name, jcr->impl->res.client->resource_name_);
+      PmStrcpy(jcr->client_name, jcr->dir_impl->res.client->resource_name_);
     }
 
     /*
      * If the current Job has no explicit fileset set use the client setting of
      * the previous Job.
      */
-    if (!jcr->impl->res.fileset) { jcr->impl->res.fileset = prev_job->fileset; }
+    if (!jcr->dir_impl->res.fileset) {
+      jcr->dir_impl->res.fileset = prev_job->fileset;
+    }
 
     /*
      * See if spooling data is not enabled yet. If so turn on spooling if
      * requested in job
      */
-    if (!jcr->impl->spool_data) { jcr->impl->spool_data = job->spool_data; }
+    if (!jcr->dir_impl->spool_data) {
+      jcr->dir_impl->spool_data = job->spool_data;
+    }
 
     // Create a migration jcr
     mig_jcr = NewDirectorJcr(DirdFreeJcr);
-    jcr->impl->mig_jcr = mig_jcr;
-    memcpy(&mig_jcr->impl->previous_jr, &jcr->impl->previous_jr,
-           sizeof(mig_jcr->impl->previous_jr));
+    jcr->dir_impl->mig_jcr = mig_jcr;
+    memcpy(&mig_jcr->dir_impl->previous_jr, &jcr->dir_impl->previous_jr,
+           sizeof(mig_jcr->dir_impl->previous_jr));
 
     /*
      * Turn the mig_jcr into a "real" job that takes on the aspects of
@@ -1129,17 +1143,17 @@ bool DoMigrationInit(JobControlRecord* jcr)
     SetJcrDefaults(mig_jcr, prev_job);
 
     // Time value on this Job
-    mig_jcr->impl->no_maxtime = true;
+    mig_jcr->dir_impl->no_maxtime = true;
 
     // Don't check for duplicates on migration and copy jobs
-    mig_jcr->impl->IgnoreDuplicateJobChecking = true;
+    mig_jcr->dir_impl->IgnoreDuplicateJobChecking = true;
 
     /*
      * Copy some overwrites back from the Control Job to the migration and copy
      * job.
      */
-    mig_jcr->impl->spool_data = jcr->impl->spool_data;
-    mig_jcr->impl->spool_size = jcr->impl->spool_size;
+    mig_jcr->dir_impl->spool_data = jcr->dir_impl->spool_data;
+    mig_jcr->dir_impl->spool_size = jcr->dir_impl->spool_size;
 
 
     if (!SetupJob(mig_jcr, true)) {
@@ -1151,21 +1165,21 @@ bool DoMigrationInit(JobControlRecord* jcr)
     mig_jcr->cjcr = jcr;
 
     // Now reset the job record from the previous job
-    memcpy(&mig_jcr->impl->jr, &jcr->impl->previous_jr,
-           sizeof(mig_jcr->impl->jr));
+    memcpy(&mig_jcr->dir_impl->jr, &jcr->dir_impl->previous_jr,
+           sizeof(mig_jcr->dir_impl->jr));
 
     // Update the jr to reflect the new values of PoolId and JobId.
-    mig_jcr->impl->jr.PoolId = jcr->impl->jr.PoolId;
-    mig_jcr->impl->jr.JobId = mig_jcr->JobId;
+    mig_jcr->dir_impl->jr.PoolId = jcr->dir_impl->jr.PoolId;
+    mig_jcr->dir_impl->jr.JobId = mig_jcr->JobId;
 
     if (SetMigrationNextPool(jcr, &pool)) {
       // If pool storage specified, use it as source
       CopyRstorage(mig_jcr, pool->storage, _("Pool resource"));
       CopyRstorage(jcr, pool->storage, _("Pool resource"));
 
-      mig_jcr->impl->res.pool = jcr->impl->res.pool;
-      mig_jcr->impl->res.next_pool = jcr->impl->res.next_pool;
-      mig_jcr->impl->jr.PoolId = jcr->impl->jr.PoolId;
+      mig_jcr->dir_impl->res.pool = jcr->dir_impl->res.pool;
+      mig_jcr->dir_impl->res.next_pool = jcr->dir_impl->res.next_pool;
+      mig_jcr->dir_impl->jr.PoolId = jcr->dir_impl->jr.PoolId;
     }
 
     /*
@@ -1173,7 +1187,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
      * This only happens when the original pool used doesn't have an explicit
      * storage.
      */
-    if (!jcr->impl->res.read_storage_list) {
+    if (!jcr->dir_impl->res.read_storage_list) {
       CopyRstorage(jcr, prev_job->storage, _("previous Job"));
     }
 
@@ -1183,16 +1197,16 @@ bool DoMigrationInit(JobControlRecord* jcr)
      * otherwise we open a connection to the reading SD and a second
      * one to the writing SD.
      */
-    jcr->impl->remote_replicate = !IsSameStorageDaemon(
-        jcr->impl->res.read_storage, jcr->impl->res.write_storage);
+    jcr->dir_impl->remote_replicate = !IsSameStorageDaemon(
+        jcr->dir_impl->res.read_storage, jcr->dir_impl->res.write_storage);
 
     // set the JobLevel to what the original job was
-    mig_jcr->setJobLevel(mig_jcr->impl->previous_jr.JobLevel);
+    mig_jcr->setJobLevel(mig_jcr->dir_impl->previous_jr.JobLevel);
 
 
     Dmsg4(dbglevel, "mig_jcr: Name=%s JobId=%d Type=%c Level=%c\n",
-          mig_jcr->impl->jr.Name, (int)mig_jcr->impl->jr.JobId,
-          mig_jcr->impl->jr.JobType, mig_jcr->impl->jr.JobLevel);
+          mig_jcr->dir_impl->jr.Name, (int)mig_jcr->dir_impl->jr.JobId,
+          mig_jcr->dir_impl->jr.JobType, mig_jcr->dir_impl->jr.JobLevel);
   }
 
   return true;
@@ -1230,17 +1244,17 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
 {
   char ed1[100];
   bool retval = false;
-  JobControlRecord* mig_jcr = jcr->impl->mig_jcr;
+  JobControlRecord* mig_jcr = jcr->dir_impl->mig_jcr;
 
   ASSERT(mig_jcr);
 
   // Make sure this job was not already migrated
-  if (jcr->impl->previous_jr.JobType != JT_BACKUP
-      && jcr->impl->previous_jr.JobType != JT_JOB_COPY
-      && jcr->impl->previous_jr.JobType != JT_ARCHIVE) {
+  if (jcr->dir_impl->previous_jr.JobType != JT_BACKUP
+      && jcr->dir_impl->previous_jr.JobType != JT_JOB_COPY
+      && jcr->dir_impl->previous_jr.JobType != JT_ARCHIVE) {
     Jmsg(jcr, M_INFO, 0,
          _("JobId %s already %s probably by another Job. %s stopped.\n"),
-         edit_int64(jcr->impl->previous_jr.JobId, ed1),
+         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
          jcr->get_ActionName(true), jcr->get_OperationName());
     jcr->setJobStatusWithPriorityCheck(JS_Terminated);
     MigrationCleanup(jcr, jcr->getJobStatus());
@@ -1250,7 +1264,7 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
   if (SameStorage(jcr)) {
     Jmsg(jcr, M_FATAL, 0,
          _("JobId %s cannot %s using the same read and write storage.\n"),
-         edit_int64(jcr->impl->previous_jr.JobId, ed1),
+         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
          jcr->get_OperationName());
     jcr->setJobStatusWithPriorityCheck(JS_Terminated);
     MigrationCleanup(jcr, jcr->getJobStatus());
@@ -1268,12 +1282,12 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
   if (HasPairedStorage(jcr)) { SetPairedStorage(jcr); }
 
   Dmsg2(dbglevel, "Read store=%s, write store=%s\n",
-        ((StorageResource*)jcr->impl->res.read_storage_list->first())
+        ((StorageResource*)jcr->dir_impl->res.read_storage_list->first())
             ->resource_name_,
-        ((StorageResource*)jcr->impl->res.write_storage_list->first())
+        ((StorageResource*)jcr->dir_impl->res.write_storage_list->first())
             ->resource_name_);
 
-  if (jcr->impl->remote_replicate) {
+  if (jcr->dir_impl->remote_replicate) {
     alist<StorageResource*>* write_storage_list;
 
     /*
@@ -1283,12 +1297,12 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
      * - Writing Storage Daemon bandwidth limiting
      * - Reading Storage Daemon bandwidth limiting
      */
-    if (jcr->impl->res.job->max_bandwidth > 0) {
-      jcr->max_bandwidth = jcr->impl->res.job->max_bandwidth;
-    } else if (jcr->impl->res.write_storage->max_bandwidth > 0) {
-      jcr->max_bandwidth = jcr->impl->res.write_storage->max_bandwidth;
-    } else if (jcr->impl->res.read_storage->max_bandwidth > 0) {
-      jcr->max_bandwidth = jcr->impl->res.read_storage->max_bandwidth;
+    if (jcr->dir_impl->res.job->max_bandwidth > 0) {
+      jcr->max_bandwidth = jcr->dir_impl->res.job->max_bandwidth;
+    } else if (jcr->dir_impl->res.write_storage->max_bandwidth > 0) {
+      jcr->max_bandwidth = jcr->dir_impl->res.write_storage->max_bandwidth;
+    } else if (jcr->dir_impl->res.read_storage->max_bandwidth > 0) {
+      jcr->max_bandwidth = jcr->dir_impl->res.read_storage->max_bandwidth;
     }
 
     // Open a message channel connection to the Reading Storage daemon.
@@ -1299,13 +1313,14 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
      * the jcr is connected to the reading storage daemon and the
      * mig_jcr to the writing storage daemon.
      */
-    mig_jcr->impl->res.write_storage = jcr->impl->res.write_storage;
-    jcr->impl->res.write_storage = NULL;
+    mig_jcr->dir_impl->res.write_storage = jcr->dir_impl->res.write_storage;
+    jcr->dir_impl->res.write_storage = NULL;
 
     // Swap the write_storage_list between the jcr and the mig_jcr.
-    write_storage_list = mig_jcr->impl->res.write_storage_list;
-    mig_jcr->impl->res.write_storage_list = jcr->impl->res.write_storage_list;
-    jcr->impl->res.write_storage_list = write_storage_list;
+    write_storage_list = mig_jcr->dir_impl->res.write_storage_list;
+    mig_jcr->dir_impl->res.write_storage_list
+        = jcr->dir_impl->res.write_storage_list;
+    jcr->dir_impl->res.write_storage_list = write_storage_list;
 
     // Start conversation with Reading Storage daemon
     jcr->setJobStatusWithPriorityCheck(JS_WaitSD);
@@ -1323,7 +1338,7 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
     }
 
     // Now start a job with the Reading Storage daemon
-    if (!StartStorageDaemonJob(jcr, jcr->impl->res.read_storage_list, NULL,
+    if (!StartStorageDaemonJob(jcr, jcr->dir_impl->res.read_storage_list, NULL,
                                /* send_bsr */ true)) {
       goto bail_out;
     }
@@ -1333,7 +1348,7 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
     // Now start a job with the Writing Storage daemon
 
     if (!StartStorageDaemonJob(mig_jcr, NULL,
-                               mig_jcr->impl->res.write_storage_list,
+                               mig_jcr->dir_impl->res.write_storage_list,
                                /* send_bsr */ false)) {
       goto bail_out;
     }
@@ -1354,8 +1369,8 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
     }
 
     // Now start a job with the Storage daemon
-    if (!StartStorageDaemonJob(jcr, jcr->impl->res.read_storage_list,
-                               jcr->impl->res.write_storage_list,
+    if (!StartStorageDaemonJob(jcr, jcr->dir_impl->res.read_storage_list,
+                               jcr->dir_impl->res.write_storage_list,
                                /* send_bsr */ true)) {
       FreePairedStorage(jcr);
       return false;
@@ -1375,12 +1390,12 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
    * is after the start of this run.
    */
   jcr->start_time = time(NULL);
-  jcr->impl->jr.StartTime = jcr->start_time;
-  jcr->impl->jr.JobTDate = jcr->start_time;
+  jcr->dir_impl->jr.StartTime = jcr->start_time;
+  jcr->dir_impl->jr.JobTDate = jcr->start_time;
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
   // Update job start record for this migration control job
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
     goto bail_out;
   }
@@ -1389,28 +1404,28 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
   jcr->setJobStarted();
 
   mig_jcr->start_time = time(NULL);
-  mig_jcr->impl->jr.StartTime = mig_jcr->start_time;
-  mig_jcr->impl->jr.JobTDate = mig_jcr->start_time;
+  mig_jcr->dir_impl->jr.StartTime = mig_jcr->start_time;
+  mig_jcr->dir_impl->jr.JobTDate = mig_jcr->start_time;
   mig_jcr->setJobStatusWithPriorityCheck(JS_Running);
 
   // Update job start record for the real migration backup job
-  if (!mig_jcr->db->UpdateJobStartRecord(mig_jcr, &mig_jcr->impl->jr)) {
+  if (!mig_jcr->db->UpdateJobStartRecord(mig_jcr, &mig_jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", mig_jcr->db->strerror());
     goto bail_out;
   }
 
   Dmsg4(dbglevel, "mig_jcr: Name=%s JobId=%d Type=%c Level=%c\n",
-        mig_jcr->impl->jr.Name, (int)mig_jcr->impl->jr.JobId,
-        mig_jcr->impl->jr.JobType, mig_jcr->impl->jr.JobLevel);
+        mig_jcr->dir_impl->jr.Name, (int)mig_jcr->dir_impl->jr.JobId,
+        mig_jcr->dir_impl->jr.JobType, mig_jcr->dir_impl->jr.JobLevel);
 
   /*
    * If we are connected to two different SDs tell the writing one
    * to be ready to receive the data and tell the reading one
    * to replicate to the other.
    */
-  if (jcr->impl->remote_replicate) {
-    StorageResource* write_storage = mig_jcr->impl->res.write_storage;
-    StorageResource* read_storage = jcr->impl->res.read_storage;
+  if (jcr->dir_impl->remote_replicate) {
+    StorageResource* write_storage = mig_jcr->dir_impl->res.write_storage;
+    StorageResource* read_storage = jcr->dir_impl->res.read_storage;
     PoolMem command(PM_MESSAGE);
     uint32_t tls_need = 0;
 
@@ -1464,27 +1479,28 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
    * mig_jcr->JobFiles/ReadBytes/JobBytes/JobErrors when replicating to
    * a remote storage daemon.
    */
-  if (jcr->impl->remote_replicate) {
+  if (jcr->dir_impl->remote_replicate) {
     WaitForStorageDaemonTermination(jcr);
     WaitForStorageDaemonTermination(mig_jcr);
-    jcr->setJobStatusWithPriorityCheck(jcr->impl->SDJobStatus);
+    jcr->setJobStatusWithPriorityCheck(jcr->dir_impl->SDJobStatus);
     if (mig_jcr->batch_started) {
       mig_jcr->db_batch->WriteBatchFileRecords(mig_jcr);
     }
   } else {
     WaitForStorageDaemonTermination(jcr);
-    jcr->setJobStatusWithPriorityCheck(jcr->impl->SDJobStatus);
+    jcr->setJobStatusWithPriorityCheck(jcr->dir_impl->SDJobStatus);
     if (jcr->batch_started) { jcr->db_batch->WriteBatchFileRecords(jcr); }
   }
 
 bail_out:
-  if (jcr->impl->remote_replicate && mig_jcr) {
+  if (jcr->dir_impl->remote_replicate && mig_jcr) {
     alist<StorageResource*>* write_storage_list;
 
     // Swap the write_storage_list between the jcr and the mig_jcr.
-    write_storage_list = mig_jcr->impl->res.write_storage_list;
-    mig_jcr->impl->res.write_storage_list = jcr->impl->res.write_storage_list;
-    jcr->impl->res.write_storage_list = write_storage_list;
+    write_storage_list = mig_jcr->dir_impl->res.write_storage_list;
+    mig_jcr->dir_impl->res.write_storage_list
+        = jcr->dir_impl->res.write_storage_list;
+    jcr->dir_impl->res.write_storage_list = write_storage_list;
 
     /*
      * Undo the clear of the write_storage in the jcr and assign the mig_jcr
@@ -1494,8 +1510,8 @@ bail_out:
      * the ConnectToStorageDaemon function will do the right thing e.g. connect
      * the jcrs in the way we want them to.
      */
-    jcr->impl->res.write_storage = mig_jcr->impl->res.write_storage;
-    mig_jcr->impl->res.write_storage = NULL;
+    jcr->dir_impl->res.write_storage = mig_jcr->dir_impl->res.write_storage;
+    mig_jcr->dir_impl->res.write_storage = NULL;
   }
 
   FreePairedStorage(jcr);
@@ -1529,9 +1545,9 @@ bool DoMigration(JobControlRecord* jcr)
   /*
    * See if this is a control job e.g. the one that selects the Jobs to Migrate
    * or Copy or one of the worker Jobs that do the actual Migration or Copy. If
-   * jcr->impl_->MigrateJobId is unset we know that its the control job.
+   * jcr->dir_impl_->MigrateJobId is unset we know that its the control job.
    */
-  if (jcr->impl->MigrateJobId == 0) {
+  if (jcr->dir_impl->MigrateJobId == 0) {
     return DoMigrationSelection(jcr);
   } else {
     return DoActualMigration(jcr);
@@ -1545,7 +1561,7 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
 {
   double kbps;
   utime_t RunTime;
-  JobControlRecord* mig_jcr = jcr->impl->mig_jcr;
+  JobControlRecord* mig_jcr = jcr->dir_impl->mig_jcr;
   char term_code[100], sd_term_msg[100];
   char sdt[MAX_TIME_LENGTH], edt[MAX_TIME_LENGTH];
   char ec1[30], ec2[30], ec3[30], ec4[30], ec5[30], elapsed[50];
@@ -1553,17 +1569,18 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
 
   Bsnprintf(term_code, sizeof(term_code), TermMsg, jcr->get_OperationName(),
             jcr->get_ActionName());
-  bstrftimes(sdt, sizeof(sdt), jcr->impl->jr.StartTime);
-  bstrftimes(edt, sizeof(edt), jcr->impl->jr.EndTime);
-  RunTime = jcr->impl->jr.EndTime - jcr->impl->jr.StartTime;
+  bstrftimes(sdt, sizeof(sdt), jcr->dir_impl->jr.StartTime);
+  bstrftimes(edt, sizeof(edt), jcr->dir_impl->jr.EndTime);
+  RunTime = jcr->dir_impl->jr.EndTime - jcr->dir_impl->jr.StartTime;
 
-  JobstatusToAscii(jcr->impl->SDJobStatus, sd_term_msg, sizeof(sd_term_msg));
-  if (jcr->impl->previous_jr.JobId != 0) {
+  JobstatusToAscii(jcr->dir_impl->SDJobStatus, sd_term_msg,
+                   sizeof(sd_term_msg));
+  if (jcr->dir_impl->previous_jr.JobId != 0) {
     // Copy/Migrate worker Job.
     if (RunTime <= 0) {
       kbps = 0;
     } else {
-      kbps = (double)jcr->impl->SDJobBytes / (1000 * RunTime);
+      kbps = (double)jcr->dir_impl->SDJobBytes / (1000 * RunTime);
     }
 
     Jmsg(jcr, msg_type, 0,
@@ -1601,38 +1618,42 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
            "  Termination:            %s\n\n"),
          BAREOS, my_name, kBareosVersionStrings.Full,
          kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
-         edit_uint64(jcr->impl->previous_jr.JobId, ec6),
-         jcr->impl->previous_jr.Job,
-         mig_jcr ? edit_uint64(mig_jcr->impl->jr.JobId, ec7) : _("*None*"),
-         edit_uint64(jcr->impl->jr.JobId, ec8), jcr->impl->jr.Job,
+         edit_uint64(jcr->dir_impl->previous_jr.JobId, ec6),
+         jcr->dir_impl->previous_jr.Job,
+         mig_jcr ? edit_uint64(mig_jcr->dir_impl->jr.JobId, ec7) : _("*None*"),
+         edit_uint64(jcr->dir_impl->jr.JobId, ec8), jcr->dir_impl->jr.Job,
          JobLevelToString(jcr->getJobLevel()),
-         jcr->impl->res.client ? jcr->impl->res.client->resource_name_
-                               : _("*None*"),
-         jcr->impl->res.fileset ? jcr->impl->res.fileset->resource_name_
-                                : _("*None*"),
-         jcr->impl->res.rpool->resource_name_, jcr->impl->res.rpool_source,
-         jcr->impl->res.read_storage
-             ? jcr->impl->res.read_storage->resource_name_
+         jcr->dir_impl->res.client ? jcr->dir_impl->res.client->resource_name_
+                                   : _("*None*"),
+         jcr->dir_impl->res.fileset ? jcr->dir_impl->res.fileset->resource_name_
+                                    : _("*None*"),
+         jcr->dir_impl->res.rpool->resource_name_,
+         jcr->dir_impl->res.rpool_source,
+         jcr->dir_impl->res.read_storage
+             ? jcr->dir_impl->res.read_storage->resource_name_
              : _("*None*"),
-         NPRT(jcr->impl->res.rstore_source),
-         jcr->impl->res.pool->resource_name_, jcr->impl->res.pool_source,
-         jcr->impl->res.write_storage
-             ? jcr->impl->res.write_storage->resource_name_
+         NPRT(jcr->dir_impl->res.rstore_source),
+         jcr->dir_impl->res.pool->resource_name_,
+         jcr->dir_impl->res.pool_source,
+         jcr->dir_impl->res.write_storage
+             ? jcr->dir_impl->res.write_storage->resource_name_
              : _("*None*"),
-         NPRT(jcr->impl->res.wstore_source),
-         jcr->impl->res.next_pool ? jcr->impl->res.next_pool->resource_name_
-                                  : _("*None*"),
-         NPRT(jcr->impl->res.npool_source),
-         jcr->impl->res.catalog->resource_name_, jcr->impl->res.catalog_source,
-         sdt, edt, edit_utime(RunTime, elapsed, sizeof(elapsed)),
-         jcr->JobPriority, edit_uint64_with_commas(jcr->impl->SDJobFiles, ec1),
-         edit_uint64_with_commas(jcr->impl->SDJobBytes, ec2),
-         edit_uint64_with_suffix(jcr->impl->SDJobBytes, ec3), (float)kbps,
+         NPRT(jcr->dir_impl->res.wstore_source),
+         jcr->dir_impl->res.next_pool
+             ? jcr->dir_impl->res.next_pool->resource_name_
+             : _("*None*"),
+         NPRT(jcr->dir_impl->res.npool_source),
+         jcr->dir_impl->res.catalog->resource_name_,
+         jcr->dir_impl->res.catalog_source, sdt, edt,
+         edit_utime(RunTime, elapsed, sizeof(elapsed)), jcr->JobPriority,
+         edit_uint64_with_commas(jcr->dir_impl->SDJobFiles, ec1),
+         edit_uint64_with_commas(jcr->dir_impl->SDJobBytes, ec2),
+         edit_uint64_with_suffix(jcr->dir_impl->SDJobBytes, ec3), (float)kbps,
          mig_jcr ? mig_jcr->VolumeName : _("*None*"), jcr->VolSessionId,
          jcr->VolSessionTime, edit_uint64_with_commas(mr->VolBytes, ec4),
-         edit_uint64_with_suffix(mr->VolBytes, ec5), jcr->impl->SDErrors,
+         edit_uint64_with_suffix(mr->VolBytes, ec5), jcr->dir_impl->SDErrors,
          sd_term_msg, kBareosVersionStrings.JoblogMessage,
-         JobTriggerToString(jcr->impl->job_trigger).c_str(), term_code);
+         JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), term_code);
   } else {
     // Copy/Migrate selection only Job.
     Jmsg(jcr, msg_type, 0,
@@ -1650,11 +1671,12 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
            "  Termination:            %s\n\n"),
          BAREOS, my_name, kBareosVersionStrings.Full,
          kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
-         edit_uint64(jcr->impl->jr.JobId, ec8), jcr->impl->jr.Job,
-         jcr->impl->res.catalog->resource_name_, jcr->impl->res.catalog_source,
-         sdt, edt, edit_utime(RunTime, elapsed, sizeof(elapsed)),
-         jcr->JobPriority, kBareosVersionStrings.JoblogMessage,
-         JobTriggerToString(jcr->impl->job_trigger).c_str(), term_code);
+         edit_uint64(jcr->dir_impl->jr.JobId, ec8), jcr->dir_impl->jr.Job,
+         jcr->dir_impl->res.catalog->resource_name_,
+         jcr->dir_impl->res.catalog_source, sdt, edt,
+         edit_utime(RunTime, elapsed, sizeof(elapsed)), jcr->JobPriority,
+         kBareosVersionStrings.JoblogMessage,
+         JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), term_code);
   }
 }
 
@@ -1665,7 +1687,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
   const char* TermMsg;
   int msg_type = M_INFO;
   MediaDbRecord mr;
-  JobControlRecord* mig_jcr = jcr->impl->mig_jcr;
+  JobControlRecord* mig_jcr = jcr->dir_impl->mig_jcr;
   PoolMem query(PM_MESSAGE);
 
   Dmsg2(100, "Enter migrate_cleanup %d %c\n", TermCode, TermCode);
@@ -1680,8 +1702,8 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
 
     char old_jobid[50], new_jobid[50];
 
-    edit_uint64(jcr->impl->previous_jr.JobId, old_jobid);
-    edit_uint64(mig_jcr->impl->jr.JobId, new_jobid);
+    edit_uint64(jcr->dir_impl->previous_jr.JobId, old_jobid);
+    edit_uint64(mig_jcr->dir_impl->jr.JobId, new_jobid);
 
     // use the PriorJobId field to store the migrated jobid in order to keep
     // track of it
@@ -1694,20 +1716,20 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
      * the jobfiles and jobbytes and the new volsessionid
      * and volsessiontime as the writing SD generates this info.
      */
-    if (jcr->impl->remote_replicate) {
-      mig_jcr->JobFiles = jcr->JobFiles = mig_jcr->impl->SDJobFiles;
-      mig_jcr->JobBytes = jcr->JobBytes = mig_jcr->impl->SDJobBytes;
+    if (jcr->dir_impl->remote_replicate) {
+      mig_jcr->JobFiles = jcr->JobFiles = mig_jcr->dir_impl->SDJobFiles;
+      mig_jcr->JobBytes = jcr->JobBytes = mig_jcr->dir_impl->SDJobBytes;
     } else {
-      mig_jcr->JobFiles = jcr->JobFiles = jcr->impl->SDJobFiles;
-      mig_jcr->JobBytes = jcr->JobBytes = jcr->impl->SDJobBytes;
+      mig_jcr->JobFiles = jcr->JobFiles = jcr->dir_impl->SDJobFiles;
+      mig_jcr->JobBytes = jcr->JobBytes = jcr->dir_impl->SDJobBytes;
       mig_jcr->VolSessionId = jcr->VolSessionId;
       mig_jcr->VolSessionTime = jcr->VolSessionTime;
     }
-    mig_jcr->impl->jr.RealEndTime = 0;
-    mig_jcr->impl->jr.PriorJobId = jcr->impl->previous_jr.JobId;
+    mig_jcr->dir_impl->jr.RealEndTime = 0;
+    mig_jcr->dir_impl->jr.PriorJobId = jcr->dir_impl->previous_jr.JobId;
 
     if (jcr->is_JobStatus(JS_Terminated)
-        && (jcr->JobErrors || jcr->impl->SDErrors)) {
+        && (jcr->JobErrors || jcr->dir_impl->SDErrors)) {
       TermCode = JS_Warnings;
     }
 
@@ -1717,8 +1739,9 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
     Mmsg(query,
          "UPDATE Job SET StartTime='%s',EndTime='%s',"
          "JobTDate=%s WHERE JobId=%s",
-         jcr->impl->previous_jr.cStartTime, jcr->impl->previous_jr.cEndTime,
-         edit_uint64(jcr->impl->previous_jr.JobTDate, ec1), new_jobid);
+         jcr->dir_impl->previous_jr.cStartTime,
+         jcr->dir_impl->previous_jr.cEndTime,
+         edit_uint64(jcr->dir_impl->previous_jr.JobTDate, ec1), new_jobid);
     jcr->db->SqlQuery(query.c_str());
 
     if (jcr->IsTerminatedOk()) {
@@ -1749,7 +1772,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
            * storage daemon we need to add data normally send to the director
            * via the FHDB interface here.
            */
-          switch (jcr->impl->res.client->Protocol) {
+          switch (jcr->dir_impl->res.client->Protocol) {
             case APT_NDMPV2:
             case APT_NDMPV3:
             case APT_NDMPV4:
@@ -1762,7 +1785,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
           }
 
           ua = new_ua_context(jcr);
-          if (jcr->impl->res.job->PurgeMigrateJob) {
+          if (jcr->dir_impl->res.job->PurgeMigrateJob) {
             // Purge old Job record
             PurgeJobsFromCatalog(ua, old_jobid);
           } else {
@@ -1792,7 +1815,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
            * storage daemon we need to add data normally send to the director
            * via the FHDB interface here.
            */
-          switch (jcr->impl->res.client->Protocol) {
+          switch (jcr->dir_impl->res.client->Protocol) {
             case APT_NDMPV2:
             case APT_NDMPV3:
             case APT_NDMPV4:
@@ -1813,7 +1836,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
       }
     }
 
-    if (!jcr->db->GetJobRecord(jcr, &jcr->impl->jr)) {
+    if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->jr)) {
       Jmsg(jcr, M_WARNING, 0,
            _("Error getting Job record for Job report: ERR=%s\n"),
            jcr->db->strerror());
@@ -1822,7 +1845,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
 
     UpdateBootstrapFile(mig_jcr);
 
-    if (!mig_jcr->db->GetJobVolumeNames(mig_jcr, mig_jcr->impl->jr.JobId,
+    if (!mig_jcr->db->GetJobVolumeNames(mig_jcr, mig_jcr->dir_impl->jr.JobId,
                                         mig_jcr->VolumeName)) {
       /*
        * Note, if the job has failed, most likely it did not write any
@@ -1830,7 +1853,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
        * it is normal. Or look at it the other way, only for a
        * normal exit should we complain about this error.
        */
-      if (jcr->IsTerminatedOk() && jcr->impl->jr.JobBytes) {
+      if (jcr->IsTerminatedOk() && jcr->dir_impl->jr.JobBytes) {
         Jmsg(jcr, M_ERROR, 0, "%s", mig_jcr->db->strerror());
       }
       mig_jcr->VolumeName[0] = 0; /* none */
@@ -1881,16 +1904,16 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
         // Close connection to Reading SD.
         if (jcr->store_bsock) {
           jcr->store_bsock->signal(BNET_TERMINATE);
-          if (jcr->impl->SD_msg_chan_started) {
-            pthread_cancel(jcr->impl->SD_msg_chan);
+          if (jcr->dir_impl->SD_msg_chan_started) {
+            pthread_cancel(jcr->dir_impl->SD_msg_chan);
           }
         }
 
         // Close connection to Writing SD (if SD-SD replication)
         if (mig_jcr->store_bsock) {
           mig_jcr->store_bsock->signal(BNET_TERMINATE);
-          if (mig_jcr->impl->SD_msg_chan_started) {
-            pthread_cancel(mig_jcr->impl->SD_msg_chan);
+          if (mig_jcr->dir_impl->SD_msg_chan_started) {
+            pthread_cancel(mig_jcr->dir_impl->SD_msg_chan);
           }
         }
         break;
@@ -1898,7 +1921,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
         TermMsg = _("Inappropriate %s term code");
         break;
     }
-  } else if (jcr->impl->HasSelectedJobs) {
+  } else if (jcr->dir_impl->HasSelectedJobs) {
     Mmsg(query, "DELETE FROM job WHERE JobId=%d", jcr->JobId);
     jcr->db->SqlQuery(query.c_str());
 

--- a/core/src/dird/ndmp_dma_backup_NDMP_NATIVE.cc
+++ b/core/src/dird/ndmp_dma_backup_NDMP_NATIVE.cc
@@ -28,7 +28,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/dird_globals.h"
 #include "dird/job.h"
 #include "dird/next_vol.h"
@@ -89,10 +89,10 @@ int NdmpLoadNext(struct ndm_session* sess)
   bool prune = false;
   struct ndmmedia* media;
   int index = 1;
-  StorageResource* store = jcr->impl->res.write_storage;
+  StorageResource* store = jcr->dir_impl->res.write_storage;
 
   // get the poolid for pool name
-  mr.PoolId = jcr->impl->jr.PoolId;
+  mr.PoolId = jcr->dir_impl->jr.PoolId;
 
 
   if (FindNextVolumeForAppend(jcr, &mr, index, unwanted_volumes, create,
@@ -169,7 +169,7 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
   char* item;
 
   ndmp_log_level
-      = std::max(jcr->impl->res.client->ndmp_loglevel, me->ndmp_loglevel);
+      = std::max(jcr->dir_impl->res.client->ndmp_loglevel, me->ndmp_loglevel);
 
   struct ndmca_media_callbacks media_callbacks;
 
@@ -187,21 +187,22 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
        edit_uint64(jcr->JobId, ed1), jcr->Job);
 
   jcr->setJobStatusWithPriorityCheck(JS_Running);
-  Dmsg2(100, "JobId=%d JobLevel=%c\n", jcr->impl->jr.JobId,
-        jcr->impl->jr.JobLevel);
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  Dmsg2(100, "JobId=%d JobLevel=%c\n", jcr->dir_impl->jr.JobId,
+        jcr->dir_impl->jr.JobLevel);
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
     return false;
   }
 
   status = 0;
-  StorageResource* store = jcr->impl->res.write_storage;
+  StorageResource* store = jcr->dir_impl->res.write_storage;
   PoolMem virtual_filename(PM_FNAME);
   IncludeExcludeItem* ie;
 
 
-  if (!NdmpBuildClientAndStorageJob(jcr, jcr->impl->res.write_storage,
-                                    jcr->impl->res.client, true, /* init_tape */
+  if (!NdmpBuildClientAndStorageJob(jcr, jcr->dir_impl->res.write_storage,
+                                    jcr->dir_impl->res.client,
+                                    true, /* init_tape */
                                     true, /* init_robot */
                                     NDM_JOB_OP_BACKUP, &ndmp_job)) {
     goto bail_out;
@@ -221,7 +222,7 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
    * Only one include set of the fileset  is allowed in NATIVE mode as
    * in NDMP also per job only one filesystem can be backed up
    */
-  fileset = jcr->impl->res.fileset;
+  fileset = jcr->dir_impl->res.fileset;
 
   if (fileset->include_items.size() > 1) {
     Jmsg(jcr, M_ERROR, 0,
@@ -260,8 +261,8 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
   nis->filesystem = item;
   nis->FileIndex = 1;
   nis->jcr = jcr;
-  nis->save_filehist = jcr->impl->res.job->SaveFileHist;
-  nis->filehist_size = jcr->impl->res.job->FileHistSize;
+  nis->save_filehist = jcr->dir_impl->res.job->SaveFileHist;
+  nis->filehist_size = jcr->dir_impl->res.job->FileHistSize;
 
   ndmp_sess.param->log.ctx = nis;
   ndmp_sess.param->log_tag = strdup("DIR-NDMP");
@@ -294,9 +295,9 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
    * individual file records to it. So we allocate it here once so its available
    * during the whole NDMP session.
    */
-  if (Bstrcasecmp(jcr->impl->backup_format, "dump")) {
+  if (Bstrcasecmp(jcr->dir_impl->backup_format, "dump")) {
     Mmsg(virtual_filename, "/@NDMP%s%%%d", nis->filesystem,
-         jcr->impl->DumpLevel);
+         jcr->dir_impl->DumpLevel);
   } else {
     Mmsg(virtual_filename, "/@NDMP%s", nis->filesystem);
   }
@@ -329,7 +330,7 @@ bool DoNdmpBackupNdmpNative(JobControlRecord* jcr)
   }
 
   // See if there were any errors during the backup.
-  jcr->impl->jr.FileIndex = 1;
+  jcr->dir_impl->jr.FileIndex = 1;
   if (!extract_post_backup_stats_ndmp_native(jcr, item, &ndmp_sess)) {
     goto cleanup;
   }
@@ -421,21 +422,21 @@ bool DoNdmpBackupInitNdmpNative(JobControlRecord* jcr)
 
   if (!AllowDuplicateJob(jcr)) { return false; }
 
-  jcr->impl->jr.PoolId
-      = GetOrCreatePoolRecord(jcr, jcr->impl->res.pool->resource_name_);
-  if (jcr->impl->jr.PoolId == 0) { return false; }
+  jcr->dir_impl->jr.PoolId
+      = GetOrCreatePoolRecord(jcr, jcr->dir_impl->res.pool->resource_name_);
+  if (jcr->dir_impl->jr.PoolId == 0) { return false; }
 
   jcr->start_time = time(NULL);
-  jcr->impl->jr.StartTime = jcr->start_time;
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  jcr->dir_impl->jr.StartTime = jcr->start_time;
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
     return false;
   }
 
   // If pool storage specified, use it instead of job storage
-  CopyWstorage(jcr, jcr->impl->res.pool->storage, _("Pool resource"));
+  CopyWstorage(jcr, jcr->dir_impl->res.pool->storage, _("Pool resource"));
 
-  if (!jcr->impl->res.write_storage_list) {
+  if (!jcr->dir_impl->res.write_storage_list) {
     Jmsg(jcr, M_FATAL, 0,
          _("No Storage specification found in Job or Pool.\n"));
     return false;
@@ -473,7 +474,8 @@ static inline bool extract_post_backup_stats_ndmp_native(
     // translate Physical to Logical Slot before storing into database
 
     media->slot_addr = GetBareosSlotNumberByElementAddress(
-        &jcr->impl->res.write_storage->runtime_storage_status->storage_mapping,
+        &jcr->dir_impl->res.write_storage->runtime_storage_status
+             ->storage_mapping,
         slot_type_t::kSlotTypeStorage, media->slot_addr);
 #  if 0
       Jmsg(jcr, M_INFO, 0, _("Physical Slot is %d\n"), media->slot_addr);
@@ -515,7 +517,7 @@ static inline bool extract_post_backup_stats_ndmp_native(
   ndm_ee = sess->control_acb->job.result_env_tab.head;
   while (ndm_ee) {
     if (!jcr->db->CreateNdmpEnvironmentString(
-            jcr, &jcr->impl->jr, ndm_ee->pval.name, ndm_ee->pval.value)) {
+            jcr, &jcr->dir_impl->jr, ndm_ee->pval.name, ndm_ee->pval.value)) {
       break;
     }
     ndm_ee = ndm_ee->next;
@@ -526,7 +528,7 @@ static inline bool extract_post_backup_stats_ndmp_native(
    * level.
    */
   if (nbf_options && nbf_options->uses_level) {
-    jcr->db->UpdateNdmpLevelMapping(jcr, &jcr->impl->jr, filesystem,
+    jcr->db->UpdateNdmpLevelMapping(jcr, &jcr->dir_impl->jr, filesystem,
                                     sess->control_acb->job.bu_level);
   }
 

--- a/core/src/dird/ndmp_dma_backup_common.cc
+++ b/core/src/dird/ndmp_dma_backup_common.cc
@@ -28,7 +28,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/backup.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/ndmp_dma_backup_common.h"
 #include "lib/edit.h"
@@ -85,8 +85,8 @@ bool FillBackupEnvironment(JobControlRecord* jcr,
     char text_level[50];
 
     // Set the dump level for the backup.
-    jcr->impl->DumpLevel = NativeToNdmpLevel(jcr, filesystem);
-    job->bu_level = jcr->impl->DumpLevel;
+    jcr->dir_impl->DumpLevel = NativeToNdmpLevel(jcr, filesystem);
+    job->bu_level = jcr->dir_impl->DumpLevel;
     if (job->bu_level == -1) { return false; }
 
     pv.name = ndmp_env_keywords[NDMP_ENV_KW_LEVEL];
@@ -167,7 +167,7 @@ bool FillBackupEnvironment(JobControlRecord* jcr,
   if (jcr->store_bsock) {
     if (nbf_options && nbf_options->uses_level) {
       Mmsg(tape_device, "%s@%s%%%d", jcr->sd_auth_key, filesystem,
-           jcr->impl->DumpLevel);
+           jcr->dir_impl->DumpLevel);
     } else {
       Mmsg(tape_device, "%s@%s", jcr->sd_auth_key, filesystem);
     }
@@ -183,7 +183,7 @@ int NativeToNdmpLevel(JobControlRecord* jcr, char* filesystem)
 {
   int level = -1;
 
-  if (!jcr->db->CreateNdmpLevelMapping(jcr, &jcr->impl->jr, filesystem)) {
+  if (!jcr->db->CreateNdmpLevelMapping(jcr, &jcr->dir_impl->jr, filesystem)) {
     return -1;
   }
 
@@ -195,7 +195,7 @@ int NativeToNdmpLevel(JobControlRecord* jcr, char* filesystem)
       level = 1;
       break;
     case L_INCREMENTAL:
-      level = jcr->db->GetNdmpLevelMapping(jcr, &jcr->impl->jr, filesystem);
+      level = jcr->db->GetNdmpLevelMapping(jcr, &jcr->dir_impl->jr, filesystem);
       break;
     default:
       Jmsg(jcr, M_FATAL, 0, _("Illegal Job Level %c for NDMP Job\n"),
@@ -220,7 +220,7 @@ void RegisterCallbackHooks(struct ndmlog* ixlog)
 #  ifdef HAVE_LMDB
   NIS* nis = (NIS*)ixlog->ctx;
 
-  if (nis->jcr->impl->res.client->ndmp_use_lmdb) {
+  if (nis->jcr->dir_impl->res.client->ndmp_use_lmdb) {
     NdmpFhdbLmdbRegister(ixlog);
   } else {
     NdmpFhdbMemRegister(ixlog);
@@ -235,7 +235,7 @@ void UnregisterCallbackHooks(struct ndmlog* ixlog)
 #  ifdef HAVE_LMDB
   NIS* nis = (NIS*)ixlog->ctx;
 
-  if (nis->jcr->impl->res.client->ndmp_use_lmdb) {
+  if (nis->jcr->dir_impl->res.client->ndmp_use_lmdb) {
     NdmpFhdbLmdbUnregister(ixlog);
   } else {
     NdmpFhdbMemUnregister(ixlog);
@@ -250,7 +250,7 @@ void ProcessFhdb(struct ndmlog* ixlog)
 #  ifdef HAVE_LMDB
   NIS* nis = (NIS*)ixlog->ctx;
 
-  if (nis->jcr->impl->res.client->ndmp_use_lmdb) {
+  if (nis->jcr->dir_impl->res.client->ndmp_use_lmdb) {
     NdmpFhdbLmdbProcessDb(ixlog);
   } else {
     NdmpFhdbMemProcessDb(ixlog);
@@ -271,20 +271,20 @@ void NdmpBackupCleanup(JobControlRecord* jcr, int TermCode)
   Dmsg2(100, "Enter NdmpBackupCleanup %d %c\n", TermCode, TermCode);
 
   if (jcr->is_JobStatus(JS_Terminated)
-      && (jcr->JobErrors || jcr->impl->SDErrors || jcr->JobWarnings)) {
+      && (jcr->JobErrors || jcr->dir_impl->SDErrors || jcr->JobWarnings)) {
     TermCode = JS_Warnings;
   }
 
   UpdateJobEnd(jcr, TermCode);
 
-  if (!jcr->db->GetJobRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_WARNING, 0,
          _("Error getting Job record for Job report: ERR=%s"),
          jcr->db->strerror());
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
   }
 
-  bstrncpy(cr.Name, jcr->impl->res.client->resource_name_, sizeof(cr.Name));
+  bstrncpy(cr.Name, jcr->dir_impl->res.client->resource_name_, sizeof(cr.Name));
   if (!jcr->db->GetClientRecord(jcr, &cr)) {
     Jmsg(jcr, M_WARNING, 0,
          _("Error getting Client record for Job report: ERR=%s"),
@@ -306,8 +306,8 @@ void NdmpBackupCleanup(JobControlRecord* jcr, int TermCode)
       msg_type = M_ERROR; /* Generate error message */
       if (jcr->store_bsock) {
         jcr->store_bsock->signal(BNET_TERMINATE);
-        if (jcr->impl->SD_msg_chan_started) {
-          pthread_cancel(jcr->impl->SD_msg_chan);
+        if (jcr->dir_impl->SD_msg_chan_started) {
+          pthread_cancel(jcr->dir_impl->SD_msg_chan);
         }
       }
       break;
@@ -315,8 +315,8 @@ void NdmpBackupCleanup(JobControlRecord* jcr, int TermCode)
       TermMsg = _("Backup Canceled");
       if (jcr->store_bsock) {
         jcr->store_bsock->signal(BNET_TERMINATE);
-        if (jcr->impl->SD_msg_chan_started) {
-          pthread_cancel(jcr->impl->SD_msg_chan);
+        if (jcr->dir_impl->SD_msg_chan_started) {
+          pthread_cancel(jcr->dir_impl->SD_msg_chan);
         }
       }
       break;

--- a/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
+++ b/core/src/dird/ndmp_dma_restore_NDMP_BAREOS.cc
@@ -29,7 +29,7 @@
 #include "dird.h"
 #include "dird/dird_globals.h"
 #include "dird/getmsg.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/msgchan.h"
 #include "dird/sd_cmds.h"
 #include "dird/storage.h"
@@ -69,7 +69,7 @@ static inline char* lookup_fileindex(JobControlRecord* jcr, int32_t FileIndex)
   TREE_NODE *node, *parent;
   PoolMem restore_pathname, tmp;
 
-  node = FirstTreeNode(jcr->impl->restore_tree_root);
+  node = FirstTreeNode(jcr->dir_impl->restore_tree_root);
   while (node) {
     // See if this is the wanted FileIndex.
     if (node->FileIndex == FileIndex) {
@@ -104,7 +104,7 @@ static inline int set_files_to_restore(JobControlRecord* jcr,
   TREE_NODE *node, *parent;
   PoolMem restore_pathname, tmp;
 
-  node = FirstTreeNode(jcr->impl->restore_tree_root);
+  node = FirstTreeNode(jcr->dir_impl->restore_tree_root);
   while (node) {
     // See if this is the wanted FileIndex and the user asked to extract it.
     if (node->FileIndex == FileIndex && node->extract) {
@@ -223,7 +223,7 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
   }
 
   // Lookup any meta tags that need to be added.
-  fileset = jcr->impl->res.fileset;
+  fileset = jcr->dir_impl->res.fileset;
   for (IncludeExcludeItem* ie : fileset->include_items) {
     // Loop over each file = entry of the fileset.
     for (int j = 0; j < ie->name_list.size(); j++) {
@@ -246,7 +246,7 @@ static inline bool fill_restore_environment(JobControlRecord* jcr,
   if (jcr->where) {
     restore_prefix = jcr->where;
   } else {
-    restore_prefix = jcr->impl->res.job->RestoreWhere;
+    restore_prefix = jcr->dir_impl->res.job->RestoreWhere;
   }
 
   if (!restore_prefix) { return false; }
@@ -315,7 +315,7 @@ bool DoNdmpRestoreInit(JobControlRecord* jcr)
 {
   FreeWstorage(jcr); /* we don't write */
 
-  if (!jcr->impl->restore_tree_root) {
+  if (!jcr->dir_impl->restore_tree_root) {
     Jmsg(jcr, M_FATAL, 0, _("Cannot NDMP restore without a file selection.\n"));
     return false;
   }
@@ -332,23 +332,24 @@ static inline int NdmpWaitForJobTermination(JobControlRecord* jcr)
    * so that we let the SD despool.
    */
   Dmsg4(100, "cancel=%d FDJS=%d JS=%d SDJS=%d\n", jcr->IsCanceled(),
-        jcr->impl->FDJobStatus.load(), jcr->getJobStatus(),
-        jcr->impl->SDJobStatus.load());
-  if (jcr->IsCanceled() || (!jcr->impl->res.job->RescheduleIncompleteJobs)) {
-    Dmsg3(100, "FDJS=%d JS=%d SDJS=%d\n", jcr->impl->FDJobStatus.load(),
-          jcr->getJobStatus(), jcr->impl->SDJobStatus.load());
+        jcr->dir_impl->FDJobStatus.load(), jcr->getJobStatus(),
+        jcr->dir_impl->SDJobStatus.load());
+  if (jcr->IsCanceled()
+      || (!jcr->dir_impl->res.job->RescheduleIncompleteJobs)) {
+    Dmsg3(100, "FDJS=%d JS=%d SDJS=%d\n", jcr->dir_impl->FDJobStatus.load(),
+          jcr->getJobStatus(), jcr->dir_impl->SDJobStatus.load());
     CancelStorageDaemonJob(jcr);
   }
 
   // Note, the SD stores in jcr->JobFiles/ReadBytes/JobBytes/JobErrors
   WaitForStorageDaemonTermination(jcr);
 
-  jcr->impl->FDJobStatus = JS_Terminated;
+  jcr->dir_impl->FDJobStatus = JS_Terminated;
   if (jcr->getJobStatus() != JS_Terminated) { return jcr->getJobStatus(); }
-  if (jcr->impl->FDJobStatus != JS_Terminated) {
-    return jcr->impl->FDJobStatus;
+  if (jcr->dir_impl->FDJobStatus != JS_Terminated) {
+    return jcr->dir_impl->FDJobStatus;
   }
-  return jcr->impl->SDJobStatus;
+  return jcr->dir_impl->SDJobStatus;
 }
 
 /**
@@ -376,26 +377,26 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
   bool retval = false;
   int NdmpLoglevel;
 
-  if (jcr->impl->res.client->ndmp_loglevel > me->ndmp_loglevel) {
-    NdmpLoglevel = jcr->impl->res.client->ndmp_loglevel;
+  if (jcr->dir_impl->res.client->ndmp_loglevel > me->ndmp_loglevel) {
+    NdmpLoglevel = jcr->dir_impl->res.client->ndmp_loglevel;
   } else {
     NdmpLoglevel = me->ndmp_loglevel;
   }
 
   // We first parse the BootStrapRecord ourself so we know what to restore.
-  jcr->impl->bsr = libbareos::parse_bsr(jcr, jcr->RestoreBootstrap);
-  if (!jcr->impl->bsr) {
+  jcr->dir_impl->bsr = libbareos::parse_bsr(jcr, jcr->RestoreBootstrap);
+  if (!jcr->dir_impl->bsr) {
     Jmsg(jcr, M_FATAL, 0, _("Error parsing bootstrap file.\n"));
     goto bail_out;
   }
 
   // Setup all paired read storage.
   SetPairedStorage(jcr);
-  if (!jcr->impl->res.paired_read_write_storage) {
+  if (!jcr->dir_impl->res.paired_read_write_storage) {
     Jmsg(jcr, M_FATAL, 0,
          _("Read storage %s doesn't point to storage definition with paired "
            "storage option.\n"),
-         jcr->impl->res.read_storage->resource_name_);
+         jcr->dir_impl->res.read_storage->resource_name_);
     goto bail_out;
   }
 
@@ -406,7 +407,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
   memset(nis, 0, sizeof(NIS));
 
   // Read the bootstrap file
-  bsr = jcr->impl->bsr;
+  bsr = jcr->dir_impl->bsr;
   while (!feof(info.bs)) {
     if (!SelectNextRstore(jcr, info)) { goto cleanup; }
 
@@ -416,8 +417,8 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
      * we perform as part of the whole job. We only free the env_table between
      * every sub-restore.
      */
-    if (!NdmpBuildClientJob(jcr, jcr->impl->res.client,
-                            jcr->impl->res.paired_read_write_storage,
+    if (!NdmpBuildClientJob(jcr, jcr->dir_impl->res.client,
+                            jcr->dir_impl->res.paired_read_write_storage,
                             NDM_JOB_OP_EXTRACT, &ndmp_job)) {
       goto cleanup;
     }
@@ -438,7 +439,8 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
     sd = jcr->store_bsock;
 
     // Now start a job with the Storage daemon
-    if (!StartStorageDaemonJob(jcr, jcr->impl->res.read_storage_list, NULL)) {
+    if (!StartStorageDaemonJob(jcr, jcr->dir_impl->res.read_storage_list,
+                               NULL)) {
       goto cleanup;
     }
 
@@ -471,13 +473,13 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
     bool first_run = true;
     bool next_sessid = true;
     bool next_fi = true;
-    int first_fi = jcr->impl->bsr->FileIndex->findex;
-    int last_fi = jcr->impl->bsr->FileIndex->findex2;
-    VolumeSessionInfo current_session{jcr->impl->bsr->sessid->sessid,
-                                      jcr->impl->bsr->sesstime->sesstime};
+    int first_fi = jcr->dir_impl->bsr->FileIndex->findex;
+    int last_fi = jcr->dir_impl->bsr->FileIndex->findex2;
+    VolumeSessionInfo current_session{jcr->dir_impl->bsr->sessid->sessid,
+                                      jcr->dir_impl->bsr->sesstime->sesstime};
     cnt = 0;
 
-    for (bsr = jcr->impl->bsr; bsr; bsr = bsr->next) {
+    for (bsr = jcr->dir_impl->bsr; bsr; bsr = bsr->next) {
       if (current_session.id != bsr->sessid->sessid) {
         current_session = {bsr->sessid->sessid, bsr->sesstime->sesstime};
         first_run = true;
@@ -527,7 +529,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
         if (jcr->store_bsock && cnt > 0) {
           jcr->store_bsock->fsend("nextrun");
           lock_mutex(mutex);
-          pthread_cond_wait(&jcr->impl->nextrun_ready, &mutex);
+          pthread_cond_wait(&jcr->dir_impl->nextrun_ready, &mutex);
           unlock_mutex(mutex);
         }
 
@@ -554,7 +556,7 @@ static inline bool DoNdmpRestoreBootstrap(JobControlRecord* jcr)
         session_initialized = true;
 
         // Copy the actual job to perform.
-        jcr->impl->jr.FileIndex = current_fi;
+        jcr->dir_impl->jr.FileIndex = current_fi;
 
         memcpy(&ndmp_sess.control_acb->job, &ndmp_job,
                sizeof(struct ndm_job_param));
@@ -663,8 +665,8 @@ cleanup:
   CloseBootstrapFile(info);
 
 bail_out:
-  FreeTree(jcr->impl->restore_tree_root);
-  jcr->impl->restore_tree_root = NULL;
+  FreeTree(jcr->dir_impl->restore_tree_root);
+  jcr->dir_impl->restore_tree_root = NULL;
   return retval;
 }
 
@@ -674,14 +676,14 @@ bool DoNdmpRestore(JobControlRecord* jcr)
 {
   int status;
 
-  jcr->impl->jr.JobLevel = L_FULL; /* Full restore */
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  jcr->dir_impl->jr.JobLevel = L_FULL; /* Full restore */
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
     goto bail_out;
   }
   Dmsg0(20, "Updated job start record\n");
 
-  Dmsg1(20, "RestoreJobId=%d\n", jcr->impl->res.job->RestoreJobId);
+  Dmsg1(20, "RestoreJobId=%d\n", jcr->dir_impl->res.job->RestoreJobId);
 
   // Validate the Job to have a NDMP client.
   if (!NdmpValidateClient(jcr)) { return false; }

--- a/core/src/dird/ndmp_dma_restore_common.cc
+++ b/core/src/dird/ndmp_dma_restore_common.cc
@@ -30,7 +30,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/restore.h"
 
@@ -179,16 +179,16 @@ void NdmpRestoreCleanup(JobControlRecord* jcr, int TermCode)
   Dmsg0(20, "In NdmpRestoreCleanup\n");
   UpdateJobEnd(jcr, TermCode);
 
-  if (jcr->impl->unlink_bsr && jcr->RestoreBootstrap) {
+  if (jcr->dir_impl->unlink_bsr && jcr->RestoreBootstrap) {
     SecureErase(jcr, jcr->RestoreBootstrap);
-    jcr->impl->unlink_bsr = false;
+    jcr->dir_impl->unlink_bsr = false;
   }
 
   if (JobCanceled(jcr)) { CancelStorageDaemonJob(jcr); }
 
   switch (TermCode) {
     case JS_Terminated:
-      if (jcr->impl->ExpectedFiles > jcr->impl->jr.JobFiles) {
+      if (jcr->dir_impl->ExpectedFiles > jcr->dir_impl->jr.JobFiles) {
         TermMsg = _("Restore OK -- warning file count mismatch");
       } else {
         TermMsg = _("Restore OK");
@@ -203,8 +203,8 @@ void NdmpRestoreCleanup(JobControlRecord* jcr, int TermCode)
       msg_type = M_ERROR; /* Generate error message */
       if (jcr->store_bsock) {
         jcr->store_bsock->signal(BNET_TERMINATE);
-        if (jcr->impl->SD_msg_chan_started) {
-          pthread_cancel(jcr->impl->SD_msg_chan);
+        if (jcr->dir_impl->SD_msg_chan_started) {
+          pthread_cancel(jcr->dir_impl->SD_msg_chan);
         }
       }
       break;
@@ -212,8 +212,8 @@ void NdmpRestoreCleanup(JobControlRecord* jcr, int TermCode)
       TermMsg = _("Restore Canceled");
       if (jcr->store_bsock) {
         jcr->store_bsock->signal(BNET_TERMINATE);
-        if (jcr->impl->SD_msg_chan_started) {
-          pthread_cancel(jcr->impl->SD_msg_chan);
+        if (jcr->dir_impl->SD_msg_chan_started) {
+          pthread_cancel(jcr->dir_impl->SD_msg_chan);
         }
       }
       break;

--- a/core/src/dird/ndmp_dma_storage.cc
+++ b/core/src/dird/ndmp_dma_storage.cc
@@ -28,7 +28,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/sd_cmds.h"
 #include "dird/storage.h"
 #include "dird/ndmp_slot2elemaddr.h"
@@ -68,10 +68,10 @@ int get_tape_info_cb(struct ndm_session* sess,
   }
 
   if (jcr->is_JobType(JT_BACKUP)) {
-    store = jcr->impl->res.write_storage;
+    store = jcr->dir_impl->res.write_storage;
 
   } else if (jcr->is_JobType(JT_RESTORE)) {
-    store = jcr->impl->res.read_storage;
+    store = jcr->dir_impl->res.read_storage;
 
   } else {
     return -1;
@@ -180,7 +180,7 @@ void DoNdmpNativeStorageStatus(UaContext* ua, StorageResource* store, char*)
 {
   struct ndm_job_param ndmp_job;
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
 
   if (!NdmpBuildStorageJob(ua->jcr, store, true, /* Query Tape Agent */
                            true,                 /* Query Robot Agent */
@@ -1072,7 +1072,7 @@ bool ndmp_native_setup_robot_and_tape_for_native_backup_job(
   ndmp_job.have_robot = 1;
   // unload tape if tape is in drive
   ndmp_job.auto_remedy = 1;
-  ndmp_job.record_size = jcr->impl->res.client->ndmp_blocksize;
+  ndmp_job.record_size = jcr->dir_impl->res.client->ndmp_blocksize;
 
   Jmsg(jcr, M_INFO, 0, _("Using Data  host %s\n"), ndmp_job.data_agent.host);
   Jmsg(jcr, M_INFO, 0, _("Using Tape  host:device:address  %s:%s:@%d\n"),

--- a/core/src/dird/newvol.cc
+++ b/core/src/dird/newvol.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,7 +36,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/expand.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 #include "cats/sql.h"
 #include "dird/ua_db.h"
@@ -71,7 +71,7 @@ bool newVolume(JobControlRecord* jcr, MediaDbRecord* mr, StorageResource* store)
     *mr = MediaDbRecord{};
     SetPoolDbrDefaultsInMediaDbr(mr, &pr);
     jcr->VolumeName[0] = 0;
-    bstrncpy(mr->MediaType, jcr->impl->res.write_storage->media_type,
+    bstrncpy(mr->MediaType, jcr->dir_impl->res.write_storage->media_type,
              sizeof(mr->MediaType));
     GeneratePluginEvent(jcr, bDirEventNewVolume); /* return void... */
     if (jcr->VolumeName[0] && IsVolumeNameLegal(NULL, jcr->VolumeName)) {
@@ -163,7 +163,7 @@ static bool PerformFullNameSubstitution(JobControlRecord* jcr,
   bool ok = false;
   POOLMEM* label = GetPoolMemory(PM_FNAME);
 
-  jcr->impl->NumVols = pr->NumVols;
+  jcr->dir_impl->NumVols = pr->NumVols;
   if (VariableExpansion(jcr, pr->LabelFormat, label)) {
     bstrncpy(mr->VolumeName, label, sizeof(mr->VolumeName));
     ok = true;

--- a/core/src/dird/recycle.cc
+++ b/core/src/dird/recycle.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -29,7 +29,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/autorecycle.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 
 namespace directordaemon {
@@ -45,8 +45,8 @@ bool FindRecycledVolume(JobControlRecord* jcr,
   bstrncpy(mr->VolStatus, "Recycle", sizeof(mr->VolStatus));
   SetStorageidInMr(store, mr);
   if (jcr->db->FindNextVolume(jcr, 1, InChanger, mr, unwanted_volumes)) {
-    jcr->impl->MediaId = mr->MediaId;
-    Dmsg1(20, "Find_next_vol MediaId=%u\n", jcr->impl->MediaId);
+    jcr->dir_impl->MediaId = mr->MediaId;
+    Dmsg1(20, "Find_next_vol MediaId=%u\n", jcr->dir_impl->MediaId);
     PmStrcpy(jcr->VolumeName, mr->VolumeName);
     SetStorageidInMr(store, mr);
 

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -27,7 +27,7 @@
 #include "dird/get_database_connection.h"
 #include "dird/job.h"
 #include "dird/job_trigger.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/run_on_incoming_connect_interval.h"
 #include "dird/scheduler.h"
 #include "dird/jcr_util.h"

--- a/core/src/dird/scheduler.cc
+++ b/core/src/dird/scheduler.cc
@@ -36,7 +36,7 @@
 #include "dird/scheduler.h"
 #include "dird/scheduler_private.h"
 #include "dird/scheduler_time_adapter.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/storage.h"
 #include "lib/parse_conf.h"

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -25,7 +25,7 @@
 #include "dird/dird.h"
 #include "dird/dird_conf.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/run_hour_validator.h"
 #include "dird/scheduler.h"
@@ -70,34 +70,34 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
   }
 
   if (run->pool != nullptr) {
-    jcr->impl->res.pool = run->pool; /* override pool */
-    jcr->impl->res.run_pool_override = true;
+    jcr->dir_impl->res.pool = run->pool; /* override pool */
+    jcr->dir_impl->res.run_pool_override = true;
   }
 
   if (run->full_pool != nullptr) {
-    jcr->impl->res.full_pool = run->full_pool; /* override full pool */
-    jcr->impl->res.run_full_pool_override = true;
+    jcr->dir_impl->res.full_pool = run->full_pool; /* override full pool */
+    jcr->dir_impl->res.run_full_pool_override = true;
   }
 
   if (run->vfull_pool != nullptr) {
-    jcr->impl->res.vfull_pool
+    jcr->dir_impl->res.vfull_pool
         = run->vfull_pool; /* override virtual full pool */
-    jcr->impl->res.run_vfull_pool_override = true;
+    jcr->dir_impl->res.run_vfull_pool_override = true;
   }
 
   if (run->inc_pool != nullptr) {
-    jcr->impl->res.inc_pool = run->inc_pool; /* override inc pool */
-    jcr->impl->res.run_inc_pool_override = true;
+    jcr->dir_impl->res.inc_pool = run->inc_pool; /* override inc pool */
+    jcr->dir_impl->res.run_inc_pool_override = true;
   }
 
   if (run->diff_pool != nullptr) {
-    jcr->impl->res.diff_pool = run->diff_pool; /* override diff pool */
-    jcr->impl->res.run_diff_pool_override = true;
+    jcr->dir_impl->res.diff_pool = run->diff_pool; /* override diff pool */
+    jcr->dir_impl->res.run_diff_pool_override = true;
   }
 
   if (run->next_pool != nullptr) {
-    jcr->impl->res.next_pool = run->next_pool; /* override next pool */
-    jcr->impl->res.run_next_pool_override = true;
+    jcr->dir_impl->res.next_pool = run->next_pool; /* override next pool */
+    jcr->dir_impl->res.run_next_pool_override = true;
   }
 
   if (run->storage != nullptr) {
@@ -108,19 +108,19 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
   }
 
   if (run->msgs != nullptr) {
-    jcr->impl->res.messages = run->msgs; /* override messages */
+    jcr->dir_impl->res.messages = run->msgs; /* override messages */
   }
 
   if (run->Priority != 0) { jcr->JobPriority = run->Priority; }
 
-  if (run->spool_data_set) { jcr->impl->spool_data = run->spool_data; }
+  if (run->spool_data_set) { jcr->dir_impl->spool_data = run->spool_data; }
 
   if (run->accurate_set) {
     jcr->accurate = run->accurate; /* overwrite accurate mode */
   }
 
   if (run->MaxRunSchedTime_set) {
-    jcr->impl->MaxRunSchedTime = run->MaxRunSchedTime;
+    jcr->dir_impl->MaxRunSchedTime = run->MaxRunSchedTime;
   }
 }
 
@@ -153,7 +153,7 @@ void SchedulerPrivate::WaitForJobsToRun()
       if (jcr != nullptr) {
         Dmsg1(local_debuglevel, "Scheduler: Running job %s.\n",
               run_job.job->resource_name_);
-        jcr->impl->job_trigger = next_job.job_trigger;
+        jcr->dir_impl->job_trigger = next_job.job_trigger;
         ExecuteJobCallback_(jcr);
       }
 

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -34,7 +34,7 @@
 #include "dird/dird_globals.h"
 #include "dird/authenticate.h"
 #include "dird/getmsg.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/msgchan.h"
 #include "dird/storage.h"
@@ -94,10 +94,10 @@ bool ConnectToStorageDaemon(JobControlRecord* jcr,
   if (jcr->store_bsock) { return true; /* already connected */ }
 
   StorageResource* store;
-  if (jcr->impl->res.write_storage) {
-    store = jcr->impl->res.write_storage;
+  if (jcr->dir_impl->res.write_storage) {
+    store = jcr->dir_impl->res.write_storage;
   } else {
-    store = jcr->impl->res.read_storage;
+    store = jcr->dir_impl->res.read_storage;
   }
 
   if (!store) {
@@ -154,7 +154,7 @@ bool ConnectToStorageDaemon(JobControlRecord* jcr,
 
 BareosSocket* open_sd_bsock(UaContext* ua)
 {
-  StorageResource* store = ua->jcr->impl->res.write_storage;
+  StorageResource* store = ua->jcr->dir_impl->res.write_storage;
 
   if (!store) {
     Dmsg0(200, "open_sd_bsock: No storage resource pointer set\n");
@@ -183,12 +183,12 @@ char* get_volume_name_from_SD(UaContext* ua,
                               drive_number_t drive)
 {
   BareosSocket* sd;
-  StorageResource* store = ua->jcr->impl->res.write_storage;
+  StorageResource* store = ua->jcr->dir_impl->res.write_storage;
   char dev_name[MAX_NAME_LENGTH];
   char* VolName = nullptr;
   int rtn_slot;
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) {
     ua->ErrorMsg(_("Could not open SD socket.\n"));
     return nullptr;
@@ -264,7 +264,7 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
   dlist<vol_list_t>* vol_list;
   BareosSocket* sd = nullptr;
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return nullptr; }
 
   bstrncpy(dev_name, store->dev_name(), sizeof(dev_name));
@@ -531,7 +531,7 @@ slot_number_t NativeGetNumSlots(UaContext* ua, StorageResource* store)
   BareosSocket* sd;
   slot_number_t slots = 0;
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return 0; }
 
   bstrncpy(dev_name, store->dev_name(), sizeof(dev_name));
@@ -559,7 +559,7 @@ drive_number_t NativeGetNumDrives(UaContext* ua, StorageResource* store)
   BareosSocket* sd;
   drive_number_t drives = 0;
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return 0; }
 
   bstrncpy(dev_name, store->dev_name(), sizeof(dev_name));
@@ -591,7 +591,7 @@ bool CancelStorageDaemonJob(UaContext* ua, StorageResource* store, char* JobId)
 
   control_jcr = new_control_jcr("*JobCancel*", JT_SYSTEM);
 
-  control_jcr->impl->res.write_storage = store;
+  control_jcr->dir_impl->res.write_storage = store;
 
   /* the next call will set control_jcr->store_bsock */
   if (!ConnectToStorageDaemon(control_jcr, 10, me->SDConnectTimeout, true)) {
@@ -619,20 +619,20 @@ bool CancelStorageDaemonJob(UaContext* ua,
                             JobControlRecord* jcr,
                             bool interactive)
 {
-  if (!ua->jcr->impl->res.write_storage_list) {
-    if (jcr->impl->res.read_storage_list) {
-      CopyWstorage(ua->jcr, jcr->impl->res.read_storage_list,
+  if (!ua->jcr->dir_impl->res.write_storage_list) {
+    if (jcr->dir_impl->res.read_storage_list) {
+      CopyWstorage(ua->jcr, jcr->dir_impl->res.read_storage_list,
                    _("Job resource"));
     } else {
-      CopyWstorage(ua->jcr, jcr->impl->res.write_storage_list,
+      CopyWstorage(ua->jcr, jcr->dir_impl->res.write_storage_list,
                    _("Job resource"));
     }
   } else {
     UnifiedStorageResource store;
-    if (jcr->impl->res.read_storage_list) {
-      store.store = jcr->impl->res.read_storage;
+    if (jcr->dir_impl->res.read_storage_list) {
+      store.store = jcr->dir_impl->res.read_storage;
     } else {
-      store.store = jcr->impl->res.write_storage;
+      store.store = jcr->dir_impl->res.write_storage;
     }
     if (!store.store) {
       Dmsg0(200, "CancelStorageDaemonJob: No storage resource pointer set\n");
@@ -661,7 +661,7 @@ bool CancelStorageDaemonJob(UaContext* ua,
 
   TerminateAndCloseJcrStoreSocket(ua->jcr);
 
-  if (!interactive) { jcr->impl->sd_canceled = true; }
+  if (!interactive) { jcr->dir_impl->sd_canceled = true; }
 
   SdMsgThreadSendSignal(jcr, TIMEOUT_SIGNAL);
 
@@ -672,7 +672,7 @@ bool CancelStorageDaemonJob(UaContext* ua,
 
 void CancelStorageDaemonJob(JobControlRecord* jcr)
 {
-  if (jcr->impl->sd_canceled) { return; /* cancel only once */ }
+  if (jcr->dir_impl->sd_canceled) { return; /* cancel only once */ }
 
   UaContext* ua = new_ua_context(jcr);
   JobControlRecord* control_jcr = new_control_jcr("*JobCancel*", JT_SYSTEM);
@@ -754,7 +754,7 @@ bool NativeTransferVolume(UaContext* ua,
   bool retval = true;
   char dev_name[MAX_NAME_LENGTH];
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return false; }
 
   bstrncpy(dev_name, store->dev_name(), sizeof(dev_name));
@@ -793,7 +793,7 @@ bool NativeAutochangerVolumeOperation(UaContext* ua,
   bool retval = true;
   char dev_name[MAX_NAME_LENGTH];
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return false; }
 
   bstrncpy(dev_name, store->dev_name(), sizeof(dev_name));
@@ -830,21 +830,23 @@ bool SendSecureEraseReqToSd(JobControlRecord* jcr)
   int32_t n;
   BareosSocket* sd = jcr->store_bsock;
 
-  if (!jcr->impl->SDSecureEraseCmd) {
-    jcr->impl->SDSecureEraseCmd = GetPoolMemory(PM_NAME);
+  if (!jcr->dir_impl->SDSecureEraseCmd) {
+    jcr->dir_impl->SDSecureEraseCmd = GetPoolMemory(PM_NAME);
   }
 
   sd->fsend(getSecureEraseCmd);
   while ((n = BgetDirmsg(sd)) >= 0) {
-    jcr->impl->SDSecureEraseCmd
-        = CheckPoolMemorySize(jcr->impl->SDSecureEraseCmd, sd->message_length);
-    if (sscanf(sd->msg, OKSecureEraseCmd, jcr->impl->SDSecureEraseCmd) == 1) {
-      Dmsg1(421, "Got SD Secure Erase Cmd: %s\n", jcr->impl->SDSecureEraseCmd);
+    jcr->dir_impl->SDSecureEraseCmd = CheckPoolMemorySize(
+        jcr->dir_impl->SDSecureEraseCmd, sd->message_length);
+    if (sscanf(sd->msg, OKSecureEraseCmd, jcr->dir_impl->SDSecureEraseCmd)
+        == 1) {
+      Dmsg1(421, "Got SD Secure Erase Cmd: %s\n",
+            jcr->dir_impl->SDSecureEraseCmd);
       break;
     } else {
       Jmsg(jcr, M_WARNING, 0, _("Unexpected SD Secure Erase Cmd: %s\n"),
            sd->msg);
-      PmStrcpy(jcr->impl->SDSecureEraseCmd, "*None*");
+      PmStrcpy(jcr->dir_impl->SDSecureEraseCmd, "*None*");
       return false;
     }
   }
@@ -874,7 +876,7 @@ bool DoStorageResolve(UaContext* ua, StorageResource* store)
   PmStrcpy(lstore.store_source, _("unknown source"));
   SetWstorage(ua->jcr, &lstore);
 
-  ua->jcr->impl->res.write_storage = store;
+  ua->jcr->dir_impl->res.write_storage = store;
   if (!(sd = open_sd_bsock(ua))) { return false; }
 
   for (int i = 1; i < ua->argc; i++) {
@@ -896,10 +898,10 @@ bool SendStoragePluginOptions(JobControlRecord* jcr)
   const char* plugin_options;
   BareosSocket* sd = jcr->store_bsock;
 
-  if (jcr->impl->res.job && jcr->impl->res.job->SdPluginOptions
-      && jcr->impl->res.job->SdPluginOptions->size()) {
+  if (jcr->dir_impl->res.job && jcr->dir_impl->res.job->SdPluginOptions
+      && jcr->dir_impl->res.job->SdPluginOptions->size()) {
     foreach_alist_index (i, plugin_options,
-                         jcr->impl->res.job->SdPluginOptions) {
+                         jcr->dir_impl->res.job->SdPluginOptions) {
       PmStrcpy(cur_plugin_options, plugin_options);
       BashSpaces(cur_plugin_options.c_str());
 

--- a/core/src/dird/stats.cc
+++ b/core/src/dird/stats.cc
@@ -29,7 +29,7 @@
 #include "dird.h"
 #include "dird/dird_globals.h"
 #include "dird/get_database_connection.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "cats/sql_pooling.h"
 #include "dird/sd_cmds.h"
 #include "dird/ua_server.h"
@@ -129,12 +129,12 @@ extern "C" void* statistics_thread(void*)
 
   jcr = new_control_jcr("*StatisticsCollector*", JT_SYSTEM);
 
-  jcr->impl->res.catalog
+  jcr->dir_impl->res.catalog
       = (CatalogResource*)my_config->GetNextRes(R_CATALOG, NULL);
   jcr->db = GetDatabaseConnection(jcr);
   if (jcr->db == NULL) {
     Jmsg(jcr, M_FATAL, 0, _("Could not open database \"%s\".\n"),
-         jcr->impl->res.catalog->db_name);
+         jcr->dir_impl->res.catalog->db_name);
     goto bail_out;
   }
 
@@ -191,7 +191,7 @@ extern "C" void* statistics_thread(void*)
           continue;
       }
 
-      jcr->impl->res.read_storage = store;
+      jcr->dir_impl->res.read_storage = store;
       if (!ConnectToStorageDaemon(jcr, 2, 1, false)) {
         UnlockRes(my_config);
         continue;

--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -31,7 +31,7 @@
 
 #include "include/bareos.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/sd_cmds.h"
 #include "include/auth_protocol_types.h"
 #include "lib/parse_conf.h"
@@ -100,21 +100,21 @@ void CopyRstorage(JobControlRecord* jcr,
 {
   if (storage) {
     StorageResource* store = nullptr;
-    if (jcr->impl->res.read_storage_list) {
-      delete jcr->impl->res.read_storage_list;
+    if (jcr->dir_impl->res.read_storage_list) {
+      delete jcr->dir_impl->res.read_storage_list;
     }
-    jcr->impl->res.read_storage_list
+    jcr->dir_impl->res.read_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
     foreach_alist (store, storage) {
-      jcr->impl->res.read_storage_list->append(store);
+      jcr->dir_impl->res.read_storage_list->append(store);
     }
-    if (!jcr->impl->res.rstore_source) {
-      jcr->impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
+    if (!jcr->dir_impl->res.rstore_source) {
+      jcr->dir_impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
     }
-    PmStrcpy(jcr->impl->res.rstore_source, where);
-    if (jcr->impl->res.read_storage_list) {
-      jcr->impl->res.read_storage
-          = (StorageResource*)jcr->impl->res.read_storage_list->first();
+    PmStrcpy(jcr->dir_impl->res.rstore_source, where);
+    if (jcr->dir_impl->res.read_storage_list) {
+      jcr->dir_impl->res.read_storage
+          = (StorageResource*)jcr->dir_impl->res.read_storage_list->first();
     }
   }
 }
@@ -128,30 +128,30 @@ void SetRstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
   StorageResource* storage = nullptr;
 
   if (!store->store) { return; }
-  if (jcr->impl->res.read_storage_list) { FreeRstorage(jcr); }
-  if (!jcr->impl->res.read_storage_list) {
-    jcr->impl->res.read_storage_list
+  if (jcr->dir_impl->res.read_storage_list) { FreeRstorage(jcr); }
+  if (!jcr->dir_impl->res.read_storage_list) {
+    jcr->dir_impl->res.read_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
   }
-  jcr->impl->res.read_storage = store->store;
-  if (!jcr->impl->res.rstore_source) {
-    jcr->impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
+  jcr->dir_impl->res.read_storage = store->store;
+  if (!jcr->dir_impl->res.rstore_source) {
+    jcr->dir_impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
   }
-  PmStrcpy(jcr->impl->res.rstore_source, store->store_source);
-  foreach_alist (storage, jcr->impl->res.read_storage_list) {
+  PmStrcpy(jcr->dir_impl->res.rstore_source, store->store_source);
+  foreach_alist (storage, jcr->dir_impl->res.read_storage_list) {
     if (store->store == storage) { return; }
   }
   /* Store not in list, so add it */
-  jcr->impl->res.read_storage_list->prepend(store->store);
+  jcr->dir_impl->res.read_storage_list->prepend(store->store);
 }
 
 void FreeRstorage(JobControlRecord* jcr)
 {
-  if (jcr->impl->res.read_storage_list) {
-    delete jcr->impl->res.read_storage_list;
-    jcr->impl->res.read_storage_list = NULL;
+  if (jcr->dir_impl->res.read_storage_list) {
+    delete jcr->dir_impl->res.read_storage_list;
+    jcr->dir_impl->res.read_storage_list = NULL;
   }
-  jcr->impl->res.read_storage = NULL;
+  jcr->dir_impl->res.read_storage = NULL;
 }
 
 // Copy the storage definitions from an alist to the JobControlRecord
@@ -161,25 +161,25 @@ void CopyWstorage(JobControlRecord* jcr,
 {
   if (storage) {
     StorageResource* st = nullptr;
-    if (jcr->impl->res.write_storage_list) {
-      delete jcr->impl->res.write_storage_list;
+    if (jcr->dir_impl->res.write_storage_list) {
+      delete jcr->dir_impl->res.write_storage_list;
     }
-    jcr->impl->res.write_storage_list
+    jcr->dir_impl->res.write_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
     foreach_alist (st, storage) {
       Dmsg1(100, "write_storage_list=%s\n", st->resource_name_);
-      jcr->impl->res.write_storage_list->append(st);
+      jcr->dir_impl->res.write_storage_list->append(st);
     }
-    if (!jcr->impl->res.wstore_source) {
-      jcr->impl->res.wstore_source = GetPoolMemory(PM_MESSAGE);
+    if (!jcr->dir_impl->res.wstore_source) {
+      jcr->dir_impl->res.wstore_source = GetPoolMemory(PM_MESSAGE);
     }
-    PmStrcpy(jcr->impl->res.wstore_source, where);
-    if (jcr->impl->res.write_storage_list) {
-      jcr->impl->res.write_storage
-          = (StorageResource*)jcr->impl->res.write_storage_list->first();
+    PmStrcpy(jcr->dir_impl->res.wstore_source, where);
+    if (jcr->dir_impl->res.write_storage_list) {
+      jcr->dir_impl->res.write_storage
+          = (StorageResource*)jcr->dir_impl->res.write_storage_list->first();
       Dmsg2(100, "write_storage=%s where=%s\n",
-            jcr->impl->res.write_storage->resource_name_,
-            jcr->impl->res.wstore_source);
+            jcr->dir_impl->res.write_storage->resource_name_,
+            jcr->dir_impl->res.wstore_source);
     }
   }
 }
@@ -193,34 +193,34 @@ void SetWstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
   StorageResource* storage = nullptr;
 
   if (!store->store) { return; }
-  if (jcr->impl->res.write_storage_list) { FreeWstorage(jcr); }
-  if (!jcr->impl->res.write_storage_list) {
-    jcr->impl->res.write_storage_list
+  if (jcr->dir_impl->res.write_storage_list) { FreeWstorage(jcr); }
+  if (!jcr->dir_impl->res.write_storage_list) {
+    jcr->dir_impl->res.write_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
   }
-  jcr->impl->res.write_storage = store->store;
-  if (!jcr->impl->res.wstore_source) {
-    jcr->impl->res.wstore_source = GetPoolMemory(PM_MESSAGE);
+  jcr->dir_impl->res.write_storage = store->store;
+  if (!jcr->dir_impl->res.wstore_source) {
+    jcr->dir_impl->res.wstore_source = GetPoolMemory(PM_MESSAGE);
   }
-  PmStrcpy(jcr->impl->res.wstore_source, store->store_source);
+  PmStrcpy(jcr->dir_impl->res.wstore_source, store->store_source);
   Dmsg2(50, "write_storage=%s where=%s\n",
-        jcr->impl->res.write_storage->resource_name_,
-        jcr->impl->res.wstore_source);
-  foreach_alist (storage, jcr->impl->res.write_storage_list) {
+        jcr->dir_impl->res.write_storage->resource_name_,
+        jcr->dir_impl->res.wstore_source);
+  foreach_alist (storage, jcr->dir_impl->res.write_storage_list) {
     if (store->store == storage) { return; }
   }
 
   // Store not in list, so add it
-  jcr->impl->res.write_storage_list->prepend(store->store);
+  jcr->dir_impl->res.write_storage_list->prepend(store->store);
 }
 
 void FreeWstorage(JobControlRecord* jcr)
 {
-  if (jcr->impl->res.write_storage_list) {
-    delete jcr->impl->res.write_storage_list;
-    jcr->impl->res.write_storage_list = NULL;
+  if (jcr->dir_impl->res.write_storage_list) {
+    delete jcr->dir_impl->res.write_storage_list;
+    jcr->dir_impl->res.write_storage_list = NULL;
   }
-  jcr->impl->res.write_storage = NULL;
+  jcr->dir_impl->res.write_storage = NULL;
 }
 
 /**
@@ -236,35 +236,37 @@ void SetPairedStorage(JobControlRecord* jcr)
   switch (jcr->getJobType()) {
     case JT_BACKUP:
       // For a backup we look at the write storage.
-      if (jcr->impl->res.write_storage_list) {
+      if (jcr->dir_impl->res.write_storage_list) {
         /*
-         * Setup the jcr->impl_->res.write_storage_list to point to all
+         * Setup the jcr->dir_impl_->res.write_storage_list to point to all
          * paired_storage entries of all the storage currently in the
          * jcrres.->write_storage_list. Save the original list under
-         * jcr->impl_->res.paired_read_write_storage_list.
+         * jcr->dir_impl_->res.paired_read_write_storage_list.
          */
-        jcr->impl->res.paired_read_write_storage_list
-            = jcr->impl->res.write_storage_list;
-        jcr->impl->res.write_storage_list
+        jcr->dir_impl->res.paired_read_write_storage_list
+            = jcr->dir_impl->res.write_storage_list;
+        jcr->dir_impl->res.write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        foreach_alist (store, jcr->impl->res.paired_read_write_storage_list) {
+        foreach_alist (store,
+                       jcr->dir_impl->res.paired_read_write_storage_list) {
           if (store->paired_storage) {
             Dmsg1(100, "write_storage_list=%s\n",
                   store->paired_storage->resource_name_);
-            jcr->impl->res.write_storage_list->append(store->paired_storage);
+            jcr->dir_impl->res.write_storage_list->append(
+                store->paired_storage);
           }
         }
 
         /*
-         * Swap the actual jcr->impl_->res.write_storage to point to the paired
-         * storage entry. We save the actual storage entry in
+         * Swap the actual jcr->dir_impl_->res.write_storage to point to the
+         * paired storage entry. We save the actual storage entry in
          * paired_read_write_storage which is for restore in the
          * FreePairedStorage() function.
          */
-        store = jcr->impl->res.write_storage;
+        store = jcr->dir_impl->res.write_storage;
         if (store->paired_storage) {
-          jcr->impl->res.write_storage = store->paired_storage;
-          jcr->impl->res.paired_read_write_storage = store;
+          jcr->dir_impl->res.write_storage = store->paired_storage;
+          jcr->dir_impl->res.paired_read_write_storage = store;
         }
       } else {
         Jmsg(jcr, M_FATAL, 0,
@@ -273,16 +275,16 @@ void SetPairedStorage(JobControlRecord* jcr)
       break;
     case JT_RESTORE:
       // For a restores we look at the read storage.
-      if (jcr->impl->res.read_storage_list) {
+      if (jcr->dir_impl->res.read_storage_list) {
         /*
-         * Setup the jcr->impl_->res.paired_read_write_storage_list to point to
-         * all paired_storage entries of all the storage currently in the
-         * jcr->impl_->res.read_storage_list.
+         * Setup the jcr->dir_impl_->res.paired_read_write_storage_list to point
+         * to all paired_storage entries of all the storage currently in the
+         * jcr->dir_impl_->res.read_storage_list.
          */
-        jcr->impl->res.paired_read_write_storage_list
+        jcr->dir_impl->res.paired_read_write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
         foreach_alist (paired_read_write_storage,
-                       jcr->impl->res.read_storage_list) {
+                       jcr->dir_impl->res.read_storage_list) {
           store = (StorageResource*)my_config->GetNextRes(R_STORAGE, NULL);
           while (store) {
             if (store->paired_storage == paired_read_write_storage) { break; }
@@ -296,15 +298,15 @@ void SetPairedStorage(JobControlRecord* jcr)
            * paired_read_write_storage as its paired storage.
            */
           if (store) {
-            jcr->impl->res.paired_read_write_storage_list->append(store);
+            jcr->dir_impl->res.paired_read_write_storage_list->append(store);
 
             /*
              * If the current processed paired_read_write_storage is also the
-             * current entry in jcr->impl_->res.read_storage update the
+             * current entry in jcr->dir_impl_->res.read_storage update the
              * jcr->paired_read_write_storage to point to this storage entry.
              */
-            if (paired_read_write_storage == jcr->impl->res.read_storage) {
-              jcr->impl->res.paired_read_write_storage = store;
+            if (paired_read_write_storage == jcr->dir_impl->res.read_storage) {
+              jcr->dir_impl->res.paired_read_write_storage = store;
             }
           }
         }
@@ -316,35 +318,36 @@ void SetPairedStorage(JobControlRecord* jcr)
     case JT_MIGRATE:
     case JT_COPY:
       // For a migrate or copy we look at the read storage.
-      if (jcr->impl->res.read_storage_list) {
+      if (jcr->dir_impl->res.read_storage_list) {
         /*
-         * Setup the jcr->impl_->res.read_storage_list to point to all
+         * Setup the jcr->dir_impl_->res.read_storage_list to point to all
          * paired_storage entries of all the storage currently in the
-         * jcr->impl_->res.read_storage_list. Save the original list under
-         * jcr->impl_->res.paired_read_write_storage_list.
+         * jcr->dir_impl_->res.read_storage_list. Save the original list under
+         * jcr->dir_impl_->res.paired_read_write_storage_list.
          */
-        jcr->impl->res.paired_read_write_storage_list
-            = jcr->impl->res.read_storage_list;
-        jcr->impl->res.read_storage_list
+        jcr->dir_impl->res.paired_read_write_storage_list
+            = jcr->dir_impl->res.read_storage_list;
+        jcr->dir_impl->res.read_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        foreach_alist (store, jcr->impl->res.paired_read_write_storage_list) {
+        foreach_alist (store,
+                       jcr->dir_impl->res.paired_read_write_storage_list) {
           if (store->paired_storage) {
             Dmsg1(100, "read_storage_list=%s\n",
                   store->paired_storage->resource_name_);
-            jcr->impl->res.read_storage_list->append(store->paired_storage);
+            jcr->dir_impl->res.read_storage_list->append(store->paired_storage);
           }
         }
 
         /*
-         * Swap the actual jcr->impl_->res.read_storage to point to the paired
-         * storage entry. We save the actual storage entry in
+         * Swap the actual jcr->dir_impl_->res.read_storage to point to the
+         * paired storage entry. We save the actual storage entry in
          * paired_read_write_storage which is for restore in the
          * FreePairedStorage() function.
          */
-        store = jcr->impl->res.read_storage;
+        store = jcr->dir_impl->res.read_storage;
         if (store->paired_storage) {
-          jcr->impl->res.read_storage = store->paired_storage;
-          jcr->impl->res.paired_read_write_storage = store;
+          jcr->dir_impl->res.read_storage = store->paired_storage;
+          jcr->dir_impl->res.paired_read_write_storage = store;
         }
       } else {
         Jmsg(jcr, M_FATAL, 0,
@@ -366,51 +369,51 @@ void SetPairedStorage(JobControlRecord* jcr)
  */
 void FreePairedStorage(JobControlRecord* jcr)
 {
-  if (jcr->impl->res.paired_read_write_storage_list) {
+  if (jcr->dir_impl->res.paired_read_write_storage_list) {
     switch (jcr->getJobType()) {
       case JT_BACKUP:
         // For a backup we look at the write storage.
-        if (jcr->impl->res.write_storage_list) {
+        if (jcr->dir_impl->res.write_storage_list) {
           /*
-           * The jcr->impl_->res.write_storage_list contain a set of paired
+           * The jcr->dir_impl_->res.write_storage_list contain a set of paired
            * storages. We just delete it content and swap back to the real
            * master storage.
            */
-          delete jcr->impl->res.write_storage_list;
-          jcr->impl->res.write_storage_list
-              = jcr->impl->res.paired_read_write_storage_list;
-          jcr->impl->res.paired_read_write_storage_list = NULL;
-          jcr->impl->res.write_storage
-              = jcr->impl->res.paired_read_write_storage;
-          jcr->impl->res.paired_read_write_storage = NULL;
+          delete jcr->dir_impl->res.write_storage_list;
+          jcr->dir_impl->res.write_storage_list
+              = jcr->dir_impl->res.paired_read_write_storage_list;
+          jcr->dir_impl->res.paired_read_write_storage_list = NULL;
+          jcr->dir_impl->res.write_storage
+              = jcr->dir_impl->res.paired_read_write_storage;
+          jcr->dir_impl->res.paired_read_write_storage = NULL;
         }
         break;
       case JT_RESTORE:
         /*
-         * The jcr->impl_->res.read_storage_list contain a set of paired
+         * The jcr->dir_impl_->res.read_storage_list contain a set of paired
          * storages. For the read we created a list of alternative storage which
          * we can just drop now.
          */
-        delete jcr->impl->res.paired_read_write_storage_list;
-        jcr->impl->res.paired_read_write_storage_list = NULL;
-        jcr->impl->res.paired_read_write_storage = NULL;
+        delete jcr->dir_impl->res.paired_read_write_storage_list;
+        jcr->dir_impl->res.paired_read_write_storage_list = NULL;
+        jcr->dir_impl->res.paired_read_write_storage = NULL;
         break;
       case JT_MIGRATE:
       case JT_COPY:
         // For a migrate or copy we look at the read storage.
-        if (jcr->impl->res.read_storage_list) {
+        if (jcr->dir_impl->res.read_storage_list) {
           /*
-           * The jcr->impl_->res.read_storage_list contains a set of paired
+           * The jcr->dir_impl_->res.read_storage_list contains a set of paired
            * storages. We just delete it content and swap back to the real
            * master storage.
            */
-          delete jcr->impl->res.read_storage_list;
-          jcr->impl->res.read_storage_list
-              = jcr->impl->res.paired_read_write_storage_list;
-          jcr->impl->res.paired_read_write_storage_list = NULL;
-          jcr->impl->res.read_storage
-              = jcr->impl->res.paired_read_write_storage;
-          jcr->impl->res.paired_read_write_storage = NULL;
+          delete jcr->dir_impl->res.read_storage_list;
+          jcr->dir_impl->res.read_storage_list
+              = jcr->dir_impl->res.paired_read_write_storage_list;
+          jcr->dir_impl->res.paired_read_write_storage_list = NULL;
+          jcr->dir_impl->res.read_storage
+              = jcr->dir_impl->res.paired_read_write_storage;
+          jcr->dir_impl->res.paired_read_write_storage = NULL;
         }
         break;
       default:
@@ -430,8 +433,8 @@ bool HasPairedStorage(JobControlRecord* jcr)
   switch (jcr->getJobType()) {
     case JT_BACKUP:
       // For a backup we look at the write storage.
-      if (jcr->impl->res.write_storage_list) {
-        foreach_alist (store, jcr->impl->res.write_storage_list) {
+      if (jcr->dir_impl->res.write_storage_list) {
+        foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {
@@ -444,8 +447,8 @@ bool HasPairedStorage(JobControlRecord* jcr)
     case JT_RESTORE:
     case JT_MIGRATE:
     case JT_COPY:
-      if (jcr->impl->res.read_storage_list) {
-        foreach_alist (store, jcr->impl->res.read_storage_list) {
+      if (jcr->dir_impl->res.read_storage_list) {
+        foreach_alist (store, jcr->dir_impl->res.read_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {
@@ -472,7 +475,7 @@ bool SelectNextRstore(JobControlRecord* jcr, bootstrap_info& info)
 {
   UnifiedStorageResource ustore;
 
-  if (bstrcmp(jcr->impl->res.read_storage->resource_name_, info.storage)) {
+  if (bstrcmp(jcr->dir_impl->res.read_storage->resource_name_, info.storage)) {
     return true; /* Same SD nothing to change */
   }
 

--- a/core/src/dird/testfind.cc
+++ b/core/src/dird/testfind.cc
@@ -35,7 +35,7 @@
 #include "dird/jcr_util.h"
 #include "dird/dird_globals.h"
 #include "dird/dird_conf.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "lib/recent_job_results_list.h"
 #include "findlib/attribs.h"
 #include "filed/fileset.h"
@@ -53,9 +53,9 @@ void TestfindFreeJcr(JobControlRecord* jcr)
 {
   Dmsg0(200, "Start testfind FreeJcr\n");
 
-  if (jcr->impl) {
-    delete jcr->impl;
-    jcr->impl = nullptr;
+  if (jcr->dir_impl) {
+    delete jcr->dir_impl;
+    jcr->dir_impl = nullptr;
   }
 
   Dmsg0(200, "End testfind FreeJcr\n");
@@ -162,10 +162,10 @@ int main(int argc, char* const* argv)
   }
 
   jcr = NewDirectorJcr(TestfindFreeJcr);
-  jcr->impl->res.fileset
+  jcr->dir_impl->res.fileset
       = (FilesetResource*)my_config->GetResWithName(R_FILESET, fileset_name);
 
-  if (jcr->impl->res.fileset == NULL) {
+  if (jcr->dir_impl->res.fileset == NULL) {
     fprintf(stderr, "%s: Fileset not found\n", fileset_name);
 
     FilesetResource* var;
@@ -433,7 +433,7 @@ static void CountFiles(FindFilesPacket* ar)
 
 static bool CopyFileset(FindFilesPacket* ff, JobControlRecord* jcr)
 {
-  FilesetResource* jcr_fileset = jcr->impl->res.fileset;
+  FilesetResource* jcr_fileset = jcr->dir_impl->res.fileset;
   int num;
   bool include = true;
 

--- a/core/src/dird/ua_db.cc
+++ b/core/src/dird/ua_db.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,7 +28,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/ua_db.h"
 #include "cats/sql_pooling.h"
 #include "dird/ua_select.h"
@@ -132,7 +132,7 @@ bool OpenDb(UaContext* ua, bool use_private)
   mult_db_conn = ua->catalog->mult_db_connections;
   if (use_private) { mult_db_conn = true; }
 
-  ua->jcr->impl->res.catalog = ua->catalog;
+  ua->jcr->dir_impl->res.catalog = ua->catalog;
   Dmsg0(100, "UA Open database\n");
   ua->db = DbSqlGetPooledConnection(
       ua->jcr, ua->catalog->db_driver, ua->catalog->db_name,

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -33,7 +33,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/dird_globals.h"
 #include "dird/sd_cmds.h"
@@ -727,7 +727,7 @@ static void DoClientCmd(UaContext* ua, ClientResource* client const char*)
 
   /* Connect to File daemon */
 
-  ua->jcr->impl->res.client = client;
+  ua->jcr->dir_impl->res.client = client;
   /* Try to connect for 15 seconds */
   ua->SendMsg(_("Connecting to Client %s at %s:%d\n"), client->resource_name_,
               client->address, client->FDport);

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -32,7 +32,7 @@
 #include "dird.h"
 #include "dird/dird_globals.h"
 #include "dird/get_database_connection.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/ua_cmdstruct.h"
 #include "cats/sql_pooling.h"
@@ -1286,17 +1286,17 @@ static bool ListNextvol(UaContext* ua, int ndays)
       found = false;
       goto get_out;
     }
-    if (!jcr->impl->jr.PoolId) {
+    if (!jcr->dir_impl->jr.PoolId) {
       ua->ErrorMsg(_("Could not find Pool for Job %s\n"), job->resource_name_);
       continue;
     }
     PoolDbRecord pr;
-    pr.PoolId = jcr->impl->jr.PoolId;
+    pr.PoolId = jcr->dir_impl->jr.PoolId;
     if (!ua->db->GetPoolRecord(jcr, &pr)) {
       bstrncpy(pr.Name, "*UnknownPool*", sizeof(pr.Name));
     }
     MediaDbRecord mr;
-    mr.PoolId = jcr->impl->jr.PoolId;
+    mr.PoolId = jcr->dir_impl->jr.PoolId;
     GetJobStorage(&store, job, run);
     SetStorageidInMr(store.store, &mr);
     /* no need to set ScratchPoolId, since we use fnv_no_create_vol */
@@ -1409,7 +1409,7 @@ bool CompleteJcrForJob(JobControlRecord* jcr,
                        PoolResource* pool)
 {
   SetJcrDefaults(jcr, job);
-  if (pool) { jcr->impl->res.pool = pool; /* override */ }
+  if (pool) { jcr->dir_impl->res.pool = pool; /* override */ }
   if (jcr->db) {
     Dmsg0(100, "complete_jcr close db\n");
     DbSqlClosePooledConnection(jcr, jcr->db);
@@ -1420,14 +1420,14 @@ bool CompleteJcrForJob(JobControlRecord* jcr,
   jcr->db = GetDatabaseConnection(jcr);
   if (jcr->db == NULL) {
     Jmsg(jcr, M_FATAL, 0, _("Could not open database \"%s\".\n"),
-         jcr->impl->res.catalog->db_name);
+         jcr->dir_impl->res.catalog->db_name);
     return false;
   }
   PoolDbRecord pr;
-  bstrncpy(pr.Name, jcr->impl->res.pool->resource_name_, sizeof(pr.Name));
+  bstrncpy(pr.Name, jcr->dir_impl->res.pool->resource_name_, sizeof(pr.Name));
   while (!jcr->db->GetPoolRecord(jcr, &pr)) { /* get by Name */
     /* Try to create the pool */
-    if (CreatePool(jcr, jcr->db, jcr->impl->res.pool, POOL_OP_CREATE) < 0) {
+    if (CreatePool(jcr, jcr->db, jcr->dir_impl->res.pool, POOL_OP_CREATE) < 0) {
       Jmsg(jcr, M_FATAL, 0, _("Pool %s not in database. %s\n"), pr.Name,
            jcr->db->strerror());
       if (jcr->db) {
@@ -1439,7 +1439,7 @@ bool CompleteJcrForJob(JobControlRecord* jcr,
       Jmsg(jcr, M_INFO, 0, _("Pool %s created in database.\n"), pr.Name);
     }
   }
-  jcr->impl->jr.PoolId = pr.PoolId;
+  jcr->dir_impl->jr.PoolId = pr.PoolId;
   return true;
 }
 

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -32,7 +32,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 #include "dird/sd_cmds.h"
 #include "dird/ua_db.h"
@@ -620,7 +620,7 @@ static bool ActionOnPurgeCmd(UaContext* ua, const char*)
   }
 
   // Choose storage
-  ua->jcr->impl->res.write_storage = store = get_storage_resource(ua);
+  ua->jcr->dir_impl->res.write_storage = store = get_storage_resource(ua);
   if (!store) { goto bail_out; }
 
   switch (store->Protocol) {
@@ -695,7 +695,7 @@ static bool ActionOnPurgeCmd(UaContext* ua, const char*)
 bail_out:
   CloseDb(ua);
   if (sd) { CloseSdBsock(ua); }
-  ua->jcr->impl->res.write_storage = NULL;
+  ua->jcr->dir_impl->res.write_storage = NULL;
   if (results) { free(results); }
 
   return true;

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -36,7 +36,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/ua_db.h"
 #include "dird/ua_input.h"
 #include "dird/ua_select.h"
@@ -1232,7 +1232,7 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
    * For NDMP restores its used in the DMA to know what to restore.
    * The tree is freed by the DMA when its done.
    */
-  ua->jcr->impl->restore_tree_root = tree.root;
+  ua->jcr->dir_impl->restore_tree_root = tree.root;
 
   return OK;
 }

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -29,7 +29,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/storage.h"
 #include "dird/ua_input.h"
 #include "dird/ua_select.h"
@@ -1332,7 +1332,7 @@ StorageResource* get_storage_resource(UaContext* ua,
           ua->ErrorMsg(_("JobId %s is not running.\n"), edit_int64(jobid, ed1));
           return NULL;
         }
-        store = jcr->impl->res.write_storage;
+        store = jcr->dir_impl->res.write_storage;
         FreeJcr(jcr);
         break;
       } else if (Bstrcasecmp(ua->argk[i], NT_("job"))
@@ -1345,7 +1345,7 @@ StorageResource* get_storage_resource(UaContext* ua,
           ua->ErrorMsg(_("Job \"%s\" is not running.\n"), ua->argv[i]);
           return NULL;
         }
-        store = jcr->impl->res.write_storage;
+        store = jcr->dir_impl->res.write_storage;
         FreeJcr(jcr);
         break;
       } else if (Bstrcasecmp(ua->argk[i], NT_("ujobid"))) {
@@ -1357,7 +1357,7 @@ StorageResource* get_storage_resource(UaContext* ua,
           ua->ErrorMsg(_("Job \"%s\" is not running.\n"), ua->argv[i]);
           return NULL;
         }
-        store = jcr->impl->res.write_storage;
+        store = jcr->dir_impl->res.write_storage;
         FreeJcr(jcr);
         break;
       }
@@ -1595,8 +1595,8 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
       }
 
       if (jcr) {
-        if (jcr->impl->res.job
-            && !ua->AclAccessOk(Job_ACL, jcr->impl->res.job->resource_name_,
+        if (jcr->dir_impl->res.job
+            && !ua->AclAccessOk(Job_ACL, jcr->dir_impl->res.job->resource_name_,
                                 true)) {
           ua->ErrorMsg(_("Unauthorized command from this console.\n"));
           goto bail_out;
@@ -1624,7 +1624,7 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
         continue;
       }
       tjobs++; /* Count of all jobs */
-      if (!ua->AclAccessOk(Job_ACL, jcr->impl->res.job->resource_name_)) {
+      if (!ua->AclAccessOk(Job_ACL, jcr->dir_impl->res.job->resource_name_)) {
         continue; /* Skip not authorized */
       }
       njobs++; /* Count of authorized jobs */
@@ -1682,7 +1682,7 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
           continue;
         }
 
-        if (!ua->AclAccessOk(Job_ACL, jcr->impl->res.job->resource_name_)) {
+        if (!ua->AclAccessOk(Job_ACL, jcr->dir_impl->res.job->resource_name_)) {
           continue; /* Skip not authorized */
         }
 
@@ -1739,7 +1739,7 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
         if (jcr->JobId == 0) { /* This is us */
           continue;
         }
-        if (!ua->AclAccessOk(Job_ACL, jcr->impl->res.job->resource_name_)) {
+        if (!ua->AclAccessOk(Job_ACL, jcr->dir_impl->res.job->resource_name_)) {
           continue; /* Skip not authorized */
         }
         Bsnprintf(buf, sizeof(buf), _("JobId=%s Job=%s"),

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -31,7 +31,7 @@
 #include "dird/dird_globals.h"
 #include "dird/authenticate.h"
 #include "dird/authenticate_console.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/pthread_detach_if_not_detached.h"
 #include "dird/ua_cmds.h"
@@ -58,14 +58,14 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 
   // exclude JT_SYSTEM job from shared config counting
   if (job_type == JT_SYSTEM) {
-    jcr->impl->job_config_resources_container_ = nullptr;
+    jcr->dir_impl->job_config_resources_container_ = nullptr;
   }
 
   /* The job and defaults are not really used, but we set them up to ensure that
    * everything is correctly initialized. */
   LockRes(my_config);
-  jcr->impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
-  SetJcrDefaults(jcr, jcr->impl->res.job);
+  jcr->dir_impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
+  SetJcrDefaults(jcr, jcr->dir_impl->res.job);
   UnlockRes(my_config);
 
   jcr->sd_auth_key = strdup("dummy"); /* dummy Storage daemon key */

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -31,7 +31,7 @@
 
 #include "include/bareos.h"
 #include "dird.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 #include "dird/sd_cmds.h"
 #include "dird/storage.h"
@@ -1014,7 +1014,7 @@ static void UpdateSlots(UaContext* ua)
     have_enabled = false;
   }
 
-  max_slots = GetNumSlots(ua, ua->jcr->impl->res.write_storage);
+  max_slots = GetNumSlots(ua, ua->jcr->dir_impl->res.write_storage);
   Dmsg1(100, "max_slots=%d\n", max_slots);
   if (max_slots <= 0) {
     ua->WarningMsg(_("No slots in changer to scan.\n"));

--- a/core/src/filed/authenticate.cc
+++ b/core/src/filed/authenticate.cc
@@ -29,7 +29,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "filed/restore.h"
 #include "lib/bnet.h"
 #include "lib/bsock.h"
@@ -146,7 +146,7 @@ bool AuthenticateDirector(JobControlRecord* jcr)
     return false;
   }
 
-  jcr->impl->director = director;
+  jcr->fd_impl->director = director;
 
   return dir->fsend("%s", (me->compatible) ? OK_hello_compat : OK_hello);
 }

--- a/core/src/filed/compression.cc
+++ b/core/src/filed/compression.cc
@@ -32,7 +32,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 
 #if defined(HAVE_LIBZ)
 #  include <zlib.h>
@@ -45,7 +45,7 @@ namespace filedaemon {
 // For compression we enable all used compressors in the fileset.
 bool AdjustCompressionBuffers(JobControlRecord* jcr)
 {
-  findFILESET* fileset = jcr->impl->ff->fileset;
+  findFILESET* fileset = jcr->fd_impl->ff->fileset;
   uint32_t compress_buf_size = 0;
 
   if (fileset) {

--- a/core/src/filed/estimate.cc
+++ b/core/src/filed/estimate.cc
@@ -28,7 +28,7 @@
 
 #include "include/bareos.h"
 #include "filed/filed.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "filed/accurate.h"
 
 namespace filedaemon {
@@ -42,14 +42,15 @@ int MakeEstimate(JobControlRecord* jcr)
 
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
-  SetFindOptions((FindFilesPacket*)jcr->impl->ff, jcr->impl->incremental,
-                 jcr->impl->since_time);
+  SetFindOptions((FindFilesPacket*)jcr->fd_impl->ff, jcr->fd_impl->incremental,
+                 jcr->fd_impl->since_time);
   /* in accurate mode, we overwrite the find_one check function */
   if (jcr->accurate) {
-    SetFindChangedFunction((FindFilesPacket*)jcr->impl->ff, AccurateCheckFile);
+    SetFindChangedFunction((FindFilesPacket*)jcr->fd_impl->ff,
+                           AccurateCheckFile);
   }
 
-  status = FindFiles(jcr, (FindFilesPacket*)jcr->impl->ff, TallyFile,
+  status = FindFiles(jcr, (FindFilesPacket*)jcr->fd_impl->ff, TallyFile,
                      PluginEstimate);
   AccurateFree(jcr);
   return status;
@@ -103,9 +104,9 @@ static int TallyFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
     }
 #endif
   }
-  jcr->impl->num_files_examined++;
+  jcr->fd_impl->num_files_examined++;
   jcr->JobFiles++; /* increment number of files seen */
-  if (jcr->impl->listing) {
+  if (jcr->fd_impl->listing) {
     memcpy(&attr.statp, &ff_pkt->statp, sizeof(struct stat));
     attr.type = ff_pkt->type;
     attr.ofname = (POOLMEM*)ff_pkt->fname;

--- a/core/src/filed/evaluate_job_command.cc
+++ b/core/src/filed/evaluate_job_command.cc
@@ -1,7 +1,7 @@
 /**
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -33,10 +33,10 @@ JobCommand::JobCommand(const char* msg) : job_{0}, sd_auth_key_{0}
 {
   ProtocolVersion protocol = ProtocolVersion::kVersionUndefinded;
 
-  std::vector<ProtocolVersion> implemented_protocols{
+  std::vector<ProtocolVersion> fd_implemented_protocols{
       ProtocolVersion::kVersionFrom_18_2, ProtocolVersion::KVersionBefore_18_2};
 
-  for (auto protocol_try : implemented_protocols) {
+  for (auto protocol_try : fd_implemented_protocols) {
     switch (protocol_try) {
       case ProtocolVersion::kVersionFrom_18_2:
         if (sscanf(msg, jobcmdssl_.c_str(), &job_id_, job_, &vol_session_id_,

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -32,7 +32,7 @@
 #include "filed/heartbeat.h"
 #include "filed/fileset.h"
 #include "filed/heartbeat.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "findlib/attribs.h"
 #include "findlib/find.h"
 #include "findlib/find_one.h"
@@ -740,8 +740,8 @@ int PluginSave(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
         goto bail_out;
       }
 
-      jcr->impl->plugin_sp = &sp;
-      ff_pkt = jcr->impl->ff;
+      jcr->fd_impl->plugin_sp = &sp;
+      ff_pkt = jcr->fd_impl->ff;
 
       // Save original flags.
       CopyBits(FO_MAX, ff_pkt->flags, flags);
@@ -987,13 +987,13 @@ int PluginEstimate(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
           default:
             break;
         }
-        jcr->impl->num_files_examined++;
+        jcr->fd_impl->num_files_examined++;
 
         if (sp.type != FT_LNKSAVED && S_ISREG(sp.statp.st_mode)) {
           if (sp.statp.st_size > 0) { jcr->JobBytes += sp.statp.st_size; }
         }
 
-        if (jcr->impl->listing) {
+        if (jcr->fd_impl->listing) {
           memcpy(&attr.statp, &sp.statp, sizeof(struct stat));
           attr.type = sp.type;
           attr.ofname = (POOLMEM*)sp.fname;
@@ -1033,7 +1033,7 @@ bool SendPluginName(JobControlRecord* jcr, BareosSocket* sd, bool start)
 {
   int status;
   int index = jcr->JobFiles;
-  struct save_pkt* sp = (struct save_pkt*)jcr->impl->plugin_sp;
+  struct save_pkt* sp = (struct save_pkt*)jcr->fd_impl->plugin_sp;
 
   if (!sp) {
     Jmsg0(jcr, M_FATAL, 0, _("Plugin save packet not found.\n"));
@@ -1229,7 +1229,7 @@ int PluginCreateFile(JobControlRecord* jcr,
   rp.olname = attr->olname;
   rp.where = jcr->where;
   rp.RegexWhere = jcr->RegexWhere;
-  rp.replace = jcr->impl->replace;
+  rp.replace = jcr->fd_impl->replace;
   rp.create_status = CF_ERROR;
 
   Dmsg4(debuglevel,
@@ -1321,7 +1321,7 @@ bool PluginSetAttributes(JobControlRecord* jcr,
   rp.olname = attr->olname;
   rp.where = jcr->where;
   rp.RegexWhere = jcr->RegexWhere;
-  rp.replace = jcr->impl->replace;
+  rp.replace = jcr->fd_impl->replace;
   rp.create_status = CF_ERROR;
 
   PlugFunc(plugin)->setFileAttributes(jcr->plugin_ctx, &rp);
@@ -2049,7 +2049,7 @@ static bRC bareosGetValue(PluginContext* ctx, bVariable var, void* value)
               NPRT(*((char**)value)));
         break;
       case bVarPrevJobName:
-        *((char**)value) = jcr->impl->PrevJob;
+        *((char**)value) = jcr->fd_impl->PrevJob;
         Dmsg1(debuglevel, "fd-plugin: return bVarPrevJobName=%s\n",
               NPRT(*((char**)value)));
         break;
@@ -2059,9 +2059,9 @@ static bRC bareosGetValue(PluginContext* ctx, bVariable var, void* value)
               jcr->getJobStatus());
         break;
       case bVarSinceTime:
-        *((int*)value) = (int)jcr->impl->since_time;
+        *((int*)value) = (int)jcr->fd_impl->since_time;
         Dmsg1(debuglevel, "fd-plugin: return bVarSinceTime=%d\n",
-              (int)jcr->impl->since_time);
+              (int)jcr->fd_impl->since_time);
         break;
       case bVarAccurate:
         *((int*)value) = (int)jcr->accurate;
@@ -2072,8 +2072,8 @@ static bRC bareosGetValue(PluginContext* ctx, bVariable var, void* value)
         break; /* a write only variable, ignore read request */
       case bVarVssClient:
 #ifdef HAVE_WIN32
-        if (jcr->impl->pVSSClient) {
-          *(void**)value = jcr->impl->pVSSClient;
+        if (jcr->fd_impl->pVSSClient) {
+          *(void**)value = jcr->fd_impl->pVSSClient;
           Dmsg1(debuglevel, "fd-plugin: return bVarVssClient=%p\n",
                 *(void**)value);
           break;
@@ -2114,7 +2114,7 @@ static bRC bareosSetValue(PluginContext* ctx, bVariable var, void* value)
 
   switch (var) {
     case bVarSinceTime:
-      jcr->impl->since_time = (*(int*)value);
+      jcr->fd_impl->since_time = (*(int*)value);
       break;
     case bVarLevel:
       jcr->setJobLevel(*(int*)value);
@@ -2124,7 +2124,7 @@ static bRC bareosSetValue(PluginContext* ctx, bVariable var, void* value)
       break;
     default:
       Jmsg1(jcr, M_ERROR, 0,
-            "Warning: bareosSetValue not implemented for var %d.\n", var);
+            "Warning: bareosSetValue not fd_implemented for var %d.\n", var);
       break;
   }
 
@@ -2278,12 +2278,14 @@ static bRC bareosAddExclude(PluginContext* ctx, const char* fname)
   // Not right time to add exlude
   if (!old) { return bRC_Error; }
 
-  if (!bctx->exclude) { bctx->exclude = new_exclude(jcr->impl->ff->fileset); }
+  if (!bctx->exclude) {
+    bctx->exclude = new_exclude(jcr->fd_impl->ff->fileset);
+  }
 
   // Set the Exclude context
   SetIncexe(jcr, bctx->exclude);
 
-  AddFileToFileset(jcr, fname, true, jcr->impl->ff->fileset);
+  AddFileToFileset(jcr, fname, true, jcr->fd_impl->ff->fileset);
 
   // Restore the current context
   SetIncexe(jcr, old);
@@ -2316,7 +2318,7 @@ static bRC bareosAddInclude(PluginContext* ctx, const char* fname)
   if (!bctx->include) { bctx->include = old; }
 
   SetIncexe(jcr, bctx->include);
-  AddFileToFileset(jcr, fname, true, jcr->impl->ff->fileset);
+  AddFileToFileset(jcr, fname, true, jcr->fd_impl->ff->fileset);
 
   // Restore the current context
   SetIncexe(jcr, old);
@@ -2374,7 +2376,7 @@ static bRC bareosNewOptions(PluginContext* ctx)
   b_plugin_ctx* bctx;
 
   if (!IsCtxGood(ctx, jcr, bctx)) { return bRC_Error; }
-  (void)NewOptions(jcr->impl->ff, jcr->impl->ff->fileset->incexe);
+  (void)NewOptions(jcr->fd_impl->ff, jcr->fd_impl->ff->fileset->incexe);
 
   return bRC_OK;
 }
@@ -2385,7 +2387,7 @@ static bRC bareosNewInclude(PluginContext* ctx)
   b_plugin_ctx* bctx;
 
   if (!IsCtxGood(ctx, jcr, bctx)) { return bRC_Error; }
-  (void)new_include(jcr->impl->ff->fileset);
+  (void)new_include(jcr->fd_impl->ff->fileset);
 
   return bRC_OK;
 }
@@ -2397,8 +2399,8 @@ static bRC bareosNewPreInclude(PluginContext* ctx)
 
   if (!IsCtxGood(ctx, jcr, bctx)) { return bRC_Error; }
 
-  bctx->include = new_preinclude(jcr->impl->ff->fileset);
-  NewOptions(jcr->impl->ff, bctx->include);
+  bctx->include = new_preinclude(jcr->fd_impl->ff->fileset);
+  NewOptions(jcr->fd_impl->ff, bctx->include);
   SetIncexe(jcr, bctx->include);
 
   return bRC_OK;
@@ -2416,7 +2418,7 @@ static bRC bareosCheckChanges(PluginContext* ctx, struct save_pkt* sp)
 
   if (!sp) { goto bail_out; }
 
-  ff_pkt = jcr->impl->ff;
+  ff_pkt = jcr->fd_impl->ff;
   /*
    * Copy fname and link because SaveFile() zaps them.
    * This avoids zapping the plugin's strings.
@@ -2462,7 +2464,7 @@ static bRC bareosAcceptFile(PluginContext* ctx, struct save_pkt* sp)
   if (!IsCtxGood(ctx, jcr, bctx)) { goto bail_out; }
   if (!sp) { goto bail_out; }
 
-  ff_pkt = jcr->impl->ff;
+  ff_pkt = jcr->fd_impl->ff;
 
   ff_pkt->fname = sp->fname;
   memcpy(&ff_pkt->statp, &sp->statp, sizeof(ff_pkt->statp));

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -340,7 +340,7 @@ static bool CheckResources()
 #endif
     }
 
-    /* pki_encrypt implies pki_sign */
+    /* pki_encrypt fd_implies pki_sign */
     if (me->pki_encrypt) { me->pki_sign = true; }
 
     if ((me->pki_encrypt || me->pki_sign) && !me->pki_keypair_file) {

--- a/core/src/filed/filed_jcr_impl.h
+++ b/core/src/filed/filed_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -21,8 +21,8 @@
    02110-1301, USA.
 */
 
-#ifndef BAREOS_FILED_JCR_PRIVATE_H_
-#define BAREOS_FILED_JCR_PRIVATE_H_
+#ifndef BAREOS_FILED_FILED_JCR_IMPL_H_
+#define BAREOS_FILED_FILED_JCR_IMPL_H_
 
 #include "include/bareos.h"
 
@@ -49,7 +49,7 @@ struct CryptoContext {
   int32_t pki_session_encoded_size{}; /**< Size of DER-encoded pki_session */
 };
 
-struct JobControlRecordPrivate {
+struct FiledJcrImpl {
   uint32_t num_files_examined{};  /**< Files examined this job */
   POOLMEM* last_fname{};          /**< Last file saved/verified */
   POOLMEM* job_metadata{};        /**< VSS job metadata */
@@ -89,4 +89,4 @@ struct JobControlRecordPrivate {
 };
 /* clang-format on */
 
-#endif  // BAREOS_FILED_JCR_PRIVATE_H_
+#endif  // BAREOS_FILED_FILED_JCR_IMPL_H_

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -29,7 +29,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "filed/compression.h"
 #include "filed/crypto.h"
 #include "filed/restore.h"
@@ -130,7 +130,7 @@ static int BcloseChksize(JobControlRecord* jcr,
     Qmsg3(jcr, M_WARNING, 0,
           _("Size of data or stream of %s not correct. Original %s, restored "
             "%s.\n"),
-          jcr->impl->last_fname, edit_uint64(osize, ec1),
+          jcr->fd_impl->last_fname, edit_uint64(osize, ec1),
           edit_uint64(fsize, ec2));
     return -1;
   }
@@ -149,16 +149,16 @@ static inline bool RestoreFinderinfo(JobControlRecord* jcr,
   attrList.commonattr = ATTR_CMN_FNDRINFO;
 
   Dmsg0(130, "Restoring Finder Info\n");
-  SetBit(FO_HFSPLUS, jcr->impl->ff->flags);
+  SetBit(FO_HFSPLUS, jcr->fd_impl->ff->flags);
   if (buflen != 32) {
     Jmsg(jcr, M_WARNING, 0,
          _("Invalid length of Finder Info (got %d, not 32)\n"), buflen);
     return false;
   }
 
-  if (setattrlist(jcr->impl->last_fname, &attrList, buf, buflen, 0) != 0) {
+  if (setattrlist(jcr->fd_impl->last_fname, &attrList, buf, buflen, 0) != 0) {
     Jmsg(jcr, M_WARNING, 0, _("Could not set Finder Info on %s\n"),
-         jcr->impl->last_fname);
+         jcr->fd_impl->last_fname);
     return false;
   }
 
@@ -216,14 +216,14 @@ static inline bool do_reStoreAcl(JobControlRecord* jcr,
 {
   bacl_exit_code retval;
 
-  jcr->impl->acl_data->last_fname = jcr->impl->last_fname;
+  jcr->fd_impl->acl_data->last_fname = jcr->fd_impl->last_fname;
   switch (stream) {
     case STREAM_ACL_PLUGIN:
-      retval = plugin_parse_acl_streams(jcr, jcr->impl->acl_data.get(), stream,
-                                        content, content_length);
+      retval = plugin_parse_acl_streams(jcr, jcr->fd_impl->acl_data.get(),
+                                        stream, content, content_length);
       break;
     default:
-      retval = parse_acl_streams(jcr, jcr->impl->acl_data.get(), stream,
+      retval = parse_acl_streams(jcr, jcr->fd_impl->acl_data.get(), stream,
                                  content, content_length);
       break;
   }
@@ -237,11 +237,11 @@ static inline bool do_reStoreAcl(JobControlRecord* jcr,
        * ACL_REPORT_ERR_MAX_PER_JOB print the error message set by the lower
        * level routine in jcr->errmsg.
        */
-      if (jcr->impl->acl_data->u.parse->nr_errors
+      if (jcr->fd_impl->acl_data->u.parse->nr_errors
           < ACL_REPORT_ERR_MAX_PER_JOB) {
         Jmsg(jcr, M_WARNING, 0, "%s", jcr->errmsg);
       }
-      jcr->impl->acl_data->u.parse->nr_errors++;
+      jcr->fd_impl->acl_data->u.parse->nr_errors++;
       break;
     case bacl_exit_ok:
       break;
@@ -261,14 +261,14 @@ static inline bool do_restore_xattr(JobControlRecord* jcr,
 {
   BxattrExitCode retval;
 
-  jcr->impl->xattr_data->last_fname = jcr->impl->last_fname;
+  jcr->fd_impl->xattr_data->last_fname = jcr->fd_impl->last_fname;
   switch (stream) {
     case STREAM_XATTR_PLUGIN:
-      retval = PluginParseXattrStreams(jcr, jcr->impl->xattr_data.get(), stream,
-                                       content, content_length);
+      retval = PluginParseXattrStreams(jcr, jcr->fd_impl->xattr_data.get(),
+                                       stream, content, content_length);
       break;
     default:
-      retval = ParseXattrStreams(jcr, jcr->impl->xattr_data.get(), stream,
+      retval = ParseXattrStreams(jcr, jcr->fd_impl->xattr_data.get(), stream,
                                  content, content_length);
       break;
   }
@@ -281,7 +281,7 @@ static inline bool do_restore_xattr(JobControlRecord* jcr,
       break;
     case BxattrExitCode::kError:
       Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
-      jcr->impl->xattr_data->u.parse->nr_errors++;
+      jcr->fd_impl->xattr_data->u.parse->nr_errors++;
       break;
     case BxattrExitCode::kSuccess:
       break;
@@ -471,16 +471,16 @@ void DoRestore(JobControlRecord* jcr)
   binit(&rctx.forkbfd);
   attr = rctx.attr = new_attr(jcr);
   if (have_acl) {
-    jcr->impl->acl_data = std::make_unique<AclData>();
-    jcr->impl->acl_data->u.parse
+    jcr->fd_impl->acl_data = std::make_unique<AclData>();
+    jcr->fd_impl->acl_data->u.parse
         = (acl_parse_data_t*)malloc(sizeof(acl_parse_data_t));
-    memset(jcr->impl->acl_data->u.parse, 0, sizeof(acl_parse_data_t));
+    memset(jcr->fd_impl->acl_data->u.parse, 0, sizeof(acl_parse_data_t));
   }
   if (have_xattr) {
-    jcr->impl->xattr_data = std::make_unique<XattrData>();
-    jcr->impl->xattr_data->u.parse
+    jcr->fd_impl->xattr_data = std::make_unique<XattrData>();
+    jcr->fd_impl->xattr_data->u.parse
         = (xattr_parse_data_t*)malloc(sizeof(xattr_parse_data_t));
-    memset(jcr->impl->xattr_data->u.parse, 0, sizeof(xattr_parse_data_t));
+    memset(jcr->fd_impl->xattr_data->u.parse, 0, sizeof(xattr_parse_data_t));
   }
 
   while (BgetMsg(sd) >= 0 && !JobCanceled(jcr)) {
@@ -572,20 +572,21 @@ void DoRestore(JobControlRecord* jcr)
          * Try to actually create the file, which returns a status telling
          * us if we need to extract or not.
          */
-        jcr->impl->num_files_examined++;
+        jcr->fd_impl->num_files_examined++;
         rctx.extract = false;
         status = CF_CORE; /* By default, let Bareos's core handle it */
 
         if (jcr->IsPlugin()) {
-          status = PluginCreateFile(jcr, attr, &rctx.bfd, jcr->impl->replace);
+          status
+              = PluginCreateFile(jcr, attr, &rctx.bfd, jcr->fd_impl->replace);
         }
 
         if (status == CF_CORE) {
-          status = CreateFile(jcr, attr, &rctx.bfd, jcr->impl->replace);
+          status = CreateFile(jcr, attr, &rctx.bfd, jcr->fd_impl->replace);
         }
         jcr->lock();
-        PmStrcpy(jcr->impl->last_fname, attr->ofname);
-        jcr->impl->last_type = attr->type;
+        PmStrcpy(jcr->fd_impl->last_fname, attr->ofname);
+        jcr->fd_impl->last_type = attr->type;
         jcr->unlock();
         Dmsg2(130, "Outfile=%s CreateFile status=%d\n", attr->ofname, status);
         switch (status) {
@@ -644,7 +645,7 @@ void DoRestore(JobControlRecord* jcr)
           }
 
           // Do we have any keys at all?
-          if (!jcr->impl->crypto.pki_recipients) {
+          if (!jcr->fd_impl->crypto.pki_recipients) {
             Jmsg(jcr, M_ERROR, 0,
                  _("No private decryption keys have been defined to decrypt "
                    "encrypted backup data.\n"));
@@ -653,11 +654,12 @@ void DoRestore(JobControlRecord* jcr)
             break;
           }
 
-          if (jcr->impl->crypto.digest) {
-            CryptoDigestFree(jcr->impl->crypto.digest);
+          if (jcr->fd_impl->crypto.digest) {
+            CryptoDigestFree(jcr->fd_impl->crypto.digest);
           }
-          jcr->impl->crypto.digest = crypto_digest_new(jcr, signing_algorithm);
-          if (!jcr->impl->crypto.digest) {
+          jcr->fd_impl->crypto.digest
+              = crypto_digest_new(jcr, signing_algorithm);
+          if (!jcr->fd_impl->crypto.digest) {
             Jmsg0(jcr, M_FATAL, 0, _("Could not create digest.\n"));
             rctx.extract = false;
             bclose(&rctx.bfd);
@@ -667,7 +669,7 @@ void DoRestore(JobControlRecord* jcr)
           // Decode and save session keys.
           cryptoerr = CryptoSessionDecode(
               (uint8_t*)sd->msg, (uint32_t)sd->message_length,
-              jcr->impl->crypto.pki_recipients, &rctx.cs);
+              jcr->fd_impl->crypto.pki_recipients, &rctx.cs);
           switch (cryptoerr) {
             case CRYPTO_ERROR_NONE:
               // Success
@@ -817,7 +819,7 @@ void DoRestore(JobControlRecord* jcr)
       case STREAM_MACOS_FORK_DATA:
         if (have_darwin_os) {
           ClearAllBits(FO_MAX, rctx.fork_flags);
-          SetBit(FO_HFSPLUS, jcr->impl->ff->flags);
+          SetBit(FO_HFSPLUS, jcr->fd_impl->ff->flags);
 
           if (rctx.stream == STREAM_ENCRYPTED_MACOS_FORK_DATA) {
             SetBit(FO_ENCRYPT, rctx.fork_flags);
@@ -832,12 +834,12 @@ void DoRestore(JobControlRecord* jcr)
 
           if (rctx.extract) {
             if (rctx.prev_stream != rctx.stream) {
-              if (BopenRsrc(&rctx.forkbfd, jcr->impl->last_fname,
+              if (BopenRsrc(&rctx.forkbfd, jcr->fd_impl->last_fname,
                             O_WRONLY | O_TRUNC | O_BINARY, 0)
                   < 0) {
                 Jmsg(jcr, M_WARNING, 0,
                      _("Cannot open resource fork for %s.\n"),
-                     jcr->impl->last_fname);
+                     jcr->fd_impl->last_fname);
                 rctx.extract = false;
                 continue;
               }
@@ -898,8 +900,8 @@ void DoRestore(JobControlRecord* jcr)
          * b)     and it is not a directory (they are never "extracted")
          * c) or the file name is empty
          */
-        if ((!rctx.extract && jcr->impl->last_type != FT_DIREND)
-            || (*jcr->impl->last_fname == 0)) {
+        if ((!rctx.extract && jcr->fd_impl->last_type != FT_DIREND)
+            || (*jcr->fd_impl->last_fname == 0)) {
           break;
         }
         if (have_acl) {
@@ -907,7 +909,7 @@ void DoRestore(JobControlRecord* jcr)
            * For anything that is not a directory we delay
            * the restore of acls till a later stage.
            */
-          if (jcr->impl->last_type != FT_DIREND) {
+          if (jcr->fd_impl->last_type != FT_DIREND) {
             PushDelayedDataStream(rctx, sd);
           } else {
             if (!do_reStoreAcl(jcr, rctx.stream, sd->msg, sd->message_length)) {
@@ -936,8 +938,8 @@ void DoRestore(JobControlRecord* jcr)
          * b)     and it is not a directory (they are never "extracted")
          * c) or the file name is empty
          */
-        if ((!rctx.extract && jcr->impl->last_type != FT_DIREND)
-            || (*jcr->impl->last_fname == 0)) {
+        if ((!rctx.extract && jcr->fd_impl->last_type != FT_DIREND)
+            || (*jcr->fd_impl->last_fname == 0)) {
           break;
         }
         if (have_xattr) {
@@ -945,7 +947,7 @@ void DoRestore(JobControlRecord* jcr)
            * For anything that is not a directory we delay
            * the restore of xattr till a later stage.
            */
-          if (jcr->impl->last_type != FT_DIREND) {
+          if (jcr->fd_impl->last_type != FT_DIREND) {
             PushDelayedDataStream(rctx, sd);
           } else {
             if (!do_restore_xattr(jcr, rctx.stream, sd->msg,
@@ -965,8 +967,8 @@ void DoRestore(JobControlRecord* jcr)
          * b)     and it is not a directory (they are never "extracted")
          * c) or the file name is empty
          */
-        if ((!rctx.extract && jcr->impl->last_type != FT_DIREND)
-            || (*jcr->impl->last_fname == 0)) {
+        if ((!rctx.extract && jcr->fd_impl->last_type != FT_DIREND)
+            || (*jcr->fd_impl->last_fname == 0)) {
           break;
         }
         if (have_xattr) {
@@ -994,7 +996,7 @@ void DoRestore(JobControlRecord* jcr)
                    == NULL) {
           Jmsg1(jcr, M_ERROR, 0,
                 _("Failed to decode message signature for %s\n"),
-                jcr->impl->last_fname);
+                jcr->fd_impl->last_fname);
         }
         break;
 
@@ -1055,15 +1057,15 @@ ok_out:
   // First output the statistics.
   Dmsg2(10, "End Do Restore. Files=%d Bytes=%s\n", jcr->JobFiles,
         edit_uint64(jcr->JobBytes, ec1));
-  if (have_acl && jcr->impl->acl_data->u.parse->nr_errors > 0) {
+  if (have_acl && jcr->fd_impl->acl_data->u.parse->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
          _("Encountered %ld acl errors while doing restore\n"),
-         jcr->impl->acl_data->u.parse->nr_errors);
+         jcr->fd_impl->acl_data->u.parse->nr_errors);
   }
-  if (have_xattr && jcr->impl->xattr_data->u.parse->nr_errors > 0) {
+  if (have_xattr && jcr->fd_impl->xattr_data->u.parse->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
          _("Encountered %ld xattr errors while doing restore\n"),
-         jcr->impl->xattr_data->u.parse->nr_errors);
+         jcr->fd_impl->xattr_data->u.parse->nr_errors);
   }
   if (non_support_data > 1 || non_support_attr > 1) {
     Jmsg(jcr, M_WARNING, 0,
@@ -1095,9 +1097,9 @@ ok_out:
   // Free Signature & Crypto Data
   FreeSignature(rctx);
   FreeSession(rctx);
-  if (jcr->impl->crypto.digest) {
-    CryptoDigestFree(jcr->impl->crypto.digest);
-    jcr->impl->crypto.digest = NULL;
+  if (jcr->fd_impl->crypto.digest) {
+    CryptoDigestFree(jcr->fd_impl->crypto.digest);
+    jcr->fd_impl->crypto.digest = NULL;
   }
 
   // Free file cipher restore context
@@ -1121,10 +1123,12 @@ ok_out:
     rctx.fork_cipher_ctx.buf = NULL;
   }
 
-  if (have_acl && jcr->impl->acl_data) { free(jcr->impl->acl_data->u.parse); }
+  if (have_acl && jcr->fd_impl->acl_data) {
+    free(jcr->fd_impl->acl_data->u.parse);
+  }
 
-  if (have_xattr && jcr->impl->xattr_data) {
-    free(jcr->impl->xattr_data->u.parse);
+  if (have_xattr && jcr->fd_impl->xattr_data) {
+    free(jcr->fd_impl->xattr_data->u.parse);
   }
 
   // Free the delayed stream stack list.
@@ -1143,7 +1147,7 @@ ok_out:
 int DoFileDigest(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
 {
   Dmsg1(50, "DoFileDigest jcr=%p\n", jcr);
-  return (DigestFile(jcr, ff_pkt, jcr->impl->crypto.digest));
+  return (DigestFile(jcr, ff_pkt, jcr->fd_impl->crypto.digest));
 }
 
 bool SparseData(JobControlRecord* jcr,
@@ -1163,7 +1167,7 @@ bool SparseData(JobControlRecord* jcr,
     if (blseek(bfd, (boffset_t)*addr, SEEK_SET) < 0) {
       BErrNo be;
       Jmsg3(jcr, M_ERROR, 0, _("Seek to %s error on %s: ERR=%s\n"),
-            edit_uint64(*addr, ec1), jcr->impl->last_fname,
+            edit_uint64(*addr, ec1), jcr->fd_impl->last_fname,
             be.bstrerror(bfd->BErrNo));
       return false;
     }
@@ -1179,8 +1183,8 @@ bool StoreData(JobControlRecord* jcr,
                const int32_t length,
                bool win32_decomp)
 {
-  if (jcr->impl->crypto.digest) {
-    CryptoDigestUpdate(jcr->impl->crypto.digest, (uint8_t*)data, length);
+  if (jcr->fd_impl->crypto.digest) {
+    CryptoDigestUpdate(jcr->fd_impl->crypto.digest, (uint8_t*)data, length);
   }
 
   if (win32_decomp) {
@@ -1188,7 +1192,7 @@ bool StoreData(JobControlRecord* jcr,
       BErrNo be;
       Jmsg2(jcr, M_ERROR, 0,
             _("Write error in Win32 Block Decomposition on %s: %s\n"),
-            jcr->impl->last_fname, be.bstrerror(bfd->BErrNo));
+            jcr->fd_impl->last_fname, be.bstrerror(bfd->BErrNo));
       return false;
     }
 #ifdef HAVE_WIN32
@@ -1198,22 +1202,22 @@ bool StoreData(JobControlRecord* jcr,
           != (ssize_t)length) {
         BErrNo be;
         Jmsg2(jcr, M_ERROR, 0, _("Write error on %s: %s\n"),
-              jcr->impl->last_fname, be.bstrerror(bfd->BErrNo));
+              jcr->fd_impl->last_fname, be.bstrerror(bfd->BErrNo));
         return false;
       }
     } else {
       if (bwrite(bfd, data, length) != (ssize_t)length) {
         BErrNo be;
         Jmsg2(jcr, M_ERROR, 0, _("Write error on %s: %s\n"),
-              jcr->impl->last_fname, be.bstrerror(bfd->BErrNo));
+              jcr->fd_impl->last_fname, be.bstrerror(bfd->BErrNo));
       }
     }
   }
 #else
   } else if (bwrite(bfd, data, length) != (ssize_t)length) {
     BErrNo be;
-    Jmsg2(jcr, M_ERROR, 0, _("Write error on %s: %s\n"), jcr->impl->last_fname,
-          be.bstrerror(bfd->BErrNo));
+    Jmsg2(jcr, M_ERROR, 0, _("Write error on %s: %s\n"),
+          jcr->fd_impl->last_fname, be.bstrerror(bfd->BErrNo));
     return false;
   }
 #endif
@@ -1256,7 +1260,7 @@ int32_t ExtractData(JobControlRecord* jcr,
   }
 
   if (BitIsSet(FO_COMPRESS, flags)) {
-    if (!DecompressData(jcr, jcr->impl->last_fname, stream, &wbuf, &wsize,
+    if (!DecompressData(jcr, jcr->fd_impl->last_fname, stream, &wbuf, &wsize,
                         false)) {
       goto bail_out;
     }
@@ -1333,7 +1337,7 @@ static bool ClosePreviousStream(JobControlRecord* jcr, r_ctx& rctx)
     // Free Signature
     FreeSignature(rctx);
     FreeSession(rctx);
-    ClearAllBits(FO_MAX, rctx.jcr->impl->ff->flags);
+    ClearAllBits(FO_MAX, rctx.jcr->fd_impl->ff->flags);
     Dmsg0(130, "Stop extracting.\n");
   } else if (IsBopen(&rctx.bfd)) {
     Jmsg0(rctx.jcr, M_ERROR, 0,

--- a/core/src/filed/sd_cmds.cc
+++ b/core/src/filed/sd_cmds.cc
@@ -27,7 +27,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "filed/authenticate.h"
 #include "lib/bnet.h"
 #include "lib/bsock.h"
@@ -91,8 +91,8 @@ void* handle_stored_connection(BareosSocket* sd)
   }
 
   if (!jcr->max_bandwidth) {
-    if (jcr->impl->director->max_bandwidth_per_job) {
-      jcr->max_bandwidth = jcr->impl->director->max_bandwidth_per_job;
+    if (jcr->fd_impl->director->max_bandwidth_per_job) {
+      jcr->max_bandwidth = jcr->fd_impl->director->max_bandwidth_per_job;
     } else if (me->max_bandwidth_per_job) {
       jcr->max_bandwidth = me->max_bandwidth_per_job;
     }

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -30,7 +30,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "lib/status_packet.h"
 #include "lib/bsock.h"
 #include "lib/edit.h"
@@ -169,21 +169,21 @@ static void ListRunningJobsPlain(StatusPacket* sp)
                  njcr->Job);
       sp->send(msg, len);
 #ifdef WIN32_VSS
-      len = Mmsg(
-          msg, _("    %s%s %s Job started: %s\n"),
-          (njcr->impl->pVSSClient && njcr->impl->pVSSClient->IsInitialized())
-              ? "VSS "
-              : "",
-          JobLevelToString(njcr->getJobLevel()),
-          job_type_to_str(njcr->getJobType()), dt);
+      len = Mmsg(msg, _("    %s%s %s Job started: %s\n"),
+                 (njcr->fd_impl->pVSSClient
+                  && njcr->fd_impl->pVSSClient->IsInitialized())
+                     ? "VSS "
+                     : "",
+                 JobLevelToString(njcr->getJobLevel()),
+                 job_type_to_str(njcr->getJobType()), dt);
 #else
       len = Mmsg(msg, _("    %s %s Job started: %s\n"),
                  JobLevelToString(njcr->getJobLevel()),
                  job_type_to_str(njcr->getJobType()), dt);
 #endif
-    } else if ((njcr->JobId == 0) && (njcr->impl->director)) {
+    } else if ((njcr->JobId == 0) && (njcr->fd_impl->director)) {
       len = Mmsg(msg, _("%s (director) connected at: %s\n"),
-                 njcr->impl->director->resource_name_, dt);
+                 njcr->fd_impl->director->resource_name_, dt);
     } else {
       /*
        * This should only occur shortly, until the JobControlRecord values are
@@ -205,11 +205,12 @@ static void ListRunningJobsPlain(StatusPacket* sp)
                edit_uint64_with_commas(njcr->max_bandwidth, b4));
     sp->send(msg, len);
     len = Mmsg(msg, _("    Files Examined=%s\n"),
-               edit_uint64_with_commas(njcr->impl->num_files_examined, b1));
+               edit_uint64_with_commas(njcr->fd_impl->num_files_examined, b1));
     sp->send(msg, len);
     if (njcr->JobFiles > 0) {
       njcr->lock();
-      len = Mmsg(msg, _("    Processing file: %s\n"), njcr->impl->last_fname);
+      len = Mmsg(msg, _("    Processing file: %s\n"),
+                 njcr->fd_impl->last_fname);
       njcr->unlock();
       sp->send(msg, len);
     }
@@ -242,7 +243,7 @@ static void ListRunningJobsApi(StatusPacket* sp)
   PoolMem msg(PM_MESSAGE);
   char dt[MAX_TIME_LENGTH], b1[32], b2[32], b3[32], b4[32];
 
-  // List running jobs for Bat/Bweb (simple to parse)
+  // List running jobs for Bat/Bweb (sfd_imple to parse)
   foreach_jcr (njcr) {
     bstrutime(dt, sizeof(dt), njcr->start_time);
     if (njcr->JobId == 0) {
@@ -251,12 +252,12 @@ static void ListRunningJobsApi(StatusPacket* sp)
       len = Mmsg(msg, "JobId=%d\n Job=%s\n", njcr->JobId, njcr->Job);
       sp->send(msg, len);
 #ifdef WIN32_VSS
-      len = Mmsg(
-          msg, " VSS=%d\n Level=%c\n JobType=%c\n JobStarted=%s\n",
-          (njcr->impl->pVSSClient && njcr->impl->pVSSClient->IsInitialized())
-              ? 1
-              : 0,
-          njcr->getJobLevel(), njcr->getJobType(), dt);
+      len = Mmsg(msg, " VSS=%d\n Level=%c\n JobType=%c\n JobStarted=%s\n",
+                 (njcr->fd_impl->pVSSClient
+                  && njcr->fd_impl->pVSSClient->IsInitialized())
+                     ? 1
+                     : 0,
+                 njcr->getJobLevel(), njcr->getJobType(), dt);
 #else
       len = Mmsg(msg, " VSS=%d\n Level=%c\n JobType=%c\n JobStarted=%s\n", 0,
                  njcr->getJobLevel(), njcr->getJobType(), dt);
@@ -275,11 +276,11 @@ static void ListRunningJobsApi(StatusPacket* sp)
                edit_int64(njcr->max_bandwidth, b4));
     sp->send(msg, len);
     len = Mmsg(msg, " Files Examined=%s\n",
-               edit_uint64(njcr->impl->num_files_examined, b1));
+               edit_uint64(njcr->fd_impl->num_files_examined, b1));
     sp->send(msg, len);
     if (njcr->JobFiles > 0) {
       njcr->lock();
-      len = Mmsg(msg, " Processing file=%s\n", njcr->impl->last_fname);
+      len = Mmsg(msg, " Processing file=%s\n", njcr->fd_impl->last_fname);
       njcr->unlock();
       sp->send(msg, len);
     }

--- a/core/src/filed/verify.cc
+++ b/core/src/filed/verify.cc
@@ -27,7 +27,7 @@
 
 #include "include/bareos.h"
 #include "filed/filed.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "findlib/find.h"
 #include "findlib/attribs.h"
 #include "lib/attribs.h"
@@ -64,20 +64,20 @@ void DoVerify(JobControlRecord* jcr)
 {
   jcr->setJobStatusWithPriorityCheck(JS_Running);
   jcr->buf_size = DEFAULT_NETWORK_BUFFER_SIZE;
-  if ((jcr->impl->big_buf = (char*)malloc(jcr->buf_size)) == NULL) {
+  if ((jcr->fd_impl->big_buf = (char*)malloc(jcr->buf_size)) == NULL) {
     Jmsg1(jcr, M_ABORT, 0, _("Cannot malloc %d network read buffer\n"),
           DEFAULT_NETWORK_BUFFER_SIZE);
   }
-  SetFindOptions((FindFilesPacket*)jcr->impl->ff, jcr->impl->incremental,
-                 jcr->impl->since_time);
+  SetFindOptions((FindFilesPacket*)jcr->fd_impl->ff, jcr->fd_impl->incremental,
+                 jcr->fd_impl->since_time);
   Dmsg0(10, "Start find files\n");
   /* Subroutine VerifyFile() is called for each file */
-  FindFiles(jcr, (FindFilesPacket*)jcr->impl->ff, VerifyFile, NULL);
+  FindFiles(jcr, (FindFilesPacket*)jcr->fd_impl->ff, VerifyFile, NULL);
   Dmsg0(10, "End find files\n");
 
-  if (jcr->impl->big_buf) {
-    free(jcr->impl->big_buf);
-    jcr->impl->big_buf = NULL;
+  if (jcr->fd_impl->big_buf) {
+    free(jcr->fd_impl->big_buf);
+    jcr->fd_impl->big_buf = NULL;
   }
   jcr->setJobStatusWithPriorityCheck(JS_Terminated);
 }
@@ -96,7 +96,7 @@ static int VerifyFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   if (JobCanceled(jcr)) { return 0; }
 
   dir = jcr->dir_bsock;
-  jcr->impl->num_files_examined++; /* bump total file count */
+  jcr->fd_impl->num_files_examined++; /* bump total file count */
 
   switch (ff_pkt->type) {
     case FT_LNKSAVED: /* Hard linked, file already saved */
@@ -112,8 +112,8 @@ static int VerifyFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
       Dmsg2(30, "FT_LNK saving: %s -> %s\n", ff_pkt->fname, ff_pkt->link);
       break;
     case FT_DIRBEGIN:
-      jcr->impl->num_files_examined--; /* correct file count */
-      return 1;                        /* ignored */
+      jcr->fd_impl->num_files_examined--; /* correct file count */
+      return 1;                           /* ignored */
     case FT_REPARSE:
     case FT_JUNCTION:
     case FT_DIREND:
@@ -197,7 +197,7 @@ static int VerifyFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
 
   jcr->lock();
   jcr->JobFiles++; /* increment number of files sent */
-  PmStrcpy(jcr->impl->last_fname, ff_pkt->fname);
+  PmStrcpy(jcr->fd_impl->last_fname, ff_pkt->fname);
   jcr->unlock();
 
   /*
@@ -330,7 +330,7 @@ static int ReadDigest(BareosWinFilePacket* bfd,
   char buf[DEFAULT_NETWORK_BUFFER_SIZE];
   int64_t n;
   int64_t bufsiz = (int64_t)sizeof(buf);
-  FindFilesPacket* ff_pkt = (FindFilesPacket*)jcr->impl->ff;
+  FindFilesPacket* ff_pkt = (FindFilesPacket*)jcr->fd_impl->ff;
   uint64_t fileAddr = 0; /* file address */
 
 
@@ -360,10 +360,10 @@ static int ReadDigest(BareosWinFilePacket* bfd,
   if (n < 0) {
     BErrNo be;
     be.SetErrno(bfd->BErrNo);
-    Dmsg2(100, "Error reading file %s: ERR=%s\n", jcr->impl->last_fname,
+    Dmsg2(100, "Error reading file %s: ERR=%s\n", jcr->fd_impl->last_fname,
           be.bstrerror());
     Jmsg(jcr, M_ERROR, 1, _("Error reading file %s: ERR=%s\n"),
-         jcr->impl->last_fname, be.bstrerror());
+         jcr->fd_impl->last_fname, be.bstrerror());
     jcr->JobErrors++;
     return -1;
   }

--- a/core/src/filed/verify_vol.cc
+++ b/core/src/filed/verify_vol.cc
@@ -29,7 +29,7 @@
 #include "include/bareos.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
-#include "filed/jcr_private.h"
+#include "filed/filed_jcr_impl.h"
 #include "lib/bsock.h"
 #include "lib/bget_msg.h"
 #include "lib/bnet.h"
@@ -166,8 +166,8 @@ void DoVerifyVolume(JobControlRecord* jcr)
         }
         jcr->lock();
         jcr->JobFiles++;
-        jcr->impl->num_files_examined++;
-        PmStrcpy(jcr->impl->last_fname, fname); /* last file examined */
+        jcr->fd_impl->num_files_examined++;
+        PmStrcpy(jcr->fd_impl->last_fname, fname); /* last file examined */
         jcr->unlock();
 
         /*
@@ -249,7 +249,7 @@ void DoVerifyVolume(JobControlRecord* jcr)
       case STREAM_RESTORE_OBJECT:
         jcr->lock();
         jcr->JobFiles++;
-        jcr->impl->num_files_examined++;
+        jcr->fd_impl->num_files_examined++;
         jcr->unlock();
 
         Dmsg2(400, "send inx=%d STREAM_RESTORE_OBJECT-%d\n", jcr->JobFiles,

--- a/core/src/include/jcr.h
+++ b/core/src/include/jcr.h
@@ -57,7 +57,9 @@ class JobControlRecord;
 
 struct AttributesDbRecord;
 struct PluginContext;
-struct JobControlRecordPrivate;
+struct DirectorJcrImpl;
+struct StoredJcrImpl;
+struct FiledJcrImpl;
 struct VolumeSessionInfo;
 
 #ifdef HAVE_WIN32
@@ -230,7 +232,12 @@ class JobControlRecord {
   PathList* path_list{};      /**< Directory list (used by findlib) */
   bool is_passive_client_connection_probing{}; /**< Set if director probes a passive client connection */
 
-  JobControlRecordPrivate* impl{nullptr}; /* Pointer to implementation of each daemon */
+  union {
+    DirectorJcrImpl* dir_impl;
+    StoredJcrImpl* sd_impl;
+    FiledJcrImpl* fd_impl;
+  };
+
 };
 /* clang-format on */
 

--- a/core/src/plugins/stored/scsicrypto/scsicrypto-sd.cc
+++ b/core/src/plugins/stored/scsicrypto/scsicrypto-sd.cc
@@ -60,7 +60,7 @@
 #include "include/bareos.h"
 #include "stored/device_control_record.h"
 #include "stored/device_status_information.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/stored.h"
 #include "lib/berrno.h"
 #include "lib/crypto_wrap.h"
@@ -343,8 +343,8 @@ static bRC do_set_scsi_encryption_key(void* value)
    * has been wrapped using RFC3394 key wrapping. We first copy the current
    * wrapped key into a temporary variable for unwrapping.
    */
-  if (dcr->jcr && dcr->jcr->impl->director) {
-    director = dcr->jcr->impl->director;
+  if (dcr->jcr && dcr->jcr->sd_impl->director) {
+    director = dcr->jcr->sd_impl->director;
     if (director->keyencrkey.value) {
       char WrappedVolEncrKey[MAX_NAME_LENGTH];
 

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -30,7 +30,7 @@
 #include "stored/acquire.h"
 #include "stored/fd_cmds.h"
 #include "stored/stored_globals.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/label.h"
 #include "stored/spool.h"
 #include "lib/bget_msg.h"
@@ -101,20 +101,20 @@ bool IsAttribute(DeviceRecord* record)
 static void UpdateFileList(JobControlRecord* jcr)
 {
   Dmsg0(100, _("... update file list\n"));
-  jcr->impl->dcr->DirAskToUpdateFileList();
+  jcr->sd_impl->dcr->DirAskToUpdateFileList();
 }
 
 static void UpdateJobmediaRecord(JobControlRecord* jcr)
 {
   Dmsg0(100, _("... create job media record\n"));
-  jcr->impl->dcr->DirCreateJobmediaRecord(false);
+  jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
 }
 
 static void UpdateJobrecord(JobControlRecord* jcr)
 {
   Dmsg2(100, _("... update job record: %llu bytes %lu files\n"), jcr->JobBytes,
         jcr->JobFiles);
-  jcr->impl->dcr->DirAskToUpdateJobRecord();
+  jcr->sd_impl->dcr->DirAskToUpdateJobRecord();
 }
 
 void DoBackupCheckpoint(JobControlRecord* jcr)
@@ -165,11 +165,11 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   POOLMEM* rec_data;
   char ec[50];
 
-  if (!jcr->impl->dcr) {
+  if (!jcr->sd_impl->dcr) {
     Jmsg0(jcr, M_FATAL, 0, _("DeviceControlRecord is NULL!!!\n"));
     return false;
   }
-  dev = jcr->impl->dcr->dev;
+  dev = jcr->sd_impl->dcr->dev;
   if (!dev) {
     Jmsg0(jcr, M_FATAL, 0, _("Device is NULL!!!\n"));
     return false;
@@ -178,19 +178,20 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   Dmsg1(100, "Start append data. res=%d\n", dev->NumReserved());
 
   if (!bs->SetBufferSize(
-          jcr->impl->dcr->device_resource->max_network_buffer_size,
+          jcr->sd_impl->dcr->device_resource->max_network_buffer_size,
           BNET_SETBUF_WRITE)) {
     Jmsg0(jcr, M_FATAL, 0, _("Unable to set network buffer size.\n"));
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
     return false;
   }
 
-  if (!AcquireDeviceForAppend(jcr->impl->dcr)) {
+  if (!AcquireDeviceForAppend(jcr->sd_impl->dcr)) {
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
     return false;
   }
 
-  if (GeneratePluginEvent(jcr, bSdEventSetupRecordTranslation, jcr->impl->dcr)
+  if (GeneratePluginEvent(jcr, bSdEventSetupRecordTranslation,
+                          jcr->sd_impl->dcr)
       != bRC_OK) {
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
     return false;
@@ -203,13 +204,13 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   }
   Dmsg1(50, "Begin append device=%s\n", dev->print_name());
 
-  if (!BeginDataSpool(jcr->impl->dcr)) {
+  if (!BeginDataSpool(jcr->sd_impl->dcr)) {
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
     return false;
   }
 
   if (!BeginAttributeSpool(jcr)) {
-    DiscardDataSpool(jcr->impl->dcr);
+    DiscardDataSpool(jcr->sd_impl->dcr);
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
     return false;
   }
@@ -220,7 +221,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   }
 
   // Write Begin Session Record
-  if (!WriteSessionLabel(jcr->impl->dcr, SOS_LABEL)) {
+  if (!WriteSessionLabel(jcr->sd_impl->dcr, SOS_LABEL)) {
     Jmsg1(jcr, M_FATAL, 0, _("Write session label failed. ERR=%s\n"),
           dev->bstrerror());
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
@@ -255,7 +256,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
    * file. 1. for the Attributes, 2. for the file data if any,
    * and 3. for the MD5 if any.
    */
-  jcr->impl->dcr->VolFirstIndex = jcr->impl->dcr->VolLastIndex = 0;
+  jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex = 0;
   jcr->run_time = time(NULL); /* start counting time for rates */
 
   auto now
@@ -263,10 +264,10 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   time_t next_checkpoint_time = now + me->checkpoint_interval;
 
   std::vector<ProcessedFile> processed_files{};
-  int64_t current_volumeid = jcr->impl->dcr->VolMediaId;
+  int64_t current_volumeid = jcr->sd_impl->dcr->VolMediaId;
 
   ProcessedFile file_currently_processed;
-  uint32_t current_block_number = jcr->impl->dcr->block->BlockNumber;
+  uint32_t current_block_number = jcr->sd_impl->dcr->block->BlockNumber;
 
   for (last_file_index = 0; ok && !jcr->IsJobCanceled();) {
     /*
@@ -333,47 +334,48 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
      * We save the original data pointer from the record so we can restore
      * that after the loop ends.
      */
-    rec_data = jcr->impl->dcr->rec->data;
+    rec_data = jcr->sd_impl->dcr->rec->data;
     while ((n = BgetMsg(bs)) > 0 && !jcr->IsJobCanceled()) {
-      jcr->impl->dcr->rec->VolSessionId = jcr->VolSessionId;
-      jcr->impl->dcr->rec->VolSessionTime = jcr->VolSessionTime;
-      jcr->impl->dcr->rec->FileIndex = file_index;
-      jcr->impl->dcr->rec->Stream = stream;
-      jcr->impl->dcr->rec->maskedStream
+      jcr->sd_impl->dcr->rec->VolSessionId = jcr->VolSessionId;
+      jcr->sd_impl->dcr->rec->VolSessionTime = jcr->VolSessionTime;
+      jcr->sd_impl->dcr->rec->FileIndex = file_index;
+      jcr->sd_impl->dcr->rec->Stream = stream;
+      jcr->sd_impl->dcr->rec->maskedStream
           = stream & STREAMMASK_TYPE; /* strip high bits */
-      jcr->impl->dcr->rec->data_len = bs->message_length;
-      jcr->impl->dcr->rec->data = bs->msg; /* use message buffer */
+      jcr->sd_impl->dcr->rec->data_len = bs->message_length;
+      jcr->sd_impl->dcr->rec->data = bs->msg; /* use message buffer */
 
       Dmsg4(850, "before writ_rec FI=%d SessId=%d Strm=%s len=%d\n",
-            jcr->impl->dcr->rec->FileIndex, jcr->impl->dcr->rec->VolSessionId,
-            stream_to_ascii(buf1, jcr->impl->dcr->rec->Stream,
-                            jcr->impl->dcr->rec->FileIndex),
-            jcr->impl->dcr->rec->data_len);
+            jcr->sd_impl->dcr->rec->FileIndex,
+            jcr->sd_impl->dcr->rec->VolSessionId,
+            stream_to_ascii(buf1, jcr->sd_impl->dcr->rec->Stream,
+                            jcr->sd_impl->dcr->rec->FileIndex),
+            jcr->sd_impl->dcr->rec->data_len);
 
-      ok = jcr->impl->dcr->WriteRecord();
+      ok = jcr->sd_impl->dcr->WriteRecord();
       if (!ok) {
         Dmsg2(90, "Got WriteBlockToDev error on device %s. %s\n",
-              jcr->impl->dcr->dev->print_name(),
-              jcr->impl->dcr->dev->bstrerror());
+              jcr->sd_impl->dcr->dev->print_name(),
+              jcr->sd_impl->dcr->dev->bstrerror());
         break;
       }
 
-      if (IsAttribute(jcr->impl->dcr->rec)) {
-        file_currently_processed.AddAttribute(jcr->impl->dcr->rec);
+      if (IsAttribute(jcr->sd_impl->dcr->rec)) {
+        file_currently_processed.AddAttribute(jcr->sd_impl->dcr->rec);
       }
 
       if (AttributesAreSpooled(jcr)) {
         SaveFullyProcessedFiles(jcr, processed_files);
       } else {
-        if (current_block_number != jcr->impl->dcr->block->BlockNumber) {
-          current_block_number = jcr->impl->dcr->block->BlockNumber;
+        if (current_block_number != jcr->sd_impl->dcr->block->BlockNumber) {
+          current_block_number = jcr->sd_impl->dcr->block->BlockNumber;
           SaveFullyProcessedFiles(jcr, processed_files);
         }
         if (me->checkpoint_interval) {
-          if (jcr->impl->dcr->VolMediaId != current_volumeid) {
+          if (jcr->sd_impl->dcr->VolMediaId != current_volumeid) {
             Jmsg0(jcr, M_INFO, 0, _("Volume changed, doing checkpoint:\n"));
             DoBackupCheckpoint(jcr);
-            current_volumeid = jcr->impl->dcr->VolMediaId;
+            current_volumeid = jcr->sd_impl->dcr->VolMediaId;
           } else {
             next_checkpoint_time = DoTimedCheckpoint(jcr, next_checkpoint_time,
                                                      me->checkpoint_interval);
@@ -387,7 +389,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
     Dmsg2(650, "End read loop with %s. Stat=%d\n", what, n);
 
     // Restore the original data pointer.
-    jcr->impl->dcr->rec->data = rec_data;
+    jcr->sd_impl->dcr->rec->data = rec_data;
 
     if (bs->IsError()) {
       if (!jcr->IsJobCanceled()) {
@@ -422,7 +424,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
    * if we are at the end of the tape or we got a fatal I/O error.
    */
   if (ok || dev->CanWrite()) {
-    if (!WriteSessionLabel(jcr->impl->dcr, EOS_LABEL)) {
+    if (!WriteSessionLabel(jcr->sd_impl->dcr, EOS_LABEL)) {
       // Print only if ok and not cancelled to avoid spurious messages
       if (ok && !jcr->IsJobCanceled()) {
         Jmsg1(jcr, M_FATAL, 0, _("Error writing end session label. ERR=%s\n"),
@@ -435,7 +437,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
     Dmsg0(90, "back from write_end_session_label()\n");
 
     // Flush out final partial block of this session
-    if (!jcr->impl->dcr->WriteBlockToDevice()) {
+    if (!jcr->sd_impl->dcr->WriteBlockToDevice()) {
       // Print only if ok and not cancelled to avoid spurious messages
       if (ok && !jcr->IsJobCanceled()) {
         Jmsg2(jcr, M_FATAL, 0, _("Fatal append error on device %s: ERR=%s\n"),
@@ -455,14 +457,14 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   }
 
   if (!ok && !jcr->is_JobStatus(JS_Incomplete)) {
-    DiscardDataSpool(jcr->impl->dcr);
+    DiscardDataSpool(jcr->sd_impl->dcr);
   } else {
     // Note: if commit is OK, the device will remain blocked
-    CommitDataSpool(jcr->impl->dcr);
+    CommitDataSpool(jcr->sd_impl->dcr);
   }
 
   // Release the device -- and send final Vol info to DIR and unlock it.
-  ReleaseDevice(jcr->impl->dcr);
+  ReleaseDevice(jcr->sd_impl->dcr);
 
   /*
    * Don't use time_t for job_elapsed as time_t can be 32 or 64 bits,
@@ -491,11 +493,11 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
 // Send attributes and digest to Director for Catalog
 bool SendAttrsToDir(JobControlRecord* jcr, DeviceRecord* rec)
 {
-  if (!jcr->impl->no_attributes) {
+  if (!jcr->sd_impl->no_attributes) {
     BareosSocket* dir = jcr->dir_bsock;
     if (AttributesAreSpooled(jcr)) { dir->SetSpooling(); }
     Dmsg0(850, "Send attributes to dir.\n");
-    if (!jcr->impl->dcr->DirUpdateFileAttributes(rec)) {
+    if (!jcr->sd_impl->dcr->DirUpdateFileAttributes(rec)) {
       Jmsg(jcr, M_FATAL, 0, _("Error updating file attributes. ERR=%s\n"),
            dir->bstrerror());
       dir->ClearSpooling();

--- a/core/src/stored/authenticate.cc
+++ b/core/src/stored/authenticate.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,7 +28,7 @@
 #include "include/bareos.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "lib/parse_conf.h"
 #include "lib/bsock.h"
 #include "lib/bnet_network_dump.h"
@@ -85,7 +85,7 @@ bool AuthenticateDirector(JobControlRecord* jcr)
 
   UnbashSpaces(dirname);
   director = (DirectorResource*)my_config->GetResWithName(R_DIRECTOR, dirname);
-  jcr->impl->director = director;
+  jcr->sd_impl->director = director;
 
   if (!director) {
     Dmsg2(debuglevel, "Connection from unknown Director %s at %s rejected.\n",

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -33,7 +33,7 @@
 #include "stored/acquire.h"
 #include "stored/butil.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/mount.h"
 #include "stored/read_record.h"
 #include "findlib/find.h"
@@ -396,9 +396,9 @@ static void DoExtract(char* devname,
   jcr = SetupJcr("bextract", devname, bsr, director, dcr, VolumeName,
                  true); /* read device */
   if (!jcr) { exit(1); }
-  dev = jcr->impl->read_dcr->dev;
+  dev = jcr->sd_impl->read_dcr->dev;
   if (!dev) { exit(1); }
-  dcr = jcr->impl->read_dcr;
+  dcr = jcr->sd_impl->read_dcr;
 
   // Make sure where directory exists and that it is a directory
   if (stat(where, &statp) < 0) {
@@ -445,7 +445,7 @@ static void DoExtract(char* devname,
 
   CleanupCompression(jcr);
 
-  CleanDevice(jcr->impl->dcr);
+  CleanDevice(jcr->sd_impl->dcr);
   delete dev;
   FreeDeviceControlRecord(dcr);
   FreeJcr(jcr);

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -35,7 +35,7 @@
 #include "stored/acquire.h"
 #include "stored/butil.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/label.h"
 #include "stored/match_bsr.h"
 #include "stored/mount.h"
@@ -238,10 +238,10 @@ int main(int argc, char* argv[])
     jcr = SetupJcr("bls", device.data(), bsr, director, dcr, VolumeNames,
                    true); /* read device */
     if (!jcr) { exit(1); }
-    jcr->impl->ignore_label_errors = ignore_label_errors;
-    dev = jcr->impl->dcr->dev;
+    jcr->sd_impl->ignore_label_errors = ignore_label_errors;
+    dev = jcr->sd_impl->dcr->dev;
     if (!dev) { exit(1); }
-    dcr = jcr->impl->dcr;
+    dcr = jcr->sd_impl->dcr;
     rec = new_record();
     attr = new_attr(jcr);
     /*
@@ -274,9 +274,9 @@ static void do_close(JobControlRecord* jcr)
 {
   FreeAttr(attr);
   FreeRecord(rec);
-  CleanDevice(jcr->impl->dcr);
+  CleanDevice(jcr->sd_impl->dcr);
   delete dev;
-  FreeDeviceControlRecord(jcr->impl->dcr);
+  FreeDeviceControlRecord(jcr->sd_impl->dcr);
   FreeJcr(jcr);
 }
 

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -39,7 +39,7 @@
 #include "stored/device.h"
 #include "stored/device_control_record.h"
 #include "stored/bsr.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "lib/parse_bsr.h"
 #include "lib/parse_conf.h"
 #include "include/jcr.h"
@@ -62,28 +62,28 @@ JobControlRecord* SetupDummyJcr(const char* name,
                                 DirectorResource* director)
 {
   JobControlRecord* jcr = new_jcr(MyFreeJcr);
-  jcr->impl = new JobControlRecordPrivate;
+  jcr->sd_impl = new StoredJcrImpl;
 
-  jcr->impl->read_session.bsr = bsr;
-  jcr->impl->director = director;
+  jcr->sd_impl->read_session.bsr = bsr;
+  jcr->sd_impl->director = director;
   jcr->VolSessionId = 1;
   jcr->VolSessionTime = (uint32_t)time(NULL);
-  jcr->impl->NumReadVolumes = 0;
-  jcr->impl->NumWriteVolumes = 0;
+  jcr->sd_impl->NumReadVolumes = 0;
+  jcr->sd_impl->NumWriteVolumes = 0;
   jcr->JobId = 0;
   jcr->setJobType(JT_CONSOLE);
   jcr->setJobLevel(L_FULL);
   jcr->setJobStatus(JS_Terminated);
   jcr->where = strdup("");
-  jcr->impl->job_name = GetPoolMemory(PM_FNAME);
-  PmStrcpy(jcr->impl->job_name, "Dummy.Job.Name");
+  jcr->sd_impl->job_name = GetPoolMemory(PM_FNAME);
+  PmStrcpy(jcr->sd_impl->job_name, "Dummy.Job.Name");
   jcr->client_name = GetPoolMemory(PM_FNAME);
   PmStrcpy(jcr->client_name, "Dummy.Client.Name");
   bstrncpy(jcr->Job, name, sizeof(jcr->Job));
-  jcr->impl->fileset_name = GetPoolMemory(PM_FNAME);
-  PmStrcpy(jcr->impl->fileset_name, "Dummy.fileset.name");
-  jcr->impl->fileset_md5 = GetPoolMemory(PM_FNAME);
-  PmStrcpy(jcr->impl->fileset_md5, "Dummy.fileset.md5");
+  jcr->sd_impl->fileset_name = GetPoolMemory(PM_FNAME);
+  PmStrcpy(jcr->sd_impl->fileset_name, "Dummy.fileset.name");
+  jcr->sd_impl->fileset_md5 = GetPoolMemory(PM_FNAME);
+  PmStrcpy(jcr->sd_impl->fileset_md5, "Dummy.fileset.md5");
 
   NewPlugins(jcr); /* instantiate plugins */
 
@@ -153,7 +153,7 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
   } else {
     VolName[0] = 0;
   }
-  if (!jcr->impl->read_session.bsr && VolName[0] == 0) {
+  if (!jcr->sd_impl->read_session.bsr && VolName[0] == 0) {
     if (!bstrncmp(dev_name, "/dev/", 5)) {
       /* Try stripping file part */
       p = dev_name + strlen(dev_name);
@@ -178,7 +178,7 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
     return false;
   }
   device_resource->dev = dev;
-  jcr->impl->dcr = dcr;
+  jcr->sd_impl->dcr = dcr;
   SetupNewDcrDevice(jcr, dcr, dev, NULL);
   if (!readonly) { dcr->SetWillWrite(); }
 
@@ -193,7 +193,7 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
   if (readonly) { /* read only access? */
     Dmsg0(100, "Acquire device for read\n");
     if (!AcquireDeviceForRead(dcr)) { return false; }
-    jcr->impl->read_dcr = dcr;
+    jcr->sd_impl->read_dcr = dcr;
   } else {
     if (!FirstOpenDevice(dcr)) {
       Jmsg1(jcr, M_FATAL, 0, _("Cannot open %s\n"), dev->print_name());
@@ -210,9 +210,9 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
  */
 static void MyFreeJcr(JobControlRecord* jcr)
 {
-  if (jcr->impl->job_name) {
-    FreePoolMemory(jcr->impl->job_name);
-    jcr->impl->job_name = NULL;
+  if (jcr->sd_impl->job_name) {
+    FreePoolMemory(jcr->sd_impl->job_name);
+    jcr->sd_impl->job_name = NULL;
   }
 
   if (jcr->client_name) {
@@ -220,14 +220,14 @@ static void MyFreeJcr(JobControlRecord* jcr)
     jcr->client_name = NULL;
   }
 
-  if (jcr->impl->fileset_name) {
-    FreePoolMemory(jcr->impl->fileset_name);
-    jcr->impl->fileset_name = NULL;
+  if (jcr->sd_impl->fileset_name) {
+    FreePoolMemory(jcr->sd_impl->fileset_name);
+    jcr->sd_impl->fileset_name = NULL;
   }
 
-  if (jcr->impl->fileset_md5) {
-    FreePoolMemory(jcr->impl->fileset_md5);
-    jcr->impl->fileset_md5 = NULL;
+  if (jcr->sd_impl->fileset_md5) {
+    FreePoolMemory(jcr->sd_impl->fileset_md5);
+    jcr->sd_impl->fileset_md5 = NULL;
   }
 
   if (jcr->comment) {
@@ -235,16 +235,16 @@ static void MyFreeJcr(JobControlRecord* jcr)
     jcr->comment = NULL;
   }
 
-  if (jcr->impl->VolList) { FreeRestoreVolumeList(jcr); }
+  if (jcr->sd_impl->VolList) { FreeRestoreVolumeList(jcr); }
 
-  if (jcr->impl->dcr) {
-    FreeDeviceControlRecord(jcr->impl->dcr);
-    jcr->impl->dcr = NULL;
+  if (jcr->sd_impl->dcr) {
+    FreeDeviceControlRecord(jcr->sd_impl->dcr);
+    jcr->sd_impl->dcr = NULL;
   }
 
-  if (jcr->impl) {
-    delete jcr->impl;
-    jcr->impl = nullptr;
+  if (jcr->sd_impl) {
+    delete jcr->sd_impl;
+    jcr->sd_impl = nullptr;
   }
 
   return;

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -76,7 +76,7 @@
 #include "stored/autochanger.h"
 #include "stored/bsr.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/sd_backends.h"
 #include "lib/btimers.h"
 #include "include/jcr.h"
@@ -311,27 +311,29 @@ void InitDeviceWaitTimers(DeviceControlRecord* dcr)
   dev->num_wait = 0;
   dev->poll = false;
 
-  jcr->impl->device_wait_times.min_wait = 60 * 60;
-  jcr->impl->device_wait_times.max_wait = 24 * 60 * 60;
-  jcr->impl->device_wait_times.max_num_wait
+  jcr->sd_impl->device_wait_times.min_wait = 60 * 60;
+  jcr->sd_impl->device_wait_times.max_wait = 24 * 60 * 60;
+  jcr->sd_impl->device_wait_times.max_num_wait
       = 9; /* 5 waits =~ 1 day, then 1 day at a time */
-  jcr->impl->device_wait_times.wait_sec = jcr->impl->device_wait_times.min_wait;
-  jcr->impl->device_wait_times.rem_wait_sec
-      = jcr->impl->device_wait_times.wait_sec;
-  jcr->impl->device_wait_times.num_wait = 0;
+  jcr->sd_impl->device_wait_times.wait_sec
+      = jcr->sd_impl->device_wait_times.min_wait;
+  jcr->sd_impl->device_wait_times.rem_wait_sec
+      = jcr->sd_impl->device_wait_times.wait_sec;
+  jcr->sd_impl->device_wait_times.num_wait = 0;
 }
 
 void InitJcrDeviceWaitTimers(JobControlRecord* jcr)
 {
   /* ******FIXME******* put these on config variables */
-  jcr->impl->device_wait_times.min_wait = 60 * 60;
-  jcr->impl->device_wait_times.max_wait = 24 * 60 * 60;
-  jcr->impl->device_wait_times.max_num_wait
+  jcr->sd_impl->device_wait_times.min_wait = 60 * 60;
+  jcr->sd_impl->device_wait_times.max_wait = 24 * 60 * 60;
+  jcr->sd_impl->device_wait_times.max_num_wait
       = 9; /* 5 waits =~ 1 day, then 1 day at a time */
-  jcr->impl->device_wait_times.wait_sec = jcr->impl->device_wait_times.min_wait;
-  jcr->impl->device_wait_times.rem_wait_sec
-      = jcr->impl->device_wait_times.wait_sec;
-  jcr->impl->device_wait_times.num_wait = 0;
+  jcr->sd_impl->device_wait_times.wait_sec
+      = jcr->sd_impl->device_wait_times.min_wait;
+  jcr->sd_impl->device_wait_times.rem_wait_sec
+      = jcr->sd_impl->device_wait_times.wait_sec;
+  jcr->sd_impl->device_wait_times.num_wait = 0;
 }
 
 /**

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -31,7 +31,7 @@
 #include "stored/bsr.h"
 #include "stored/acquire.h"
 #include "stored/fd_cmds.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/ndmp_tape.h"
 #include "stored/read_record.h"
 #include "stored/stored_globals.h"
@@ -132,27 +132,27 @@ bool job_cmd(JobControlRecord* jcr)
   }
   bstrncpy(jcr->Job, job, sizeof(jcr->Job));
   UnbashSpaces(job_name);
-  jcr->impl->job_name = GetPoolMemory(PM_NAME);
-  PmStrcpy(jcr->impl->job_name, job_name);
+  jcr->sd_impl->job_name = GetPoolMemory(PM_NAME);
+  PmStrcpy(jcr->sd_impl->job_name, job_name);
   UnbashSpaces(client_name);
   jcr->client_name = GetPoolMemory(PM_NAME);
   PmStrcpy(jcr->client_name, client_name);
   UnbashSpaces(fileset_name);
-  jcr->impl->fileset_name = GetPoolMemory(PM_NAME);
-  PmStrcpy(jcr->impl->fileset_name, fileset_name);
+  jcr->sd_impl->fileset_name = GetPoolMemory(PM_NAME);
+  PmStrcpy(jcr->sd_impl->fileset_name, fileset_name);
   jcr->setJobType(JobType);
   jcr->setJobLevel(level);
-  jcr->impl->no_attributes = no_attributes;
-  jcr->impl->spool_attributes = spool_attributes;
-  jcr->impl->spool_data = spool_data;
-  jcr->impl->spool_size = str_to_int64(spool_size);
-  jcr->impl->fileset_md5 = GetPoolMemory(PM_NAME);
-  PmStrcpy(jcr->impl->fileset_md5, fileset_md5);
-  jcr->impl->PreferMountedVols = PreferMountedVols;
-  jcr->impl->RemainingQuota = quota;
+  jcr->sd_impl->no_attributes = no_attributes;
+  jcr->sd_impl->spool_attributes = spool_attributes;
+  jcr->sd_impl->spool_data = spool_data;
+  jcr->sd_impl->spool_size = str_to_int64(spool_size);
+  jcr->sd_impl->fileset_md5 = GetPoolMemory(PM_NAME);
+  PmStrcpy(jcr->sd_impl->fileset_md5, fileset_md5);
+  jcr->sd_impl->PreferMountedVols = PreferMountedVols;
+  jcr->sd_impl->RemainingQuota = quota;
   UnbashSpaces(backup_format);
-  jcr->impl->backup_format = GetPoolMemory(PM_NAME);
-  PmStrcpy(jcr->impl->backup_format, backup_format);
+  jcr->sd_impl->backup_format = GetPoolMemory(PM_NAME);
+  PmStrcpy(jcr->sd_impl->backup_format, backup_format);
   jcr->authenticated = false;
 
   Dmsg1(50, "Quota set as %llu\n", quota);
@@ -195,8 +195,8 @@ bool DoJobRun(JobControlRecord* jcr)
    */
   lock_mutex(mutex);
   while (!jcr->authenticated && !JobCanceled(jcr)) {
-    errstat
-        = pthread_cond_timedwait(&jcr->impl->job_start_wait, &mutex, &timeout);
+    errstat = pthread_cond_timedwait(&jcr->sd_impl->job_start_wait, &mutex,
+                                     &timeout);
     if (errstat == ETIMEDOUT || errstat == EINVAL || errstat == EPERM) {
       break;
     }
@@ -222,7 +222,7 @@ bool DoJobRun(JobControlRecord* jcr)
          */
         Dmsg2(800, "Wait for end job jid=%d %p\n", jcr->JobId, jcr);
         lock_mutex(mutex);
-        pthread_cond_wait(&jcr->impl->job_end_wait, &mutex);
+        pthread_cond_wait(&jcr->sd_impl->job_end_wait, &mutex);
         unlock_mutex(mutex);
       }
       Dmsg2(800, "Done jid=%d %p\n", jcr->JobId, jcr);
@@ -287,7 +287,7 @@ bool nextRunCmd(JobControlRecord* jcr)
 
       lock_mutex(mutex);
       while (!jcr->authenticated && !JobCanceled(jcr)) {
-        errstat = pthread_cond_timedwait(&jcr->impl->job_start_wait, &mutex,
+        errstat = pthread_cond_timedwait(&jcr->sd_impl->job_start_wait, &mutex,
                                          &timeout);
         if (errstat == ETIMEDOUT || errstat == EINVAL || errstat == EPERM) {
           break;
@@ -311,7 +311,7 @@ bool nextRunCmd(JobControlRecord* jcr)
          */
         Dmsg2(800, "Wait for end job jid=%d %p\n", jcr->JobId, jcr);
         lock_mutex(mutex);
-        pthread_cond_wait(&jcr->impl->job_end_wait, &mutex);
+        pthread_cond_wait(&jcr->sd_impl->job_end_wait, &mutex);
         unlock_mutex(mutex);
       }
       Dmsg2(800, "Done jid=%d %p\n", jcr->JobId, jcr);
@@ -407,27 +407,27 @@ void StoredFreeJcr(JobControlRecord* jcr)
     jcr->file_bsock = NULL;
   }
 
-  if (jcr->impl->job_name) { FreePoolMemory(jcr->impl->job_name); }
+  if (jcr->sd_impl->job_name) { FreePoolMemory(jcr->sd_impl->job_name); }
 
   if (jcr->client_name) {
     FreeMemory(jcr->client_name);
     jcr->client_name = NULL;
   }
 
-  if (jcr->impl->fileset_name) { FreeMemory(jcr->impl->fileset_name); }
+  if (jcr->sd_impl->fileset_name) { FreeMemory(jcr->sd_impl->fileset_name); }
 
-  if (jcr->impl->fileset_md5) { FreeMemory(jcr->impl->fileset_md5); }
+  if (jcr->sd_impl->fileset_md5) { FreeMemory(jcr->sd_impl->fileset_md5); }
 
-  if (jcr->impl->backup_format) { FreeMemory(jcr->impl->backup_format); }
+  if (jcr->sd_impl->backup_format) { FreeMemory(jcr->sd_impl->backup_format); }
 
-  if (jcr->impl->read_session.bsr) {
-    libbareos::FreeBsr(jcr->impl->read_session.bsr);
-    jcr->impl->read_session.bsr = NULL;
+  if (jcr->sd_impl->read_session.bsr) {
+    libbareos::FreeBsr(jcr->sd_impl->read_session.bsr);
+    jcr->sd_impl->read_session.bsr = NULL;
   }
 
-  if (jcr->impl->read_session.rctx) {
-    FreeReadContext(jcr->impl->read_session.rctx);
-    jcr->impl->read_session.rctx = NULL;
+  if (jcr->sd_impl->read_session.rctx) {
+    FreeReadContext(jcr->sd_impl->read_session.rctx);
+    jcr->sd_impl->read_session.rctx = NULL;
   }
 
   if (jcr->compress.deflate_buffer || jcr->compress.inflate_buffer) {
@@ -442,46 +442,48 @@ void StoredFreeJcr(JobControlRecord* jcr)
     jcr->RestoreBootstrap = NULL;
   }
 
-  if (jcr->impl->next_dev || jcr->impl->prev_dev) {
+  if (jcr->sd_impl->next_dev || jcr->sd_impl->prev_dev) {
     Emsg0(M_FATAL, 0, _("In FreeJcr(), but still attached to device!!!!\n"));
   }
 
-  pthread_cond_destroy(&jcr->impl->job_start_wait);
-  pthread_cond_destroy(&jcr->impl->job_end_wait);
+  pthread_cond_destroy(&jcr->sd_impl->job_start_wait);
+  pthread_cond_destroy(&jcr->sd_impl->job_end_wait);
 
   // Avoid a double free
-  if (jcr->impl->dcr == jcr->impl->read_dcr) { jcr->impl->read_dcr = NULL; }
-
-  if (jcr->impl->dcr) {
-    FreeDeviceControlRecord(jcr->impl->dcr);
-    jcr->impl->dcr = NULL;
+  if (jcr->sd_impl->dcr == jcr->sd_impl->read_dcr) {
+    jcr->sd_impl->read_dcr = NULL;
   }
 
-  if (jcr->impl->read_dcr) {
-    FreeDeviceControlRecord(jcr->impl->read_dcr);
-    jcr->impl->read_dcr = NULL;
+  if (jcr->sd_impl->dcr) {
+    FreeDeviceControlRecord(jcr->sd_impl->dcr);
+    jcr->sd_impl->dcr = NULL;
   }
 
-  if (jcr->impl->plugin_options) { delete jcr->impl->plugin_options; }
+  if (jcr->sd_impl->read_dcr) {
+    FreeDeviceControlRecord(jcr->sd_impl->read_dcr);
+    jcr->sd_impl->read_dcr = NULL;
+  }
 
-  if (jcr->impl->read_store) {
+  if (jcr->sd_impl->plugin_options) { delete jcr->sd_impl->plugin_options; }
+
+  if (jcr->sd_impl->read_store) {
     DirectorStorage* store = nullptr;
-    foreach_alist (store, jcr->impl->read_store) {
+    foreach_alist (store, jcr->sd_impl->read_store) {
       delete store->device;
       delete store;
     }
-    delete jcr->impl->read_store;
-    jcr->impl->read_store = NULL;
+    delete jcr->sd_impl->read_store;
+    jcr->sd_impl->read_store = NULL;
   }
 
-  if (jcr->impl->write_store) {
+  if (jcr->sd_impl->write_store) {
     DirectorStorage* store = nullptr;
-    foreach_alist (store, jcr->impl->write_store) {
+    foreach_alist (store, jcr->sd_impl->write_store) {
       delete store->device;
       delete store;
     }
-    delete jcr->impl->write_store;
-    jcr->impl->write_store = NULL;
+    delete jcr->sd_impl->write_store;
+    jcr->sd_impl->write_store = NULL;
   }
 
   FreePlugins(jcr); /* release instantiated plugins */
@@ -492,9 +494,9 @@ void StoredFreeJcr(JobControlRecord* jcr)
                    GetFirstPortHostOrder(me->SDaddrs));
   }
 
-  if (jcr->impl) {
-    delete jcr->impl;
-    jcr->impl = nullptr;
+  if (jcr->sd_impl) {
+    delete jcr->sd_impl;
+    jcr->sd_impl = nullptr;
   }
 
   Dmsg0(200, "End stored FreeJcr\n");
@@ -505,7 +507,7 @@ void StoredFreeJcr(JobControlRecord* jcr)
 JobControlRecord* NewStoredJcr()
 {
   JobControlRecord* jcr = new_jcr(StoredFreeJcr);
-  jcr->impl = new JobControlRecordPrivate;
+  jcr->sd_impl = new StoredJcrImpl;
   return jcr;
 }
 

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -35,7 +35,7 @@
 #include "stored/append.h"
 #include "stored/device.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/label.h"
 #include "stored/mount.h"
 #include "stored/read_record.h"
@@ -113,7 +113,7 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
   bool retval = false;
   bool translated_record = false;
   JobControlRecord* jcr = dcr->jcr;
-  Device* dev = jcr->impl->dcr->dev;
+  Device* dev = jcr->sd_impl->dcr->dev;
   char buf1[100], buf2[100];
 
   /*
@@ -139,10 +139,10 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
 
         if (jcr->is_JobType(JT_MIGRATE) || jcr->is_JobType(JT_COPY)) {
           bstrncpy(jcr->Job, label->Job, sizeof(jcr->Job));
-          PmStrcpy(jcr->impl->job_name, label->JobName);
+          PmStrcpy(jcr->sd_impl->job_name, label->JobName);
           PmStrcpy(jcr->client_name, label->ClientName);
-          PmStrcpy(jcr->impl->fileset_name, label->FileSetName);
-          PmStrcpy(jcr->impl->fileset_md5, label->FileSetMD5);
+          PmStrcpy(jcr->sd_impl->fileset_name, label->FileSetName);
+          PmStrcpy(jcr->sd_impl->fileset_md5, label->FileSetMD5);
         }
         jcr->setJobType(label->JobType);
         jcr->setJobLevel(label->JobLevel);
@@ -155,7 +155,7 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
         jcr->start_time = jcr->sched_time;
 
         /* write the SOS Label with the existing timestamp infos */
-        if (!WriteSessionLabel(jcr->impl->dcr, SOS_LABEL)) {
+        if (!WriteSessionLabel(jcr->sd_impl->dcr, SOS_LABEL)) {
           Jmsg1(jcr, M_FATAL, 0, _("Write session label failed. ERR=%s\n"),
                 dev->bstrerror());
           jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
@@ -201,9 +201,10 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
         stream_to_ascii(buf2, rec->Stream, rec->FileIndex), rec->data_len);
 
   // Perform record translations.
-  jcr->impl->dcr->before_rec = rec;
-  jcr->impl->dcr->after_rec = NULL;
-  if (GeneratePluginEvent(jcr, bSdEventWriteRecordTranslation, jcr->impl->dcr)
+  jcr->sd_impl->dcr->before_rec = rec;
+  jcr->sd_impl->dcr->after_rec = NULL;
+  if (GeneratePluginEvent(jcr, bSdEventWriteRecordTranslation,
+                          jcr->sd_impl->dcr)
       != bRC_OK) {
     goto bail_out;
   }
@@ -214,17 +215,17 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
    * taken place we just point the after_rec pointer to same DeviceRecord as in
    * the before_rec pointer.
    */
-  if (!jcr->impl->dcr->after_rec) {
-    jcr->impl->dcr->after_rec = jcr->impl->dcr->before_rec;
+  if (!jcr->sd_impl->dcr->after_rec) {
+    jcr->sd_impl->dcr->after_rec = jcr->sd_impl->dcr->before_rec;
   } else {
     translated_record = true;
   }
 
-  while (!WriteRecordToBlock(jcr->impl->dcr, jcr->impl->dcr->after_rec)) {
+  while (!WriteRecordToBlock(jcr->sd_impl->dcr, jcr->sd_impl->dcr->after_rec)) {
     Dmsg4(200, "!WriteRecordToBlock blkpos=%u:%u len=%d rem=%d\n", dev->file,
-          dev->block_num, jcr->impl->dcr->after_rec->data_len,
-          jcr->impl->dcr->after_rec->remainder);
-    if (!jcr->impl->dcr->WriteBlockToDevice()) {
+          dev->block_num, jcr->sd_impl->dcr->after_rec->data_len,
+          jcr->sd_impl->dcr->after_rec->remainder);
+    if (!jcr->sd_impl->dcr->WriteBlockToDevice()) {
       Dmsg2(90, "Got WriteBlockToDev error on device %s. %s\n",
             dev->print_name(), dev->bstrerror());
       Jmsg2(jcr, M_FATAL, 0, _("Fatal append error on device %s: ERR=%s\n"),
@@ -235,36 +236,36 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
   }
 
   // Restore packet
-  jcr->impl->dcr->after_rec->VolSessionId
-      = jcr->impl->dcr->after_rec->last_VolSessionId;
-  jcr->impl->dcr->after_rec->VolSessionTime
-      = jcr->impl->dcr->after_rec->last_VolSessionTime;
+  jcr->sd_impl->dcr->after_rec->VolSessionId
+      = jcr->sd_impl->dcr->after_rec->last_VolSessionId;
+  jcr->sd_impl->dcr->after_rec->VolSessionTime
+      = jcr->sd_impl->dcr->after_rec->last_VolSessionTime;
 
-  if (jcr->impl->dcr->after_rec->FileIndex < 0) {
+  if (jcr->sd_impl->dcr->after_rec->FileIndex < 0) {
     retval = true; /* don't send LABELs to Dir */
     goto bail_out;
   }
 
-  jcr->JobBytes
-      += jcr->impl->dcr->after_rec->data_len; /* increment bytes of this job */
+  jcr->JobBytes += jcr->sd_impl->dcr->after_rec
+                       ->data_len; /* increment bytes of this job */
 
   Dmsg5(500, "wrote_record JobId=%d FI=%s SessId=%d Strm=%s len=%d\n",
-        jcr->JobId, FI_to_ascii(buf1, jcr->impl->dcr->after_rec->FileIndex),
-        jcr->impl->dcr->after_rec->VolSessionId,
-        stream_to_ascii(buf2, jcr->impl->dcr->after_rec->Stream,
-                        jcr->impl->dcr->after_rec->FileIndex),
-        jcr->impl->dcr->after_rec->data_len);
+        jcr->JobId, FI_to_ascii(buf1, jcr->sd_impl->dcr->after_rec->FileIndex),
+        jcr->sd_impl->dcr->after_rec->VolSessionId,
+        stream_to_ascii(buf2, jcr->sd_impl->dcr->after_rec->Stream,
+                        jcr->sd_impl->dcr->after_rec->FileIndex),
+        jcr->sd_impl->dcr->after_rec->data_len);
 
-  if (IsAttribute(jcr->impl->dcr->after_rec)) {
-    SendAttrsToDir(jcr, jcr->impl->dcr->after_rec);
+  if (IsAttribute(jcr->sd_impl->dcr->after_rec)) {
+    SendAttrsToDir(jcr, jcr->sd_impl->dcr->after_rec);
   }
 
   retval = true;
 
 bail_out:
   if (translated_record) {
-    FreeRecord(jcr->impl->dcr->after_rec);
-    jcr->impl->dcr->after_rec = NULL;
+    FreeRecord(jcr->sd_impl->dcr->after_rec);
+    jcr->sd_impl->dcr->after_rec = NULL;
   }
 
   return retval;
@@ -393,22 +394,22 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
   if (me->autoxflateonreplication) { return; }
 
   // Check autodeflation.
-  switch (jcr->impl->read_dcr->autodeflate) {
+  switch (jcr->sd_impl->read_dcr->autodeflate) {
     case AutoXflateMode::IO_DIRECTION_IN:
     case AutoXflateMode::IO_DIRECTION_INOUT:
       Dmsg0(200, "Clearing autodeflate on read_dcr\n");
-      jcr->impl->read_dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
+      jcr->sd_impl->read_dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
       break;
     default:
       break;
   }
 
-  if (jcr->impl->dcr) {
-    switch (jcr->impl->dcr->autodeflate) {
+  if (jcr->sd_impl->dcr) {
+    switch (jcr->sd_impl->dcr->autodeflate) {
       case AutoXflateMode::IO_DIRECTION_OUT:
       case AutoXflateMode::IO_DIRECTION_INOUT:
         Dmsg0(200, "Clearing autodeflate on write dcr\n");
-        jcr->impl->dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
+        jcr->sd_impl->dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
         break;
       default:
         break;
@@ -416,22 +417,22 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
   }
 
   // Check autoinflation.
-  switch (jcr->impl->read_dcr->autoinflate) {
+  switch (jcr->sd_impl->read_dcr->autoinflate) {
     case AutoXflateMode::IO_DIRECTION_IN:
     case AutoXflateMode::IO_DIRECTION_INOUT:
       Dmsg0(200, "Clearing autoinflate on read_dcr\n");
-      jcr->impl->read_dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
+      jcr->sd_impl->read_dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
       break;
     default:
       break;
   }
 
-  if (jcr->impl->dcr) {
-    switch (jcr->impl->dcr->autoinflate) {
+  if (jcr->sd_impl->dcr) {
+    switch (jcr->sd_impl->dcr->autoinflate) {
       case AutoXflateMode::IO_DIRECTION_OUT:
       case AutoXflateMode::IO_DIRECTION_INOUT:
         Dmsg0(200, "Clearing autoinflate on write dcr\n");
-        jcr->impl->dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
+        jcr->sd_impl->dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
         break;
       default:
         break;
@@ -448,7 +449,7 @@ bool DoMacRun(JobControlRecord* jcr)
   bool ok = true;
   bool acquire_fail = false;
   BareosSocket* dir = jcr->dir_bsock;
-  Device* dev = jcr->impl->dcr->dev;
+  Device* dev = jcr->sd_impl->dcr->dev;
 
   switch (jcr->getJobType()) {
     case JT_MIGRATE:
@@ -470,7 +471,7 @@ bool DoMacRun(JobControlRecord* jcr)
 
   Dmsg0(20, "Start read data.\n");
 
-  if (jcr->impl->NumReadVolumes == 0) {
+  if (jcr->sd_impl->NumReadVolumes == 0) {
     Jmsg(jcr, M_FATAL, 0, _("No Volume names found for %s.\n"), Type);
     goto bail_out;
   }
@@ -479,27 +480,29 @@ bool DoMacRun(JobControlRecord* jcr)
   CheckAutoXflation(jcr);
 
   // See if we perform both read and write or read only.
-  if (jcr->impl->remote_replicate) {
+  if (jcr->sd_impl->remote_replicate) {
     BareosSocket* sd;
 
-    if (!jcr->impl->read_dcr) {
+    if (!jcr->sd_impl->read_dcr) {
       Jmsg(jcr, M_FATAL, 0, _("Read device not properly initialized.\n"));
       goto bail_out;
     }
 
-    Dmsg1(100, "read_dcr=%p\n", jcr->impl->read_dcr);
+    Dmsg1(100, "read_dcr=%p\n", jcr->sd_impl->read_dcr);
     Dmsg3(200, "Found %d volumes names for %s. First=%s\n",
-          jcr->impl->NumReadVolumes, Type, jcr->impl->VolList->VolumeName);
+          jcr->sd_impl->NumReadVolumes, Type,
+          jcr->sd_impl->VolList->VolumeName);
 
     // Ready devices for reading.
-    if (!AcquireDeviceForRead(jcr->impl->read_dcr)) {
+    if (!AcquireDeviceForRead(jcr->sd_impl->read_dcr)) {
       ok = false;
       acquire_fail = true;
       goto bail_out;
     }
 
     Dmsg2(200, "===== After acquire pos %u:%u\n",
-          jcr->impl->read_dcr->dev->file, jcr->impl->read_dcr->dev->block_num);
+          jcr->sd_impl->read_dcr->dev->file,
+          jcr->sd_impl->read_dcr->dev->block_num);
 
     jcr->sendJobStatus(JS_Running);
 
@@ -518,12 +521,12 @@ bool DoMacRun(JobControlRecord* jcr)
     // Expect to receive back the Ticket number.
     if (BgetMsg(sd) >= 0) {
       Dmsg1(110, "<stored: %s", sd->msg);
-      if (sscanf(sd->msg, OK_start_replicate, &jcr->impl->Ticket) != 1) {
+      if (sscanf(sd->msg, OK_start_replicate, &jcr->sd_impl->Ticket) != 1) {
         Jmsg(jcr, M_FATAL, 0, _("Bad response to start replicate: %s\n"),
              sd->msg);
         goto bail_out;
       }
-      Dmsg1(110, "Got Ticket=%d\n", jcr->impl->Ticket);
+      Dmsg1(110, "Got Ticket=%d\n", jcr->sd_impl->Ticket);
     } else {
       Jmsg(jcr, M_FATAL, 0,
            _("Bad response from stored to start replicate command\n"));
@@ -531,7 +534,7 @@ bool DoMacRun(JobControlRecord* jcr)
     }
 
     // Let the remote SD know we are now really going to send the data.
-    sd->fsend(ReplicateData, jcr->impl->Ticket);
+    sd->fsend(ReplicateData, jcr->sd_impl->Ticket);
     Dmsg1(110, ">stored: %s", sd->msg);
 
     // Expect to get response to the replicate data cmd from Storage daemon
@@ -545,7 +548,7 @@ bool DoMacRun(JobControlRecord* jcr)
     UpdateJobStatistics(jcr, now);
 
     // Read all data and send it to remote SD.
-    ok = ReadRecords(jcr->impl->read_dcr, CloneRecordToRemoteSd,
+    ok = ReadRecords(jcr->sd_impl->read_dcr, CloneRecordToRemoteSd,
                      MountNextReadVolume);
 
     /*
@@ -579,26 +582,27 @@ bool DoMacRun(JobControlRecord* jcr)
     /* Inform Storage daemon that we are done */
     sd->signal(BNET_TERMINATE);
   } else {
-    if (!jcr->impl->read_dcr) {
+    if (!jcr->sd_impl->read_dcr) {
       Jmsg(jcr, M_FATAL, 0, _("Read device not properly initialized.\n"));
       goto bail_out;
     }
 
-    Dmsg2(100, "read_dcr=%p write_dcr=%p\n", jcr->impl->read_dcr,
-          jcr->impl->dcr);
+    Dmsg2(100, "read_dcr=%p write_dcr=%p\n", jcr->sd_impl->read_dcr,
+          jcr->sd_impl->dcr);
     Dmsg3(200, "Found %d volumes names for %s. First=%s\n",
-          jcr->impl->NumReadVolumes, Type, jcr->impl->VolList->VolumeName);
+          jcr->sd_impl->NumReadVolumes, Type,
+          jcr->sd_impl->VolList->VolumeName);
 
     // Ready devices for reading and writing.
-    if (!AcquireDeviceForAppend(jcr->impl->dcr)
-        || !AcquireDeviceForRead(jcr->impl->read_dcr)) {
+    if (!AcquireDeviceForAppend(jcr->sd_impl->dcr)
+        || !AcquireDeviceForRead(jcr->sd_impl->read_dcr)) {
       ok = false;
       acquire_fail = true;
       goto bail_out;
     }
 
-    Dmsg2(200, "===== After acquire pos %u:%u\n", jcr->impl->dcr->dev->file,
-          jcr->impl->dcr->dev->block_num);
+    Dmsg2(200, "===== After acquire pos %u:%u\n", jcr->sd_impl->dcr->dev->file,
+          jcr->sd_impl->dcr->dev->block_num);
 
     jcr->sendJobStatus(JS_Running);
 
@@ -606,7 +610,7 @@ bool DoMacRun(JobControlRecord* jcr)
     now = (utime_t)time(NULL);
     UpdateJobStatistics(jcr, now);
 
-    if (!BeginDataSpool(jcr->impl->dcr)) {
+    if (!BeginDataSpool(jcr->sd_impl->dcr)) {
       ok = false;
       goto bail_out;
     }
@@ -616,20 +620,20 @@ bool DoMacRun(JobControlRecord* jcr)
       goto bail_out;
     }
 
-    jcr->impl->dcr->VolFirstIndex = jcr->impl->dcr->VolLastIndex = 0;
+    jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex = 0;
     jcr->run_time = time(NULL);
-    SetStartVolPosition(jcr->impl->dcr);
+    SetStartVolPosition(jcr->sd_impl->dcr);
     jcr->JobFiles = 0;
 
     // Read all data and make a local clone of it.
-    ok = ReadRecords(jcr->impl->read_dcr, CloneRecordInternally,
+    ok = ReadRecords(jcr->sd_impl->read_dcr, CloneRecordInternally,
                      MountNextReadVolume);
   }
 
 bail_out:
   if (!ok) { jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated); }
 
-  if (!acquire_fail && !jcr->impl->remote_replicate && jcr->impl->dcr) {
+  if (!acquire_fail && !jcr->sd_impl->remote_replicate && jcr->sd_impl->dcr) {
     /*
      * Don't use time_t for job_elapsed as time_t can be 32 or 64 bits,
      *   and the subsequent Jmsg() editing will break
@@ -647,7 +651,7 @@ bail_out:
       jcr->setJobStatusWithPriorityCheck(JS_Terminated);
 
       // Write End Of Session Label
-      DeviceControlRecord* dcr = jcr->impl->dcr;
+      DeviceControlRecord* dcr = jcr->sd_impl->dcr;
       if (!WriteSessionLabel(dcr, EOS_LABEL)) {
         // Print only if ok and not cancelled to avoid spurious messages
 
@@ -662,7 +666,7 @@ bail_out:
         jcr->setJobStatusWithPriorityCheck(currentJobStatus);
       }
       // Flush out final partial block of this session
-      if (!jcr->impl->dcr->WriteBlockToDevice()) {
+      if (!jcr->sd_impl->dcr->WriteBlockToDevice()) {
         Jmsg2(jcr, M_FATAL, 0, _("Fatal append error on device %s: ERR=%s\n"),
               dev->print_name(), dev->bstrerror());
         Dmsg0(100, _("Set ok=FALSE after WriteBlockToDevice.\n"));
@@ -674,10 +678,10 @@ bail_out:
 
 
     if (!ok) {
-      DiscardDataSpool(jcr->impl->dcr);
+      DiscardDataSpool(jcr->sd_impl->dcr);
     } else {
       // Note: if commit is OK, the device will remain blocked
-      CommitDataSpool(jcr->impl->dcr);
+      CommitDataSpool(jcr->sd_impl->dcr);
     }
 
     job_elapsed = time(NULL) - jcr->run_time;
@@ -696,11 +700,11 @@ bail_out:
     }
   }
 
-  if (!jcr->impl->remote_replicate && jcr->impl->dcr) {
-    if (!ReleaseDevice(jcr->impl->dcr)) { ok = false; }
+  if (!jcr->sd_impl->remote_replicate && jcr->sd_impl->dcr) {
+    if (!ReleaseDevice(jcr->sd_impl->dcr)) { ok = false; }
   }
-  if (jcr->impl->read_dcr) {
-    if (!ReleaseDevice(jcr->impl->read_dcr)) { ok = false; }
+  if (jcr->sd_impl->read_dcr) {
+    if (!ReleaseDevice(jcr->sd_impl->read_dcr)) { ok = false; }
   }
 
   jcr->sendJobStatus(); /* update director */

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -31,7 +31,7 @@
 #include "stored/acquire.h"
 #include "stored/autochanger.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/label.h"
 #include "lib/edit.h"
 #include "include/jcr.h"
@@ -911,13 +911,13 @@ bool MountNextReadVolume(DeviceControlRecord* dcr)
 {
   Device* dev = dcr->dev;
   JobControlRecord* jcr = dcr->jcr;
-  Dmsg2(90, "NumReadVolumes=%d CurReadVolume=%d\n", jcr->impl->NumReadVolumes,
-        jcr->impl->CurReadVolume);
+  Dmsg2(90, "NumReadVolumes=%d CurReadVolume=%d\n",
+        jcr->sd_impl->NumReadVolumes, jcr->sd_impl->CurReadVolume);
 
   VolumeUnused(dcr); /* release current volume */
   // End Of Tape -- mount next Volume (if another specified)
-  if (jcr->impl->NumReadVolumes > 1
-      && jcr->impl->CurReadVolume < jcr->impl->NumReadVolumes) {
+  if (jcr->sd_impl->NumReadVolumes > 1
+      && jcr->sd_impl->CurReadVolume < jcr->sd_impl->NumReadVolumes) {
     dev->Lock();
     dev->close(dcr);
     dev->SetRead();

--- a/core/src/stored/read.cc
+++ b/core/src/stored/read.cc
@@ -31,7 +31,7 @@
 #include "stored/acquire.h"
 #include "stored/bsr.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/mount.h"
 #include "stored/read_record.h"
 #include "lib/bnet.h"
@@ -57,7 +57,7 @@ static char rec_header[] = "rechdr %ld %ld %ld %ld %ld";
 bool DoReadData(JobControlRecord* jcr)
 {
   BareosSocket* fd = jcr->file_bsock;
-  DeviceControlRecord* dcr = jcr->impl->read_dcr;
+  DeviceControlRecord* dcr = jcr->sd_impl->read_dcr;
   bool ok = true;
 
   Dmsg0(20, "Start read data.\n");
@@ -67,14 +67,14 @@ bool DoReadData(JobControlRecord* jcr)
     return false;
   }
 
-  if (jcr->impl->NumReadVolumes == 0) {
+  if (jcr->sd_impl->NumReadVolumes == 0) {
     Jmsg(jcr, M_FATAL, 0, _("No Volume names found for restore.\n"));
     fd->fsend(FD_error);
     return false;
   }
 
   Dmsg2(200, "Found %d volumes names to restore. First=%s\n",
-        jcr->impl->NumReadVolumes, jcr->impl->VolList->VolumeName);
+        jcr->sd_impl->NumReadVolumes, jcr->sd_impl->VolList->VolumeName);
 
   // Ready device for reading
   if (!AcquireDeviceForRead(dcr)) {
@@ -96,7 +96,7 @@ bool DoReadData(JobControlRecord* jcr)
   // Send end of data to FD
   fd->signal(BNET_EOD);
 
-  if (!ReleaseDevice(jcr->impl->read_dcr)) { ok = false; }
+  if (!ReleaseDevice(jcr->sd_impl->read_dcr)) { ok = false; }
 
   Dmsg0(30, "Done reading.\n");
   return ok;

--- a/core/src/stored/record.cc
+++ b/core/src/stored/record.cc
@@ -29,7 +29,7 @@
  */
 
 #include "include/bareos.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/stored.h"
 #include "stored/device_control_record.h"
 #include "lib/attribs.h"
@@ -670,7 +670,8 @@ bool DeviceControlRecord::WriteRecord()
   }
 
   jcr->JobBytes += after_rec->data_len; /* increment bytes this job */
-  if (jcr->impl->RemainingQuota && jcr->JobBytes > jcr->impl->RemainingQuota) {
+  if (jcr->sd_impl->RemainingQuota
+      && jcr->JobBytes > jcr->sd_impl->RemainingQuota) {
     Jmsg0(jcr, M_FATAL, 0, _("Quota Exceeded. Job Terminated.\n"));
     goto bail_out;
   }

--- a/core/src/stored/sd_cmds.cc
+++ b/core/src/stored/sd_cmds.cc
@@ -36,7 +36,7 @@
 #include "stored/stored_globals.h"
 #include "stored/append.h"
 #include "stored/authenticate.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/sd_stats.h"
 #include "stored/sd_stats.h"
 #include "lib/bnet.h"
@@ -138,7 +138,7 @@ void* handle_stored_connection(BareosSocket* sd, char* job_name)
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
   }
 
-  pthread_cond_signal(&jcr->impl->job_start_wait); /* wake waiting job */
+  pthread_cond_signal(&jcr->sd_impl->job_start_wait); /* wake waiting job */
   FreeJcr(jcr);
 
   return NULL;
@@ -225,7 +225,7 @@ bool DoListenRun(JobControlRecord* jcr)
    */
   lock_mutex(mutex);
   while (!jcr->authenticated && !JobCanceled(jcr)) {
-    errstat = pthread_cond_wait(&jcr->impl->job_start_wait, &mutex);
+    errstat = pthread_cond_wait(&jcr->sd_impl->job_start_wait, &mutex);
     if (errstat == EINVAL || errstat == EPERM) { break; }
     Dmsg1(800, "=== Auth cond errstat=%d\n", errstat);
   }
@@ -280,13 +280,13 @@ static bool StartReplicationSession(JobControlRecord* jcr)
   BareosSocket* sd = jcr->store_bsock;
 
   Dmsg1(120, "Start replication session: %s", sd->msg);
-  if (jcr->impl->session_opened) {
+  if (jcr->sd_impl->session_opened) {
     PmStrcpy(jcr->errmsg, _("Attempt to open already open session.\n"));
     sd->fsend(NO_open);
     return false;
   }
 
-  jcr->impl->session_opened = true;
+  jcr->sd_impl->session_opened = true;
 
   // Send "Ticket" to Storage Daemon
   sd->fsend(OK_start_replicate, jcr->VolSessionId);
@@ -305,7 +305,7 @@ static bool ReplicateData(JobControlRecord* jcr)
   BareosSocket* sd = jcr->store_bsock;
 
   Dmsg1(120, "Replicate data: %s", sd->msg);
-  if (jcr->impl->session_opened) {
+  if (jcr->sd_impl->session_opened) {
     utime_t now;
 
     // Update the initial Job Statistics.
@@ -334,7 +334,7 @@ static bool EndReplicationSession(JobControlRecord* jcr)
   BareosSocket* sd = jcr->store_bsock;
 
   Dmsg1(120, "stored<stored: %s", sd->msg);
-  if (!jcr->impl->session_opened) {
+  if (!jcr->sd_impl->session_opened) {
     PmStrcpy(jcr->errmsg, _("Attempt to close non-open session.\n"));
     sd->fsend(NOT_opened);
     return false;

--- a/core/src/stored/sd_plugins.cc
+++ b/core/src/stored/sd_plugins.cc
@@ -30,7 +30,7 @@
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "sd_plugins.h"
 #include "lib/crypto_cache.h"
 #include "stored/sd_stats.h"
@@ -501,7 +501,7 @@ static inline PluginContext* instantiate_plugin(JobControlRecord* jcr,
 
 /**
  * Send a bSdEventNewPluginOptions event to all plugins configured in
- * jcr->impl_->plugin_options.
+ * jcr->sd_impl_->plugin_options.
  */
 void DispatchNewPluginOptions(JobControlRecord* jcr)
 {
@@ -517,11 +517,11 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
 
   if (!sd_plugin_list || sd_plugin_list->empty()) { return; }
 
-  if (jcr->impl->plugin_options && jcr->impl->plugin_options->size()) {
+  if (jcr->sd_impl->plugin_options && jcr->sd_impl->plugin_options->size()) {
     eventType = bSdEventNewPluginOptions;
     event.eventType = eventType;
 
-    foreach_alist_index (i, plugin_options, jcr->impl->plugin_options) {
+    foreach_alist_index (i, plugin_options, jcr->sd_impl->plugin_options) {
       // Make a private copy of plugin options.
       PmStrcpy(priv_plugin_options, plugin_options);
 
@@ -671,7 +671,7 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
   if (jcr) {
     switch (var) {
       case bsdVarJob:
-        *((char**)value) = jcr->impl->job_name;
+        *((char**)value) = jcr->sd_impl->job_name;
         Dmsg1(debuglevel, "sd-plugin: return bsdVarJobName=%s\n",
               NPRT(*((char**)value)));
         break;
@@ -695,8 +695,8 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
               NPRT(*((char**)value)));
         break;
       case bsdVarPool:
-        if (jcr->impl->dcr) {
-          *((char**)value) = jcr->impl->dcr->pool_name;
+        if (jcr->sd_impl->dcr) {
+          *((char**)value) = jcr->sd_impl->dcr->pool_name;
           Dmsg1(debuglevel, "sd-plugin: return bsdVarPool=%s\n",
                 NPRT(*((char**)value)));
         } else {
@@ -704,8 +704,8 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
         }
         break;
       case bsdVarPoolType:
-        if (jcr->impl->dcr) {
-          *((char**)value) = jcr->impl->dcr->pool_type;
+        if (jcr->sd_impl->dcr) {
+          *((char**)value) = jcr->sd_impl->dcr->pool_type;
           Dmsg1(debuglevel, "sd-plugin: return bsdVarPoolType=%s\n",
                 NPRT(*((char**)value)));
         } else {
@@ -713,8 +713,8 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
         }
         break;
       case bsdVarStorage:
-        if (jcr->impl->dcr && jcr->impl->dcr->device_resource) {
-          *((char**)value) = jcr->impl->dcr->device_resource->resource_name_;
+        if (jcr->sd_impl->dcr && jcr->sd_impl->dcr->device_resource) {
+          *((char**)value) = jcr->sd_impl->dcr->device_resource->resource_name_;
           Dmsg1(debuglevel, "sd-plugin: return bsdVarStorage=%s\n",
                 NPRT(*((char**)value)));
         } else {
@@ -722,8 +722,8 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
         }
         break;
       case bsdVarMediaType:
-        if (jcr->impl->dcr) {
-          *((char**)value) = jcr->impl->dcr->media_type;
+        if (jcr->sd_impl->dcr) {
+          *((char**)value) = jcr->sd_impl->dcr->media_type;
           Dmsg1(debuglevel, "sd-plugin: return bsdVarMediaType=%s\n",
                 NPRT(*((char**)value)));
         } else {
@@ -741,8 +741,8 @@ static bRC bareosGetValue(PluginContext* ctx, bsdrVariable var, void* value)
               jcr->getJobStatus());
         break;
       case bsdVarVolumeName:
-        if (jcr->impl->dcr) {
-          *((char**)value) = jcr->impl->dcr->VolumeName;
+        if (jcr->sd_impl->dcr) {
+          *((char**)value) = jcr->sd_impl->dcr->VolumeName;
           Dmsg1(debuglevel, "sd-plugin: return bsdVarVolumeName=%s\n",
                 NPRT(*((char**)value)));
         } else {

--- a/core/src/stored/sd_stats.cc
+++ b/core/src/stored/sd_stats.cc
@@ -29,7 +29,7 @@
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "lib/util.h"
 #include "include/jcr.h"
 #include "lib/parse_conf.h"
@@ -294,8 +294,9 @@ void UpdateJobStatistics(JobControlRecord* jcr, utime_t now)
   job_stat->timestamp = now;
   job_stat->JobFiles = jcr->JobFiles;
   job_stat->JobBytes = jcr->JobBytes;
-  if (jcr->impl->dcr && jcr->impl->dcr->device_resource) {
-    job_stat->DevName = strdup(jcr->impl->dcr->device_resource->resource_name_);
+  if (jcr->sd_impl->dcr && jcr->sd_impl->dcr->device_resource) {
+    job_stat->DevName
+        = strdup(jcr->sd_impl->dcr->device_resource->resource_name_);
   } else {
     job_stat->DevName = strdup("unknown");
   }

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -31,7 +31,7 @@
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/spool.h"
 #include "stored/status.h"
 #include "lib/status_packet.h"
@@ -667,8 +667,8 @@ static void ListRunningJobs(StatusPacket* sp)
                  job_type_to_str(jcr->getJobType()), jcr->Job);
       sp->send(msg, len);
     }
-    dcr = jcr->impl->dcr;
-    rdcr = jcr->impl->read_dcr;
+    dcr = jcr->sd_impl->dcr;
+    rdcr = jcr->sd_impl->read_dcr;
     if ((dcr && dcr->device_resource) || (rdcr && rdcr->device_resource)) {
       bstrncpy(JobName, jcr->Job, sizeof(JobName));
       /* There are three periods after the Job name */
@@ -754,7 +754,7 @@ static inline void SendDriveReserveMessages(JobControlRecord* jcr,
   char* msg;
 
   jcr->lock();
-  msgs = jcr->impl->reserve_msgs;
+  msgs = jcr->sd_impl->reserve_msgs;
   if (!msgs || msgs->size() == 0) { goto bail_out; }
   for (i = msgs->size() - 1; i >= 0; i--) {
     msg = (char*)msgs->get(i);
@@ -782,7 +782,7 @@ static void ListJobsWaitingOnReservation(StatusPacket* sp)
   }
 
   foreach_jcr (jcr) {
-    if (!jcr->impl->reserve_msgs) { continue; }
+    if (!jcr->sd_impl->reserve_msgs) { continue; }
     SendDriveReserveMessages(jcr, sp);
   }
   endeach_jcr(jcr);

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -38,7 +38,7 @@
 #include "stored/autochanger.h"
 #include "stored/bsr.h"
 #include "stored/device.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/job.h"
 #include "stored/label.h"
 #include "stored/ndmp_tape.h"
@@ -505,7 +505,7 @@ extern "C" void* device_initialization(void*)
   jcr->setJobType(JT_SYSTEM);
 
   // Initialize job start condition variable
-  errstat = pthread_cond_init(&jcr->impl->job_start_wait, nullptr);
+  errstat = pthread_cond_init(&jcr->sd_impl->job_start_wait, nullptr);
   if (errstat != 0) {
     BErrNo be;
     Jmsg1(jcr, M_ABORT, 0,
@@ -514,7 +514,7 @@ extern "C" void* device_initialization(void*)
   }
 
   // Initialize job end condition variable
-  errstat = pthread_cond_init(&jcr->impl->job_end_wait, nullptr);
+  errstat = pthread_cond_init(&jcr->sd_impl->job_end_wait, nullptr);
   if (errstat != 0) {
     BErrNo be;
     Jmsg1(jcr, M_ABORT, 0,
@@ -534,9 +534,9 @@ extern "C" void* device_initialization(void*)
     }
 
     dcr = new StorageDaemonDeviceControlRecord;
-    jcr->impl->dcr = dcr;
+    jcr->sd_impl->dcr = dcr;
     SetupNewDcrDevice(jcr, dcr, dev, nullptr);
-    jcr->impl->dcr->SetWillWrite();
+    jcr->sd_impl->dcr->SetWillWrite();
     GeneratePluginEvent(jcr, bSdEventDeviceInit, dcr);
     if (dev->AttachedToAutochanger()) {
       // If autochanger set slot in dev structure
@@ -550,7 +550,7 @@ extern "C" void* device_initialization(void*)
               dev->print_name());
         Dmsg1(20, "Could not open device %s\n", dev->print_name());
         FreeDeviceControlRecord(dcr);
-        jcr->impl->dcr = nullptr;
+        jcr->sd_impl->dcr = nullptr;
         continue;
       }
     }
@@ -568,7 +568,7 @@ extern "C" void* device_initialization(void*)
       }
     }
     FreeDeviceControlRecord(dcr);
-    jcr->impl->dcr = nullptr;
+    jcr->sd_impl->dcr = nullptr;
   }
   FreeJcr(jcr);
   init_done = true;
@@ -620,16 +620,16 @@ static
         jcr->MyThreadSendSignal(TIMEOUT_SIGNAL);
         Dmsg1(100, "term_stored killing JobId=%d\n", jcr->JobId);
         /* ***FIXME*** wiffle through all dcrs */
-        if (jcr->impl->dcr && jcr->impl->dcr->dev
-            && jcr->impl->dcr->dev->blocked()) {
-          pthread_cond_broadcast(&jcr->impl->dcr->dev->wait_next_vol);
+        if (jcr->sd_impl->dcr && jcr->sd_impl->dcr->dev
+            && jcr->sd_impl->dcr->dev->blocked()) {
+          pthread_cond_broadcast(&jcr->sd_impl->dcr->dev->wait_next_vol);
           Dmsg1(100, "JobId=%u broadcast wait_device_release\n",
                 (uint32_t)jcr->JobId);
           ReleaseDeviceCond();
         }
-        if (jcr->impl->read_dcr && jcr->impl->read_dcr->dev
-            && jcr->impl->read_dcr->dev->blocked()) {
-          pthread_cond_broadcast(&jcr->impl->read_dcr->dev->wait_next_vol);
+        if (jcr->sd_impl->read_dcr && jcr->sd_impl->read_dcr->dev
+            && jcr->sd_impl->read_dcr->dev->blocked()) {
+          pthread_cond_broadcast(&jcr->sd_impl->read_dcr->dev->wait_next_vol);
           Dmsg1(100, "JobId=%u broadcast wait_device_release\n",
                 (uint32_t)jcr->JobId);
           ReleaseDeviceCond();

--- a/core/src/stored/stored_jcr_impl.h
+++ b/core/src/stored/stored_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -21,8 +21,8 @@
    02110-1301, USA.
 */
 
-#ifndef BAREOS_STORED_JCR_PRIVATE_H_
-#define BAREOS_STORED_JCR_PRIVATE_H_
+#ifndef BAREOS_STORED_STORED_JCR_IMPL_H_
+#define BAREOS_STORED_STORED_JCR_IMPL_H_
 
 #include "stored/read_ctx.h"
 #include "stored/stored_conf.h"
@@ -65,7 +65,7 @@ struct DeviceWaitTimes {
 
 
 /* clang-format off */
-struct JobControlRecordPrivate {
+struct StoredJcrImpl {
   JobControlRecord* next_dev{}; /**< Next JobControlRecord attached to device */
   JobControlRecord* prev_dev{}; /**< Previous JobControlRecord attached to device */
   pthread_cond_t job_start_wait = PTHREAD_COND_INITIALIZER; /**< Wait for FD to start Job */
@@ -104,4 +104,4 @@ struct JobControlRecordPrivate {
 };
 /* clang-format on */
 
-#endif  // BAREOS_STORED_JCR_PRIVATE_H_
+#endif  // BAREOS_STORED_STORED_JCR_IMPL_H_

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -26,7 +26,7 @@
 #include "dird/get_database_connection.h"
 #include "dird/dird_conf.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -99,11 +99,11 @@ void CatalogTest::SetUp()
   // connect to database
   {
     jcr = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
-    jcr->impl->res.catalog
+    jcr->dir_impl->res.catalog
         = (directordaemon::CatalogResource*)my_config->GetResWithName(
             directordaemon::R_CATALOG, catalog_backend_name.c_str());
 
-    ASSERT_NE(jcr->impl->res.catalog, nullptr);
+    ASSERT_NE(jcr->dir_impl->res.catalog, nullptr);
 
     auto backenddir = std::vector<std::string>{backend_dir};
     DbSetBackendDirs(backenddir);

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -39,7 +39,7 @@ TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
   JobControlRecord* jcr
       = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
 
-  jcr->impl->res.client = static_cast<directordaemon::ClientResource*>(
+  jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
                                                 "fd-no-connection"));
   directordaemon::UaContext* ua = nullptr;

--- a/core/src/tests/messages_resource.cc
+++ b/core/src/tests/messages_resource.cc
@@ -31,7 +31,7 @@
 #include "dird/dird_globals.h"
 #include "dird/get_database_connection.h"
 #include "dird/job.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "lib/messages_resource.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -33,7 +33,7 @@
 #include "cats/cats.h"
 #include "dird/dird_conf.h"
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/job.h"
 #include "dird/run_on_incoming_connect_interval.h"
 #include "dird/scheduler.h"
@@ -145,7 +145,7 @@ static void SchedulerJobCallback(JobControlRecord* jcr)
   ++test_results.job_counter;
 
   // add job-name to map
-  test_results.job_names[jcr->impl->res.job->resource_name_]++;
+  test_results.job_names[jcr->dir_impl->res.job->resource_name_]++;
   FreeJcr(jcr);
 }
 

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -29,7 +29,7 @@
 
 
 #include "dird/dird_globals.h"
-#include "dird/jcr_private.h"
+#include "dird/director_jcr_impl.h"
 #include "dird/scheduler.h"
 #include "dird/dird_conf.h"
 #define DIRECTOR_DAEMON
@@ -144,7 +144,9 @@ void SimulatedTimeSource::ExecuteJob(JobControlRecord* jcr)
   list_of_job_execution_time_stamps.emplace_back(
       time_adapter->time_source_->SystemTime());
 
-  if (debug) { std::cout << jcr->impl->res.job->resource_name_ << std::endl; }
+  if (debug) {
+    std::cout << jcr->dir_impl->res.job->resource_name_ << std::endl;
+  }
 
   if (counter_of_number_of_jobs_run == maximum_number_of_jobs_run) {
     scheduler->Terminate();

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -38,7 +38,7 @@
 #include "lib/parse_conf.h"
 #include "stored/butil.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/job.h"
 #include "stored/sd_plugins.h"
 #include "stored/sd_stats.h"

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -40,7 +40,7 @@
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
 #include "stored/device_control_record.h"
-#include "stored/jcr_private.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/job.h"
 #include "stored/sd_plugins.h"
 #include "stored/sd_stats.h"
@@ -135,7 +135,7 @@ void WaitThenUnreserve(std::unique_ptr<TestJob>&);
 void WaitThenUnreserve(std::unique_ptr<TestJob>& job)
 {
   std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  job->jcr->impl->dcr->UnreserveDevice();
+  job->jcr->sd_impl->dcr->UnreserveDevice();
   ReleaseDeviceCond();
 }
 

--- a/core/src/win32/filed/vss.cc
+++ b/core/src/win32/filed/vss.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -33,7 +33,7 @@
 
 #  include "include/bareos.h"
 #  include "filed/filed.h"
-#  include "filed/jcr_private.h"
+#  include "filed/filed_jcr_impl.h"
 #  include "lib/thread_specific_data.h"
 
 #  include "ms_atl.h"
@@ -54,9 +54,9 @@ static bool VSSPathConvert(const char* szFilePath,
 {
   JobControlRecord* jcr = GetJcrFromThreadSpecificData();
 
-  if (jcr && jcr->impl->pVSSClient) {
-    return jcr->impl->pVSSClient->GetShadowPath(szFilePath, szShadowPath,
-                                                nBuflen);
+  if (jcr && jcr->fd_impl->pVSSClient) {
+    return jcr->fd_impl->pVSSClient->GetShadowPath(szFilePath, szShadowPath,
+                                                   nBuflen);
   }
 
   return false;
@@ -68,9 +68,9 @@ static bool VSSPathConvertW(const wchar_t* szFilePath,
 {
   JobControlRecord* jcr = GetJcrFromThreadSpecificData();
 
-  if (jcr && jcr->impl->pVSSClient) {
-    return jcr->impl->pVSSClient->GetShadowPathW(szFilePath, szShadowPath,
-                                                 nBuflen);
+  if (jcr && jcr->fd_impl->pVSSClient) {
+    return jcr->fd_impl->pVSSClient->GetShadowPathW(szFilePath, szShadowPath,
+                                                    nBuflen);
   }
 
   return false;
@@ -82,15 +82,15 @@ void VSSInit(JobControlRecord* jcr)
   if (g_MajorVersion == 5) {
     switch (g_MinorVersion) {
       case 1:
-        jcr->impl->pVSSClient = new VSSClientXP();
+        jcr->fd_impl->pVSSClient = new VSSClientXP();
         break;
       case 2:
-        jcr->impl->pVSSClient = new VSSClient2003();
+        jcr->fd_impl->pVSSClient = new VSSClient2003();
         break;
     }
     // Vista or Longhorn or later
   } else if (g_MajorVersion >= 6) {
-    jcr->impl->pVSSClient = new VSSClientVista();
+    jcr->fd_impl->pVSSClient = new VSSClientVista();
   }
 
   // Setup the callback functions.


### PR DESCRIPTION
When we moved the daemon-specific functionality of the `JobControlRecord` into `JobControlRecordPrivate`, we essentially introduced three different types that were all named `JobControlRecordPrivate` - one for the Director, one for the Storage Daemon and one for the File Daemon. This could lead to ODR violations when you tried to link parts of the daemons together.
In fact, that implementation already behaved like a union of the three different types (i.e. requiring per-implementation initialisation and teardown, undefined behaviour when accessing via the wrong type, etc.).

This patch renames the daemon's individual `JobControlRecordPrivate` to `DirectorJcrImpl`, `StoredJcrImpl` and `FiledJcrImpl`. The implementation-pointer was changed to a union of `dir_impl`, `sd_impl` and `fd_impl`. With this change applied you can now build programs that use two or more of the JCR types.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

