### PR TITLE
btraceback: make the gdb script processing failsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - unify and merge builds where possible [PR #1309]
 - python plugins: give python3 plugins priority over python2 plugins in packages [PR #1332]
 - VMware Plugin: fix restore of backups taken before version 22 [PR #1337]
+- btraceback: make the gdb script processing failsafe [PR #1334]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -421,5 +422,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1331]: https://github.com/bareos/bareos/pull/1331
 [PR #1332]: https://github.com/bareos/bareos/pull/1332
 [PR #1333]: https://github.com/bareos/bareos/pull/1333
+[PR #1334]: https://github.com/bareos/bareos/pull/1334
 [PR #1337]: https://github.com/bareos/bareos/pull/1337
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/btraceback.in
+++ b/core/scripts/btraceback.in
@@ -78,9 +78,9 @@ case ${DEBUGGER} in
       ;;
    GDB)
       if [ ${POSTMORTEM} != NONE -a -s ${POSTMORTEM} ]; then
-         ${GDB} -quiet -batch -x @scriptdir@/btraceback.gdb $1 ${POSTMORTEM} >> ${WD}/bareos.$2.traceback 2>&1
+         ${GDB} -quiet  $1 ${POSTMORTEM}  < @scriptdir@/btraceback.gdb >> ${WD}/bareos.$2.traceback 2>&1
       else
-         ${GDB} -quiet -batch -x @scriptdir@/btraceback.gdb $1 $2 >> ${WD}/bareos.$2.traceback 2>&1
+         ${GDB} -quiet  $1 $2 < @scriptdir@/btraceback.gdb >> ${WD}/bareos.$2.traceback 2>&1
       fi
       ;;
    MDB)

--- a/systemtests/tests/py3plug-fd-postgres/python-modules/BareosFdPluginLocalFileset.py
+++ b/systemtests/tests/py3plug-fd-postgres/python-modules/BareosFdPluginLocalFileset.py
@@ -1,1 +1,0 @@
-../../py2plug-fd-local-fileset/python-modules/BareosFdPluginLocalFileset.py


### PR DESCRIPTION
`gdb` stops processing a script file at the first error. This can lead to missing information in the backtraces. 
Instead of running the gdb script via `-batch -x <scriptfile>`, we now just read the scriptfile from stdin, so that gdb will just continue with the next command if one command fails.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
