### PR TITLE
bsmtp: fix and update code, and change CLI parsing to CLI11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: fix crashes of storage tools when autoxflate plugin is loaded [PR #1348]
 - webui: enable sorting on version column [PR #1365]
 - dird: skip disabled clients in status command [PR #1367]
+- bsmtp: fix and update code, and change CLI parsing to CLI11 [PR #1316]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -35,6 +36,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #935]: https://github.com/bareos/bareos/pull/935
 [PR #1011]: https://github.com/bareos/bareos/pull/1011
 [PR #1130]: https://github.com/bareos/bareos/pull/1130
+[PR #1316]: https://github.com/bareos/bareos/pull/1316
 [PR #1325]: https://github.com/bareos/bareos/pull/1325
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
 [PR #1339]: https://github.com/bareos/bareos/pull/1339

--- a/core/src/tools/CMakeLists.txt
+++ b/core/src/tools/CMakeLists.txt
@@ -23,7 +23,7 @@ if(HAVE_WIN32)
   list(APPEND BSMTPSRCS ../win32/tools/bsmtpres.rc)
 endif()
 add_executable(bsmtp ${BSMTPSRCS})
-target_link_libraries(bsmtp bareos)
+target_link_libraries(bsmtp bareos CLI11::CLI11)
 
 add_executable(drivetype drivetype.cc)
 target_link_libraries(drivetype bareos bareosfind)

--- a/docs/manuals/CMakeLists.txt
+++ b/docs/manuals/CMakeLists.txt
@@ -198,12 +198,11 @@ if(${docs-build-json})
     DEPENDS bscan
   )
 
-  # bsmtp -? return 1 so ||: is needed
   add_custom_command(
     OUTPUT ${USAGE_DIR}/bsmtp.txt
-    COMMAND bsmtp -? > /dev/null 2>&1 ||:
+    COMMAND bsmtp --help > /dev/null
     COMMAND ${PROJECT_SOURCE_DIR}/scripts/get-usage.sh $<TARGET_FILE:bsmtp>
-            ${USAGE_DIR} '-? ||:' ||:
+            ${USAGE_DIR}
     DEPENDS bsmtp
   )
 

--- a/docs/manuals/source/include/autogenerated/usage/bsmtp.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bsmtp.txt
@@ -1,16 +1,53 @@
+Usage: bsmtp [OPTIONS] recipients...
 
-Usage: bsmtp [-f from] [-h mailhost] [-s subject] [-c copy] [recipient ...]
-       -4          forces bsmtp to use IPv4 addresses only.
-       -6          forces bsmtp to use IPv6 addresses only.
-       -8          set charset to UTF-8
-       -a          use any ip protocol for address resolution
-       -c          set the Cc: field
-       -d <nn>     set debug level to <nn>
-       -dt         print a timestamp in debug output
-       -f          set the From: field
-       -h          use mailhost:port as the SMTP server
-       -s          set the Subject: field
-       -r          set the Reply-To: field
-       -l          set the maximum number of lines to send (default: unlimited)
-       -?          print this message.
+Positionals:
+    recipients TEXT ...
+        REQUIRED
+        List of recipients. 
 
+
+Options:
+    --version
+        Display program version information and exit 
+
+    -?,--help
+        Print this help message and exit. 
+
+    -4,--ipv4-protocol
+        Forces bsmtp to use IPv4 addresses only. 
+
+    -6,--ipv6-protocol
+        Forces bsmtp to use IPv6 addresses only. 
+
+    -8,--utf8
+        set charset to UTF-8. 
+
+    -a,--any-protocol
+        Use any ip protocol for address resolution. 
+
+    -c,--copy-to TEXT
+        Set the Cc: field. 
+
+    -d,--debug-level <level>
+        Set debug level to <level>. 
+
+    --dt,--debug-timestamps
+        Print timestamps in debug output. 
+
+    -f,--from TEXT
+        REQUIRED
+        Set the From: field. 
+
+    -h,--mailhost <mailhost/IPv4_address:port>,<[mailhost/IPv6_address]:port>
+        REQUIRED
+        Use mailhost:port as the SMTP server. 
+
+    -s,--subject TEXT
+        REQUIRED
+        Set the Subject: field. 
+
+    -r,--reply-to TEXT
+        Set the Reply-To: field. 
+
+    -l,--max-lines UINT
+        Set the maximum number of lines to send. 


### PR DESCRIPTION
## Description

A few months ago, we upgraded the bareos daemons to use CLI11 as a CLI arguments parsing tool, but `bsmtp` and `bscrypto` were left behind. This PR brings them to the fold.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

bstmp is still manually tested.