### PR TITLE
bareos-fd-postgres: properly close database connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - ndmp_tape.cc: do not log current rctx->rec in joblog [PR #1324]
 - dird: stored: set statistics collection as deprecated [PR #1320]
 - webui: switch from mod_php to php-fpm [PR #1287]
+- bareos-fd-postgres: properly close database connection [PR #1326]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -365,6 +366,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1270]: https://github.com/bareos/bareos/pull/1270
 [PR #1271]: https://github.com/bareos/bareos/pull/1271
 [PR #1272]: https://github.com/bareos/bareos/pull/1272
+[PR #1273]: https://github.com/bareos/bareos/pull/1273
 [PR #1275]: https://github.com/bareos/bareos/pull/1275
 [PR #1277]: https://github.com/bareos/bareos/pull/1277
 [PR #1278]: https://github.com/bareos/bareos/pull/1278
@@ -374,6 +376,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1283]: https://github.com/bareos/bareos/pull/1283
 [PR #1284]: https://github.com/bareos/bareos/pull/1284
 [PR #1285]: https://github.com/bareos/bareos/pull/1285
+[PR #1287]: https://github.com/bareos/bareos/pull/1287
 [PR #1288]: https://github.com/bareos/bareos/pull/1288
 [PR #1295]: https://github.com/bareos/bareos/pull/1295
 [PR #1296]: https://github.com/bareos/bareos/pull/1296
@@ -388,5 +391,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1315]: https://github.com/bareos/bareos/pull/1315
 [PR #1317]: https://github.com/bareos/bareos/pull/1317
 [PR #1318]: https://github.com/bareos/bareos/pull/1318
+[PR #1320]: https://github.com/bareos/bareos/pull/1320
 [PR #1324]: https://github.com/bareos/bareos/pull/1324
+[PR #1326]: https://github.com/bareos/bareos/pull/1326
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -452,6 +452,12 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             )
         return bareosfd.bRC_OK
 
+    def __dbConClose(self):
+        try:
+            self.dbCon.close()
+        except Exception as e:
+            pass
+
     def closeDbConnection(self):
         # TODO Error Handling
         # Get Backup Start Date
@@ -469,6 +475,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 + "CHECKPOINT LOCATION: %s, " % self.labelItems["CHECKPOINT LOCATION"]
                 + "START WAL LOCATION: %s\n" % self.labelItems["START WAL LOCATION"],
             )
+            self.__dbConClose()
             self.PostgressFullBackupRunning = False
         except Exception as e:
             bareosfd.JobMessage(
@@ -523,6 +530,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 self.files_to_backup.append("ROP")
                 return self.checkForWalFiles()
             else:
+                self.__dbConClose()
                 return bareosfd.bRC_OK
 
     def end_backup_job(self):
@@ -534,6 +542,8 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         if self.PostgressFullBackupRunning:
             self.closeDbConnection()
             self.PostgressFullBackupRunning = False
+        else:
+            self.__dbConClose()
         return bareosfd.bRC_OK
 
     def wait_for_wal_archiving(self, LSN):

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -531,7 +531,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_More
         else:
             if self.PostgressFullBackupRunning:
-                self.completed_backup_job_and_close_db()
+                self.complete_backup_job_and_close_db()
                 # Now we can also create the Restore object with the right timestamp
                 self.files_to_backup.append("ROP")
                 return self.checkForWalFiles()
@@ -546,7 +546,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         especially when job was cancelled
         """
         if self.PostgressFullBackupRunning:
-            self.completed_backup_job_and_close_db()
+            self.complete_backup_job_and_close_db()
             self.PostgressFullBackupRunning = False
         else:
             self.close_db_connection()

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -455,7 +455,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
     def __dbConClose(self):
         try:
             self.dbCon.close()
-        except Exception as e:
+        except pg8000.exceptions.InterfaceError as e:
             pass
 
     def closeDbConnection(self):

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -452,13 +452,19 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             )
         return bareosfd.bRC_OK
 
-    def __dbConClose(self):
+    def close_db_connection(self):
+        """
+        Make sure the DB connection is closed properly. Will not throw if the connection was already closed.
+        """
         try:
             self.dbCon.close()
         except pg8000.exceptions.InterfaceError as e:
             pass
 
-    def closeDbConnection(self):
+    def complete_backup_job_and_close_db(self):
+        """
+        Call pg_stop_backup() on PostgreSQL DB to mark the backup job as completed.
+        """
         # TODO Error Handling
         # Get Backup Start Date
         self.parseBackupLabelFile()
@@ -475,7 +481,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 + "CHECKPOINT LOCATION: %s, " % self.labelItems["CHECKPOINT LOCATION"]
                 + "START WAL LOCATION: %s\n" % self.labelItems["START WAL LOCATION"],
             )
-            self.__dbConClose()
+            self.close_db_connection()
             self.PostgressFullBackupRunning = False
         except Exception as e:
             bareosfd.JobMessage(
@@ -525,12 +531,12 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             return bareosfd.bRC_More
         else:
             if self.PostgressFullBackupRunning:
-                self.closeDbConnection()
+                self.completed_backup_job_and_close_db()
                 # Now we can also create the Restore object with the right timestamp
                 self.files_to_backup.append("ROP")
                 return self.checkForWalFiles()
             else:
-                self.__dbConClose()
+                self.close_db_connection()
                 return bareosfd.bRC_OK
 
     def end_backup_job(self):
@@ -540,10 +546,10 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         especially when job was cancelled
         """
         if self.PostgressFullBackupRunning:
-            self.closeDbConnection()
+            self.completed_backup_job_and_close_db()
             self.PostgressFullBackupRunning = False
         else:
-            self.__dbConClose()
+            self.close_db_connection()
         return bareosfd.bRC_OK
 
     def wait_for_wal_archiving(self, LSN):


### PR DESCRIPTION
This will properly close the database connection after a Postgres WAL backup was made. As far as I could see a call to  `close()` is completely missing in the current code. As the the connection may already been closed I put it in a try/except to ignore all errors that may occur.

On my test system this prevents the PostgreSQL server to log

`unexpected EOF on client connection with an open transaction`

every backup.

- [x] Short description and the purpose of this PR is present
- [x] ~Your name is present in the AUTHORS file (optional)~

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
