### PR TITLE
filed: fix handling of `STREAM_ACL_PLUGIN` during restore

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -214,7 +214,7 @@ OS:
            - python-bareos
 
   FreeBSD:
-    "12.2":
+    "12.3":
       TYPE: freebsd
       ARCH:
         - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: stored: set statistics collection as deprecated [PR #1320]
 - webui: switch from mod_php to php-fpm [PR #1287]
 - bareos-fd-postgres: properly close database connection [PR #1326]
+- filed: fix handling of `STREAM_ACL_PLUGIN` during restore [PR #1308]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -388,6 +389,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1305]: https://github.com/bareos/bareos/pull/1305
 [PR #1306]: https://github.com/bareos/bareos/pull/1306
 [PR #1307]: https://github.com/bareos/bareos/pull/1307
+[PR #1308]: https://github.com/bareos/bareos/pull/1308
 [PR #1313]: https://github.com/bareos/bareos/pull/1313
 [PR #1314]: https://github.com/bareos/bareos/pull/1314
 [PR #1315]: https://github.com/bareos/bareos/pull/1315

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1367,6 +1367,7 @@ bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
           memcpy(acl_data->u.build->content, ap.content, ap.content_length);
           acl_data->u.build->content_length = ap.content_length;
           free(ap.content);
+          acl_data->u.build->content[acl_data->u.build->content_length] = '\0';
           retval = SendAclStream(jcr, acl_data, STREAM_ACL_PLUGIN);
         } else {
           retval = bacl_exit_ok;

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -339,6 +339,7 @@ static inline bool PopDelayedDataStreams(JobControlRecord* jcr, r_ctx& rctx)
       case STREAM_ACL_FREEBSD_NFS4_ACL:
       case STREAM_ACL_HURD_DEFAULT_ACL:
       case STREAM_ACL_HURD_ACCESS_ACL:
+      case STREAM_ACL_PLUGIN:
         if (!do_reStoreAcl(jcr, dds->stream, dds->content,
                            dds->content_length)) {
           goto bail_out;
@@ -894,6 +895,7 @@ void DoRestore(JobControlRecord* jcr)
       case STREAM_ACL_FREEBSD_NFS4_ACL:
       case STREAM_ACL_HURD_DEFAULT_ACL:
       case STREAM_ACL_HURD_ACCESS_ACL:
+      case STREAM_ACL_PLUGIN:
         /*
          * Do not restore ACLs when
          * a) The current file is not extracted

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -107,7 +107,7 @@ bacl_exit_code SendAclStream(JobControlRecord* jcr,
     return bacl_exit_fatal;
   }
 
-  // Send the buffer to the storage deamon
+  // Send the buffer to the storage daemon
   Dmsg1(400, "Backing up ACL <%s>\n", acl_data->u.build->content);
   msgsave = sd->msg;
   sd->msg = acl_data->u.build->content;

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -912,7 +912,7 @@ static void pt_out(char* buf)
  *  desired, but not currently printed.
  *
  *  If the level is negative, the details of file and line number are not
- * printed.
+ *  printed.
  */
 void d_msg(const char* file, int line, int level, const char* fmt, ...)
 {

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -885,8 +885,8 @@ static inline bool PyAclPacketToNative(PyAclPacket* pAclPacket,
     }
 
     if (ap->content) { free(ap->content); }
-    ap->content = (char*)malloc(ap->content_length);
-    memcpy(ap->content, buf, ap->content_length);
+    ap->content = (char*)malloc(ap->content_length + 1);
+    memcpy(ap->content, buf, ap->content_length + 1);
   } else {
     PyErr_SetString(PyExc_TypeError,
                     "acl packet content needs to be of bytearray type");

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -887,6 +887,9 @@ static inline bool PyAclPacketToNative(PyAclPacket* pAclPacket,
     if (ap->content) { free(ap->content); }
     ap->content = (char*)malloc(ap->content_length);
     memcpy(ap->content, buf, ap->content_length);
+  } else {
+    PyErr_SetString(PyExc_TypeError,
+                    "acl packet content needs to be of bytearray type");
   }
 
   return true;
@@ -1368,9 +1371,6 @@ static PyObject* PyBareosDebugMessage(PyObject*, PyObject* args)
   int level;
   char* dbgmsg = NULL;
   PluginContext* plugin_ctx = plugin_context;
-  /* plugin_private_context* ppc = */
-  /*     (plugin_private_context*)plugin_ctx->plugin_private_context;
-   */
 
   if (!PyArg_ParseTuple(args, "i|z:BareosDebugMessage", &level, &dbgmsg)) {
     return NULL;

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -890,6 +890,7 @@ static inline bool PyAclPacketToNative(PyAclPacket* pAclPacket,
   } else {
     PyErr_SetString(PyExc_TypeError,
                     "acl packet content needs to be of bytearray type");
+    return false;
   }
 
   return true;

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -417,6 +417,45 @@ class BareosFdPluginBaseclass(object):
             "handle_backup_file() entry point in Python called with %s\n" % (savepkt),
         )
         return bRC_OK
+
+    def get_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my get_acl() entry point in Python called with %s\n" % (acl)
+        )
+        acl.content = bytearray(b"Hello ACL")
+        return bareosfd.bRC_OK
+
+    def set_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my set_acl() entry point in Python called with %s\n" % (acl)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_acl() entry point in Python called with %s\n" % (acl),
+        )
+        return bareosfd.bRC_OK
+
+    def get_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my get_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        xattr.name = bytearray(b"XATTR name")
+        xattr.value = bytearray(b"XATTR value")
+
+        # return values:
+        #   bareosfd.bRC_More to be called again to add more xattrs,
+        #   bareosfd.bRC_OK to finish adding xattrs
+        return bareosfd.bRC_OK
+
+    def set_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_xattr() entry point in Python called with %s\n" % (xattr),
+        )
+        return bareosfd.bRC_OK
 
 
 # vim: ts=4 tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
@@ -387,30 +387,6 @@ class BareosFdPluginBaseclass(object):
         )
         return bRC_OK
 
-    def get_acl(self, acl):
-        bareosfd.DebugMessage(
-            100, "get_acl() entry point in Python called with %s\n" % (acl)
-        )
-        return bRC_OK
-
-    def set_acl(self, acl):
-        bareosfd.DebugMessage(
-            100, "set_acl() entry point in Python called with %s\n" % (acl)
-        )
-        return bRC_OK
-
-    def get_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "get_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        return bRC_OK
-
-    def set_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "set_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        return bRC_OK
-
     def handle_backup_file(self, savepkt):
         bareosfd.DebugMessage(
             100,
@@ -422,7 +398,6 @@ class BareosFdPluginBaseclass(object):
         bareosfd.DebugMessage(
             100, "my get_acl() entry point in Python called with %s\n" % (acl)
         )
-        acl.content = bytearray(b"Hello ACL")
         return bareosfd.bRC_OK
 
     def set_acl(self, acl):
@@ -439,8 +414,6 @@ class BareosFdPluginBaseclass(object):
         bareosfd.DebugMessage(
             100, "my get_xattr() entry point in Python called with %s\n" % (xattr)
         )
-        xattr.name = bytearray(b"XATTR name")
-        xattr.value = bytearray(b"XATTR value")
 
         # return values:
         #   bareosfd.bRC_More to be called again to add more xattrs,

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
@@ -132,38 +132,3 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_Error
         else:
             return bareosfd.bRC_OK
-
-    def get_acl(self, acl):
-        bareosfd.DebugMessage(
-            100, "my get_acl() entry point in Python called with %s\n" % (acl)
-        )
-        acl.content = bytearray(b"Hello ACL")
-        return bareosfd.bRC_OK
-
-    def set_acl(self, acl):
-        bareosfd.DebugMessage(
-            100, "my set_acl() entry point in Python called with %s\n" % (acl)
-        )
-        bareosfd.JobMessage(
-            bareosfd.M_INFO,
-            "my set_acl() entry point in Python called with %s\n" % (acl),
-        )
-        return bareosfd.bRC_OK
-
-    def get_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "my get_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        xattr.name = bytearray(b"Hello XATTR")
-        xattr.value = bytearray(b"Hello XATTR")
-        return bareosfd.bRC_OK
-
-    def set_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        bareosfd.JobMessage(
-            bareosfd.M_INFO,
-            "my set_xattr() entry point in Python called with %s\n" % (xattr),
-        )
-        return bareosfd.bRC_OK

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
@@ -43,6 +43,7 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             "Constructor called in module %s with plugindef=%s\n"
             % (__name__, plugindef),
         )
+        self.current_xattr_number = 0
         super(BareosFdPluginLocalFileset, self).__init__(plugindef, mandatory_options)
 
     def filename_is_allowed(self, filename, allowregex, denyregex):
@@ -132,3 +133,41 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_Error
         else:
             return bareosfd.bRC_OK
+
+    def get_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "get_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        import sys
+
+        if sys.version_info >= (3, 0):
+            xattr.name = bytearray(
+                bytes("XATTR name " + str(self.current_xattr_number), "utf-8")
+            )
+            xattr.value = bytearray(
+                bytes("XATTR value " + str(self.current_xattr_number), "utf-8")
+            )
+        else:
+            xattr.name = bytearray(
+                bytes("XATTR name " + str(self.current_xattr_number))
+            )
+            xattr.value = bytearray(
+                bytes("XATTR value " + str(self.current_xattr_number))
+            )
+
+        self.current_xattr_number += 1
+        if self.current_xattr_number < 4:
+            return bareosfd.bRC_More
+        else:
+            self.current_xattr_number = 0
+            return bareosfd.bRC_OK
+
+    def set_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_xattr() entry point in Python called with %s\n" % (xattr),
+        )
+        return bareosfd.bRC_OK

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
@@ -137,11 +137,16 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
         bareosfd.DebugMessage(
             100, "my get_acl() entry point in Python called with %s\n" % (acl)
         )
+        acl.content = bytearray(b"Hello ACL")
         return bareosfd.bRC_OK
 
     def set_acl(self, acl):
         bareosfd.DebugMessage(
             100, "my set_acl() entry point in Python called with %s\n" % (acl)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_acl() entry point in Python called with %s\n" % (acl),
         )
         return bareosfd.bRC_OK
 
@@ -149,10 +154,16 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
         bareosfd.DebugMessage(
             100, "my get_xattr() entry point in Python called with %s\n" % (xattr)
         )
+        xattr.name = bytearray(b"Hello XATTR")
+        xattr.value = bytearray(b"Hello XATTR")
         return bareosfd.bRC_OK
 
     def set_xattr(self, xattr):
         bareosfd.DebugMessage(
             100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_xattr() entry point in Python called with %s\n" % (xattr),
         )
         return bareosfd.bRC_OK

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
@@ -43,7 +43,6 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             "Constructor called in module %s with plugindef=%s\n"
             % (__name__, plugindef),
         )
-        self.current_xattr_number = 0
         super(BareosFdPluginLocalFileset, self).__init__(plugindef, mandatory_options)
 
     def filename_is_allowed(self, filename, allowregex, denyregex):
@@ -133,41 +132,3 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_Error
         else:
             return bareosfd.bRC_OK
-
-    def get_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "get_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        import sys
-
-        if sys.version_info >= (3, 0):
-            xattr.name = bytearray(
-                bytes("XATTR name " + str(self.current_xattr_number), "utf-8")
-            )
-            xattr.value = bytearray(
-                bytes("XATTR value " + str(self.current_xattr_number), "utf-8")
-            )
-        else:
-            xattr.name = bytearray(
-                bytes("XATTR name " + str(self.current_xattr_number))
-            )
-            xattr.value = bytearray(
-                bytes("XATTR value " + str(self.current_xattr_number))
-            )
-
-        self.current_xattr_number += 1
-        if self.current_xattr_number < 4:
-            return bareosfd.bRC_More
-        else:
-            self.current_xattr_number = 0
-            return bareosfd.bRC_OK
-
-    def set_xattr(self, xattr):
-        bareosfd.DebugMessage(
-            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
-        )
-        bareosfd.JobMessage(
-            bareosfd.M_INFO,
-            "my set_xattr() entry point in Python called with %s\n" % (xattr),
-        )
-        return bareosfd.bRC_OK

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2022 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -132,3 +132,27 @@ class BareosFdPluginLocalFileset(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_Error
         else:
             return bareosfd.bRC_OK
+
+    def get_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my get_acl() entry point in Python called with %s\n" % (acl)
+        )
+        return bareosfd.bRC_OK
+
+    def set_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my set_acl() entry point in Python called with %s\n" % (acl)
+        )
+        return bareosfd.bRC_OK
+
+    def get_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my get_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        return bareosfd.bRC_OK
+
+    def set_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        return bareosfd.bRC_OK

--- a/core/src/plugins/filed/python/test/bareosfd_test.py
+++ b/core/src/plugins/filed/python/test/bareosfd_test.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -145,7 +145,10 @@ class TestBareosFd(unittest.TestCase):
 
     def test_AclPacket(self):
         test_AclPacket = bareosfd.AclPacket()
-        self.assertEqual('AclPacket(fname="<NULL>", content="")', str(test_AclPacket))
+        test_AclPacket.content = bytearray(b"Hello ACL")
+        self.assertEqual(
+            'AclPacket(fname="<NULL>", content="Hello ACL")', str(test_AclPacket)
+        )
 
     def test_XattrPacket(self):
         test_XattrPacket = bareosfd.XattrPacket()

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
@@ -7,6 +7,6 @@ FileSet {
       acl support = yes
       xattr support = yes
     }
-    Plugin = "@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-fd-local-fileset:filename=@tmpdir@/file-list"
+    Plugin = "@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-fd-local-fileset-acl-xattr:filename=@tmpdir@/file-list"
   }
 }

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
@@ -1,7 +1,12 @@
 FileSet {
   Name = "PluginTest"
   Description = "Test the Plugin functionality with a Python Plugin."
+
   Include {
+    Options{
+      acl support = yes
+      xattr support = yes
+    }
     Plugin = "@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=bareos-fd-local-fileset:filename=@tmpdir@/file-list"
   }
 }

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/BareosFdPluginLocalFileset.py
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/BareosFdPluginLocalFileset.py
@@ -1,1 +1,0 @@
-../../../../core/src/plugins/filed/python/pyfiles/BareosFdPluginLocalFileset.py

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/BareosFdPluginLocalFilesetAclXattr.py
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/BareosFdPluginLocalFilesetAclXattr.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+import bareosfd
+import os
+import re
+from BareosFdPluginLocalFilesBaseclass import BareosFdPluginLocalFilesBaseclass
+import stat
+
+
+class BareosFdPluginLocalFilesetAclXattr(BareosFdPluginLocalFilesBaseclass):  # noqa
+    """
+    Simple Bareos-FD-Plugin-Class that parses a file and backups all files
+    listed there Filename is taken from plugin argument 'filename'
+    """
+
+    def __init__(self, plugindef, mandatory_options=None):
+        bareosfd.DebugMessage(
+            100,
+            "Constructor called in module %s with plugindef=%s\n"
+            % (__name__, plugindef),
+        )
+        self.current_xattr_number = 0
+        super(BareosFdPluginLocalFilesetAclXattr, self).__init__(
+            plugindef, mandatory_options
+        )
+
+    def filename_is_allowed(self, filename, allowregex, denyregex):
+        """
+        Check, if filename is allowed.
+        True, if matches allowreg and not denyregex.
+        If allowreg is None, filename always matches
+        If denyreg is None, it never matches
+        """
+        if allowregex is None or allowregex.search(filename):
+            allowed = True
+        else:
+            allowed = False
+        if denyregex is None or not denyregex.search(filename):
+            denied = False
+        else:
+            denied = True
+        if not allowed or denied:
+            bareosfd.DebugMessage(100, "File %s denied by configuration\n" % (filename))
+            bareosfd.JobMessage(
+                bareosfd.M_ERROR,
+                "File %s denied by configuration\n" % (filename),
+            )
+            return False
+        else:
+            return True
+
+    def start_backup_job(self):
+        """
+        At this point, plugin options were passed and checked already.
+        We try to read from filename and setup the list of file to backup
+        in self.files_to_backup
+        """
+        bareosfd.DebugMessage(
+            100,
+            "Using %s to search for local files\n" % self.options["filename"],
+        )
+        if os.path.exists(self.options["filename"]):
+            try:
+                config_file = open(self.options["filename"], "r")
+            except:
+                bareosfd.DebugMessage(
+                    100,
+                    "Could not open file %s\n" % (self.options["filename"]),
+                )
+                return bareosfd.bRC_Error
+        else:
+            bareosfd.DebugMessage(
+                100, "File %s does not exist\n" % (self.options["filename"])
+            )
+            return bareosfd.bRC_Error
+        # Check, if we have allow or deny regular expressions defined
+        if "allow" in self.options:
+            self.allow = re.compile(self.options["allow"])
+        if "deny" in self.options:
+            self.deny = re.compile(self.options["deny"])
+
+        for listItem in config_file.read().splitlines():
+            if os.path.isfile(listItem) and self.filename_is_allowed(
+                listItem, self.allow, self.deny
+            ):
+                self.append_file_to_backup(listItem)
+            if os.path.isdir(listItem):
+                fullDirName = listItem
+                # FD requires / at the end of a directory name
+                if not fullDirName.endswith(tuple("/")):
+                    fullDirName += "/"
+                self.append_file_to_backup(fullDirName)
+                for topdir, dirNames, fileNames in os.walk(listItem):
+                    for fileName in fileNames:
+                        if self.filename_is_allowed(
+                            os.path.join(topdir, fileName),
+                            self.allow,
+                            self.deny,
+                        ):
+                            self.append_file_to_backup(os.path.join(topdir, fileName))
+                    for dirName in dirNames:
+                        fullDirName = os.path.join(topdir, dirName) + "/"
+                        self.append_file_to_backup(fullDirName)
+        bareosfd.DebugMessage(150, "Filelist: %s\n" % (self.files_to_backup))
+
+        if not self.files_to_backup:
+            bareosfd.JobMessage(
+                bareosfd.M_ERROR,
+                "No (allowed) files to backup found\n",
+            )
+            return bareosfd.bRC_Error
+        else:
+            return bareosfd.bRC_OK
+
+    def get_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "get_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        import sys
+
+        if sys.version_info >= (3, 0):
+            xattr.name = bytearray(
+                bytes("XATTR name " + str(self.current_xattr_number), "utf-8")
+            )
+            xattr.value = bytearray(
+                bytes("XATTR value " + str(self.current_xattr_number), "utf-8")
+            )
+        else:
+            xattr.name = bytearray(
+                bytes("XATTR name " + str(self.current_xattr_number))
+            )
+            xattr.value = bytearray(
+                bytes("XATTR value " + str(self.current_xattr_number))
+            )
+
+        self.current_xattr_number += 1
+        if self.current_xattr_number < 4:
+            return bareosfd.bRC_More
+        else:
+            self.current_xattr_number = 0
+            return bareosfd.bRC_OK
+
+    def set_xattr(self, xattr):
+        bareosfd.DebugMessage(
+            100, "my set_xattr() entry point in Python called with %s\n" % (xattr)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_xattr() entry point in Python called with %s\n" % (xattr),
+        )
+        return bareosfd.bRC_OK
+
+    def get_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my get_acl() entry point in Python called with %s\n" % (acl)
+        )
+        acl.content = bytearray(b"Hello ACL")
+        return bareosfd.bRC_OK
+
+    def set_acl(self, acl):
+        bareosfd.DebugMessage(
+            100, "my set_acl() entry point in Python called with %s\n" % (acl)
+        )
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "my set_acl() entry point in Python called with %s\n" % (acl),
+        )
+        return bareosfd.bRC_OK

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/bareos-fd-local-fileset-acl-xattr.py
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/bareos-fd-local-fileset-acl-xattr.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+
+# Provided by the Bareos FD Python plugin interface
+import bareosfd
+
+# This module contains the wrapper functions called by the Bareos-FD, the
+# functions call the corresponding methods from your plugin class
+import BareosFdWrapper
+
+from BareosFdWrapper import *  # noqa
+
+# This module contains the used plugin class
+import BareosFdPluginLocalFilesetAclXattr
+
+
+def load_bareos_plugin(gcplugindef):
+    """
+    This function is called by the Bareos-FD to load the plugin
+    We use it to instantiate the plugin class
+    """
+    # BareosFdWrapper.bareos_fd_plugin_object is the module attribute that
+    # holds the plugin class object
+    BareosFdWrapper.bareos_fd_plugin_object = (
+        BareosFdPluginLocalFilesetAclXattr.BareosFdPluginLocalFilesetAclXattr(
+            gcplugindef
+        )
+    )
+    return bareosfd.bRC_OK
+
+
+# the rest is done in the Plugin module

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/bareos-fd-local-fileset.py
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/python-modules/bareos-fd-local-fileset.py
@@ -1,1 +1,0 @@
-../../../../core/src/plugins/filed/python/pyfiles/bareos-fd-local-fileset.py

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/testrunner
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/testrunner
@@ -37,6 +37,8 @@ setup_data
 find ${tmp}/data/weird-files -type l -exec rm {} \;
 find tmp/data/weird-files -links +1 -type f -exec rm {} \;
 
+grep py3 <<< "$TestName" && rm tmp/data/weird-files/filename-with-non-utf8-bytestring*
+
 print_debug "$(locale)"
 
 start_test

--- a/systemtests/tests/py2plug-fd-local-fileset-basic/testrunner
+++ b/systemtests/tests/py2plug-fd-local-fileset-basic/testrunner
@@ -81,4 +81,6 @@ check_for_zombie_jobs storage=File
 check_two_logs
 check_restore_diff ${BackupDirectory}
 
+expect_grep 'name="XATTR name 3", value="XATTR value 3"' tmp/log2.out "could not find recovered XATTR in restore log"
+expect_grep 'content="Hello ACL"' tmp/log2.out "could not find recovered ACL in restore log"
 end_test

--- a/systemtests/tests/python-bareos/python-modules/bareos_fd_pluginoptions/BareosFdPluginoptions.py
+++ b/systemtests/tests/python-bareos/python-modules/bareos_fd_pluginoptions/BareosFdPluginoptions.py
@@ -40,6 +40,8 @@ class BareosFdPluginoptions(BareosFdPluginLocalFileset):
             "Constructor called in module %s with plugindef=%s\n"
             % (__name__, plugindef),
         )
+
+        self.current_xattr_number = 0
         # Last argument of super constructor is a list of mandatory arguments
         super(BareosFdPluginLocalFileset, self).__init__(plugindef, ["filename"])
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The handling of acl streams created by plugins was missing in the restore code of the filedaemon, whi ch results in the error message: `Warning: Unknown stream=1020 ignored. This shouldn't happen!`.

This PR fixes the problem, and also adds some example code how to handle the acl data in the python plugins.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
