### PR TITLE
dird: filed: stored: remove deprecated `maxconnections` option from configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - remove no longer used pkglists [PR #1335]
 - core: remove deprecated make_catalog_backup.pl [PR #1378]
 - cats: remove remains of deprecated databases [PR #1377]
+- dird: filed: stored: remove deprecated `maxconnections` option from configuration [PR #1340]
 
 ### Changed
 - cats: fix issue where `startfile` field gets wrongly updated [PR #1346]
@@ -58,6 +59,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
 [PR #1336]: https://github.com/bareos/bareos/pull/1336
 [PR #1339]: https://github.com/bareos/bareos/pull/1339
+[PR #1340]: https://github.com/bareos/bareos/pull/1340
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1345]: https://github.com/bareos/bareos/pull/1345
 [PR #1346]: https://github.com/bareos/bareos/pull/1346

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -133,7 +133,6 @@ static ResourceItem dir_items[] = {
 #endif
   { "Subscriptions", CFG_TYPE_PINT32, ITEM(res_dir, subscriptions), 0, CFG_ITEM_DEFAULT, "0", "12.4.4-", NULL },
   { "MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dir, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL },
-  { "MaximumConnections", CFG_TYPE_PINT32, ITEM(res_dir, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "30", NULL, NULL },
   { "MaximumConsoleConnections", CFG_TYPE_PINT32, ITEM(res_dir, MaxConsoleConnections), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL },
   { "Password", CFG_TYPE_AUTOPASSWORD, ITEM(res_dir, password_), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL },
   { "FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_dir, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "180" /* 3 minutes */, NULL, NULL },

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -120,7 +120,6 @@ class DirectorResource
   std::vector<std::string> backend_directories;
   MessagesResource* messages = nullptr; /* Daemon message handler */
   uint32_t MaxConcurrentJobs = 0; /* Max concurrent jobs for whole director */
-  uint32_t MaxConnections = 0;    /* Max concurrent connections */
   uint32_t MaxConsoleConnections = 0; /* Max concurrent console connections */
   utime_t FDConnectTimeout = {0};     /* Timeout for connect in seconds */
   utime_t SDConnectTimeout = {0};     /* Timeout for connect in seconds */

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -93,7 +93,6 @@ static ResourceItem cli_items[] = {
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_client, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_client, scripts_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_client, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL},
-  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_client, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
   {"Messages", CFG_TYPE_RES, ITEM(res_client, messages), R_MSGS, 0, NULL, NULL, NULL},
   {"SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_client, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
   {"HeartbeatInterval", CFG_TYPE_TIME, ITEM(res_client, heartbeat_interval), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL},

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -97,7 +97,6 @@ class ClientResource
   char* scripts_directory = nullptr;
   MessagesResource* messages = nullptr; /* Daemon message handler */
   uint32_t MaxConcurrentJobs = 0;
-  uint32_t MaxConnections = 0;
   utime_t SDConnectTimeout = {0};       /* Timeout in seconds */
   utime_t heartbeat_interval = {0};     /* Interval to send heartbeats */
   uint32_t max_network_buffer_size = 0; /* Max network buf size */

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -48,7 +48,7 @@
 #  include <arpa/nameser.h>
 #endif
 #ifdef HAVE_RESOLV_H
-//#include <resolv.h>
+// #include <resolv.h>
 #endif
 
 #ifdef HAVE_POLL_H
@@ -289,7 +289,7 @@ void BnetThreadServerTcp(
       return;
     }
 
-    listen(fd_ptr->fd, 50); /* tell system we are ready */
+    listen(fd_ptr->fd, kListenBacklog); /* tell system we are ready */
     sockfds->append(fd_ptr);
 
 #ifdef HAVE_POLL

--- a/core/src/lib/bnet_server_tcp.h
+++ b/core/src/lib/bnet_server_tcp.h
@@ -24,6 +24,8 @@
 #include <atomic>
 #include <functional>
 
+constexpr int kListenBacklog = 50;
+
 class ConfigurationParser;
 class ThreadList;
 class IPADDR;

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -167,10 +167,8 @@ void NdmpLoghandler(struct ndmlog* log, char* tag, int level, char* msg)
   nis = (NIS*)log->ctx;
   if (!nis) { return; }
 
-  /*
-   * If the log level of this message is under our logging treshold we
-   * log it as part of the Job.
-   */
+  /* If the log level of this message is under our logging treshold we
+   * log it as part of the Job. */
   if (level <= (int)nis->LogLevel) {
     if (nis->jcr) {
       // Look at the tag field to see what is logged.
@@ -1164,7 +1162,7 @@ extern "C" void* ndmp_thread_server(void* arg)
             be.bstrerror());
 #  endif
     }
-    listen(fd_ptr->fd, me->MaxConnections); /* tell system we are ready */
+    listen(fd_ptr->fd, kListenBacklog); /* tell system we are ready */
     sockfds.push_back(fd_ptr);
 #  ifdef HAVE_POLL
     nfds++;

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -88,7 +88,6 @@ static ResourceItem store_items[] = {
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_store, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_store, scripts_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_store, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "20", NULL, NULL},
-  {"MaximumConnections", CFG_TYPE_PINT32, ITEM(res_store, MaxConnections), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "42", "15.2.3-", NULL},
   {"Messages", CFG_TYPE_RES, ITEM(res_store, messages), R_MSGS, 0, NULL, NULL, NULL},
   {"SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
   {"FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -107,7 +107,6 @@ class StorageResource
   char* scripts_directory = nullptr;
   std::vector<std::string> backend_directories;
   uint32_t MaxConcurrentJobs = 0;      /**< Maximum concurrent jobs to run */
-  uint32_t MaxConnections = 0;         /**< Maximum connections to allow */
   uint32_t ndmploglevel = 0;           /**< Initial NDMP log level */
   uint32_t jcr_watchdog_time = 0;      /**< Absolute time after which a Job gets
                                       terminated regardless of its progress */

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -104,13 +104,6 @@
           "default_value": "1",
           "equals": true
         },
-        "MaximumConnections": {
-          "datatype": "PINT32",
-          "code": 0,
-          "default_value": "30",
-          "deprecated": true,
-          "equals": true
-        },
         "MaximumConsoleConnections": {
           "datatype": "PINT32",
           "code": 0,

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -229,14 +229,6 @@
           "default_value": "20",
           "equals": true
         },
-        "MaximumConnections": {
-          "datatype": "PINT32",
-          "code": 0,
-          "default_value": "42",
-          "deprecated": true,
-          "equals": true,
-          "versions": "15.2.3-"
-        },
         "Messages": {
           "datatype": "RES",
           "code": 2,
@@ -516,14 +508,6 @@
           "code": 0,
           "default_value": "20",
           "equals": true
-        },
-        "MaximumConnections": {
-          "datatype": "PINT32",
-          "code": 0,
-          "default_value": "42",
-          "deprecated": true,
-          "equals": true,
-          "versions": "15.2.3-"
         },
         "Messages": {
           "datatype": "RES",

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -236,14 +236,6 @@
           "default_value": "20",
           "equals": true
         },
-        "MaximumConnections": {
-          "datatype": "PINT32",
-          "code": 0,
-          "default_value": "42",
-          "deprecated": true,
-          "equals": true,
-          "versions": "15.2.3-"
-        },
         "Messages": {
           "datatype": "RES",
           "code": 4,

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-19.2.7-show-verbose.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-19.2.7-show-verbose.conf.in
@@ -12,7 +12,6 @@ Director {
   BackendDirectory = "@backenddir@"
   # Subscriptions = 0
   MaximumConcurrentJobs = 10
-  # MaximumConnections = 30
   # MaximumConsoleConnections = 20
   Password = "@dir_password@"
   # FdConnectTimeout = 3 minutes

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -16,7 +16,6 @@ Director {
   BackendDirectory = "@backenddir@"
   Subscriptions = 10
   MaximumConcurrentJobs = 100
-  MaximumConnections = 300
   MaximumConsoleConnections = 200
   Password = "@dir_password@"
   FdConnectTimeout = 1 minutes

--- a/systemtests/tests/config-dump/etc/orig/bareos-dir-19.2.7-show-verbose.conf
+++ b/systemtests/tests/config-dump/etc/orig/bareos-dir-19.2.7-show-verbose.conf
@@ -11,7 +11,6 @@ Director {
   #  WorkingDirectory = "/var/lib/bareos"
   #  Subscriptions = 0
   MaximumConcurrentJobs = 10
-  #  MaximumConnections = 30
   #  MaximumConsoleConnections = 20
   Password = "[md5]1499042c6de7a645bcb4c21f3e05dc3a"
   #  FdConnectTimeout = 3 minutes


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

This PR removes the deprecated configuation option `maximum connections` from all daemons.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

