### PR TITLE
dird: config: console: prohibit PAM usage with user ACL and Profiles in consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - core: use distinct names for JobControlRecordPrivate [PR #1307]
 - webui-selenium-test: use options instead of chrome_options [PR #1306]
 - systemtests: improve webui testing [PR #1313]
+- dird: prohibit PAM usage with user ACL and Profiles in consoles [PR #1318]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -366,5 +367,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1300]: https://github.com/bareos/bareos/pull/1300
 [PR #1303]: https://github.com/bareos/bareos/pull/1303
 [PR #1305]: https://github.com/bareos/bareos/pull/1305
+[PR #1306]: https://github.com/bareos/bareos/pull/1306
+[PR #1307]: https://github.com/bareos/bareos/pull/1307
 [PR #1313]: https://github.com/bareos/bareos/pull/1313
+[PR #1318]: https://github.com/bareos/bareos/pull/1318
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -212,6 +212,13 @@ struct UserAcl {
   alist<const char*>* ACL_lists[Num_ACL] = {0}; /**< Pointers to ACLs */
   alist<ProfileResource*>* profiles
       = nullptr; /**< Pointers to profile resources */
+  bool HasAcl()
+  {
+    for (int i = Job_ACL; i < Num_ACL; ++i) {
+      if (ACL_lists[i]) { return true; }
+    }
+    return false;
+  }
 };
 
 // Console Resource

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -186,15 +186,14 @@ bool CheckResources()
   BStringList consoles_with_auth_problems;
   foreach_res (console, R_CONSOLE) {
     if (console->use_pam_authentication_
-        && (console->user_acl.ACL_lists[0] || console->user_acl.profiles)) {
-      consoles_with_auth_problems.push_back(
-          std::string(console->resource_name_));
+        && (console->user_acl.HasAcl() || console->user_acl.profiles)) {
+      consoles_with_auth_problems.emplace_back(console->resource_name_);
     }
   }
   if (!consoles_with_auth_problems.empty()) {
     Jmsg(nullptr, M_FATAL, 0,
-         "Console(s) `%s` using `Use Pam Authentication` while "
-         "having ACL or a Profile activated\n",
+         "Combining `Use Pam Authentication` with ACL commands or `Profile` in "
+         "Console(s) `%s` is not allowed\n",
          consoles_with_auth_problems.Join(',').c_str());
     UnlockRes(my_config);
     return false;

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -182,6 +182,24 @@ bool CheckResources()
     }
   }
 
+  ConsoleResource* console;
+  BStringList consoles_with_auth_problems;
+  foreach_res (console, R_CONSOLE) {
+    if (console->use_pam_authentication_
+        && (console->user_acl.ACL_lists[0] || console->user_acl.profiles)) {
+      consoles_with_auth_problems.push_back(
+          std::string(console->resource_name_));
+    }
+  }
+  if (!consoles_with_auth_problems.empty()) {
+    Jmsg(nullptr, M_FATAL, 0,
+         "Console(s) `%s` using `Use Pam Authentication` while "
+         "having ACL or a Profile activated\n",
+         consoles_with_auth_problems.Join(',').c_str());
+    UnlockRes(my_config);
+    return false;
+  }
+
   CloseMsg(nullptr);              /* close temp message handler */
   InitMsg(nullptr, me->messages); /* open daemon message handler */
   if (me->secure_erase_cmdline) {

--- a/systemtests/tests/bconsole-pam/testrunner
+++ b/systemtests/tests/bconsole-pam/testrunner
@@ -26,6 +26,9 @@ export TestName
 #shellcheck source=../environment.in
 . ./environment
 
+usepam_and_acl_config=$conf/bareos-dir.d/console/has_usepam_and_profile_with_acl.conf
+rm -f $usepam_and_acl_config
+
 JobName=backup-bareos-fd
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
@@ -145,6 +148,28 @@ if ! ${rscripts}/bareos-ctl-dir status >/dev/null; then
   exit 1
 fi
 
+
+echo "Console {
+  Name = \"usepam_acl\"
+  Password = \"secret\"
+  UsePamAuthentication = yes
+  Profile = \"operator\"
+}" > $usepam_and_acl_config
+
+cat <<END_OF_DATA >"$tmp"/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/usepam_acl.out
+reload
+messages
+quit
+END_OF_DATA
+
+${BAREOS_BCONSOLE_BINARY} -c ${conf} -p etc/user1.cred < $tmp/bconcmds >${tmp}/log1.out 2>${tmp}/err1.out
+
+expect_grep "Console(s) \`usepam_acl\` using \`Use Pam Authentication\` while having ACL or a Profile activated" \
+            "$tmp/usepam_acl.out" \
+            "wesh"
 
 stop_bareos > $output 2>&1
 

--- a/systemtests/tests/bconsole-pam/testrunner
+++ b/systemtests/tests/bconsole-pam/testrunner
@@ -167,9 +167,13 @@ END_OF_DATA
 
 ${BAREOS_BCONSOLE_BINARY} -c ${conf} -p etc/user1.cred < $tmp/bconcmds >${tmp}/log1.out 2>${tmp}/err1.out
 
-expect_grep "Console(s) \`usepam_acl\` using \`Use Pam Authentication\` while having ACL or a Profile activated" \
+expect_not_grep "reloaded" \
             "$tmp/usepam_acl.out" \
-            "wesh"
+            "Reload was succesful. This should not happen"
+
+expect_grep "Combining \`Use Pam Authentication\` with ACL commands or \`Profile\` in Console(s) \`usepam_acl\` is not allowed" \
+            "$tmp/usepam_acl.out" \
+            "Use Pam Authentication with ACL error was not shown"
 
 stop_bareos > $output 2>&1
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

This PR makes Bareos consider malformed, consoles whose configuration having simultaneously `use PAM authentication` and ACL commands, or a Profile having ACL.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
