### PR TITLE
Deprecate python2 plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
 - marked config directive `Compatible` as deprecated [PR #1284]
 - deprecated `Maximum Connections` directive from all daemons and removed all uses in code. Directive has no effect anymore [PR #1285]
+- Deprecate python2 plugins [PR #1331]
 
 ### Removed
 - removed the `-r` run job option. [PR #1206]
@@ -408,4 +409,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1324]: https://github.com/bareos/bareos/pull/1324
 [PR #1326]: https://github.com/bareos/bareos/pull/1326
 [PR #1327]: https://github.com/bareos/bareos/pull/1327
+[PR #1331]: https://github.com/bareos/bareos/pull/1331
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/dird/python/python-dir.cc
+++ b/core/src/plugins/dird/python/python-dir.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2014 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -260,6 +260,8 @@ static bRC newPlugin(PluginContext* plugin_ctx)
      any other events it is interested in.  */
   bareos_core_functions->registerBareosEvents(plugin_ctx, 1,
                                               bDirEventNewPluginOptions);
+
+#include "plugins/include/joblog_warn_about_python2_deprecation.inc"
 
   return bRC_OK;
 }

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -238,6 +238,8 @@ static bRC newPlugin(PluginContext* plugin_ctx)
       bEventPluginCommand, bEventJobStart, bEventRestoreCommand,
       bEventEstimateCommand, bEventBackupCommand, bEventRestoreObject);
 
+#include "plugins/include/joblog_warn_about_python2_deprecation.inc"
+
   return bRC_OK;
 }
 

--- a/core/src/plugins/include/joblog_warn_about_python2_deprecation.inc
+++ b/core/src/plugins/include/joblog_warn_about_python2_deprecation.inc
@@ -1,0 +1,28 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+// issue job warning for python 2 deprecation
+#if PY_VERSION_HEX < VERSION_HEX(3, 0, 0)
+  Jmsg(plugin_ctx, M_WARNING,
+       LOGPREFIX
+       "Python 2 plugins are deprecated in Bareos 22 and will be removed in "
+       "Bareos 23. Please switch to python 3 plugins. \n");
+#endif

--- a/core/src/plugins/stored/python/python-sd.cc
+++ b/core/src/plugins/stored/python/python-sd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2014 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -264,6 +264,8 @@ static bRC newPlugin(PluginContext* plugin_ctx)
    */
   bareos_core_functions->registerBareosEvents(plugin_ctx, 1,
                                               bSdEventNewPluginOptions);
+
+#include "plugins/include/joblog_warn_about_python2_deprecation.inc"
 
   return bRC_OK;
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR deprecates python2 plugins. An job warning is issued on every job using a python2 plugin in the newPlugin() function of each python2 plugin(fd, sd, dir)
#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
