### PR TITLE
status subscription: extend output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bareos-fd-postgres: properly close database connection [PR #1326]
 - filed: fix handling of `STREAM_ACL_PLUGIN` during restore [PR #1308]
 - dird: fix tls protocol shown and document TLS Protocol & ciphers restriction [PR #1319]
+- status subscription: extend output [PR #1312]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -393,6 +394,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1306]: https://github.com/bareos/bareos/pull/1306
 [PR #1307]: https://github.com/bareos/bareos/pull/1307
 [PR #1308]: https://github.com/bareos/bareos/pull/1308
+[PR #1312]: https://github.com/bareos/bareos/pull/1312
 [PR #1313]: https://github.com/bareos/bareos/pull/1313
 [PR #1314]: https://github.com/bareos/bareos/pull/1314
 [PR #1315]: https://github.com/bareos/bareos/pull/1315

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -844,28 +844,38 @@ class BareosDb : public BareosDbQueryEnum {
                                 uint32_t JobId,
                                 OutputFormatter* sendit,
                                 e_list_type type);
+
+  enum class CollapseMode
+  {
+    NoCollapse,
+    Collapse
+  };
+
   bool ListSqlQuery(JobControlRecord* jcr,
                     const char* query,
                     OutputFormatter* sendit,
                     e_list_type type,
-                    bool verbose);
+                    const bool verbose);
   bool ListSqlQuery(JobControlRecord* jcr,
                     SQL_QUERY query,
                     OutputFormatter* sendit,
                     e_list_type type,
-                    bool verbose);
+                    const bool verbose);
   bool ListSqlQuery(JobControlRecord* jcr,
                     const char* query,
                     OutputFormatter* sendit,
                     e_list_type type,
                     const char* description,
-                    bool verbose = false);
+                    const bool verbose = false,
+                    const CollapseMode collapse = CollapseMode::NoCollapse);
   bool ListSqlQuery(JobControlRecord* jcr,
                     SQL_QUERY query,
                     OutputFormatter* sendit,
                     e_list_type type,
                     const char* description,
-                    bool verbose);
+                    const bool verbose,
+                    const CollapseMode collapse = CollapseMode::NoCollapse);
+
   void ListClientRecords(JobControlRecord* jcr,
                          char* clientname,
                          OutputFormatter* sendit,

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -515,6 +515,14 @@ static bool DoSubscriptionStatus(UaContext* ua)
   }
 
   if (kw_all || kw_detail) {
+    ua->send->ObjectKeyValue(
+        "version", "Bareos version: ", kBareosVersionStrings.Full, "%s");
+    ua->send->ObjectKeyValue("os", kBareosVersionStrings.GetOsInfo(),
+                             " (%s)\n");
+    ua->send->ObjectKeyValue("binary-info",
+                             "Binary info: ", kBareosVersionStrings.BinaryInfo,
+                             "%s\n");
+    ua->send->ObjectKeyValue("report-time", "Report time: ", now, "%s\n");
     ua->SendMsg(_("\nDetailed backup unit report:\n"));
     ua->db->ListSqlQuery(
         ua->jcr,

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -269,9 +269,7 @@ static void DoAllStatus(UaContext* ua)
   /* Count Storage items */
   LockRes(my_config);
   i = 0;
-  foreach_res (store, R_STORAGE) {
-    i++;
-  }
+  foreach_res (store, R_STORAGE) { i++; }
   unique_store = (StorageResource**)malloc(i * sizeof(StorageResource));
   /* Find Unique Storage address/port */
   i = 0;
@@ -304,9 +302,7 @@ static void DoAllStatus(UaContext* ua)
   /* Count Client items */
   LockRes(my_config);
   i = 0;
-  foreach_res (client, R_CLIENT) {
-    i++;
-  }
+  foreach_res (client, R_CLIENT) { i++; }
   unique_client = (ClientResource**)malloc(i * sizeof(ClientResource));
   /* Find Unique Client address/port */
   i = 0;
@@ -487,9 +483,10 @@ static bool show_scheduled_preview(UaContext*,
  */
 static bool DoSubscriptionStatus(UaContext* ua)
 {
-  if (!ua->AclAccessOk(Command_ACL, "configure")) {
-    ua->ErrorMsg(_("%s %s: is an invalid command or needs access right to the"
-                   " \"configure\" command.\n"),
+  if (ua->AclHasRestrictions(Client_ACL) || ua->AclHasRestrictions(Job_ACL)
+          || ua->AclHasRestrictions(FileSet_ACL)) {
+    ua->ErrorMsg(_("%s %s: needs access to all client, job"
+                   " and fileset resources.\n"),
                  ua->argk[0], ua->argk[1]);
     return false;
   }
@@ -917,9 +914,7 @@ static void ListScheduledJobs(UaContext* ua)
     }
   } /* end for loop over resources */
   UnlockRes(my_config);
-  foreach_dlist (sp, sched) {
-    PrtRuntime(ua, sp);
-  }
+  foreach_dlist (sp, sched) { PrtRuntime(ua, sp); }
   if (num_jobs == 0 && !ua->api) { ua->SendMsg(_("No Scheduled Jobs.\n")); }
   if (!ua->api) ua->SendMsg("====\n");
   Dmsg0(200, "Leave list_sched_jobs_runs()\n");

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -269,7 +269,9 @@ static void DoAllStatus(UaContext* ua)
   /* Count Storage items */
   LockRes(my_config);
   i = 0;
-  foreach_res (store, R_STORAGE) { i++; }
+  foreach_res (store, R_STORAGE) {
+    i++;
+  }
   unique_store = (StorageResource**)malloc(i * sizeof(StorageResource));
   /* Find Unique Storage address/port */
   i = 0;
@@ -302,7 +304,9 @@ static void DoAllStatus(UaContext* ua)
   /* Count Client items */
   LockRes(my_config);
   i = 0;
-  foreach_res (client, R_CLIENT) { i++; }
+  foreach_res (client, R_CLIENT) {
+    i++;
+  }
   unique_client = (ClientResource**)malloc(i * sizeof(ClientResource));
   /* Find Unique Client address/port */
   i = 0;
@@ -484,7 +488,7 @@ static bool show_scheduled_preview(UaContext*,
 static bool DoSubscriptionStatus(UaContext* ua)
 {
   if (ua->AclHasRestrictions(Client_ACL) || ua->AclHasRestrictions(Job_ACL)
-          || ua->AclHasRestrictions(FileSet_ACL)) {
+      || ua->AclHasRestrictions(FileSet_ACL)) {
     ua->ErrorMsg(_("%s %s: needs access to all client, job"
                    " and fileset resources.\n"),
                  ua->argk[0], ua->argk[1]);
@@ -512,44 +516,38 @@ static bool DoSubscriptionStatus(UaContext* ua)
 
   if (kw_all || kw_detail) {
     ua->SendMsg(_("\nDetailed backup unit report:\n"));
-    ua->send->ObjectStart("unit-detail");
     ua->db->ListSqlQuery(
         ua->jcr,
         BareosDb::SQL_QUERY::subscription_select_backup_unit_overview_0,
-        ua->send, HORZ_LIST, true);
-    ua->send->ObjectEnd("unit-detail");
+        ua->send, HORZ_LIST, "unit-detail", true);
   }
   if (kw_all || kw_detail || !kw_unknown) {
     ua->SendMsg(_("\nBackup unit totals:\n"));
-    ua->send->ObjectStart("total-units-required");
-
     PoolMem query(PM_MESSAGE);
     ua->db->FillQuery(
         query, BareosDb::SQL_QUERY::subscription_select_backup_unit_total_1,
         me->subscriptions);
-    ua->db->ListSqlQuery(ua->jcr, query.c_str(), ua->send, VERT_LIST, true);
-    ua->send->ObjectEnd("total-units-required");
+    ua->db->ListSqlQuery(ua->jcr, query.c_str(), ua->send, VERT_LIST,
+                         "total-units-required", true,
+                         BareosDb::CollapseMode::Collapse);
   }
   if (kw_all || kw_unknown) {
     ua->SendMsg(
         _("\nClients/Filesets that cannot be categorized for backup units "
           "yet:\n"));
-    ua->send->ObjectStart("filesets-not-catogorized");
     ua->db->ListSqlQuery(
         ua->jcr,
         BareosDb::SQL_QUERY::subscription_select_unclassified_client_fileset_0,
-        ua->send, HORZ_LIST, true);
-    ua->send->ObjectEnd("filesets-not-catogorized");
+        ua->send, HORZ_LIST, "filesets-not-catogorized", true);
 
     ua->SendMsg(
         _("\nAmount of data that cannot be categorized for backup units "
           "yet:\n"));
-    ua->send->ObjectStart("data-not-categorized");
     ua->db->ListSqlQuery(
         ua->jcr,
         BareosDb::SQL_QUERY::subscription_select_unclassified_amount_data_0,
-        ua->send, VERT_LIST, true);
-    ua->send->ObjectEnd("data-not-categorized");
+        ua->send, VERT_LIST, "data-not-categorized", true,
+        BareosDb::CollapseMode::Collapse);
   }
   return true;
 }
@@ -914,7 +912,9 @@ static void ListScheduledJobs(UaContext* ua)
     }
   } /* end for loop over resources */
   UnlockRes(my_config);
-  foreach_dlist (sp, sched) { PrtRuntime(ua, sp); }
+  foreach_dlist (sp, sched) {
+    PrtRuntime(ua, sp);
+  }
   if (num_jobs == 0 && !ua->api) { ua->SendMsg(_("No Scheduled Jobs.\n")); }
   if (!ua->api) ua->SendMsg("====\n");
   Dmsg0(200, "Leave list_sched_jobs_runs()\n");

--- a/core/src/lib/crypto.h
+++ b/core/src/lib/crypto.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -27,6 +27,9 @@
 
 #ifndef BAREOS_LIB_CRYPTO_H_
 #define BAREOS_LIB_CRYPTO_H_
+
+#include <optional>
+#include <string>
 
 template <typename T> class alist;
 
@@ -188,5 +191,9 @@ const char* crypto_digest_name(crypto_digest_t type);
 const char* crypto_digest_name(DIGEST* digest);
 crypto_digest_t CryptoDigestStreamType(int stream);
 const char* crypto_strerror(crypto_error_t error);
+
+std::optional<std::string> compute_hash(const std::string& unhashed,
+                                        const std::string& digestname
+                                        = "SHA256");
 
 #endif  // BAREOS_LIB_CRYPTO_H_

--- a/systemtests/tests/bareos/testrunner-status-subscriptions
+++ b/systemtests/tests/bareos/testrunner-status-subscriptions
@@ -37,7 +37,7 @@ END_OF_DATA
 run_bconsole
 
 # remove lines starting with @ so output is comparable
-sed -i -e '/^@/d' "$tmp"/status-subscription*.txt
+sed -i'.bak' -e '/^@/d' -e '/^Bareos version:/d' -e '/^Binary info:/d' -e '/^Report time:/d' -e '/^Checksum:/d' "$tmp"/status-subscription*.txt
 
 for f in status-subscriptions status-subscriptions-detail status-subscriptions-unknown; do
   if ! diff -u expected/$f.txt "$tmp/$f.txt"; then

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -23,4 +23,6 @@ Director {                            # define myself
   # Plugin Names = ""
   Working Directory =  "@working_dir@"
   DirPort = @dir_port@
+
+  Subscriptions = 10
 }

--- a/systemtests/tests/python-bareos/test_acl.py
+++ b/systemtests/tests/python-bareos/test_acl.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -375,3 +375,30 @@ class PythonBareosAclTest(bareos_unittest.Json):
         #
         self._test_list_with_valid_jobid(director, jobid1)
         self._test_list_with_invalid_jobid(director, jobid2)
+
+    def _test_status_subscription(self, username, password):
+        logger = logging.getLogger()
+
+        configured_subscriptions = "10"
+
+        director_root = bareos.bsock.DirectorConsoleJson(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
+        )
+
+        result = director_root.call("status subscription all")
+        self.assertEqual(
+            configured_subscriptions, result["total-units-required"]["configured"]
+        )
+
+    def test_status_subscription_admin(self):
+        username = self.get_operator_username()
+        password = self.get_operator_password(username)
+        self._test_status_subscription(username, password)
+
+    def test_status_subscription_user_fails(self):
+        with self.assertRaises(bareos.exceptions.JsonRpcErrorReceivedException):
+            self._test_status_subscription(u"client-bareos-fd", u"secret")


### PR DESCRIPTION
While working on https://github.com/bareos/bareos/pull/1280 some improvements to the `status subscription` command did come up and are now handled in this separate PR.

- improve the JSON output, reducing the depth of the structure and make it better understand- and parseable 
- add information Bareos version (also in case the calculation of units will change with other versions), current date and simple checksum.
- add ACL test.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
