### PR TITLE
core: make resource/configuration locking safer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - devtools: add `pr-tool` to automate PR review and merge [PR #935]
 - build: replace sprintf by snprintf due to upgraded MacOS compiler, change linking of googletest [PR #1361]
 - storage daemon: fix crash on volume swap [PR #1356]
+- core: make resource/configuration locking safer [PR #1325]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -25,6 +26,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - add explanation about binary version numbers [PR #1354]
 
 [PR #935]: https://github.com/bareos/bareos/pull/935
+[PR #1325]: https://github.com/bareos/bareos/pull/1325
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1346]: https://github.com/bareos/bareos/pull/1346

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -258,10 +258,8 @@ static void ReadAndProcessInput(FILE* input, BareosSocket* UA_sock)
         at_prompt = false;
       }
 
-      /*
-       * Suppress output if running
-       * in background or user hit ctl-c
-       */
+      /* Suppress output if running
+       * in background or user hit ctl-c */
       if (!stop && !usrbrk()) {
         if (UA_sock->msg) { ConsoleOutput(UA_sock->msg); }
       }
@@ -584,10 +582,8 @@ int GetCmd(FILE* input, const char* prompt, BareosSocket* sock, int)
   StripTrailingJunk(line);
   command = line;
 
-  /*
-   * Split "line" into multiple commands separated by the eol character.
-   *   Each part is pointed to by "next" until finally it becomes null.
-   */
+  /* Split "line" into multiple commands separated by the eol character.
+   *   Each part is pointed to by "next" until finally it becomes null. */
   if (eol == '\0') {
     next = NULL;
   } else {

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -671,13 +671,12 @@ static bool SelectDirector(const char* director,
 
   *ret_cons = NULL;
   *ret_dir = NULL;
-  {
-    ResLocker _{console::my_config};
-    numdir = 0;
-    foreach_res (director_resource_tmp, R_DIRECTOR) { numdir++; }
-    numcon = 0;
-    foreach_res (console_resource_tmp, R_CONSOLE) { numcon++; }
-  }
+
+  numdir = 0;
+  foreach_res (director_resource_tmp, R_DIRECTOR) { numdir++; }
+  numcon = 0;
+  foreach_res (console_resource_tmp, R_CONSOLE) { numcon++; }
+
 
   if (numdir == 1) { /* No choose */
     director_resource_tmp
@@ -685,12 +684,11 @@ static bool SelectDirector(const char* director,
   }
 
   if (director) { /* Command line choice overwrite the no choose option */
-    {
-      ResLocker _{my_config};
-      foreach_res (director_resource_tmp, R_DIRECTOR) {
-        if (bstrcmp(director_resource_tmp->resource_name_, director)) { break; }
-      }
+
+    foreach_res (director_resource_tmp, R_DIRECTOR) {
+      if (bstrcmp(director_resource_tmp->resource_name_, director)) { break; }
     }
+
     if (!director_resource_tmp) { /* Can't find Director used as argument */
       ConsoleOutputFormat(_("Can't find %s in Director list\n"), director);
       return 0;
@@ -701,16 +699,15 @@ static bool SelectDirector(const char* director,
     UA_sock = new BareosSocketTCP;
   try_again:
     ConsoleOutput(_("Available Directors:\n"));
-    {
-      ResLocker _{my_config};
-      numdir = 0;
-      foreach_res (director_resource_tmp, R_DIRECTOR) {
-        ConsoleOutputFormat(_("%2d:  %s at %s:%d\n"), 1 + numdir++,
-                            director_resource_tmp->resource_name_,
-                            director_resource_tmp->address,
-                            director_resource_tmp->DIRport);
-      }
+
+    numdir = 0;
+    foreach_res (director_resource_tmp, R_DIRECTOR) {
+      ConsoleOutputFormat(_("%2d:  %s at %s:%d\n"), 1 + numdir++,
+                          director_resource_tmp->resource_name_,
+                          director_resource_tmp->address,
+                          director_resource_tmp->DIRport);
     }
+
     if (GetCmd(stdin, _("Select Director by entering a number: "), UA_sock, 600)
         < 0) {
       WSACleanup(); /* Cleanup Windows sockets */
@@ -970,7 +967,6 @@ int main(int argc, char* argv[])
   ConInit(stdin);
 
   if (list_directors) {
-    ResLocker _{my_config};
     foreach_res (director_resource, R_DIRECTOR) {
       ConsoleOutputFormat("%s\n", director_resource->resource_name_);
     }

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -430,14 +430,12 @@ static void eliminate_orphaned_client_records()
   const char* query;
 
   printf(_("Checking for orphaned Client entries.\n"));
-  /*
-   * In English:
+  /* In English:
    *   Wiffle through Client for every Client
    *   joining with the Job table including every Client even if
    *   there is not a match in Job (left outer join), then
    *   filter out only those where no Job points to a Client
-   *   i.e. Job.Client is NULL
-   */
+   *   i.e. Job.Client is NULL */
   query
       = "SELECT Client.ClientId,Client.Name FROM Client "
         "LEFT OUTER JOIN Job USING(ClientId) "
@@ -472,14 +470,12 @@ static void eliminate_orphaned_job_records()
   const char* query;
 
   printf(_("Checking for orphaned Job entries.\n"));
-  /*
-   * In English:
+  /* In English:
    *   Wiffle through Job for every Job
    *   joining with the Client table including every Job even if
    *   there is not a match in Client (left outer join), then
    *   filter out only those where no Client exists
-   *   i.e. Client.Name is NULL
-   */
+   *   i.e. Client.Name is NULL */
   query
       = "SELECT Job.JobId,Job.Name FROM Job "
         "LEFT OUTER JOIN Client USING(ClientId) "

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -876,7 +876,6 @@ int main(int argc, char* argv[])
     my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
     my_config->ParseConfig();
 
-    ResLocker _{my_config};
     foreach_res (catalog, R_CATALOG) {
       if (!catalogname.empty()
           && bstrcmp(catalog->resource_name_, catalogname.c_str())) {

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -875,7 +875,8 @@ int main(int argc, char* argv[])
 
     my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
     my_config->ParseConfig();
-    LockRes(my_config);
+
+    ResLocker _{my_config};
     foreach_res (catalog, R_CATALOG) {
       if (!catalogname.empty()
           && bstrcmp(catalog->resource_name_, catalogname.c_str())) {
@@ -887,7 +888,7 @@ int main(int argc, char* argv[])
         break;
       }
     }
-    UnlockRes(my_config);
+
     if (!found) {
       if (!catalogname.empty()) {
         Pmsg2(0,
@@ -902,10 +903,11 @@ int main(int argc, char* argv[])
       }
       exit(1);
     } else {
-      LockRes(my_config);
-      me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
-      my_config->own_resource_ = me;
-      UnlockRes(my_config);
+      {
+        ResLocker _{my_config};
+        me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
+        my_config->own_resource_ = me;
+      }
       if (!me) {
         Pmsg0(0, _("Error no Director resource defined.\n"));
         exit(1);

--- a/core/src/dird/expand.cc
+++ b/core/src/dird/expand.cc
@@ -229,7 +229,7 @@ static var_rc_t lookup_counter_var(var_t*,
   PmMemcpy(buf, var_ptr, var_len);
   (buf.c_str())[var_len] = 0;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   for (counter = NULL; (counter = (CounterResource*)my_config->GetNextRes(
                             R_COUNTER, (BareosResource*)counter));) {
     if (bstrcmp(counter->resource_name_, buf.c_str())) {
@@ -278,7 +278,6 @@ static var_rc_t lookup_counter_var(var_t*,
       break;
     }
   }
-  UnlockRes(my_config);
 
   return status;
 }
@@ -421,7 +420,7 @@ static var_rc_t operate_var(var_t*,
     (buf.c_str())[val_len] = 0;
     Dmsg1(100, "Val=%s\n", buf.c_str());
 
-    LockRes(my_config);
+    ResLocker _{my_config};
     for (counter = NULL; (counter = (CounterResource*)my_config->GetNextRes(
                               R_COUNTER, (BareosResource*)counter));) {
       if (bstrcmp(counter->resource_name_, buf.c_str())) {
@@ -429,7 +428,7 @@ static var_rc_t operate_var(var_t*,
         break;
       }
     }
-    UnlockRes(my_config);
+
     return status;
   }
   *out_size = 0;

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -149,11 +149,9 @@ bool CheckResources()
       }
     }
 
-    /*
-     * If we collect statistics on this SD make sure any other entry pointing to
+    /* If we collect statistics on this SD make sure any other entry pointing to
      * the same SD does not collect statistics otherwise we collect the same
-     * data multiple times.
-     */
+     * data multiple times. */
     if (store->collectstats) {
       nstore = store;
       while ((nstore = (StorageResource*)my_config->GetNextRes(
@@ -232,10 +230,8 @@ bool DoReloadConfig()
 
 
   if (is_reloading) {
-    /*
-     * Note: don't use Jmsg here, as it could produce a race condition
-     * on multiple parallel reloads
-     */
+    /* Note: don't use Jmsg here, as it could produce a race condition
+     * on multiple parallel reloads */
     Qmsg(nullptr, M_ERROR, 0, _("Already reloading. Request ignored.\n"));
     return false;
   }

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -183,8 +183,7 @@ void SchedulerPrivate::FillSchedulerJobQueueOrSleep()
 
 static time_t CalculateRuntime(time_t time, uint32_t minute)
 {
-  struct tm tm {
-  };
+  struct tm tm {};
   Blocaltime(&time, &tm);
   tm.tm_min = minute;
   tm.tm_sec = 0;
@@ -203,7 +202,7 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
 
   JobResource* job = nullptr;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   foreach_res (job, R_JOB) {
     if (!IsAutomaticSchedulerJob(job)) { continue; }
 
@@ -231,7 +230,6 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
       }
     }
   }
-  UnlockRes(my_config);
   Dmsg0(local_debuglevel, "Finished AddJobsForThisAndNextHourToQueue\n");
 }
 

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -202,7 +202,6 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
 
   JobResource* job = nullptr;
 
-  ResLocker _{my_config};
   foreach_res (job, R_JOB) {
     if (!IsAutomaticSchedulerJob(job)) { continue; }
 

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1286,7 +1286,7 @@ static void AllStorageSetdebug(UaContext* ua,
   std::vector<StorageResource*> storages_with_unique_address;
   StorageResource* storage_in_config = nullptr;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   do {
     storage_in_config = static_cast<StorageResource*>(
         my_config->GetNextRes(R_STORAGE, storage_in_config));
@@ -1307,7 +1307,6 @@ static void AllStorageSetdebug(UaContext* ua,
       }
     }
   } while (storage_in_config);
-  UnlockRes(my_config);
 
   for (StorageResource* store : storages_with_unique_address) {
     DoStorageSetdebugFunction(ua, store, level, trace_flag, timestamp_flag);
@@ -1342,7 +1341,7 @@ static void AllClientSetdebug(UaContext* ua,
   std::vector<ClientResource*> clients_with_unique_address;
   ClientResource* client_in_config = nullptr;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   do {
     client_in_config = static_cast<ClientResource*>(
         my_config->GetNextRes(R_CLIENT, client_in_config));
@@ -1363,7 +1362,6 @@ static void AllClientSetdebug(UaContext* ua,
       }
     }
   } while (client_in_config);
-  UnlockRes(my_config);
 
   for (ClientResource* client : clients_with_unique_address) {
     DoClientSetdebugFunction(ua, client, level, trace_flag, hangup_flag,

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -616,13 +616,11 @@ bool Do_a_command(UaContext* ua)
         ua->LogAuditEventCmdline();
       }
 
-      /*
-       * Some commands alter the JobStatus of the JobControlRecord.
+      /* Some commands alter the JobStatus of the JobControlRecord.
        * As the console JobControlRecord keeps running,
        * we set it to running state again.
        * ua->jcr->setJobStatus(JS_Running)
-       * isn't enough, as it does not overwrite error states.
-       */
+       * isn't enough, as it does not overwrite error states. */
       ua->jcr->setJobStatus(JS_Running);
 
       if (ua->api) { user->signal(BNET_CMD_BEGIN); }
@@ -2028,10 +2026,8 @@ static bool TruncateCmd(UaContext* ua, const char*)
   PoolDbRecord pool_dbr;
   StorageDbRecord storage_dbr;
   drive_number_t drive_number = 0;
-  /*
-   * Look for volumes that can be recycled,
-   * are enabled and have used more than the first block.
-   */
+  /* Look for volumes that can be recycled,
+   * are enabled and have used more than the first block. */
   mr.Recycle = 1;
   mr.Enabled = VOL_ENABLED;
   mr.VolBytes = (512 * 126); /* search volumes with more than 64,512 bytes
@@ -2065,11 +2061,9 @@ static bool TruncateCmd(UaContext* ua, const char*)
   ua->send->AddAclFilterTuple(2, Pool_ACL);
   ua->send->AddAclFilterTuple(3, Storage_ACL);
 
-  /*
-   * storage parameter is only required
+  /* storage parameter is only required
    * if ACL forbids access to all storages.
-   * Otherwise the user should not be asked for this parameter.
-   */
+   * Otherwise the user should not be asked for this parameter. */
   i = FindArgWithValue(ua, "storage");
   if ((i >= 0) || ua->AclHasRestrictions(Storage_ACL)) {
     if (!SelectStorageDbr(ua, &storage_dbr, "storage")) { goto bail_out; }
@@ -2077,11 +2071,9 @@ static bool TruncateCmd(UaContext* ua, const char*)
     parsed_args++;
   }
 
-  /*
-   * pool parameter is only required
+  /* pool parameter is only required
    * if ACL forbids access to all pools.
-   * Otherwise the user should not be asked for this parameter.
-   */
+   * Otherwise the user should not be asked for this parameter. */
   i = FindArgWithValue(ua, "pool");
   if ((i >= 0) || ua->AclHasRestrictions(Pool_ACL)) {
     if (!SelectPoolDbr(ua, &pool_dbr, "pool")) { goto bail_out; }
@@ -2089,12 +2081,10 @@ static bool TruncateCmd(UaContext* ua, const char*)
     if (i >= 0) { parsed_args++; }
   }
 
-  /*
-   * parse volume parameter.
+  /* parse volume parameter.
    * Currently only support one volume parameter
    * (multiple volume parameter have been intended before,
-   * but this causes problems with parsing and ACL handling).
-   */
+   * but this causes problems with parsing and ACL handling). */
   i = FindArgWithValue(ua, "volume");
   if (i >= 0) {
     if (IsNameValid(ua->argv[i])) {
@@ -2140,11 +2130,9 @@ static bool TruncateCmd(UaContext* ua, const char*)
   ua->db->ListSqlQuery(ua->jcr, tmp.c_str(), ua->send, HORZ_LIST, "volumes",
                        true);
 
-  /*
-   * execute query to get media ids.
+  /* execute query to get media ids.
    * Second execution is only required,
-   * because function is also used in other contextes.
-   */
+   * because function is also used in other contextes. */
   // tmp.strcpy(ua->db->cmd);
   if (!ua->db->GetQueryDbids(ua->jcr, tmp, mediaIds)) {
     Dmsg0(100, "No results from db_get_query_dbids\n");
@@ -2383,13 +2371,11 @@ static void DeleteJob(UaContext* ua)
       s = strdup(ua->argv[i]);
       tok = s;
 
-      /*
-       * We could use strtok() here.  But we're not going to, because:
+      /* We could use strtok() here.  But we're not going to, because:
        * (a) strtok() is deprecated, having been replaced by strsep();
        * (b) strtok() is broken in significant ways.
        * we could use strsep() instead, but it's not universally available.
-       * so we grow our own using strchr().
-       */
+       * so we grow our own using strchr(). */
       sep = strchr(tok, ',');
       while (sep != NULL) {
         *sep = '\0';
@@ -2446,10 +2432,8 @@ static bool DeleteJobIdRange(UaContext* ua, char* tok)
     j2 = (JobId_t)str_to_uint64(tok2);
 
     if (j2 > j1) {
-      /*
-       * See if the range is big if more then 25 Jobs are deleted
-       * ask the user for confirmation.
-       */
+      /* See if the range is big if more then 25 Jobs are deleted
+       * ask the user for confirmation. */
       if ((!ua->batch) && ((j2 - j1) > 25)) {
         Bsnprintf(buf, sizeof(buf),
                   _("Are you sure you want to delete %d JobIds ? (yes/no): "),
@@ -2682,10 +2666,8 @@ static bool wait_cmd(UaContext* ua, const char*)
   char jobstatus = '?'; /* Unknown by default */
   PoolMem temp(PM_MESSAGE);
 
-  /*
-   * no args
-   * Wait until no job is running
-   */
+  /* no args
+   * Wait until no job is running */
   if (ua->argc == 1) {
     Bmicrosleep(0, 200000); /* let job actually start */
     for (bool running = true; running;) {
@@ -2866,10 +2848,8 @@ static bool DotHelpCmd(UaContext* ua, const char*)
 {
   int i, j;
 
-  /*
-   * Implement DotHelpCmd here instead of ua_dotcmds.c,
-   * because comsize and commands are defined here.
-   */
+  /* Implement DotHelpCmd here instead of ua_dotcmds.c,
+   * because comsize and commands are defined here. */
 
   // Want to display a specific help section
   j = FindArgWithValue(ua, NT_("item"));

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -867,7 +867,7 @@ bool DotJobdefsCmd(UaContext* ua, const char*)
 {
   JobResource* jobdefs;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("jobdefs");
   foreach_res (jobdefs, R_JOBDEFS) {
     if (ua->AclAccessOk(Job_ACL, jobdefs->resource_name_)) {
@@ -877,7 +877,6 @@ bool DotJobdefsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("jobdefs");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -899,7 +898,7 @@ bool DotJobsCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("jobs");
   foreach_res (job, R_JOB) {
     if (!type || type == job->JobType) {
@@ -915,7 +914,6 @@ bool DotJobsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("jobs");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -954,7 +952,7 @@ bool DotFilesetsCmd(UaContext* ua, const char*)
 {
   FilesetResource* fs;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("filesets");
   foreach_res (fs, R_FILESET) {
     if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
@@ -964,7 +962,6 @@ bool DotFilesetsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("filesets");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -973,7 +970,7 @@ bool DotCatalogsCmd(UaContext* ua, const char*)
 {
   CatalogResource* cat;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("catalogs");
   foreach_res (cat, R_CATALOG) {
     if (ua->AclAccessOk(Catalog_ACL, cat->resource_name_)) {
@@ -983,7 +980,6 @@ bool DotCatalogsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("catalogs");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -997,7 +993,7 @@ bool DotClientsCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("clients");
   foreach_res (client, R_CLIENT) {
     if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
@@ -1011,7 +1007,6 @@ bool DotClientsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("clients");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1020,7 +1015,7 @@ bool DotConsolesCmd(UaContext* ua, const char*)
 {
   ConsoleResource* console;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("consoles");
   foreach_res (console, R_CONSOLE) {
     ua->send->ObjectStart();
@@ -1028,7 +1023,6 @@ bool DotConsolesCmd(UaContext* ua, const char*)
     ua->send->ObjectEnd();
   }
   ua->send->ArrayEnd("consoles");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1037,7 +1031,7 @@ bool DotUsersCmd(UaContext* ua, const char*)
 {
   UserResource* user;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("users");
   foreach_res (user, R_USER) {
     ua->send->ObjectStart();
@@ -1045,7 +1039,6 @@ bool DotUsersCmd(UaContext* ua, const char*)
     ua->send->ObjectEnd();
   }
   ua->send->ArrayEnd("users");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1054,7 +1047,7 @@ bool DotMsgsCmd(UaContext* ua, const char*)
 {
   MessagesResource* msgs = NULL;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("messages");
   foreach_res (msgs, R_MSGS) {
     ua->send->ObjectStart();
@@ -1062,7 +1055,6 @@ bool DotMsgsCmd(UaContext* ua, const char*)
     ua->send->ObjectEnd();
   }
   ua->send->ArrayEnd("messages");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1079,7 +1071,7 @@ bool DotPoolsCmd(UaContext* ua, const char*)
     length = 0;
   }
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("pools");
   foreach_res (pool, R_POOL) {
     if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
@@ -1091,7 +1083,6 @@ bool DotPoolsCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("pools");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1105,7 +1096,7 @@ bool DotStorageCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("storages");
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
@@ -1119,7 +1110,6 @@ bool DotStorageCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("storages");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1128,7 +1118,7 @@ bool DotProfilesCmd(UaContext* ua, const char*)
 {
   ProfileResource* profile;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("profiles");
   foreach_res (profile, R_PROFILE) {
     ua->send->ObjectStart();
@@ -1136,7 +1126,6 @@ bool DotProfilesCmd(UaContext* ua, const char*)
     ua->send->ObjectEnd();
   }
   ua->send->ArrayEnd("profiles");
-  UnlockRes(my_config);
 
   return true;
 }
@@ -1319,7 +1308,7 @@ bool DotScheduleCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   ua->send->ArrayStart("schedules");
   foreach_res (sched, R_SCHEDULE) {
     if (ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) {
@@ -1333,7 +1322,6 @@ bool DotScheduleCmd(UaContext* ua, const char*)
     }
   }
   ua->send->ArrayEnd("schedules");
-  UnlockRes(my_config);
 
   return true;
 }

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -867,7 +867,6 @@ bool DotJobdefsCmd(UaContext* ua, const char*)
 {
   JobResource* jobdefs;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("jobdefs");
   foreach_res (jobdefs, R_JOBDEFS) {
     if (ua->AclAccessOk(Job_ACL, jobdefs->resource_name_)) {
@@ -898,7 +897,6 @@ bool DotJobsCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("jobs");
   foreach_res (job, R_JOB) {
     if (!type || type == job->JobType) {
@@ -952,7 +950,6 @@ bool DotFilesetsCmd(UaContext* ua, const char*)
 {
   FilesetResource* fs;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("filesets");
   foreach_res (fs, R_FILESET) {
     if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
@@ -970,7 +967,6 @@ bool DotCatalogsCmd(UaContext* ua, const char*)
 {
   CatalogResource* cat;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("catalogs");
   foreach_res (cat, R_CATALOG) {
     if (ua->AclAccessOk(Catalog_ACL, cat->resource_name_)) {
@@ -993,7 +989,6 @@ bool DotClientsCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("clients");
   foreach_res (client, R_CLIENT) {
     if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
@@ -1015,7 +1010,6 @@ bool DotConsolesCmd(UaContext* ua, const char*)
 {
   ConsoleResource* console;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("consoles");
   foreach_res (console, R_CONSOLE) {
     ua->send->ObjectStart();
@@ -1031,7 +1025,6 @@ bool DotUsersCmd(UaContext* ua, const char*)
 {
   UserResource* user;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("users");
   foreach_res (user, R_USER) {
     ua->send->ObjectStart();
@@ -1047,7 +1040,6 @@ bool DotMsgsCmd(UaContext* ua, const char*)
 {
   MessagesResource* msgs = NULL;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("messages");
   foreach_res (msgs, R_MSGS) {
     ua->send->ObjectStart();
@@ -1071,7 +1063,6 @@ bool DotPoolsCmd(UaContext* ua, const char*)
     length = 0;
   }
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("pools");
   foreach_res (pool, R_POOL) {
     if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
@@ -1096,7 +1087,6 @@ bool DotStorageCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("storages");
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
@@ -1118,7 +1108,6 @@ bool DotProfilesCmd(UaContext* ua, const char*)
 {
   ProfileResource* profile;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("profiles");
   foreach_res (profile, R_PROFILE) {
     ua->send->ObjectStart();
@@ -1308,7 +1297,6 @@ bool DotScheduleCmd(UaContext* ua, const char*)
   enabled = FindArg(ua, NT_("enabled")) >= 0;
   disabled = FindArg(ua, NT_("disabled")) >= 0;
 
-  ResLocker _{my_config};
   ua->send->ArrayStart("schedules");
   foreach_res (sched, R_SCHEDULE) {
     if (ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) {

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -629,10 +629,8 @@ bool DotBvfsGetJobidsCmd(UaContext* ua, const char*)
   if (jr.JobLevel == L_BASE) {
     jobids.add(edit_int64(jr.JobId, ed1));
   } else {
-    /*
-     * If we have the "all" option, we do a search on all defined fileset for
-     * this client
-     */
+    /* If we have the "all" option, we do a search on all defined fileset for
+     * this client */
     if (FindArg(ua, "all") > 0) {
       ua->db->FillQuery(query, BareosDb::SQL_QUERY::uar_sel_filesetid,
                         edit_int64(jr.ClientId, ed1));
@@ -797,10 +795,8 @@ bool DotAdminCmds(UaContext* ua, const char*)
   }
 
   if (!dir && !store && !client) {
-    /*
-     * We didn't find an appropriate keyword above, so
-     * prompt the user.
-     */
+    /* We didn't find an appropriate keyword above, so
+     * prompt the user. */
     StartPrompt(ua, _("Available daemons are: \n"));
     AddPrompt(ua, _("Director"));
     AddPrompt(ua, _("Storage"));
@@ -1398,11 +1394,9 @@ bool DotDefaultsCmd(UaContext* ua, const char*)
     if (job) {
       UnifiedStorageResource store;
 
-      /*
-       * BAT parses the result of this command message by message,
+      /* BAT parses the result of this command message by message,
        * instead of looking for a separator.
-       * Therefore the SendBuffer() function is called after each line.
-       */
+       * Therefore the SendBuffer() function is called after each line. */
       ua->send->ObjectKeyValue("job", "%s=", job->resource_name_, "%s\n");
       ua->send->SendBuffer();
       ua->send->ObjectKeyValue("pool", "%s=", job->pool->resource_name_,

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -231,12 +231,11 @@ bool show_cmd(UaContext* ua, const char*)
     return true;
   }
 
-  LockRes(my_config);
+  ResLocker _{my_config};
 
   // Without parameter, show all ressources.
   if (ua->argc == 1 || FindArg(ua, "all") > 0) {
     ShowAll(ua, hide_sensitive_data, show_verbose);
-    UnlockRes(my_config);
     return true;
   }
 
@@ -260,7 +259,6 @@ bool show_cmd(UaContext* ua, const char*)
         ShowDisabledSchedules(ua);
       }
       ua->send->ObjectEnd("disabled");
-      UnlockRes(my_config);
       return true;
     }
 
@@ -290,7 +288,6 @@ bool show_cmd(UaContext* ua, const char*)
           if (!res) {
             ua->ErrorMsg(_("%s resource %s not found.\n"), res_name,
                          ua->argv[i]);
-            UnlockRes(my_config);
             return true;
           }
           break;
@@ -307,7 +304,6 @@ bool show_cmd(UaContext* ua, const char*)
     }
   }
 
-  UnlockRes(my_config);
   return true;
 }
 
@@ -1165,7 +1161,8 @@ static inline bool parse_fileset_selection_param(PoolMem& selection,
     FilesetResource* fs;
     PoolMem temp(PM_MESSAGE);
 
-    LockRes(my_config);
+
+    ResLocker _{my_config};
     foreach_res (fs, R_FILESET) {
       if (!ua->AclAccessOk(FileSet_ACL, fs->resource_name_, false)) {
         continue;
@@ -1178,7 +1175,7 @@ static inline bool parse_fileset_selection_param(PoolMem& selection,
       PmStrcat(selection, temp.c_str());
     }
     PmStrcat(selection, ") ");
-    UnlockRes(my_config);
+
   } else if (fileset >= 0) {
     if (!ua->AclAccessOk(FileSet_ACL, ua->argv[fileset], true)) {
       ua->ErrorMsg(_("Access to specified FileSet not allowed.\n"));

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -213,10 +213,8 @@ bool show_cmd(UaContext* ua, const char*)
 {
   Dmsg1(20, "show: %s\n", ua->UA_sock->msg);
 
-  /*
-   * When the console has no access to the configure cmd then any show cmd
-   * will suppress all sensitive information like for instance passwords.
-   */
+  /* When the console has no access to the configure cmd then any show cmd
+   * will suppress all sensitive information like for instance passwords. */
 
   bool hide_sensitive_data = !ua->AclAccessOk(Command_ACL, "configure", false);
 
@@ -453,17 +451,13 @@ static void SetQueryRange(PoolMem& query_range, UaContext* ua, JobDbRecord* jr)
 {
   int i;
 
-  /*
-   * Ensure query range is an empty string instead of NULL
-   * to avoid any issues.
-   */
+  /* Ensure query range is an empty string instead of NULL
+   * to avoid any issues. */
   if (query_range.c_str() == NULL) { PmStrcpy(query_range, ""); }
 
-  /*
-   * See if this is a second call to SetQueryRange() if so and any acl
+  /* See if this is a second call to SetQueryRange() if so and any acl
    * filters have been set we setup a new query_range filter including a
-   * limit filter.
-   */
+   * limit filter. */
   if (query_range.strlen()) {
     if (!ua->send->has_acl_filters()) { return; }
     PmStrcpy(query_range, "");
@@ -532,10 +526,8 @@ static bool ListMedia(UaContext* ua,
                                optionslist.count, ua->send, llist);
       ua->send->ObjectEnd("volume");
     } else {
-      /*
-       * If no job or jobid keyword found, then we list all media
-       * Is a specific pool wanted?
-       */
+      /* If no job or jobid keyword found, then we list all media
+       * Is a specific pool wanted? */
 
       PoolDbRecord pr;
       int i = FindArgWithValue(ua, NT_("pool"));
@@ -561,12 +553,10 @@ static bool ListMedia(UaContext* ua,
 
         // List all volumes, flat
         if (FindArg(ua, NT_("all")) > 0) {
-          /*
-           * The result of "list media all"
+          /* The result of "list media all"
            * does not contain the Pool information,
            * therefore checking the Pool_ACL is not possible.
-           * For this reason, we prevent this command.
-           */
+           * For this reason, we prevent this command. */
           if (ua->AclHasRestrictions(Pool_ACL) && (llist != VERT_LIST)) {
             ua->ErrorMsg(
                 _("Restricted permission. Use the commands 'list media' or "
@@ -758,10 +748,8 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
   } else if ((Bstrcasecmp(ua->argk[1], NT_("jobid"))
               || Bstrcasecmp(ua->argk[1], NT_("ujobid")))
              && ua->argv[1]) {
-    /*
-     * List JOBID=nn
-     * List UJOBID=xxx
-     */
+    /* List JOBID=nn
+     * List UJOBID=xxx */
     if (ua->argv[1]) {
       jobid = GetJobidFromCmdline(ua);
       if (jobid > 0) {
@@ -880,10 +868,8 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
   } else if (Bstrcasecmp(ua->argk[1], NT_("log"))) {
     bool reverse;
 
-    /*
-     * List last <limit> LOG entries
-     * default is DEFAULT_LOG_LINES entries
-     */
+    /* List last <limit> LOG entries
+     * default is DEFAULT_LOG_LINES entries */
     reverse = FindArg(ua, NT_("reverse")) >= 0;
 
     if (strlen(query_range.c_str()) == 0) {
@@ -1346,10 +1332,8 @@ RunResource* find_next_run(RunResource* run,
     run = run->next;
   }
   for (; run; run = run->next) {
-    /*
-     * Find runs in next 24 hours.  Day 0 is today, so if
-     *   ndays=1, look at today and tomorrow.
-     */
+    /* Find runs in next 24 hours.  Day 0 is today, so if
+     *   ndays=1, look at today and tomorrow. */
     for (day = 0; day <= ndays; day++) {
       future = now + (day * 60 * 60 * 24);
 

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -1161,8 +1161,6 @@ static inline bool parse_fileset_selection_param(PoolMem& selection,
     FilesetResource* fs;
     PoolMem temp(PM_MESSAGE);
 
-
-    ResLocker _{my_config};
     foreach_res (fs, R_FILESET) {
       if (!ua->AclAccessOk(FileSet_ACL, fs->resource_name_, false)) {
         continue;

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -187,12 +187,10 @@ bool RestoreCmd(UaContext* ua, const char*)
     goto bail_out;
   }
 
-  /*
-   * Request user to select JobIds or files by various different methods
+  /* Request user to select JobIds or files by various different methods
    *  last 20 jobs, where File saved, most recent backup, ...
    *  In the end, a list of files are pumped into
-   *  AddFindex()
-   */
+   *  AddFindex() */
   switch (UserSelectJobidsOrFiles(ua, &rx)) {
     case 0: /* error */
       goto bail_out;
@@ -214,11 +212,9 @@ bool RestoreCmd(UaContext* ua, const char*)
   }
   if (!job) { goto bail_out; }
 
-  /*
-   * When doing NDMP_NATIVE restores, we don't create any bootstrap file
+  /* When doing NDMP_NATIVE restores, we don't create any bootstrap file
    * as we only send a namelist for restore. The storage handling is
-   * done by the NDMP state machine via robot and tape interface.
-   */
+   * done by the NDMP state machine via robot and tape interface. */
   if (job->Protocol == PT_NDMP_NATIVE) {
     ua->InfoMsg(
         _("Skipping BootStrapRecord creation as we are doing NDMP_NATIVE "
@@ -527,11 +523,9 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
         done = true;
         break;
       case 1: /* current */
-        /*
-         * Note, we add one second here just to include any job
+        /* Note, we add one second here just to include any job
          *  that may have finished within the current second,
-         *  which happens a lot in scripting small jobs.
-         */
+         *  which happens a lot in scripting small jobs. */
         bstrutime(date, sizeof(date), now);
         have_date = true;
         break;
@@ -762,10 +756,8 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
   POOLMEM* JobIds = GetPoolMemory(PM_FNAME);
   *JobIds = 0;
   rx->TotalFiles = 0;
-  /*
-   * Find total number of files to be restored, and filter the JobId
-   *  list to contain only ones permitted by the ACL conditions.
-   */
+  /* Find total number of files to be restored, and filter the JobId
+   *  list to contain only ones permitted by the ACL conditions. */
   JobDbRecord jr;
   for (p = rx->JobIds;;) {
     char ed1[50];
@@ -1125,10 +1117,8 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
   tree.all = rx->all;
   last_JobId = 0;
 
-  /*
-   * For display purposes, the same JobId, with different volumes may
-   * appear more than once, however, we only insert it once.
-   */
+  /* For display purposes, the same JobId, with different volumes may
+   * appear more than once, however, we only insert it once. */
   p = rx->JobIds;
   tree.FileEstimate = 0;
 
@@ -1162,11 +1152,9 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
     PmStrcat(rx->JobIds, rx->BaseJobIds);
   }
 
-  /*
-   * Look at the first JobId on the list (presumably the oldest) and
+  /* Look at the first JobId on the list (presumably the oldest) and
    *  if it is marked purged, don't do the manual selection because
-   *  the Job was pruned, so the tree is incomplete.
-   */
+   *  the Job was pruned, so the tree is incomplete. */
   if (tree.FileCount != 0) {
     // Find out if any Job is purged
     Mmsg(rx->query, "SELECT SUM(PurgedFiles) FROM Job WHERE JobId IN (%s)",
@@ -1205,10 +1193,8 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
       OK = UserSelectFilesFromTree(&tree);
     }
 
-    /*
-     * Walk down through the tree finding all files marked to be
-     *  extracted making a bootstrap file.
-     */
+    /* Walk down through the tree finding all files marked to be
+     *  extracted making a bootstrap file. */
     if (OK) {
       for (TREE_NODE* node = FirstTreeNode(tree.root); node;
            node = NextTreeNode(node)) {
@@ -1227,11 +1213,9 @@ static bool BuildDirectoryTree(UaContext* ua, RestoreContext* rx)
     }
   }
 
-  /*
-   * We keep the tree with selected restore files.
+  /* We keep the tree with selected restore files.
    * For NDMP restores its used in the DMA to know what to restore.
-   * The tree is freed by the DMA when its done.
-   */
+   * The tree is freed by the DMA when its done. */
   ua->jcr->dir_impl->restore_tree_root = tree.root;
 
   return OK;
@@ -1345,10 +1329,8 @@ static bool SelectBackupsBeforeDate(UaContext* ua,
     goto bail_out;
   }
 
-  /*
-   * Note, this is needed because I don't seem to get the callback from the call
-   * just above.
-   */
+  /* Note, this is needed because I don't seem to get the callback from the call
+   * just above. */
   rx->JobTDate = 0;
   ua->db->FillQuery(rx->query, BareosDb::SQL_QUERY::uar_sel_all_temp1);
   if (!ua->db->SqlQuery(rx->query, LastFullHandler, (void*)rx)) {
@@ -1409,10 +1391,8 @@ static bool SelectBackupsBeforeDate(UaContext* ua,
       if (ua->pint32_val) {
         PoolMem JobIds(PM_FNAME);
 
-        /*
-         * Change the list of jobs needed to do the restore to the copies of the
-         * Job.
-         */
+        /* Change the list of jobs needed to do the restore to the copies of the
+         * Job. */
         PmStrcpy(JobIds, rx->JobIds);
         rx->last_jobid[0] = rx->JobIds[0] = 0;
         ua->db->FillQuery(rx->query, BareosDb::SQL_QUERY::uar_sel_jobid_copies,

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -1519,17 +1519,16 @@ void FindStorageResource(UaContext* ua,
     return;
   }
   // Try looking up Storage by name
-  {
-    ResLocker _{my_config};
-    foreach_res (store, R_STORAGE) {
-      if (bstrcmp(Storage, store->resource_name_)) {
-        if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
-          rx.store = store;
-        }
-        break;
+
+  foreach_res (store, R_STORAGE) {
+    if (bstrcmp(Storage, store->resource_name_)) {
+      if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
+        rx.store = store;
       }
+      break;
     }
   }
+
 
   if (rx.store) {
     int i;
@@ -1550,7 +1549,6 @@ void FindStorageResource(UaContext* ua,
 
   // If no storage resource, try to find one from MediaType
   if (!rx.store) {
-    ResLocker _{my_config};
     foreach_res (store, R_STORAGE) {
       if (bstrcmp(MediaType, store->media_type)) {
         if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -158,7 +158,6 @@ StorageResource* select_storage_resource(UaContext* ua, bool autochanger_only)
     StartPrompt(ua, _("The defined Storage resources are:\n"));
   }
 
-  ResLocker _{my_config};
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
       if (autochanger_only && !store->autochanger) {
@@ -194,14 +193,12 @@ FilesetResource* select_fileset_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined FileSet resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (fs, R_FILESET) {
-      if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
-        fileset_resource_names.emplace_back(fs->resource_name_);
-      }
+  foreach_res (fs, R_FILESET) {
+    if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
+      fileset_resource_names.emplace_back(fs->resource_name_);
     }
   }
+
 
   SortCaseInsensitive(fileset_resource_names);
 
@@ -255,12 +252,9 @@ CatalogResource* get_catalog_resource(UaContext* ua)
   if (!catalog) {
     StartPrompt(ua, _("The defined Catalog resources are:\n"));
 
-    {
-      ResLocker _{my_config};
-      foreach_res (catalog, R_CATALOG) {
-        if (ua->AclAccessOk(Catalog_ACL, catalog->resource_name_)) {
-          AddPrompt(ua, catalog->resource_name_);
-        }
+    foreach_res (catalog, R_CATALOG) {
+      if (ua->AclAccessOk(Catalog_ACL, catalog->resource_name_)) {
+        AddPrompt(ua, catalog->resource_name_);
       }
     }
 
@@ -269,7 +263,6 @@ CatalogResource* get_catalog_resource(UaContext* ua)
         < 0) {
       return NULL;
     }
-
     catalog = ua->GetCatalogResWithName(name);
   }
 
@@ -285,15 +278,12 @@ JobResource* select_enable_disable_job_resource(UaContext* ua, bool enable)
 
   StartPrompt(ua, _("The defined Job resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (job, R_JOB) {
-      if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
-      if (job->enabled == enable) { /* Already enabled/disabled? */
-        continue;                   /* yes, skip */
-      }
-      job_resource_names.emplace_back(job->resource_name_);
+  foreach_res (job, R_JOB) {
+    if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
+    if (job->enabled == enable) { /* Already enabled/disabled? */
+      continue;                   /* yes, skip */
     }
+    job_resource_names.emplace_back(job->resource_name_);
   }
 
   SortCaseInsensitive(job_resource_names);
@@ -321,12 +311,9 @@ JobResource* select_job_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Job resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (job, R_JOB) {
-      if (ua->AclAccessOk(Job_ACL, job->resource_name_)) {
-        job_resource_names.emplace_back(job->resource_name_);
-      }
+  foreach_res (job, R_JOB) {
+    if (ua->AclAccessOk(Job_ACL, job->resource_name_)) {
+      job_resource_names.emplace_back(job->resource_name_);
     }
   }
 
@@ -372,13 +359,11 @@ JobResource* select_restore_job_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Restore Job resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (job, R_JOB) {
-      if (job->JobType == JT_RESTORE
-          && ua->AclAccessOk(Job_ACL, job->resource_name_)) {
-        restore_job_names.emplace_back(job->resource_name_);
-      }
+
+  foreach_res (job, R_JOB) {
+    if (job->JobType == JT_RESTORE
+        && ua->AclAccessOk(Job_ACL, job->resource_name_)) {
+      restore_job_names.emplace_back(job->resource_name_);
     }
   }
 
@@ -406,12 +391,9 @@ ClientResource* select_client_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Client resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (client, R_CLIENT) {
-      if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
-        client_resource_names.emplace_back(client->resource_name_);
-      }
+  foreach_res (client, R_CLIENT) {
+    if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
+      client_resource_names.emplace_back(client->resource_name_);
     }
   }
 
@@ -442,15 +424,12 @@ ClientResource* select_enable_disable_client_resource(UaContext* ua,
 
   StartPrompt(ua, _("The defined Client resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (client, R_CLIENT) {
-      if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
-      if (client->enabled == enable) { /* Already enabled/disabled? */
-        continue;                      /* yes, skip */
-      }
-      client_resource_names.emplace_back(client->resource_name_);
+  foreach_res (client, R_CLIENT) {
+    if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
+    if (client->enabled == enable) { /* Already enabled/disabled? */
+      continue;                      /* yes, skip */
     }
+    client_resource_names.emplace_back(client->resource_name_);
   }
 
   SortCaseInsensitive(client_resource_names);
@@ -505,15 +484,12 @@ ScheduleResource* select_enable_disable_schedule_resource(UaContext* ua,
 
   StartPrompt(ua, _("The defined Schedule resources are:\n"));
 
-  {
-    ResLocker _{my_config};
-    foreach_res (sched, R_SCHEDULE) {
-      if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
-      if (sched->enabled == enable) { /* Already enabled/disabled? */
-        continue;                     /* yes, skip */
-      }
-      schedule_resource_names.emplace_back(sched->resource_name_);
+  foreach_res (sched, R_SCHEDULE) {
+    if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
+    if (sched->enabled == enable) { /* Already enabled/disabled? */
+      continue;                     /* yes, skip */
     }
+    schedule_resource_names.emplace_back(sched->resource_name_);
   }
 
   SortCaseInsensitive(schedule_resource_names);
@@ -595,8 +571,9 @@ bool SelectClientDbr(UaContext* ua, ClientDbRecord* cr)
   }
 
   if (num_clients <= 0) {
-    ua->ErrorMsg(_(
-        "No clients defined. You must run a job before using this command.\n"));
+    ua->ErrorMsg(
+        _("No clients defined. You must run a job before using this "
+          "command.\n"));
     if (ids) { free(ids); }
     return false;
   }
@@ -950,14 +927,13 @@ PoolResource* select_pool_resource(UaContext* ua)
   std::vector<std::string> pool_resource_names;
 
   StartPrompt(ua, _("The defined Pool resources are:\n"));
-  {
-    ResLocker _{my_config};
-    foreach_res (pool, R_POOL) {
-      if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
-        pool_resource_names.emplace_back(pool->resource_name_);
-      }
+
+  foreach_res (pool, R_POOL) {
+    if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
+      pool_resource_names.emplace_back(pool->resource_name_);
     }
   }
+
 
   SortCaseInsensitive(pool_resource_names);
 
@@ -1481,7 +1457,6 @@ int GetMediaType(UaContext* ua, char* MediaType, int max_media)
 
   StartPrompt(ua, _("Media Types defined in conf file:\n"));
 
-  ResLocker _{my_config};
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
       AddPrompt(ua, store->media_type);

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -158,7 +158,7 @@ StorageResource* select_storage_resource(UaContext* ua, bool autochanger_only)
     StartPrompt(ua, _("The defined Storage resources are:\n"));
   }
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
       if (autochanger_only && !store->autochanger) {
@@ -168,7 +168,6 @@ StorageResource* select_storage_resource(UaContext* ua, bool autochanger_only)
       }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(storage_resource_names);
 
@@ -195,13 +194,14 @@ FilesetResource* select_fileset_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined FileSet resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (fs, R_FILESET) {
-    if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
-      fileset_resource_names.emplace_back(fs->resource_name_);
+  {
+    ResLocker _{my_config};
+    foreach_res (fs, R_FILESET) {
+      if (ua->AclAccessOk(FileSet_ACL, fs->resource_name_)) {
+        fileset_resource_names.emplace_back(fs->resource_name_);
+      }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(fileset_resource_names);
 
@@ -234,9 +234,10 @@ CatalogResource* get_catalog_resource(UaContext* ua)
   }
 
   if (ua->gui && !catalog) {
-    LockRes(my_config);
-    catalog = (CatalogResource*)my_config->GetNextRes(R_CATALOG, NULL);
-    UnlockRes(my_config);
+    {
+      ResLocker _{my_config};
+      catalog = (CatalogResource*)my_config->GetNextRes(R_CATALOG, NULL);
+    }
 
     if (!catalog) {
       ua->ErrorMsg(_("Could not find a Catalog resource\n"));
@@ -254,13 +255,14 @@ CatalogResource* get_catalog_resource(UaContext* ua)
   if (!catalog) {
     StartPrompt(ua, _("The defined Catalog resources are:\n"));
 
-    LockRes(my_config);
-    foreach_res (catalog, R_CATALOG) {
-      if (ua->AclAccessOk(Catalog_ACL, catalog->resource_name_)) {
-        AddPrompt(ua, catalog->resource_name_);
+    {
+      ResLocker _{my_config};
+      foreach_res (catalog, R_CATALOG) {
+        if (ua->AclAccessOk(Catalog_ACL, catalog->resource_name_)) {
+          AddPrompt(ua, catalog->resource_name_);
+        }
       }
     }
-    UnlockRes(my_config);
 
     if (DoPrompt(ua, _("Catalog"), _("Select Catalog resource"), name,
                  sizeof(name))
@@ -283,15 +285,16 @@ JobResource* select_enable_disable_job_resource(UaContext* ua, bool enable)
 
   StartPrompt(ua, _("The defined Job resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (job, R_JOB) {
-    if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
-    if (job->enabled == enable) { /* Already enabled/disabled? */
-      continue;                   /* yes, skip */
+  {
+    ResLocker _{my_config};
+    foreach_res (job, R_JOB) {
+      if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
+      if (job->enabled == enable) { /* Already enabled/disabled? */
+        continue;                   /* yes, skip */
+      }
+      job_resource_names.emplace_back(job->resource_name_);
     }
-    job_resource_names.emplace_back(job->resource_name_);
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(job_resource_names);
 
@@ -318,13 +321,14 @@ JobResource* select_job_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Job resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (job, R_JOB) {
-    if (ua->AclAccessOk(Job_ACL, job->resource_name_)) {
-      job_resource_names.emplace_back(job->resource_name_);
+  {
+    ResLocker _{my_config};
+    foreach_res (job, R_JOB) {
+      if (ua->AclAccessOk(Job_ACL, job->resource_name_)) {
+        job_resource_names.emplace_back(job->resource_name_);
+      }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(job_resource_names);
 
@@ -368,14 +372,15 @@ JobResource* select_restore_job_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Restore Job resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (job, R_JOB) {
-    if (job->JobType == JT_RESTORE
-        && ua->AclAccessOk(Job_ACL, job->resource_name_)) {
-      restore_job_names.emplace_back(job->resource_name_);
+  {
+    ResLocker _{my_config};
+    foreach_res (job, R_JOB) {
+      if (job->JobType == JT_RESTORE
+          && ua->AclAccessOk(Job_ACL, job->resource_name_)) {
+        restore_job_names.emplace_back(job->resource_name_);
+      }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(restore_job_names);
 
@@ -401,13 +406,14 @@ ClientResource* select_client_resource(UaContext* ua)
 
   StartPrompt(ua, _("The defined Client resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (client, R_CLIENT) {
-    if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
-      client_resource_names.emplace_back(client->resource_name_);
+  {
+    ResLocker _{my_config};
+    foreach_res (client, R_CLIENT) {
+      if (ua->AclAccessOk(Client_ACL, client->resource_name_)) {
+        client_resource_names.emplace_back(client->resource_name_);
+      }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(client_resource_names);
 
@@ -436,15 +442,16 @@ ClientResource* select_enable_disable_client_resource(UaContext* ua,
 
   StartPrompt(ua, _("The defined Client resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (client, R_CLIENT) {
-    if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
-    if (client->enabled == enable) { /* Already enabled/disabled? */
-      continue;                      /* yes, skip */
+  {
+    ResLocker _{my_config};
+    foreach_res (client, R_CLIENT) {
+      if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
+      if (client->enabled == enable) { /* Already enabled/disabled? */
+        continue;                      /* yes, skip */
+      }
+      client_resource_names.emplace_back(client->resource_name_);
     }
-    client_resource_names.emplace_back(client->resource_name_);
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(client_resource_names);
 
@@ -498,15 +505,16 @@ ScheduleResource* select_enable_disable_schedule_resource(UaContext* ua,
 
   StartPrompt(ua, _("The defined Schedule resources are:\n"));
 
-  LockRes(my_config);
-  foreach_res (sched, R_SCHEDULE) {
-    if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
-    if (sched->enabled == enable) { /* Already enabled/disabled? */
-      continue;                     /* yes, skip */
+  {
+    ResLocker _{my_config};
+    foreach_res (sched, R_SCHEDULE) {
+      if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
+      if (sched->enabled == enable) { /* Already enabled/disabled? */
+        continue;                     /* yes, skip */
+      }
+      schedule_resource_names.emplace_back(sched->resource_name_);
     }
-    schedule_resource_names.emplace_back(sched->resource_name_);
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(schedule_resource_names);
 
@@ -942,13 +950,14 @@ PoolResource* select_pool_resource(UaContext* ua)
   std::vector<std::string> pool_resource_names;
 
   StartPrompt(ua, _("The defined Pool resources are:\n"));
-  LockRes(my_config);
-  foreach_res (pool, R_POOL) {
-    if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
-      pool_resource_names.emplace_back(pool->resource_name_);
+  {
+    ResLocker _{my_config};
+    foreach_res (pool, R_POOL) {
+      if (ua->AclAccessOk(Pool_ACL, pool->resource_name_)) {
+        pool_resource_names.emplace_back(pool->resource_name_);
+      }
     }
   }
-  UnlockRes(my_config);
 
   SortCaseInsensitive(pool_resource_names);
 
@@ -1472,13 +1481,12 @@ int GetMediaType(UaContext* ua, char* MediaType, int max_media)
 
   StartPrompt(ua, _("Media Types defined in conf file:\n"));
 
-  LockRes(my_config);
+  ResLocker _{my_config};
   foreach_res (store, R_STORAGE) {
     if (ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
       AddPrompt(ua, store->media_type);
     }
   }
-  UnlockRes(my_config);
 
   return (DoPrompt(ua, _("Media Type"), _("Select the Media Type"), MediaType,
                    max_media)

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -726,11 +726,9 @@ bool SelectPoolDbr(UaContext* ua, PoolDbRecord* pr, const char* argk)
 
   new (&opr) PoolDbRecord();  // placement new instead of memset
 
-  /*
-   * *None* is only returned when selecting a recyclepool, and in that case
+  /* *None* is only returned when selecting a recyclepool, and in that case
    * the calling code is only interested in opr.Name, so then we can leave
-   * pr as all zero.
-   */
+   * pr as all zero. */
   if (!bstrcmp(name, _("*None*"))) {
     bstrncpy(opr.Name, name, sizeof(opr.Name));
 
@@ -826,11 +824,9 @@ bool SelectStorageDbr(UaContext* ua, StorageDbRecord* sr, const char* argk)
 
   new (&osr) StorageDbRecord();  // placement new instead of memset
 
-  /*
-   * *None* is only returned when selecting a recyclestorage, and in that case
+  /* *None* is only returned when selecting a recyclestorage, and in that case
    * the calling code is only interested in osr.Name, so then we can leave
-   * sr as all zero.
-   */
+   * sr as all zero. */
   if (!bstrcmp(name, _("*None*"))) {
     bstrncpy(osr.Name, name, sizeof(osr.Name));
 
@@ -1593,10 +1589,8 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
     }
   }
 
-  /*
-   * If we didn't select any Jobs using jobid, job or ujobid keywords try
-   * other selections.
-   */
+  /* If we didn't select any Jobs using jobid, job or ujobid keywords try
+   * other selections. */
   if (cnt == 0) {
     char buf[1000];
     int tjobs = 0; /* Total # number jobs */
@@ -1656,10 +1650,8 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
         }
       }
 
-      /*
-       * Select from all available Jobs the Jobs matching the selection
-       * criterium.
-       */
+      /* Select from all available Jobs the Jobs matching the selection
+       * criterium. */
       foreach_jcr (jcr) {
         if (jcr->JobId == 0) { /* This is us */
           continue;
@@ -1702,10 +1694,8 @@ alist<JobId_t*>* select_jobs(UaContext* ua, const char* reason)
         goto bail_out;
       }
 
-      /*
-       * Only ask for confirmation when not in batch mode and there is no yes
-       * on the cmdline.
-       */
+      /* Only ask for confirmation when not in batch mode and there is no yes
+       * on the cmdline. */
       if (!ua->batch && FindArg(ua, NT_("yes")) == -1) {
         if (!GetYesno(ua, _("Confirm cancel (yes/no): ")) || !ua->pint32_val) {
           goto bail_out;
@@ -1791,10 +1781,8 @@ bool GetUserSlotList(UaContext* ua,
   bstrncpy(search_argument, argument, sizeof(search_argument));
   i = FindArgWithValue(ua, search_argument);
   if (i == -1) { /* not found */
-    /*
-     * See if the last letter of search_argument is a 's'
-     * When it is strip it and try if that argument is given.
-     */
+    /* See if the last letter of search_argument is a 's'
+     * When it is strip it and try if that argument is given. */
     len = strlen(search_argument);
     if (len > 0 && search_argument[len - 1] == 's') {
       search_argument[len - 1] = '\0';

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -63,10 +63,11 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 
   /* The job and defaults are not really used, but we set them up to ensure that
    * everything is correctly initialized. */
-  LockRes(my_config);
-  jcr->dir_impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
-  SetJcrDefaults(jcr, jcr->dir_impl->res.job);
-  UnlockRes(my_config);
+  {
+    ResLocker _{my_config};
+    jcr->dir_impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
+    SetJcrDefaults(jcr, jcr->dir_impl->res.job);
+  }
 
   jcr->sd_auth_key = strdup("dummy"); /* dummy Storage daemon key */
   CreateUniqueJobName(jcr, base_name);

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -389,30 +389,24 @@ static bool show_scheduled_preview(UaContext*,
       tm.tm_min = run->minute;         /* Set run minute */
       tm.tm_sec = 0;                   /* Zero secs */
 
-      /*
-       * Convert the time into a user parsable string.
+      /* Convert the time into a user parsable string.
        * As we use locale specific strings for weekday and month we
-       * need to keep track of the longest data string used.
-       */
+       * need to keep track of the longest data string used. */
       runtime = mktime(&tm);
       bstrftime_wd(dt, sizeof(dt), runtime);
       date_len = strlen(dt);
       if (date_len > *max_date_len) {
         if (*max_date_len == 0) {
-          /*
-           * When the datelen changes during the loop the locale generates a
+          /* When the datelen changes during the loop the locale generates a
            * date string that is variable. Only thing we can do about that is
            * start from scratch again. We invoke this by return false from this
-           * function.
-           */
+           * function. */
           *max_date_len = date_len;
           PmStrcpy(overview, "");
           return false;
         } else {
-          /*
-           * This is the first determined length we use this until we are proven
-           * wrong.
-           */
+          /* This is the first determined length we use this until we are proven
+           * wrong. */
           *max_date_len = date_len;
         }
       }
@@ -466,10 +460,8 @@ static bool show_scheduled_preview(UaContext*,
     }
   }
 
-  /*
-   * If we make it till here the length of the datefield is constant or didn't
-   * change.
-   */
+  /* If we make it till here the length of the datefield is constant or didn't
+   * change. */
   return true;
 }
 
@@ -1445,10 +1437,8 @@ static void StatusContentApi(UaContext* ua, StorageResource* store)
             }
             break;
           case slot_status_t::kSlotStatusEmpty:
-            /*
-             * See if this empty slot is empty because the volume is loaded
-             * in one of the drives.
-             */
+            /* See if this empty slot is empty because the volume is loaded
+             * in one of the drives. */
             vl2 = vol_is_loaded_in_drive(store, vol_list,
                                          vl1->bareos_slot_number);
             if (vl2) {
@@ -1550,10 +1540,8 @@ static void StatusContentJson(UaContext* ua, StorageResource* store)
             }
             break;
           case slot_status_t::kSlotStatusEmpty:
-            /*
-             * See if this empty slot is empty because the volume is loaded
-             * in one of the drives.
-             */
+            /* See if this empty slot is empty because the volume is loaded
+             * in one of the drives. */
             vl2 = vol_is_loaded_in_drive(store, vol_list,
                                          vl1->bareos_slot_number);
             if (vl2) {
@@ -1652,10 +1640,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
       _("------+------------------+-----------+----------------+---------------"
         "-----------|\n"));
 
-  /*
-   * Walk through the list getting the media records
-   * Slots start numbering at 1.
-   */
+  /* Walk through the list getting the media records
+   * Slots start numbering at 1. */
   foreach_dlist (vl1, vol_list->contents) {
     vl2 = NULL;
     switch (vl1->slot_type) {
@@ -1678,10 +1664,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
         switch (vl1->slot_status) {
           case slot_status_t::kSlotStatusEmpty:
             if (vl1->slot_type == slot_type_t::kSlotTypeStorage) {
-              /*
-               * See if this empty slot is empty because the volume is loaded
-               * in one of the drives.
-               */
+              /* See if this empty slot is empty because the volume is loaded
+               * in one of the drives. */
               vl2 = vol_is_loaded_in_drive(store, vol_list,
                                            vl1->bareos_slot_number);
               if (!vl2) {
@@ -1696,10 +1680,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
             }
             FALLTHROUGH_INTENDED;
           case slot_status_t::kSlotStatusFull: {
-            /*
-             * We get here for all slots with content and for empty
-             * slots with their volume loaded in a drive.
-             */
+            /* We get here for all slots with content and for empty
+             * slots with their volume loaded in a drive. */
             MediaDbRecord mr;
             if (vl1->slot_status == slot_status_t::kSlotStatusFull) {
               if (!vl1->VolName) {

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -266,28 +266,26 @@ static void DoAllStatus(UaContext* ua)
 
   DoDirectorStatus(ua);
 
-  {
-    /* Count Storage items */
-    ResLocker _{my_config};
-    i = 0;
-    foreach_res (store, R_STORAGE) { i++; }
-    unique_store = (StorageResource**)malloc(i * sizeof(StorageResource));
-    /* Find Unique Storage address/port */
-    i = 0;
-    foreach_res (store, R_STORAGE) {
-      found = false;
-      if (!ua->AclAccessOk(Storage_ACL, store->resource_name_)) { continue; }
-      for (j = 0; j < i; j++) {
-        if (bstrcmp(unique_store[j]->address, store->address)
-            && unique_store[j]->SDport == store->SDport) {
-          found = true;
-          break;
-        }
+
+  /* Count Storage items */
+  i = 0;
+  foreach_res (store, R_STORAGE) { i++; }
+  unique_store = (StorageResource**)malloc(i * sizeof(StorageResource));
+  /* Find Unique Storage address/port */
+  i = 0;
+  foreach_res (store, R_STORAGE) {
+    found = false;
+    if (!ua->AclAccessOk(Storage_ACL, store->resource_name_)) { continue; }
+    for (j = 0; j < i; j++) {
+      if (bstrcmp(unique_store[j]->address, store->address)
+          && unique_store[j]->SDport == store->SDport) {
+        found = true;
+        break;
       }
-      if (!found) {
-        unique_store[i++] = store;
-        Dmsg2(40, "Stuffing: %s:%d\n", store->address, store->SDport);
-      }
+    }
+    if (!found) {
+      unique_store[i++] = store;
+      Dmsg2(40, "Stuffing: %s:%d\n", store->address, store->SDport);
     }
   }
 
@@ -300,28 +298,27 @@ static void DoAllStatus(UaContext* ua)
   }
   free(unique_store);
 
-  {
-    /* Count Client items */
-    ResLocker _{my_config};
-    i = 0;
-    foreach_res (client, R_CLIENT) { i++; }
-    unique_client = (ClientResource**)malloc(i * sizeof(ClientResource));
-    /* Find Unique Client address/port */
-    i = 0;
-    foreach_res (client, R_CLIENT) {
-      found = false;
-      if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
-      for (j = 0; j < i; j++) {
-        if (bstrcmp(unique_client[j]->address, client->address)
-            && unique_client[j]->FDport == client->FDport) {
-          found = true;
-          break;
-        }
+
+  /* Count Client items */
+
+  i = 0;
+  foreach_res (client, R_CLIENT) { i++; }
+  unique_client = (ClientResource**)malloc(i * sizeof(ClientResource));
+  /* Find Unique Client address/port */
+  i = 0;
+  foreach_res (client, R_CLIENT) {
+    found = false;
+    if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) { continue; }
+    for (j = 0; j < i; j++) {
+      if (bstrcmp(unique_client[j]->address, client->address)
+          && unique_client[j]->FDport == client->FDport) {
+        found = true;
+        break;
       }
-      if (!found) {
-        unique_client[i++] = client;
-        Dmsg2(40, "Stuffing: %s:%d\n", client->address, client->FDport);
-      }
+    }
+    if (!found) {
+      unique_client[i++] = client;
+      Dmsg2(40, "Stuffing: %s:%d\n", client->address, client->FDport);
     }
   }
 
@@ -656,20 +653,35 @@ static void DoSchedulerStatus(UaContext* ua)
   ua->SendMsg("Schedule               Jobs Triggered\n");
   ua->SendMsg("===========================================================\n");
 
-  {
-    ResLocker _{my_config};
-    foreach_res (sched, R_SCHEDULE) {
-      int cnt = 0;
 
-      if (!sched->enabled) { continue; }
+  foreach_res (sched, R_SCHEDULE) {
+    int cnt = 0;
 
-      if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
+    if (!sched->enabled) { continue; }
 
-      if (schedule_given_by_cmdline_args) {
-        if (!bstrcmp(sched->resource_name_, schedulename)) { continue; }
+    if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
+
+    if (schedule_given_by_cmdline_args) {
+      if (!bstrcmp(sched->resource_name_, schedulename)) { continue; }
+    }
+
+    if (job) {
+      if (job->schedule
+          && bstrcmp(sched->resource_name_, job->schedule->resource_name_)) {
+        if (cnt++ == 0) { ua->SendMsg("%s\n", sched->resource_name_); }
+        if (!job->enabled || (job->client && !job->client->enabled)) {
+          ua->SendMsg("                       %s (disabled)\n",
+                      job->resource_name_);
+        } else {
+          ua->SendMsg("                       %s\n", job->resource_name_);
+        }
       }
+    } else {
+      foreach_res (job, R_JOB) {
+        if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-      if (job) {
+        if (client && job->client != client) { continue; }
+
         if (job->schedule
             && bstrcmp(sched->resource_name_, job->schedule->resource_name_)) {
           if (cnt++ == 0) { ua->SendMsg("%s\n", sched->resource_name_); }
@@ -680,29 +692,12 @@ static void DoSchedulerStatus(UaContext* ua)
             ua->SendMsg("                       %s\n", job->resource_name_);
           }
         }
-      } else {
-        foreach_res (job, R_JOB) {
-          if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
-
-          if (client && job->client != client) { continue; }
-
-          if (job->schedule
-              && bstrcmp(sched->resource_name_,
-                         job->schedule->resource_name_)) {
-            if (cnt++ == 0) { ua->SendMsg("%s\n", sched->resource_name_); }
-            if (!job->enabled || (job->client && !job->client->enabled)) {
-              ua->SendMsg("                       %s (disabled)\n",
-                          job->resource_name_);
-            } else {
-              ua->SendMsg("                       %s\n", job->resource_name_);
-            }
-          }
-        }
       }
-
-      if (cnt > 0) { ua->SendMsg("\n"); }
     }
+
+    if (cnt > 0) { ua->SendMsg("\n"); }
   }
+
 
   // Build an overview.
   if (days > 0) { /* future */
@@ -729,46 +724,39 @@ start_again:
           }
         }
       } else {
-        {
-          ResLocker _{my_config};
-          foreach_res (job, R_JOB) {
-            if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
+        foreach_res (job, R_JOB) {
+          if (!ua->AclAccessOk(Job_ACL, job->resource_name_)) { continue; }
 
-            if (job->schedule && job->schedule->enabled && job->enabled) {
-              // skip if client is set but not enabled
-              if (job->client && job->client == client
-                  && !job->client->enabled) {
-                continue;
-              }
-              if (!show_scheduled_preview(ua, job->schedule, overview,
-                                          &max_date_len, time_to_check)) {
-                job = NULL;
-                goto start_again;
-              }
+          if (job->schedule && job->schedule->enabled && job->enabled) {
+            // skip if client is set but not enabled
+            if (job->client && job->client == client && !job->client->enabled) {
+              continue;
+            }
+            if (!show_scheduled_preview(ua, job->schedule, overview,
+                                        &max_date_len, time_to_check)) {
+              job = NULL;
+              goto start_again;
             }
           }
         }
+
         job = NULL;
       }
     } else {
       // List all schedules.
-      {
-        ResLocker _{my_config};
-        foreach_res (sched, R_SCHEDULE) {
-          if (!sched->enabled) { continue; }
 
-          if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) {
-            continue;
-          }
+      foreach_res (sched, R_SCHEDULE) {
+        if (!sched->enabled) { continue; }
 
-          if (schedule_given_by_cmdline_args) {
-            if (!bstrcmp(sched->resource_name_, schedulename)) { continue; }
-          }
+        if (!ua->AclAccessOk(Schedule_ACL, sched->resource_name_)) { continue; }
 
-          if (!show_scheduled_preview(ua, sched, overview, &max_date_len,
-                                      time_to_check)) {
-            goto start_again;
-          }
+        if (schedule_given_by_cmdline_args) {
+          if (!bstrcmp(sched->resource_name_, schedulename)) { continue; }
+        }
+
+        if (!show_scheduled_preview(ua, sched, overview, &max_date_len,
+                                    time_to_check)) {
+          goto start_again;
         }
       }
     }
@@ -916,42 +904,40 @@ static void ListScheduledJobs(UaContext* ua)
   }
 
   // Loop through all jobs
-  {
-    ResLocker _{my_config};
-    foreach_res (job, R_JOB) {
-      if (!ua->AclAccessOk(Job_ACL, job->resource_name_) || !job->enabled
-          || (job->client && !job->client->enabled)) {
-        continue;
+  foreach_res (job, R_JOB) {
+    if (!ua->AclAccessOk(Job_ACL, job->resource_name_) || !job->enabled
+        || (job->client && !job->client->enabled)) {
+      continue;
+    }
+    for (run = NULL; (run = find_next_run(run, job, runtime, days));) {
+      UnifiedStorageResource store;
+      level = job->JobLevel;
+      if (run->level) { level = run->level; }
+      priority = job->Priority;
+      if (run->Priority) { priority = run->Priority; }
+      if (!hdr_printed) {
+        PrtRunhdr(ua);
+        hdr_printed = true;
       }
-      for (run = NULL; (run = find_next_run(run, job, runtime, days));) {
-        UnifiedStorageResource store;
-        level = job->JobLevel;
-        if (run->level) { level = run->level; }
-        priority = job->Priority;
-        if (run->Priority) { priority = run->Priority; }
-        if (!hdr_printed) {
-          PrtRunhdr(ua);
-          hdr_printed = true;
-        }
-        sp = (sched_pkt*)malloc(sizeof(sched_pkt));
-        sp->job = job;
-        sp->level = level;
-        sp->priority = priority;
-        sp->runtime = runtime;
-        sp->pool = run->pool;
-        GetJobStorage(&store, job, run);
-        sp->store = store.store;
-        if (sp->store) {
-          Dmsg3(250, "job=%s storage=%s MediaType=%s\n", job->resource_name_,
-                sp->store->resource_name_, sp->store->media_type);
-        } else {
-          Dmsg1(250, "job=%s could not get job storage\n", job->resource_name_);
-        }
-        sched->BinaryInsertMultiple(sp, CompareByRuntimePriority);
-        num_jobs++;
+      sp = (sched_pkt*)malloc(sizeof(sched_pkt));
+      sp->job = job;
+      sp->level = level;
+      sp->priority = priority;
+      sp->runtime = runtime;
+      sp->pool = run->pool;
+      GetJobStorage(&store, job, run);
+      sp->store = store.store;
+      if (sp->store) {
+        Dmsg3(250, "job=%s storage=%s MediaType=%s\n", job->resource_name_,
+              sp->store->resource_name_, sp->store->media_type);
+      } else {
+        Dmsg1(250, "job=%s could not get job storage\n", job->resource_name_);
       }
-    } /* end for loop over resources */
-  }
+      sched->BinaryInsertMultiple(sp, CompareByRuntimePriority);
+      num_jobs++;
+    }
+  } /* end for loop over resources */
+
   foreach_dlist (sp, sched) { PrtRuntime(ua, sp); }
   if (num_jobs == 0 && !ua->api) { ua->SendMsg(_("No Scheduled Jobs.\n")); }
   if (!ua->api) ua->SendMsg("====\n");

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -309,10 +309,8 @@ static inline bool SetupEncryptionDigests(b_save_ctx& bsctx)
          stream_to_ascii(bsctx.digest_stream));
   }
 
-  /**
-   * Set up signature digest handling. If this fails, the signature digest
-   * will be set to NULL and not used.
-   */
+  /* Set up signature digest handling. If this fails, the signature digest
+   * will be set to NULL and not used. */
   /* TODO landonf: We should really only calculate the digest once, for
    * both verification and signing.
    */
@@ -700,20 +698,16 @@ int SaveFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
     if (!CryptoSessionSend(jcr, sd)) { goto bail_out; }
   }
 
-  /*
-   * For a command plugin use the setting from the plugins savepkt no_read field
+  /* For a command plugin use the setting from the plugins savepkt no_read field
    * which is saved in the ff_pkt->no_read variable. do_read is the inverted
-   * value of this variable as no_read == TRUE means do_read == FALSE
-   */
+   * value of this variable as no_read == TRUE means do_read == FALSE */
   if (ff_pkt->cmd_plugin) {
     do_read = !ff_pkt->no_read;
   } else {
-    /*
-     * Open any file with data that we intend to save, then save it.
+    /* Open any file with data that we intend to save, then save it.
      *
      * Note, if is_win32_backup, we must open the Directory so that
-     * the BackupRead will save its permissions and ownership streams.
-     */
+     * the BackupRead will save its permissions and ownership streams. */
     if (ff_pkt->type != FT_LNKSAVED && S_ISREG(ff_pkt->statp.st_mode)) {
 #ifdef HAVE_WIN32
       do_read = !IsPortableBackup(&ff_pkt->bfd) || ff_pkt->statp.st_size > 0;
@@ -962,10 +956,8 @@ static DWORD WINAPI send_efs_data(PBYTE pbData,
 
   if (ulLength == 0) { return ERROR_SUCCESS; }
 
-  /*
-   * See if we can fit the data into the current bctx->rbuf which can hold
-   * bctx->rsize bytes.
-   */
+  /* See if we can fit the data into the current bctx->rbuf which can hold
+   * bctx->rsize bytes. */
   if (ulLength <= (ULONG)bctx->rsize) {
     sd->message_length = ulLength;
     memcpy(bctx->rbuf, pbData, ulLength);
@@ -997,8 +989,7 @@ static inline bool SendEncryptedData(b_ctx& bctx)
           _("Encrypted file but no EFS support functions\n"));
   }
 
-  /*
-   * The EFS read function, ReadEncryptedFileRaw(), works in a specific way.
+  /* The EFS read function, ReadEncryptedFileRaw(), works in a specific way.
    * You have to give it a function that it calls repeatedly every time the
    * read buffer is filled.
    *
@@ -1073,10 +1064,8 @@ static int send_data(JobControlRecord* jcr,
 
   if (!SetupEncryptionContext(bctx)) { goto bail_out; }
 
-  /*
-   * Send Data header to Storage daemon
-   *    <file-index> <stream> <info>
-   */
+  /* Send Data header to Storage daemon
+   *    <file-index> <stream> <info> */
   if (!sd->fsend("%ld %d 0", jcr->JobFiles, stream)) {
     if (!jcr->IsJobCanceled()) {
       Jmsg1(jcr, M_FATAL, 0, _("Network send error to SD. ERR=%s\n"),
@@ -1086,10 +1075,8 @@ static int send_data(JobControlRecord* jcr,
   }
   Dmsg1(300, ">stored: datahdr %s", sd->msg);
 
-  /*
-   * Make space at beginning of buffer for fileAddr because this
-   *   same buffer will be used for writing if compression is off.
-   */
+  /* Make space at beginning of buffer for fileAddr because this
+   *   same buffer will be used for writing if compression is off. */
   if (BitIsSet(FO_SPARSE, ff_pkt->flags)
       || BitIsSet(FO_OFFSETS, ff_pkt->flags)) {
     bctx.rbuf += OFFSET_FADDR_SIZE;
@@ -1223,10 +1210,8 @@ bool EncodeAndSendAttributes(JobControlRecord* jcr,
     return false;
   }
 
-  /**
-   * Send Attributes header to Storage daemon
-   *    <file-index> <stream> <info>
-   */
+  /* Send Attributes header to Storage daemon
+   *    <file-index> <stream> <info> */
   if (!sd->fsend("%ld %d 0", jcr->JobFiles, attr_stream)) {
     if (!jcr->IsCanceled() && !jcr->IsIncomplete()) {
       Jmsg1(jcr, M_FATAL, 0, _("Network send error to SD. ERR=%s\n"),
@@ -1236,8 +1221,7 @@ bool EncodeAndSendAttributes(JobControlRecord* jcr,
   }
   Dmsg1(300, ">stored: attrhdr %s", sd->msg);
 
-  /**
-   * Send file attributes to Storage daemon
+  /* Send file attributes to Storage daemon
    *   File_index
    *   File type
    *   Filename (full path)
@@ -1258,8 +1242,7 @@ bool EncodeAndSendAttributes(JobControlRecord* jcr,
    *   Binary Object data
    *
    * For a directory, link is the same as fname, but with trailing
-   * slash. For a linked file, link is the link.
-   */
+   * slash. For a linked file, link is the link. */
   if (!IS_FT_OBJECT(ff_pkt->type)
       && ff_pkt->type != FT_DELETED) { /* already stripped */
     StripPath(ff_pkt);
@@ -1404,12 +1387,10 @@ void StripPath(FindFilesPacket* ff_pkt)
           strlen(ff_pkt->link));
   }
 
-  /**
-   * Strip path. If it doesn't succeed put it back. If it does, and there
+  /* Strip path. If it doesn't succeed put it back. If it does, and there
    * is a different link string, attempt to strip the link. If it fails,
    * back them both back. Do not strip symlinks. I.e. if either stripping
-   * fails don't strip anything.
-   */
+   * fails don't strip anything. */
   if (!do_strip(ff_pkt->StripPath, ff_pkt->fname)) {
     UnstripPath(ff_pkt);
     goto rtn;
@@ -1444,15 +1425,11 @@ void UnstripPath(FindFilesPacket* ff_pkt)
 #if defined(WIN32_VSS)
 static void CloseVssBackupSession(JobControlRecord* jcr)
 {
-  /*
-   * STOP VSS ON WIN32
-   * Tell vss to close the backup session
-   */
+  /* STOP VSS ON WIN32
+   * Tell vss to close the backup session */
   if (jcr->fd_impl->pVSSClient) {
-    /*
-     * We are about to call the BackupComplete VSS method so let all plugins
-     * know that by raising the bEventVssBackupComplete event.
-     */
+    /* We are about to call the BackupComplete VSS method so let all plugins
+     * know that by raising the bEventVssBackupComplete event. */
     GeneratePluginEvent(jcr, bEventVssBackupComplete);
     if (jcr->fd_impl->pVSSClient->CloseBackup()) {
       // Inform user about writer states

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -108,11 +108,11 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr,
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
   Dmsg1(300, "filed: opened data connection %d to stored\n", sd->fd_);
-
-  LockRes(my_config);
-  ClientResource* client
-      = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
-  UnlockRes(my_config);
+  ClientResource* client = nullptr;
+  {
+    ResLocker _{my_config};
+    client = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
+  }
   uint32_t buf_size;
   if (client) {
     buf_size = client->max_network_buffer_size;

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -421,8 +421,7 @@ static bool CheckResources()
         }
       }
 
-      /*
-       * Crypto recipients. We're always included as a recipient.
+      /* Crypto recipients. We're always included as a recipient.
        * The symmetric session key will be encrypted for each of these readers.
        */
       me->pki_recipients = new alist<X509_KEYPAIR*>(10, not_owned_by_alist);

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -307,7 +307,7 @@ static bool CheckResources()
   DirectorResource* director;
   const std::string& configfile = my_config->get_base_config_path();
 
-  LockRes(my_config);
+  ResLocker _{my_config};
 
   me = (ClientResource*)my_config->GetNextRes(R_CLIENT, nullptr);
   my_config->own_resource_ = me;
@@ -458,16 +458,13 @@ static bool CheckResources()
 
 
   /* Verify that a director record exists */
-  LockRes(my_config);
   director = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
-  UnlockRes(my_config);
+
   if (!director) {
     Emsg1(M_FATAL, 0, _("No Director resource defined in %s\n"),
           configfile.c_str());
     OK = false;
   }
-
-  UnlockRes(my_config);
 
   if (OK) {
     CloseMsg(nullptr);              /* close temp message handler */

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -178,9 +178,7 @@ static inline void DropDelayedDataStreams(r_ctx& rctx, bool reuse)
 
   if (!rctx.delayed_streams || rctx.delayed_streams->empty()) { return; }
 
-  foreach_alist (dds, rctx.delayed_streams) {
-    free(dds->content);
-  }
+  foreach_alist (dds, rctx.delayed_streams) { free(dds->content); }
 
   rctx.delayed_streams->destroy();
   if (reuse) { rctx.delayed_streams->init(10, owned_by_alist); }
@@ -417,10 +415,12 @@ void DoRestore(JobControlRecord* jcr)
   sd = jcr->store_bsock;
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
-  LockRes(my_config);
-  ClientResource* client
-      = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
-  UnlockRes(my_config);
+  ClientResource* client = nullptr;
+  {
+    ResLocker _{my_config};
+    client = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
+  }
+
   if (client) {
     buf_size = client->max_network_buffer_size;
   } else {

--- a/core/src/filed/verify_vol.cc
+++ b/core/src/filed/verify_vol.cc
@@ -68,10 +68,11 @@ void DoVerifyVolume(JobControlRecord* jcr)
   dir = jcr->dir_bsock;
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
-  LockRes(my_config);
-  ClientResource* client
-      = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
-  UnlockRes(my_config);
+  ClientResource* client = nullptr;
+  {
+    ResLocker _{my_config};
+    client = (ClientResource*)my_config->GetNextRes(R_CLIENT, NULL);
+  }
   uint32_t buf_size;
   if (client) {
     buf_size = client->max_network_buffer_size;

--- a/core/src/filed/verify_vol.cc
+++ b/core/src/filed/verify_vol.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -130,15 +130,13 @@ void DoVerifyVolume(JobControlRecord* jcr)
         *fname = 0;
         *lname = 0;
 
-        /*
-         * An Attributes record consists of:
+        /* An Attributes record consists of:
          *    File_index
          *    Type   (FT_types)
          *    Filename
          *    Attributes
          *    Link name (if file linked i.e. FT_LNK)
-         *    Extended Attributes (if Win32)
-         */
+         *    Extended Attributes (if Win32) */
         if (sscanf(sd->msg, "%d %d", &record_file_index, &type) != 2) {
           Jmsg(jcr, M_FATAL, 0, _("Error scanning record header: %s\n"),
                sd->msg);
@@ -171,8 +169,7 @@ void DoVerifyVolume(JobControlRecord* jcr)
         PmStrcpy(jcr->fd_impl->last_fname, fname); /* last file examined */
         jcr->unlock();
 
-        /*
-         * Send file attributes to Director
+        /* Send file attributes to Director
          *   File_index
          *   Stream
          *   Verify Options
@@ -180,8 +177,7 @@ void DoVerifyVolume(JobControlRecord* jcr)
          *   Encoded attributes
          *   Link name (if type==FT_LNK)
          * For a directory, link is the same as fname, but with trailing
-         * slash. For a linked file, link is the link.
-         */
+         * slash. For a linked file, link is the link. */
         /* Send file attributes to Director */
         Dmsg2(200, "send Attributes inx=%d fname=%s\n", jcr->JobFiles, fname);
         if (type == FT_LNK || type == FT_LNKSAVED) {

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -501,6 +501,10 @@ class ResLocker {
     config_res_->b_LockRes(__FILE__, __LINE__);
   }
   ~ResLocker() { config_res_->b_UnlockRes(__FILE__, __LINE__); }
+  ResLocker(const ResLocker&) = delete;
+  ResLocker& operator=(const ResLocker&) = delete;
+  ResLocker(ResLocker&&) = delete;
+  ResLocker& operator=(ResLocker&&) = delete;
 };
 
 #endif  // BAREOS_LIB_PARSE_CONF_H_

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -492,7 +492,15 @@ inline std::shared_ptr<ConfigResourcesContainer> _init_foreach_res_(
        ((var)                                                     \
         = static_cast<decltype(var)>(my_config->GetNextRes((type), var)));)
 
-#define LockRes(x) (x)->b_LockRes(__FILE__, __LINE__)
-#define UnlockRes(x) (x)->b_UnlockRes(__FILE__, __LINE__)
+class ResLocker {
+  const ConfigurationParser* config_res_;
+
+ public:
+  ResLocker(const ConfigurationParser* config) : config_res_(config)
+  {
+    config_res_->b_LockRes(__FILE__, __LINE__);
+  }
+  ~ResLocker() { config_res_->b_UnlockRes(__FILE__, __LINE__); }
+};
 
 #endif  // BAREOS_LIB_PARSE_CONF_H_

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -95,15 +95,21 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
   BareosResource* res;
   int rindex = rcode;
 
-  if (lock) { LockRes(this); }
+  if (lock) {
+    ResLocker _{this};
 
-  res = config_resources_container_->configuration_resources_[rindex];
-  while (res) {
-    if (bstrcmp(res->resource_name_, name)) { break; }
-    res = res->next_;
+    res = config_resources_container_->configuration_resources_[rindex];
+    while (res) {
+      if (bstrcmp(res->resource_name_, name)) { break; }
+      res = res->next_;
+    }
+  } else {
+    res = config_resources_container_->configuration_resources_[rindex];
+    while (res) {
+      if (bstrcmp(res->resource_name_, name)) { break; }
+      res = res->next_;
+    }
   }
-
-  if (lock) { UnlockRes(this); }
 
   return res;
 }

--- a/core/src/qt-tray-monitor/monitoritemthread.cc
+++ b/core/src/qt-tray-monitor/monitoritemthread.cc
@@ -95,13 +95,11 @@ QStringList MonitorItemThread::createRes(const cl_opts& cl)
 {
   QStringList tabRefs;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
 
   int monitorItems = 0;
   MonitorResource* monitorRes;
-  foreach_res (monitorRes, R_MONITOR) {
-    monitorItems++;
-  }
+  foreach_res (monitorRes, R_MONITOR) { monitorItems++; }
 
   if (monitorItems != 1) {
     const std::string& configfile = my_config->get_base_config_path();
@@ -158,8 +156,6 @@ QStringList MonitorItemThread::createRes(const cl_opts& cl)
     items.append(item);
     nitems++;
   }
-
-  UnlockRes(my_config);
 
   if (nitems == 0) {
     Emsg1(M_ERROR_TERM, 0,

--- a/core/src/qt-tray-monitor/monitoritemthread.cc
+++ b/core/src/qt-tray-monitor/monitoritemthread.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -264,7 +264,7 @@ static DeviceResource* find_device_res(char* archive_device_string,
   DeviceResource* device_resource;
 
   Dmsg0(900, "Enter find_device_res\n");
-  LockRes(my_config);
+  ResLocker _{my_config};
   foreach_res (device_resource, R_DEVICE) {
     Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
           archive_device_string);
@@ -292,7 +292,6 @@ static DeviceResource* find_device_res(char* archive_device_string,
       }
     }
   }
-  UnlockRes(my_config);
 
   if (!found) {
     Pmsg2(0, _("Could not find device \"%s\" in config file %s.\n"),

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -140,10 +140,8 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
 
   InitReservationsLock();
 
-  /*
-   * If no volume name already given and no bsr, and it is a file,
-   * try getting name from Filename
-   */
+  /* If no volume name already given and no bsr, and it is a file,
+   * try getting name from Filename */
   if (!VolumeName.empty()) {
     bstrncpy(VolName, VolumeName.c_str(), sizeof(VolName));
     if (VolumeName.size() >= MAX_NAME_LENGTH) {

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -264,7 +264,6 @@ static DeviceResource* find_device_res(char* archive_device_string,
   DeviceResource* device_resource;
 
   Dmsg0(900, "Enter find_device_res\n");
-  ResLocker _{my_config};
   foreach_res (device_resource, R_DEVICE) {
     Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
           archive_device_string);

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -603,12 +603,10 @@ static
   StopWatchdog();
 
   if (sig == SIGTERM) { /* normal shutdown request? */
-    /*
-     * This is a normal shutdown request. We wiffle through
+    /* This is a normal shutdown request. We wiffle through
      *   all open jobs canceling them and trying to wake
      *   them up so that they will report back the correct
-     *   volume status.
-     */
+     *   volume status. */
     foreach_jcr (jcr) {
       BareosSocket* fd;
       if (jcr->JobId == 0) { continue; /* ignore console */ }

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -497,7 +497,7 @@ extern "C" void* device_initialization(void*)
   Device* dev;
   int errstat;
 
-  LockRes(my_config);
+  ResLocker _{my_config};
 
   pthread_detach(pthread_self());
   jcr = NewStoredJcr();
@@ -572,7 +572,6 @@ extern "C" void* device_initialization(void*)
   }
   FreeJcr(jcr);
   init_done = true;
-  UnlockRes(my_config);
   return nullptr;
 }
 

--- a/docs/manuals/source/DeveloperGuide/directorConsole.rst
+++ b/docs/manuals/source/DeveloperGuide/directorConsole.rst
@@ -129,7 +129,7 @@ Example
 
 ::
 
-    LockRes();
+    ResLocker _{my_config};
     ua->send->array_start("storages");
     foreach_res(store, R_STORAGE) {
         if (acl_access_ok(ua, Storage_ACL, store->name())) {
@@ -139,7 +139,6 @@ Example
         }
     }
     ua->send->array_end("storages");
-    UnlockRes();
 
 results to
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

When interacting with configuration within the code, we usually need to lock it and then unlock when we finish.
Locking and unlocking is currently done manually, which would increase the risk of locking and forgetting to unlock, or unlocking a config that is not locked.
This PR tries to mitigate that and make configuration locking and unlocking a bit more resilient

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems