### PR TITLE
bareos-fd-postgres: properly close database connection

### DIFF
--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -447,6 +447,12 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             )
         return bareosfd.bRC_OK
 
+    def __dbConClose(self):
+        try:
+            self.dbCon.close()
+        except Exception as e:
+            pass
+
     def closeDbConnection(self):
         # TODO Error Handling
         # Get Backup Start Date
@@ -464,6 +470,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 + "CHECKPOINT LOCATION: %s, " % self.labelItems["CHECKPOINT LOCATION"]
                 + "START WAL LOCATION: %s\n" % self.labelItems["START WAL LOCATION"],
             )
+            self.__dbConClose()
             self.PostgressFullBackupRunning = False
         except Exception as e:
             bareosfd.JobMessage(
@@ -518,6 +525,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 self.files_to_backup.append("ROP")
                 return self.checkForWalFiles()
             else:
+                self.__dbConClose()
                 return bareosfd.bRC_OK
 
     def end_backup_job(self):
@@ -529,6 +537,8 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         if self.PostgressFullBackupRunning:
             self.closeDbConnection()
             self.PostgressFullBackupRunning = False
+        else:
+            self.__dbConClose()
         return bareosfd.bRC_OK
 
     def wait_for_wal_archiving(self, LSN):


### PR DESCRIPTION
This will properly close the database connection after a Postgres WAL backup was made. As far as I could see a call to  `close()` is completely missing in the current code. As the the connection may already been closed I put it in a try/except to ignore all errors that may occur.

On my test system this prevents the PostgreSQL server to log

`unexpected EOF on client connection with an open transaction`

every backup.

- [x] Short description and the purpose of this PR is present
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
