### PR TITLE
VMware Plugin: fix restore of backups taken before version 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: fix for crash when starting rescheduled jobs [PR #1327]
 - unify and merge builds where possible [PR #1309]
 - python plugins: give python3 plugins priority over python2 plugins in packages [PR #1332]
+- VMware Plugin: fix restore of backups taken before version 22 [PR #1337]
 
 ### Deprecated
 - make_catalog_backup.pl is now a shell wrapper script which will be removed in version 23.
@@ -420,4 +421,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1331]: https://github.com/bareos/bareos/pull/1331
 [PR #1332]: https://github.com/bareos/bareos/pull/1332
 [PR #1333]: https://github.com/bareos/bareos/pull/1333
+[PR #1337]: https://github.com/bareos/bareos/pull/1337
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -2468,11 +2468,22 @@ class BareosVADPWrapper(object):
         Restore power state according to restore_powerstate option
         """
 
-        if not self.restore_vm_info:
+        if not self.restore_vm_info and self.restore_vm_info_json:
             self.restore_vm_info = json.loads(self.restore_vm_info_json)
 
         if self.options["restore_powerstate"] == "off":
             return bareosfd.bRC_OK
+
+        if (
+            self.options["restore_powerstate"] == "previous"
+            and self.restore_vm_info is None
+        ):
+            bareosfd.JobMessage(
+                bareosfd.M_WARNING,
+                "Previous power state of VM %s unknown, skipping restore powerstate\n"
+                % (self.vm.name),
+            )
+            return bareosfd.bRC_Error
 
         if self.options["restore_powerstate"] == "on" or (
             self.options["restore_powerstate"] == "previous"


### PR DESCRIPTION
When restoring backups taken with Bareos versions before 22, this fix makes sure that such backups are restorable.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?


##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
