### PR TITLE
dird: update JobStatus to DB in cases we wait for media

### DIFF
--- a/core/src/dird/getmsg.cc
+++ b/core/src/dird/getmsg.cc
@@ -83,6 +83,12 @@ static void SetJcrSdJobStatus(JobControlRecord* jcr, int SDJobStatus)
   }
   jcr->dir_impl->SDJobStatus = SDJobStatus;
 
+  jcr->setJobStatus(SDJobStatus);
+
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+    Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
+  }
+
   // Some SD Job status setting are propagated to the controlling Job.
   switch (jcr->dir_impl->SDJobStatus) {
     case JS_Incomplete:

--- a/core/src/dird/getmsg.cc
+++ b/core/src/dird/getmsg.cc
@@ -85,7 +85,7 @@ static void SetJcrSdJobStatus(JobControlRecord* jcr, int SDJobStatus)
 
   jcr->setJobStatus(SDJobStatus);
 
-  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->impl->jr)) {
+  if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
   }
 


### PR DESCRIPTION
Update JobStatus as **wait for media** to DB in cases where job is waiting for valid media to write.
From my point of view if job is in wait for media status it can't be marked as Running job(right technically it is running job from director perspective but it will do nothing until the issue with valid media will be resolved).
   
### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
