### PR TITLE
Fix gcc warnings in ndmjob program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Changed
+
 ### Removed
 - remove no longer used pkglists [PR #1335]
 
@@ -15,4 +17,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
+[PR #1343]: https://github.com/bareos/bareos/pull/1343
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,11 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - cats: fix issue where `startfile` field gets wrongly updated [PR #1346]
 - Python Plugins: Avoid pop(0) performance impact [PR #1351]
 
+### Fixed
+- Fix gcc warnings in ndmjob program [PR #1343]
+
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
+[PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
-[PR #1343]: https://github.com/bareos/bareos/pull/1343
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/ndmp/ndmjob_args.c
+++ b/core/src/ndmp/ndmjob_args.c
@@ -825,6 +825,7 @@ void dump_settings(void)
 
 int copy_args_expanding_macros(int argc, char* argv[], char* av[], int max_ac)
 {
+  (void) max_ac; //unused
   int i, ac = 0, rc;
   char* arg;
   char* p;

--- a/core/src/ndmp/ndmjob_main_util.c
+++ b/core/src/ndmp/ndmjob_main_util.c
@@ -96,6 +96,7 @@ void error_byebye(char* fmt, ...)
 
 void ndmjob_log_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
 {
+  (void) log; //unused
   char tagbuf[32];
 
   if (the_mode == 'D') {
@@ -125,6 +126,8 @@ void ndmjob_log_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
 #ifndef NDMOS_OPTION_NO_CONTROL_AGENT
 void ndmjob_ixlog_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
 {
+  (void) log; //unused
+  (void) lev; //unused
   fprintf(index_fp, "%s %s\n", tag, msg);
   fflush(index_fp); /* this doesn't change the run time */
 }

--- a/core/src/ndmp/ndmjob_simulator.c
+++ b/core/src/ndmp/ndmjob_simulator.c
@@ -957,7 +957,7 @@ static void robot_state_load(struct ndm_session* sess, struct robot_state* rs)
     robot_state_init(rs);
     return;
   }
-  if (read(fd, (void*)rs, sizeof(*rs)) < sizeof(*rs)) {
+  if (read(fd, (void*)rs, (sizeof(*rs)) < sizeof(*rs))) {
     robot_state_init(rs);
     close(fd);
     return;
@@ -977,7 +977,7 @@ static int robot_state_save(struct ndm_session* sess, struct robot_state* rs)
   snprintf(filename, sizeof filename, "%s/state", sess->robot_acb->sim_dir);
   fd = open(filename, O_WRONLY | O_TRUNC | O_CREAT, 0666);
   if (fd < 0) return -1;
-  if (write(fd, (void*)rs, sizeof(*rs)) < sizeof(*rs)) {
+  if (write(fd, (void*)rs, (sizeof(*rs)) < sizeof(*rs))) {
     close(fd);
     return -1;
   }
@@ -1464,11 +1464,13 @@ static ndmp9_error ndmjob_scsi_open(struct ndm_session* sess, char* name)
 
 static ndmp9_error ndmjob_scsi_close(struct ndm_session* sess)
 {
+  (void) sess; //unused
   return NDMP9_NO_ERR;
 }
 
 static ndmp9_error ndmjob_scsi_reset(struct ndm_session* sess)
 {
+  (void) sess; //unused
   return NDMP9_NO_ERR;
 }
 
@@ -1493,10 +1495,11 @@ static int ndmjob_validate_password(struct ndm_session* sess,
                                     char* name,
                                     char* pass)
 {
-  if (strcmp(name, "ndmp") != 0) return 0;
-
-  if (strcmp(pass, "ndmp") != 0) return 0;
-
+  (void) sess; //unused
+  if (strcmp(name, "ndmp") != 0)
+    return 0;
+  if (strcmp(pass, "ndmp") != 0)
+    return 0;
   return 1; /* OK */
 }
 

--- a/core/src/ndmp/ndmjr_none.c
+++ b/core/src/ndmp/ndmjr_none.c
@@ -43,6 +43,10 @@
 #include "ndmjr_none.h"
 
 
-int ndmjr_none_apply(struct ndm_job_param* job, char* reason) { return 0; }
+int ndmjr_none_apply(struct ndm_job_param* job, char* reason) {
+  (void) job; //unused
+  (void) reason; //unused
+  return 0;
+}
 
 #endif /* !NDMOS_OPTION_NO_CONTROL_AGENT */


### PR DESCRIPTION
On Fedora 37 the gcc will report many warnings as errors, so the warnings need an fix.

```
cd /builddir/build/BUILD/bareos-Release-22.0.0/redhat-linux-build/core/src/ndmp && ccache /usr/lib64/ccache/gcc -D_FILE_OFFSET_BITS=64 -I/usr/include/tirpc -I/builddir/build/BUILD/bareos-Release-22.0.0/core/src -I/builddir/build/BUILD/bareos-Release-22.0.0/redhat-linux-build/core/src/ndmp -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m64  -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -Wno-error=maybe-uninitialized -Wno-error=format-truncation -fdebug-prefix-map=/builddir/build/BUILD/bareos-Release-22.0.0/core=. -fmacro-prefix-map=/builddir/build/BUILD/bareos-Release-22.0.0/core=. -Werror -Wall -Wextra -DNDMOS_OPTION_NO_TEST_AGENTS -DNDMOS_CONST_VENDOR_NAME=\"Bareos\ GmbH\ \&\ Co.KG\" -DNDMOS_CONST_PRODUCT_NAME=\"Bareos\" -DHAVE_LINUX_OS -MD -MT core/src/ndmp/CMakeFiles/ndmjob.dir/ndmjr_none.c.o -MF CMakeFiles/ndmjob.dir/ndmjr_none.c.o.d -o CMakeFiles/ndmjob.dir/ndmjr_none.c.o -c /builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjr_none.c
ccache /usr/bin/ar qc libstored_objects.a CMakeFiles/stored_objects.dir/append.cc.o CMakeFiles/stored_objects.dir/askdir.cc.o CMakeFiles/stored_objects.dir/authenticate.cc.o CMakeFiles/stored_objects.dir/dir_cmd.cc.o CMakeFiles/stored_objects.dir/fd_cmds.cc.o CMakeFiles/stored_objects.dir/job.cc.o CMakeFiles/stored_objects.dir/mac.cc.o CMakeFiles/stored_objects.dir/ndmp_tape.cc.o CMakeFiles/stored_objects.dir/read.cc.o CMakeFiles/stored_objects.dir/sd_cmds.cc.o CMakeFiles/stored_objects.dir/sd_stats.cc.o CMakeFiles/stored_objects.dir/socket_server.cc.o CMakeFiles/stored_objects.dir/status.cc.o
ccache /usr/bin/ranlib libstored_objects.a
gmake[2]: Leaving directory '/builddir/build/BUILD/bareos-Release-22.0.0/redhat-linux-build'
[ 55%] Built target stored_objects
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjr_none.c: In function 'ndmjr_none_apply':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjr_none.c:46:44: error: unused parameter 'job' [-Werror=unused-parameter]
   46 | int ndmjr_none_apply(struct ndm_job_param* job, char* reason) { return 0; }
      |                      ~~~~~~~~~~~~~~~~~~~~~~^~~
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjr_none.c:46:55: error: unused parameter 'reason' [-Werror=unused-parameter]
   46 | int ndmjr_none_apply(struct ndm_job_param* job, char* reason) { return 0; }
      |                                                 ~~~~~~^~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [core/src/ndmp/CMakeFiles/ndmjob.dir/build.make:177: core/src/ndmp/CMakeFiles/ndmjob.dir/ndmjr_none.c.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_main_util.c: In function 'ndmjob_log_deliver':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_main_util.c:97:40: error: unused parameter 'log' [-Werror=unused-parameter]
   97 | void ndmjob_log_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
      |                         ~~~~~~~~~~~~~~~^~~
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_main_util.c: In function 'ndmjob_ixlog_deliver':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_main_util.c:126:42: error: unused parameter 'log' [-Werror=unused-parameter]
  126 | void ndmjob_ixlog_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
      |                           ~~~~~~~~~~~~~~~^~~
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_main_util.c:126:62: error: unused parameter 'lev' [-Werror=unused-parameter]
  126 | void ndmjob_ixlog_deliver(struct ndmlog* log, char* tag, int lev, char* msg)
      |                                                          ~~~~^~~
cc1: all warnings being treated as errors
gmake[2]: *** [core/src/ndmp/CMakeFiles/ndmjob.dir/build.make:135: core/src/ndmp/CMakeFiles/ndmjob.dir/ndmjob_main_util.c.o] Error 1
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_args.c: In function 'copy_args_expanding_macros':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_args.c:826:72: error: unused parameter 'max_ac' [-Werror=unused-parameter]
  826 | int copy_args_expanding_macros(int argc, char* argv[], char* av[], int max_ac)
      |                                                                    ~~~~^~~~~~
cc1: all warnings being treated as errors
gmake[2]: *** [core/src/ndmp/CMakeFiles/ndmjob.dir/build.make:79: core/src/ndmp/CMakeFiles/ndmjob.dir/ndmjob_args.c.o] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/bareos-Release-22.0.0/redhat-linux-build'
[ 55%] Built target bareossd-droplet
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c: In function 'robot_state_load':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c:960:40: error: comparison of integer expressions of different signedness: 'ssize_t' {aka 'long int'} and 'long unsigned int' [-Werror=sign-compare]
  960 |   if (read(fd, (void*)rs, sizeof(*rs)) < sizeof(*rs)) {
      |                                        ^
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c: In function 'robot_state_save':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c:980:41: error: comparison of integer expressions of different signedness: 'ssize_t' {aka 'long int'} and 'long unsigned int' [-Werror=sign-compare]
  980 |   if (write(fd, (void*)rs, sizeof(*rs)) < sizeof(*rs)) {
      |                                         ^
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c: In function 'ndmjob_scsi_close':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c:1465:58: error: unused parameter 'sess' [-Werror=unused-parameter]
 1465 | static ndmp9_error ndmjob_scsi_close(struct ndm_session* sess)
      |                                      ~~~~~~~~~~~~~~~~~~~~^~~~
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c: In function 'ndmjob_scsi_reset':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c:1470:58: error: unused parameter 'sess' [-Werror=unused-parameter]
 1470 | static ndmp9_error ndmjob_scsi_reset(struct ndm_session* sess)
      |                                      ~~~~~~~~~~~~~~~~~~~~^~~~
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c: In function 'ndmjob_validate_password':
/builddir/build/BUILD/bareos-Release-22.0.0/core/src/ndmp/ndmjob_simulator.c:1492:57: error: unused parameter 'sess' [-Werror=unused-parameter]
 1492 | static int ndmjob_validate_password(struct ndm_session* sess,
      |                                     ~~~~~~~~~~~~~~~~~~~~^~~~
cc1: all warnings being treated as errors
gmake[2]: *** [core/src/ndmp/CMakeFiles/ndmjob.dir/build.make:163: core/src/ndmp/CMakeFiles/ndmjob.dir/ndmjob_simulator.c.o] Error 1
gmake[2]: Leaving directory '/builddir/build/BUILD/bareos-Release-22.0.0/redhat-linux-build'
gmake[1]: *** [CMakeFiles/Makefile2:3331: core/src/ndmp/CMakeFiles/ndmjob.dir/all] Error 2
gmake[1]: *** Waiting for unfinished jobs....
```



#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- ~Your name is present in the AUTHORS file (optional)~

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

