### PR TITLE
fix file count mismatch on restores that use recycled volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: adapt links to new URLs after website relaunch. [PR #1275]
 - dird: fix possible crash in tls context on configuration reload [PR #1249]
 - dird: RunScript fixes [PR #1217]
+- fix file count mismatch on restores that use recycled volumes [PR #1330]
   - fix show command output for RunScript RunsOnClient
   - fix show verbose for RunScripts
   - execute console runscripts only on the Director
@@ -412,6 +413,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1324]: https://github.com/bareos/bareos/pull/1324
 [PR #1326]: https://github.com/bareos/bareos/pull/1326
 [PR #1327]: https://github.com/bareos/bareos/pull/1327
+[PR #1330]: https://github.com/bareos/bareos/pull/1330
 [PR #1331]: https://github.com/bareos/bareos/pull/1331
 [PR #1332]: https://github.com/bareos/bareos/pull/1332
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -102,21 +102,18 @@ bool BareosDb::CreateJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
  */
 bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
 {
-  int count;
-  char ed1[50], ed2[50], ed3[50];
-
   DbLocker _{this};
 
   /* clang-format off */
   Mmsg(cmd,
-       "UPDATE JobMedia SET LastIndex=%lu, EndFile=%lu, EndBlock=%lu, JobBytes=%s "
-       "WHERE JobId=%s AND MediaId=%s",
+       "UPDATE JobMedia SET LastIndex=%lu, EndFile=%lu, EndBlock=%lu, JobBytes=%llu "
+       "WHERE JobId=%lu AND MediaId=%lu",
        jm->LastIndex,
        jm->EndFile,
        jm->EndBlock,
-       edit_uint64(jm->JobBytes, ed3),
-       edit_int64(jm->JobId, ed1),
-       edit_int64(jm->MediaId, ed2));
+       jm->JobBytes,
+       jm->JobId,
+       jm->MediaId);
   /* clang-format on */
 
   bool update_result = false;
@@ -128,9 +125,8 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
           _("Update JobMedia record %s failed: ERR=%s\n Trying to insert: \n"),
           cmd, sql_strerror());
 
-    Mmsg(cmd, "SELECT count(*) from JobMedia WHERE JobId=%s",
-         edit_int64(jm->JobId, ed1));
-    count = GetSqlRecordMax(jcr);
+    Mmsg(cmd, "SELECT count(*) from JobMedia WHERE JobId=%lu", jm->JobId);
+    int count = GetSqlRecordMax(jcr);
     if (count < 0) { count = 0; }
     count++;
 
@@ -138,14 +134,14 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
     Mmsg(cmd,
          "INSERT INTO JobMedia (JobId,MediaId,FirstIndex,LastIndex,"
          "StartFile,EndFile,StartBlock,EndBlock,VolIndex,JobBytes) "
-         "VALUES (%s,%s,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%s)",
-         edit_int64(jm->JobId, ed1),
-         edit_int64(jm->MediaId, ed2),
+         "VALUES (%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%lu,%llu)",
+         jm->JobId,
+         jm->MediaId,
          jm->FirstIndex, jm->LastIndex,
          jm->StartFile, jm->EndFile,
          jm->StartBlock, jm->EndBlock,
          count,
-         edit_uint64(jm->JobBytes, ed3));
+         jm->JobBytes);
     /* clang-format on */
 
     if (INSERT_DB(jcr, cmd) != 1) {

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -106,8 +106,15 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
 
   /* clang-format off */
   Mmsg(cmd,
-       "UPDATE JobMedia SET LastIndex=%lu, EndFile=%lu, EndBlock=%lu, JobBytes=%llu "
+       "UPDATE JobMedia SET "
+       "FirstIndex = (CASE WHEN firstindex=0 THEN %lu ELSE firstindex END), "
+       "StartBlock = (CASE WHEN startblock=0 THEN %lu ELSE startblock END), "
+       "StartFile  = (CASE WHEN startfile=0 THEN %lu ELSE startfile END), "
+       "LastIndex=%lu, EndFile=%lu, EndBlock=%lu, JobBytes=%llu "
        "WHERE JobId=%lu AND MediaId=%lu",
+       jm->FirstIndex,
+       jm->StartBlock,
+       jm->StartFile,
        jm->LastIndex,
        jm->EndFile,
        jm->EndBlock,

--- a/core/src/dird/restore.cc
+++ b/core/src/dird/restore.cc
@@ -432,23 +432,24 @@ void NativeRestoreCleanup(JobControlRecord* jcr, int TermCode)
 
   if (JobCanceled(jcr)) { CancelStorageDaemonJob(jcr); }
 
-  if (jcr->dir_impl->ExpectedFiles != jcr->JobFiles) { TermCode = JS_Warnings; }
+  if (jcr->dir_impl->ExpectedFiles != jcr->JobFiles) {
+    TermCode = JS_Warnings;
+    Jmsg(jcr, M_WARNING, 0,
+         _("File count mismatch: expected=%lu , restored=%lu\n"),
+         jcr->dir_impl->ExpectedFiles, jcr->JobFiles);
+  }
 
   switch (TermCode) {
     case JS_Terminated:
       TermMsg = _("Restore OK");
       break;
     case JS_Warnings:
-      if (jcr->dir_impl->ExpectedFiles != jcr->dir_impl->jr.JobFiles) {
-        TermMsg = _("Restore OK -- warning file count mismatch");
-      } else {
-        TermMsg = _("Restore OK -- with warnings");
-      }
+      TermMsg = _("Restore OK -- with warnings");
       break;
     case JS_FatalError:
     case JS_ErrorTerminated:
       TermMsg = _("*** Restore Error ***");
-      msg_type = M_ERROR; /* Generate error message */
+      msg_type = M_ERROR;  // Generate error message
       if (jcr->store_bsock) {
         jcr->store_bsock->signal(BNET_TERMINATE);
         if (jcr->dir_impl->SD_msg_chan_started) {

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -700,7 +700,7 @@ check_two_logs()
       echo "Restore error!"
       rstat=2
    fi
-   if grep "^  Termination: .*Restore OK -- warning file count mismatch" "$restore_log" >/dev/null 2>&1; then
+   if grep ".* Warning: File count mismatch" "$restore_log" >/dev/null 2>&1; then
       echo "File count mismatch in restore!"
       rstat=3
    fi

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -678,7 +678,7 @@ change_jobname()
 check_two_logs()
 {
    default_backup_log="${tmp}/log1.out"
-   backup_log=${2:-${default_backup_log}}
+   backup_log=${1:-${default_backup_log}}
 
    default_restore_log="${tmp}/log2.out"
    restore_log=${2:-${default_restore_log}}
@@ -688,6 +688,7 @@ check_two_logs()
    fi
 
    if grep "^  Termination: .*Backup Error" "$backup_log" >/dev/null 2>&1; then
+      echo "Backup error!"
       bstat=2
    fi
 
@@ -696,9 +697,11 @@ check_two_logs()
    fi
 
    if grep "^  Termination: .*Restore Error" "$restore_log" >/dev/null 2>&1; then
+      echo "Restore error!"
       rstat=2
    fi
-   if grep "^  Termination: *Restore OK -- warning file count mismatch" "$restore_log" >/dev/null 2>&1; then
+   if grep "^  Termination: .*Restore OK -- warning file count mismatch" "$restore_log" >/dev/null 2>&1; then
+      echo "File count mismatch in restore!"
       rstat=3
    fi
    if grep "^  Termination: .*Verify Differences" "$restore_log" >/dev/null 2>&1; then

--- a/systemtests/tests/bareos/etc/bareos/bareos-dir.d/job/recyclejob.conf
+++ b/systemtests/tests/bareos/etc/bareos/bareos-dir.d/job/recyclejob.conf
@@ -1,0 +1,14 @@
+Job {
+  Name = "recyclejob"
+  Type = Backup
+  Level = Full
+  Client = "bareos-fd"
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = quickrecycle
+  Priority = 10
+  Full Backup Pool = quickrecycle                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/bareos/etc/bareos/bareos-dir.d/pool/quickrecycle.conf
+++ b/systemtests/tests/bareos/etc/bareos/bareos-dir.d/pool/quickrecycle.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = quickrecycle
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 2 seconds         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 70K          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "recyclable-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/bareos/testrunner-volume-recycling
+++ b/systemtests/tests/bareos/testrunner-volume-recycling
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+#
+# Run multiple backups in parallel and
+#   then restore them.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+backupjob="recyclejob"
+recycle_backuplog="$tmp/recycle-backuplog.out"
+recycle_restorelog="$tmp/recycle-restorelog.out"
+recyle_restoredirectory="$tmp/recycle-restore"
+
+rm -f $recycle_backuplog
+rm -f $recycle_restorelog
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $recycle_backuplog
+run job=$backupjob level=Full yes
+wait
+@sleep 2
+run job=$backupjob level=Full yes
+wait
+@sleep 2
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+backup_with_recycled_volume=$(awk '/Job queued./{i++}i==2 {print; exit;}' "$recycle_backuplog" | sed -n -e 's/^.*JobId=//p')
+volume_tobe_recycled=$(grep "Labeled new Volume" $recycle_backuplog | sed -n -e 's/^.*Labeled new Volume "//p' | sed -n -e 's/" on device .*//p')
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $recycle_restorelog
+restore jobid=$backup_with_recycled_volume client=bareos-fd fileset=SelfTest where=$recyle_restoredirectory select all done yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+expect_grep "Recycled volume \"$volume_tobe_recycled\"" \
+            "$recycle_backuplog" \
+            "Volume was not recycled!"
+
+expect_grep "New volume \"$volume_tobe_recycled\" mounted on device \"FileStorage\"" \
+            "$recycle_backuplog" \
+            "Recycled volume was not reused!"
+
+check_two_logs "$recycle_backuplog" "$recycle_restorelog"
+check_restore_diff "${BackupDirectory}" "$recyle_restoredirectory"
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

When using recycled volumes, the restore process may report wrong expected number of files.
This PR fixes the issue.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
