### PR TITLE
python plugins: give python3 plugins priority over python2 plugins in packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - status subscription: extend output [PR #1312]
 - dird: fix for crash when starting rescheduled jobs [PR #1327]
 - unify and merge builds where possible [PR #1309]
+- python plugins: give python3 plugins priority over python2 plugins in packages [PR #1332]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -410,4 +411,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1326]: https://github.com/bareos/bareos/pull/1326
 [PR #1327]: https://github.com/bareos/bareos/pull/1327
 [PR #1331]: https://github.com/bareos/bareos/pull/1331
+[PR #1332]: https://github.com/bareos/bareos/pull/1332
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -460,7 +460,7 @@ Requires:   bareos-filedaemon = %{version}
 Summary:    LDAP Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
-Requires:   bareos-filedaemon-python-plugin = %{version}
+Requires:   bareos-filedaemon-python2-plugin = %{version}
 Requires:   python-ldap
 
 %package    filedaemon-ovirt-python-plugin
@@ -468,30 +468,45 @@ Summary:    Ovirt Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
 Requires:   bareos-filedaemon-python-plugin = %{version}
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %package    filedaemon-libcloud-python-plugin
 Summary:    Libcloud Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
 Requires:   bareos-filedaemon-python-plugin = %{version}
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %package    filedaemon-postgresql-python-plugin
 Summary:    PostgreSQL Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
 Requires:   bareos-filedaemon-python-plugin = %{version}
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %package    filedaemon-percona-xtrabackup-python-plugin
 Summary:    Percona xtrabackup Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
 Requires:   bareos-filedaemon-python-plugin = %{version}
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %package    filedaemon-mariabackup-python-plugin
 Summary:    Mariabackup Python plugin for Bareos File daemon
 Group:      Productivity/Archiving/Backup
 Requires:   bareos-filedaemon = %{version}
 Requires:   bareos-filedaemon-python-plugin = %{version}
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 
   %if 0%{?python2_available}
@@ -537,6 +552,10 @@ Summary:        Bareos VMware plugin
 Group:          Productivity/Archiving/Backup
 Requires:       bareos-vadp-dumper
 Requires:       bareos-filedaemon-python-plugin >= 15.2
+
+%if 0%{?rhel} != 7
+Suggests:       bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %description -n bareos-vmware-plugin
 Uses the VMware API to take snapshots of running VMs and takes
@@ -730,6 +749,9 @@ This package provides some additional tools, not part of the Bareos project.
 Summary:     Additional File Daemon Python plugins, not part of the Bareos project
 Group:       Productivity/Archiving/Backup
 Requires:    bareos-filedaemon-python-plugin
+%if 0%{?rhel} != 7
+Suggests:   bareos-filedaemon-python3-plugin = %{version}
+%endif
 
 %description contrib-filedaemon-python-plugins
 %{dscr}
@@ -741,6 +763,9 @@ This package provides additional File Daemon Python plugins, not part of the Bar
 Summary:     Additional Director Python plugins, not part of the Bareos project
 Group:       Productivity/Archiving/Backup
 Requires:    bareos-director-python-plugin
+%if 0%{?rhel} != 7
+Suggests:   bareos-director-python3-plugin = %{version}
+%endif
 
 %description contrib-director-python-plugins
 %{dscr}

--- a/debian/control.bareos-director-python-plugins-common
+++ b/debian/control.bareos-director-python-plugins-common
@@ -13,8 +13,7 @@ Package:        bareos-contrib-director-python-plugins
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-director-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-director-python3-plugin (= ${binary:Version}) | bareos-director-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - contributed Director plugins
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.

--- a/debian/control.bareos-director-python2-plugin
+++ b/debian/control.bareos-director-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-director-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin

--- a/debian/control.bareos-director-python3-plugin
+++ b/debian/control.bareos-director-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-director-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-director (= ${binary:Version}), bareos-director-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-director-python-plugin (= ${binary:Version})
 Replaces:       bareos-director-python-plugin
 Conflicts:      bareos-director-python-plugin

--- a/debian/control.bareos-filedaemon-python-plugins-common
+++ b/debian/control.bareos-filedaemon-python-plugins-common
@@ -24,8 +24,7 @@ Package:        bareos-filedaemon-percona-xtrabackup-python-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-filedaemon-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - file daemon Percona XtraBackup plugin
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.
@@ -36,8 +35,7 @@ Package:        bareos-filedaemon-mariabackup-python-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-filedaemon-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - file daemon Mariabackup plugin
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.
@@ -48,8 +46,7 @@ Package:        bareos-filedaemon-postgresql-python-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-filedaemon-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - file daemon PostgreSQL plugin
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.
@@ -60,8 +57,7 @@ Package:        bareos-filedaemon-libcloud-python-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-filedaemon-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - file daemon Apache Libcloud plugin
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.
@@ -72,8 +68,7 @@ Package:        bareos-contrib-filedaemon-python-plugins
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugin (= ${binary:Version}), ${misc:Depends}
-Recommends:     bareos-filedaemon-python3-plugin
+Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version}), ${misc:Depends}
 Description: Backup Archiving Recovery Open Sourced - contributed File Daemon plugins
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.

--- a/debian/control.bareos-filedaemon-python2-plugin
+++ b/debian/control.bareos-filedaemon-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-filedaemon-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-filedaemon (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin

--- a/debian/control.bareos-filedaemon-python3-plugin
+++ b/debian/control.bareos-filedaemon-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-filedaemon-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-filedaemon (= ${binary:Version}), bareos-filedaemon-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Recommends:     python3-dateutil
 Provides:       bareos-filedaemon-python-plugin (= ${binary:Version})
 Replaces:       bareos-filedaemon-python-plugin

--- a/debian/control.bareos-storage-python2-plugin
+++ b/debian/control.bareos-storage-python2-plugin
@@ -2,7 +2,7 @@ Package:        bareos-storage-python2-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin

--- a/debian/control.bareos-storage-python3-plugin
+++ b/debian/control.bareos-storage-python3-plugin
@@ -2,7 +2,7 @@ Package:        bareos-storage-python3-plugin
 Architecture:   any
 Section:        python
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
-Depends:        bareos-common (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
+Depends:        bareos-common (= ${binary:Version}), bareos-storage (= ${binary:Version}), bareos-storage-python-plugins-common (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Provides:       bareos-storage-python-plugin (= ${binary:Version})
 Replaces:       bareos-storage-python-plugin
 Conflicts:      bareos-storage-python-plugin

--- a/debian/control.vmware
+++ b/debian/control.vmware
@@ -1,6 +1,6 @@
 Package: bareos-vmware-plugin
 Architecture: any
-Depends:  bareos-vadp-dumper, bareos-filedaemon-python-plugin (>= 15.2)
+Depends: bareos-vadp-dumper (= ${binary:Version}), bareos-common (= ${binary:Version}), bareos-filedaemon-python3-plugin (= ${binary:Version}) | bareos-filedaemon-python2-plugin (= ${binary:Version})
 Description: Bareos VMware plugin
  Uses the VMware API to take snapshots of running VMs and takes
  full and incremental backup so snapshots. Restore of a snapshot


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The python2 plugin packages have been renamed to python27-plugin, so that the preferred python3 plugin version will be installed first instead of the deprecated python2 version.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
