### PR TITLE
FreeBSD: build cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bsmtp: fix and update code, and change CLI parsing to CLI11 [PR #1316]
 - ua_restore: Add additional client info for restore report [PR #1374]
 - restore: fix failed restores showing Restore ok with warning [PR #1387]
+- FreeBSD: build cleanup [PR #1336]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -42,6 +43,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1316]: https://github.com/bareos/bareos/pull/1316
 [PR #1325]: https://github.com/bareos/bareos/pull/1325
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
+[PR #1336]: https://github.com/bareos/bareos/pull/1336
 [PR #1339]: https://github.com/bareos/bareos/pull/1339
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1346]: https://github.com/bareos/bareos/pull/1346

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-bconsole/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-bconsole/Makefile
@@ -7,5 +7,8 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 
 LIB_DEPENDS+=  libbareos.so:sysutils/baroes.com-common
 
+# optional overrides, used by build system.
+.-include "overrides.mk"
+
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -44,6 +44,7 @@ STORAGE_DAEMON_GROUP=operator
 PLIST_SUB+=	LIBVERSION=${DISTVERSION:C/\..*//} # major version
 PLIST_SUB+=	DISTVERSION=${DISTVERSION:C/(.{6}).*/\1/} # full version
 
+DEFAULT_VERSIONS+=ssl=openssl
 USES+=ssl
 USES+=gettext-runtime
 USES+=readline
@@ -73,6 +74,8 @@ LIB_DEPENDS+=	liblzo2.so:archivers/lzo2 \
 		          libjansson.so:devel/jansson
 LIB_DEPENDS+= libpython3.7m.so:lang/python37
 
+# optional overrides, used by build system.
+.-include "BareosCommonMakefile-overrides.mk"
 
 #GNU_CONFIGURE=	yes
 CMAKE_VERBOSE = yes
@@ -125,11 +128,5 @@ CMAKE_ARGS+= -DCMAKE_VERBOSE_MAKEFILE=ON \
   -Dfd-group=$(DAEMON_GROUP) \
   -Ddefault_db_backend="XXX_REPLACE_WITH_DATABASE_DRIVER_XXX" \
   -DVERSION_STRING=$(DISTVERSION)
-
-post-install:
-	find ${STAGEDIR} -name '*.conf' -exec mv -v {} {}.sample \;
-	@${MKDIR} ${STAGEDIR}/var/lib/bareos/storage
-	@${MKDIR} ${STAGEDIR}/var/log/bareos
-	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 .include <bsd.port.mk>

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosPackageOnlyMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosPackageOnlyMakefile
@@ -3,16 +3,34 @@ NO_INSTALL=     yes
 NO_BUILD=       yes
 NO_LICENSES_INSTALL= yes
 
-build:
-	echo build
+do-fetch:
+	@echo fetch ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} fetch
 
-stage:
-	@echo building master package in ${MASTERDIR}
+do-extract:
+	@echo extract ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} extract
+
+do-patch:
+	@echo patch ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} patch
+
+do-configure:
+	@echo configure ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} configure
+
+do-build:
+	@echo build ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} build
+
+#do-install:
+#	@echo install ${PORTNAME}${PKGNAMESUFFIX} via  master package in ${MASTERDIR}
+#	@make -C ${MASTERDIR} install
+
+do-stage:
+	@echo stage ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	@make -C ${MASTERDIR} stage
+
+pre-package:
+	@echo package ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
 	@make -C ${MASTERDIR} package
-	@echo running fake stage: packaging built binaries from ${MASTERDIR}
-	@echo copying ${MASTERDIR}/work/stage ${WRKDIR}
-	@mkdir -p ${WRKDIR}
-	@cp -a ${MASTERDIR}/work/stage ${WRKDIR}
-	@mkdir -p ${WRKDIR}/.metadir
-	@[ -e pkg-install ] && cp -a pkg-install ${WRKDIR}/.metadir/+INSTALL || touch ${WRKDIR}/.metadir/+INSTALL
-	@[ -e pkg-message ] && cp -a pkg-message ${WRKDIR}/.metadir/+DISPLAY || touch ${WRKDIR}/.metadir/+DISPLAY

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/Makefile
@@ -9,11 +9,22 @@ LIB_DEPENDS+= liblzo2.so:archivers/lzo2 \
               libjansson.so:devel/jansson \
               libreadline.so:devel/readline
 
+# optional overrides, used by build system.
+.-include "overrides.mk"
+
 post-patch:
-	@${REINPLACE_CMD} -e 's|pg_dump|/usr/local/bin/pg_dump|g' ${WRKSRC}/core/src/cats/make_catalog_backup.in
+	@echo post-patch ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	${REINPLACE_CMD} -e 's|^pg_dump|/usr/local/bin/pg_dump|g' ${WRKSRC}/core/src/cats/make_catalog_backup.in
+
+post-install:
+	@echo post-install ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	find ${STAGEDIR} -name '*.conf' -exec mv -v {} {}.sample \;
+	@${MKDIR} ${STAGEDIR}/var/lib/bareos/storage
+	@${MKDIR} ${STAGEDIR}/var/log/bareos
+	@${MKDIR} ${STAGEDIR}/var/run/bareos
 
 pre-package:
-	if [ -f work/.build/Testing/TAG ]; then echo "Testing/TAG exists, not running ctest a second time"; else cd work/.build && REGRESS_DEBUG=1  ctest -V -S CTestScript.cmake || echo "ctest result:$?"; fi
-
+	@echo pre-package ${PORTNAME}${PKGNAMESUFFIX} via master package in ${MASTERDIR}
+	if [ -f ${WRKDIR}/.build/Testing/TAG ]; then echo "Testing/TAG exists, not running ctest a second time"; else cd ${WRKDIR}/.build && sudo REGRESS_DEBUG=1 ctest -V -S CTestScript.cmake || echo "ctest result:$?"; fi
 
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-database-common/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-database-common/Makefile
@@ -8,5 +8,8 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 LIB_DEPENDS+=  libbareos.so:sysutils/baroes.com-common
 
 
+# optional overrides, used by build system.
+.-include "overrides.mk"
+
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-database-postgresql/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-database-postgresql/Makefile
@@ -6,10 +6,13 @@ PLIST=		${PKGDIR}/pkg-plist.database-postgresql
 MASTERDIR=	${.CURDIR}/../bareos.com-common
 
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
-LIB_DEPENDS+=  libbareosql.so:sysutils/bareos.com-database-common
+LIB_DEPENDS+=  libbareossql.so:sysutils/bareos.com-database-common
 LIB_DEPENDS+=  libbareoscats.so:sysutils/bareos.com-database-common
 
 USES+=pgsql
+
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-database-tools/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-database-tools/Makefile
@@ -9,8 +9,11 @@ LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossd.so:sysutils/bareos.com-common
 
-LIB_DEPENDS+=  libbareosql.so:sysutils/bareos.com-database-common
+LIB_DEPENDS+=  libbareossql.so:sysutils/bareos.com-database-common
 LIB_DEPENDS+=  libbareoscats.so:sysutils/bareos.com-database-common
+
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
@@ -22,7 +22,8 @@ LIB_DEPENDS+=  libbareoscats.so:sysutils/bareos.com-database-common
 
 RUN_DEPENDS+=  bareos-dbcheck:sysutils/bareos.com-database-tools
 
-USES=ssl
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon-python-plugins-common/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon-python-plugins-common/Makefile
@@ -7,7 +7,10 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 
-USES=python
+USES+=python:3.7
+
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon-python3-plugin/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon-python3-plugin/Makefile
@@ -7,7 +7,10 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 
-USES=python
+USES+=python:3.7
+
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-filedaemon/Makefile
@@ -10,7 +10,8 @@ LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareoslmdb.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
 
-USES=ssl
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-storage-tape/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-storage-tape/Makefile
@@ -8,5 +8,8 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossd.so:sysutils/bareos.com-common
 
+# optional overrides, used by build system.
+.-include "overrides.mk"
+
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-storage/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-storage/Makefile
@@ -11,5 +11,8 @@ LIB_DEPENDS+=  libbareosndmp.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossd.so:sysutils/bareos.com-common
 
+# optional overrides, used by build system.
+.-include "overrides.mk"
+
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-tools/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-tools/Makefile
@@ -6,8 +6,11 @@ PLIST=		${PKGDIR}/pkg-plist.tools
 MASTERDIR=	${.CURDIR}/../bareos.com-common
 
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
-LIB_DEPENDS+=  libbareosds.so:sysutils/bareos.com-common
+LIB_DEPENDS+=  libbareossd.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
+
+# optional overrides, used by build system.
+.-include "overrides.mk"
 
 .include "${MASTERDIR}/BareosPackageOnlyMakefile"
 .include "${MASTERDIR}/BareosCommonMakefile"

--- a/systemtests/tests/notls/testrunner
+++ b/systemtests/tests/notls/testrunner
@@ -31,7 +31,6 @@ cat <<END_OF_DATA >$tmp/bconcmds
 messages
 @$out $tmp/log1.out
 setdebug level=1000 storage=File trace=1
-label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 run job=$JobName yes
 run job=$JobName yes
@@ -52,7 +51,7 @@ messages
 @#
 @$out $tmp/log2.out
 wait
-restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done
+restore client=bareos-fd where=$tmp/bareos-restores select all done
 yes
 wait
 messages


### PR DESCRIPTION
* fix dependencies
* cleanup Makefile dependencies
* set dependency for Python-3.7, as packaging currently requires this version.
* prepare Makefiles to use custom WRKDIR

This PR separates the FreeBSD changes from https://github.com/bareos/bareos/pull/1294


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~
- [x] https://git.bareos.com/bareos/CD/pulls/55 merged?

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems