### PR TITLE
ndmp_tape.cc: do not log current rctx->rec in joblog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 - dird: fix director resource not showing when using `show director` [PR #1322]
 
+### Changed
+- ndmp_tape.cc: do not log current rctx->rec in joblog [PR #1323]
+
 ## [21.1.5] - 2022-11-09
 
 ### Breaking Changes
@@ -635,4 +638,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1301]: https://github.com/bareos/bareos/pull/1301
 [PR #1303]: https://github.com/bareos/bareos/pull/1303
 [PR #1322]: https://github.com/bareos/bareos/pull/1322
+[PR #1323]: https://github.com/bareos/bareos/pull/1323
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -402,7 +402,6 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
       rec = dcr->before_rec;
     }
 
-    Jmsg1(jcr, M_INFO, 0, _("rctx->rec is at %p.\n"), rctx->rec);
     if (rec != rctx->rec) {
       Dmsg1(400, _("recstream: %d, rctxstream: %d .\n"), rec->maskedStream,
             rctx->rec->maskedStream);


### PR DESCRIPTION
This is a debug output used in PR 1013 which was overseen to be removed.

### Thank you for contributing to the Bareos Project!

**Backport of PR #1324 to bareos-21**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems