### PR TITLE
checkpoints: fix performance drop on big volume restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - Fix gcc warnings in ndmjob program [PR #1343]
 - filed: avoid reading from ephemeral buffer [PR #1373]
+- checkpoints: fix performance drop on big volume restores [PR #1345]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -47,6 +48,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1336]: https://github.com/bareos/bareos/pull/1336
 [PR #1339]: https://github.com/bareos/bareos/pull/1339
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
+[PR #1345]: https://github.com/bareos/bareos/pull/1345
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
 [PR #1348]: https://github.com/bareos/bareos/pull/1348
 [PR #1351]: https://github.com/bareos/bareos/pull/1351

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SDSRCS
     append.cc
     askdir.cc
     authenticate.cc
+    checkpointhandler.cc
     dir_cmd.cc
     fd_cmds.cc
     job.cc

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -80,7 +80,7 @@ set(SDSRCS
     append.cc
     askdir.cc
     authenticate.cc
-    checkpointhandler.cc
+    checkpoint_handler.cc
     dir_cmd.cc
     fd_cmds.cc
     job.cc

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -103,6 +103,7 @@ static void UpdateJobmediaRecord(JobControlRecord* jcr)
 {
   Dmsg0(100, _("... create job media record\n"));
   jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
+  jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex;
 }
 
 static void UpdateJobrecord(JobControlRecord* jcr)

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -28,7 +28,7 @@
 #include "stored/append.h"
 #include "stored/stored.h"
 #include "stored/acquire.h"
-#include "stored/checkpointhandler.h"
+#include "stored/checkpoint_handler.h"
 #include "stored/fd_cmds.h"
 #include "stored/stored_globals.h"
 #include "stored/stored_jcr_impl.h"

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -213,7 +213,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex = 0;
   jcr->run_time = time(NULL); /* start counting time for rates */
 
-  bool checkpoints_enabled = me->checkpoint_interval > 0 ? true : false;
+  const bool checkpoints_enabled = me->checkpoint_interval > 0;
   CheckpointHandler checkpoint_handler(me->checkpoint_interval);
 
   std::vector<ProcessedFile> processed_files{};
@@ -314,9 +314,9 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
         file_currently_processed.AddAttribute(jcr->sd_impl->dcr->rec);
       }
 
-      bool block_changed
+      const bool block_changed
           = current_block_number != jcr->sd_impl->dcr->block->BlockNumber;
-      bool volume_changed
+      const bool volume_changed
           = jcr->sd_impl->dcr->VolMediaId != current_volumeid && block_changed;
 
       if (AttributesAreSpooled(jcr)) {
@@ -326,12 +326,12 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
           current_block_number = jcr->sd_impl->dcr->block->BlockNumber;
           if (SaveFullyProcessedFilesAttributes(jcr, processed_files)) {
             if (checkpoints_enabled) {
-              checkpoint_handler.SetReadyForCheckpoint(true);
+              checkpoint_handler.SetReadyForCheckpoint();
             }
           }
         }
 
-        if (checkpoints_enabled && checkpoint_handler.ReadyForCheckpoint()) {
+        if (checkpoints_enabled && checkpoint_handler.IsReadyForCheckpoint()) {
           if (volume_changed) {
             checkpoint_handler.DoVolumeChangeBackupCheckpoint(jcr);
             current_volumeid = jcr->sd_impl->dcr->VolMediaId;

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -193,8 +193,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
     ok = false;
   }
 
-  /*
-   * Get Data from daemon, write to device.  To clarify what is
+  /* Get Data from daemon, write to device.  To clarify what is
    * going on here.  We expect:
    * - A stream header
    * - Multiple records of data
@@ -208,8 +207,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
    *
    * So we get the (stream header, data, EOD) three time for each
    * file. 1. for the Attributes, 2. for the file data if any,
-   * and 3. for the MD5 if any.
-   */
+   * and 3. for the MD5 if any. */
   jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex = 0;
   jcr->run_time = time(NULL); /* start counting time for rates */
 
@@ -223,15 +221,13 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   uint32_t current_block_number = jcr->sd_impl->dcr->block->BlockNumber;
 
   for (last_file_index = 0; ok && !jcr->IsJobCanceled();) {
-    /*
-     * Read Stream header from the daemon.
+    /* Read Stream header from the daemon.
      *
      * The stream header consists of the following:
      * - file_index (sequential Bareos file index, base 1)
      * - stream     (Bareos number to distinguish parts of data)
      * - info       (Info for Storage daemon -- compressed, encrypted, ...)
-     *               info is not currently used, so is read, but ignored!
-     */
+     *               info is not currently used, so is read, but ignored! */
     if ((n = BgetMsg(bs)) <= 0) {
       if (n == BNET_SIGNAL && bs->message_length == BNET_EOD) {
         break; /* end of data */
@@ -251,11 +247,9 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
 
     Dmsg2(890, "<filed: Header FilInx=%d stream=%d\n", file_index, stream);
 
-    /*
-     * We make sure the file_index is advancing sequentially.
+    /* We make sure the file_index is advancing sequentially.
      * An incomplete job can start the file_index at any number.
-     * otherwise, it must start at 1.
-     */
+     * otherwise, it must start at 1. */
 
     bool incomplete_job_rerun_fileindex_positive
         = jcr->rerunning && file_index > 0 && last_file_index == 0;
@@ -279,11 +273,9 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       file_currently_processed = ProcessedFile{file_index};
     }
 
-    /*
-     * Read data stream from the daemon. The data stream is just raw bytes.
+    /* Read data stream from the daemon. The data stream is just raw bytes.
      * We save the original data pointer from the record so we can restore
-     * that after the loop ends.
-     */
+     * that after the loop ends. */
     rec_data = jcr->sd_impl->dcr->rec->data;
     while ((n = BgetMsg(bs)) > 0 && !jcr->IsJobCanceled()) {
       jcr->sd_impl->dcr->rec->VolSessionId = jcr->VolSessionId;
@@ -375,10 +367,8 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
 
   Dmsg1(200, "Write EOS label JobStatus=%c\n", jcr->getJobStatus());
 
-  /*
-   * Check if we can still write. This may not be the case
-   * if we are at the end of the tape or we got a fatal I/O error.
-   */
+  /* Check if we can still write. This may not be the case
+   * if we are at the end of the tape or we got a fatal I/O error. */
   if (ok || dev->CanWrite()) {
     if (!WriteSessionLabel(jcr->sd_impl->dcr, EOS_LABEL)) {
       // Print only if ok and not cancelled to avoid spurious messages
@@ -420,10 +410,8 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   // Release the device -- and send final Vol info to DIR and unlock it.
   ReleaseDevice(jcr->sd_impl->dcr);
 
-  /*
-   * Don't use time_t for job_elapsed as time_t can be 32 or 64 bits,
-   * and the subsequent Jmsg() editing will break
-   */
+  /* Don't use time_t for job_elapsed as time_t can be 32 or 64 bits,
+   * and the subsequent Jmsg() editing will break */
   job_elapsed = time(NULL) - jcr->run_time;
   if (job_elapsed <= 0) { job_elapsed = 1; }
 

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -46,11 +46,6 @@ static char OK_data[] = "3000 OK data\n";
 static char OK_append[] = "3000 OK append data\n";
 static char OK_replicate[] = "3000 OK replicate data\n";
 
-/* Forward referenced functions */
-
-void PossibleIncompleteJob(JobControlRecord*, int32_t) {}
-
-
 ProcessedFileData::ProcessedFileData(DeviceRecord* record)
     : volsessionid_(record->VolSessionId)
     , volsessiontime_(record->VolSessionTime)
@@ -285,7 +280,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       }
       Jmsg2(jcr, M_FATAL, 0, _("Error reading data header from %s. ERR=%s\n"),
             what, bs->bstrerror());
-      PossibleIncompleteJob(jcr, last_file_index);
       ok = false;
       break;
     }
@@ -294,7 +288,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       Jmsg2(jcr, M_FATAL, 0, _("Malformed data header from %s: %s\n"), what,
             bs->msg);
       ok = false;
-      PossibleIncompleteJob(jcr, last_file_index);
       break;
     }
 
@@ -316,7 +309,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       Jmsg3(jcr, M_FATAL, 0,
             _("FileIndex=%d from %s not positive or sequential=%d\n"),
             file_index, what, last_file_index);
-      PossibleIncompleteJob(jcr, last_file_index);
       ok = false;
       break;
     }
@@ -397,7 +389,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
               bs->bstrerror());
         Jmsg2(jcr, M_FATAL, 0, _("Network error reading from %s. ERR=%s\n"),
               what, bs->bstrerror());
-        PossibleIncompleteJob(jcr, last_file_index);
       }
       ok = false;
       break;
@@ -429,7 +420,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       if (ok && !jcr->IsJobCanceled()) {
         Jmsg1(jcr, M_FATAL, 0, _("Error writing end session label. ERR=%s\n"),
               dev->bstrerror());
-        PossibleIncompleteJob(jcr, last_file_index);
       }
       jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
       ok = false;
@@ -443,7 +433,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
         Jmsg2(jcr, M_FATAL, 0, _("Fatal append error on device %s: ERR=%s\n"),
               dev->print_name(), dev->bstrerror());
         Dmsg0(100, _("Set ok=FALSE after WriteBlockToDevice.\n"));
-        PossibleIncompleteJob(jcr, last_file_index);
       }
       jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
       ok = false;

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -94,7 +94,7 @@ bool IsAttribute(DeviceRecord* record)
          || CryptoDigestStreamType(record->maskedStream) != CRYPTO_DIGEST_NONE;
 }
 
-static void SaveFullyProcessedFiles(
+static void SaveFullyProcessedFilesAttributes(
     JobControlRecord* jcr,
     std::vector<ProcessedFile>& processed_files)
 {
@@ -312,11 +312,11 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       }
 
       if (AttributesAreSpooled(jcr)) {
-        SaveFullyProcessedFiles(jcr, processed_files);
+        SaveFullyProcessedFilesAttributes(jcr, processed_files);
       } else {
         if (current_block_number != jcr->sd_impl->dcr->block->BlockNumber) {
           current_block_number = jcr->sd_impl->dcr->block->BlockNumber;
-          SaveFullyProcessedFiles(jcr, processed_files);
+          SaveFullyProcessedFilesAttributes(jcr, processed_files);
         }
         if (me->checkpoint_interval) {
           if (jcr->sd_impl->dcr->VolMediaId != current_volumeid) {
@@ -394,7 +394,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
       if (file_currently_processed.GetFileIndex() > 0) {
         processed_files.push_back(std::move(file_currently_processed));
       }
-      SaveFullyProcessedFiles(jcr, processed_files);
+      SaveFullyProcessedFilesAttributes(jcr, processed_files);
     }
   }
 

--- a/core/src/stored/append.h
+++ b/core/src/stored/append.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/append.h
+++ b/core/src/stored/append.h
@@ -64,8 +64,6 @@ class ProcessedFile {
 bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what);
 bool IsAttribute(DeviceRecord* record);
 bool SendAttrsToDir(JobControlRecord* jcr, DeviceRecord* rec);
-
-void DoBackupCheckpoint(JobControlRecord* jcr);
 }  // namespace storagedaemon
 
 #endif  // BAREOS_STORED_APPEND_H_

--- a/core/src/stored/checkpoint_handler.cc
+++ b/core/src/stored/checkpoint_handler.cc
@@ -65,13 +65,11 @@ void CheckpointHandler::DoBackupCheckpoint(JobControlRecord* jcr)
   UpdateFileList(jcr);
   UpdateJobmediaRecord(jcr);
 
-  SetReadyForCheckpoint(false);
+  ClearReadyForCheckpoint();
 
   Dmsg0(100, _("Checkpoint completed\n"));
 }
 
-/* On volume changes, the SD already creates a jobmedia table entry for the
-   finished volume, so we only need to update the File and Job tables */
 void CheckpointHandler::DoVolumeChangeBackupCheckpoint(JobControlRecord* jcr)
 {
   Jmsg0(jcr, M_INFO, 0, _("Volume changed, doing checkpoint:\n"));

--- a/core/src/stored/checkpoint_handler.cc
+++ b/core/src/stored/checkpoint_handler.cc
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301, USA.
 */
 
-#include "checkpointhandler.h"
+#include "checkpoint_handler.h"
 
 #include "stored/stored_jcr_impl.h"
 #include "stored/device_control_record.h"

--- a/core/src/stored/checkpoint_handler.h
+++ b/core/src/stored/checkpoint_handler.h
@@ -32,13 +32,14 @@ class CheckpointHandler {
   void DoBackupCheckpoint(JobControlRecord* jcr);
   void DoTimedCheckpoint(JobControlRecord* jcr);
   void DoVolumeChangeBackupCheckpoint(JobControlRecord* jcr);
-  void SetReadyForCheckpoint(bool ready) { ready_for_checkpoint_ = ready; }
-  bool ReadyForCheckpoint() const { return ready_for_checkpoint_; }
+  void SetReadyForCheckpoint() { ready_for_checkpoint_ = true; }
+  bool IsReadyForCheckpoint() const { return ready_for_checkpoint_; }
 
  private:
   void UpdateFileList(JobControlRecord* jcr);
   void UpdateJobmediaRecord(JobControlRecord* jcr);
   void UpdateJobrecord(JobControlRecord* jcr);
+  void ClearReadyForCheckpoint() { ready_for_checkpoint_ = false; }
 
   bool ready_for_checkpoint_ = false;
   time_t next_checkpoint_time_{};

--- a/core/src/stored/checkpoint_handler.h
+++ b/core/src/stored/checkpoint_handler.h
@@ -19,8 +19,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301, USA.
 */
 
-#ifndef BAREOS_STORED_CHECKPOINTHANDLER_H_
-#define BAREOS_STORED_CHECKPOINTHANDLER_H_
+#ifndef BAREOS_STORED_CHECKPOINT_HANDLER_H_
+#define BAREOS_STORED_CHECKPOINT_HANDLER_H_
 
 #include "include/jcr.h"
 
@@ -46,4 +46,4 @@ class CheckpointHandler {
 };
 
 }  // namespace storagedaemon
-#endif  // BAREOS_STORED_CHECKPOINTHANDLER_H_
+#endif  // BAREOS_STORED_CHECKPOINT_HANDLER_H_

--- a/core/src/stored/checkpointhandler.cc
+++ b/core/src/stored/checkpointhandler.cc
@@ -63,6 +63,22 @@ void CheckpointHandler::DoBackupCheckpoint(JobControlRecord* jcr)
 
   jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex;
 
+  SetReadyForCheckpoint(false);
+
+  Dmsg0(100, _("Checkpoint completed\n"));
+}
+
+/* On volume changes, the SD already creates a jobmedia table entry for the
+   finished volume, so we only need to update the File and Job tables */
+void CheckpointHandler::DoVolumeChangeBackupCheckpoint(JobControlRecord* jcr)
+{
+  Jmsg0(jcr, M_INFO, 0, _("Volume changed, doing checkpoint:\n"));
+  Dmsg0(100, _("Checkpoint: Syncing current backup status to catalog\n"));
+  UpdateJobrecord(jcr);
+  UpdateFileList(jcr);
+
+  SetReadyForCheckpoint(false);
+
   Dmsg0(100, _("Checkpoint completed\n"));
 }
 

--- a/core/src/stored/checkpointhandler.cc
+++ b/core/src/stored/checkpointhandler.cc
@@ -45,6 +45,10 @@ void CheckpointHandler::UpdateJobmediaRecord(JobControlRecord* jcr)
 {
   Dmsg0(100, _("... create job media record\n"));
   jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
+
+  jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex;
+  jcr->sd_impl->dcr->StartFile = jcr->sd_impl->dcr->EndFile;
+  jcr->sd_impl->dcr->StartBlock = jcr->sd_impl->dcr->EndBlock + 1;
 }
 
 void CheckpointHandler::UpdateJobrecord(JobControlRecord* jcr)
@@ -60,8 +64,6 @@ void CheckpointHandler::DoBackupCheckpoint(JobControlRecord* jcr)
   UpdateJobrecord(jcr);
   UpdateFileList(jcr);
   UpdateJobmediaRecord(jcr);
-
-  jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex;
 
   SetReadyForCheckpoint(false);
 

--- a/core/src/stored/checkpointhandler.cc
+++ b/core/src/stored/checkpointhandler.cc
@@ -1,0 +1,84 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#include "checkpointhandler.h"
+
+#include "stored/stored_jcr_impl.h"
+#include "stored/device_control_record.h"
+
+namespace storagedaemon {
+
+CheckpointHandler::CheckpointHandler(time_t interval)
+    : checkpoint_interval_(interval)
+{
+  auto now
+      = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  this->next_checkpoint_time_ = now + checkpoint_interval_;
+}
+
+
+void CheckpointHandler::UpdateFileList(JobControlRecord* jcr)
+{
+  Dmsg0(100, _("... update file list\n"));
+  jcr->sd_impl->dcr->DirAskToUpdateFileList();
+}
+
+void CheckpointHandler::UpdateJobmediaRecord(JobControlRecord* jcr)
+{
+  Dmsg0(100, _("... create job media record\n"));
+  jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
+}
+
+void CheckpointHandler::UpdateJobrecord(JobControlRecord* jcr)
+{
+  Dmsg2(100, _("... update job record: %llu bytes %lu files\n"), jcr->JobBytes,
+        jcr->JobFiles);
+  jcr->sd_impl->dcr->DirAskToUpdateJobRecord();
+}
+
+void CheckpointHandler::DoBackupCheckpoint(JobControlRecord* jcr)
+{
+  Dmsg0(100, _("Checkpoint: Syncing current backup status to catalog\n"));
+  UpdateJobrecord(jcr);
+  UpdateFileList(jcr);
+  UpdateJobmediaRecord(jcr);
+
+  jcr->sd_impl->dcr->VolFirstIndex = jcr->sd_impl->dcr->VolLastIndex;
+
+  Dmsg0(100, _("Checkpoint completed\n"));
+}
+
+void CheckpointHandler::DoTimedCheckpoint(JobControlRecord* jcr)
+{
+  const time_t now
+      = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+  if (now > next_checkpoint_time_) {
+    while (next_checkpoint_time_ <= now) {
+      next_checkpoint_time_ += checkpoint_interval_;
+    }
+    Jmsg(jcr, M_INFO, 0,
+         _("Doing timed backup checkpoint. Next checkpoint in %d seconds\n"),
+         checkpoint_interval_);
+    DoBackupCheckpoint(jcr);
+  }
+}
+
+}  // namespace storagedaemon

--- a/core/src/stored/checkpointhandler.cc
+++ b/core/src/stored/checkpointhandler.cc
@@ -75,13 +75,7 @@ void CheckpointHandler::DoBackupCheckpoint(JobControlRecord* jcr)
 void CheckpointHandler::DoVolumeChangeBackupCheckpoint(JobControlRecord* jcr)
 {
   Jmsg0(jcr, M_INFO, 0, _("Volume changed, doing checkpoint:\n"));
-  Dmsg0(100, _("Checkpoint: Syncing current backup status to catalog\n"));
-  UpdateJobrecord(jcr);
-  UpdateFileList(jcr);
-
-  SetReadyForCheckpoint(false);
-
-  Dmsg0(100, _("Checkpoint completed\n"));
+  DoBackupCheckpoint(jcr);
 }
 
 void CheckpointHandler::DoTimedCheckpoint(JobControlRecord* jcr)

--- a/core/src/stored/checkpointhandler.h
+++ b/core/src/stored/checkpointhandler.h
@@ -31,12 +31,16 @@ class CheckpointHandler {
   CheckpointHandler(time_t interval);
   void DoBackupCheckpoint(JobControlRecord* jcr);
   void DoTimedCheckpoint(JobControlRecord* jcr);
+  void DoVolumeChangeBackupCheckpoint(JobControlRecord* jcr);
+  void SetReadyForCheckpoint(bool ready) { ready_for_checkpoint_ = ready; }
+  bool ReadyForCheckpoint() const { return ready_for_checkpoint_; }
 
  private:
   void UpdateFileList(JobControlRecord* jcr);
   void UpdateJobmediaRecord(JobControlRecord* jcr);
   void UpdateJobrecord(JobControlRecord* jcr);
 
+  bool ready_for_checkpoint_ = false;
   time_t next_checkpoint_time_{};
   time_t checkpoint_interval_{};
 };

--- a/core/src/stored/checkpointhandler.h
+++ b/core/src/stored/checkpointhandler.h
@@ -1,0 +1,45 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#ifndef BAREOS_STORED_CHECKPOINTHANDLER_H_
+#define BAREOS_STORED_CHECKPOINTHANDLER_H_
+
+#include "include/jcr.h"
+
+namespace storagedaemon {
+
+class CheckpointHandler {
+ public:
+  CheckpointHandler(time_t interval);
+  void DoBackupCheckpoint(JobControlRecord* jcr);
+  void DoTimedCheckpoint(JobControlRecord* jcr);
+
+ private:
+  void UpdateFileList(JobControlRecord* jcr);
+  void UpdateJobmediaRecord(JobControlRecord* jcr);
+  void UpdateJobrecord(JobControlRecord* jcr);
+
+  time_t next_checkpoint_time_{};
+  time_t checkpoint_interval_{};
+};
+
+}  // namespace storagedaemon
+#endif  // BAREOS_STORED_CHECKPOINTHANDLER_H_

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/bigfileset.conf.in
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/bigfileset.conf.in
@@ -1,6 +1,6 @@
 FileSet {
-  Name = "SelfTest"
-  Description = "fileset just to backup some files for selftest"
+  Name = "bigfileset"
+  Description = "fileset that contains the systemtest directory of the source directory"
   Include {
     Options {
       Signature = MD5 # calculate md5 checksum per file
@@ -14,7 +14,6 @@ FileSet {
       fstype = zfs
       fstype = btrfs
     }
-    File=<@tmpdir@/file-list
-
+    File = "@PROJECT_SOURCE_DIR@/tests/"
   }
 }

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/job/slow-backup-bareos-fd.conf
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/job/slow-backup-bareos-fd.conf
@@ -8,5 +8,5 @@ Job {
   Messages = Standard
   Pool = SmallFull
   Full Backup Pool = SmallFull
-  Maximum Bandwidth = 10K
+  Maximum Bandwidth = 30K
 }

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/pool/FullSmallvolumes.conf
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/pool/FullSmallvolumes.conf
@@ -4,7 +4,7 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 365 days
-  Maximum Volume Bytes = 69k
+  Maximum Volume Bytes = 150k
   Maximum Volumes = 100
   Label Format = "SmallFull-"
 }

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-and-spooling
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-and-spooling
@@ -29,7 +29,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $backup_log
-run job=$slowjob level=Full spooldata=yes yes
+run job=$slowjob fileset=SelfTest level=Full spooldata=yes yes
 wait
 messages
 quit

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
@@ -30,7 +30,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $backup_log
-run job=$slowjob level=Full yes
+run job=$slowjob fileset=bigfileset level=Full yes
 quit
 END_OF_DATA
 
@@ -59,7 +59,6 @@ if [[ -z $volume_checkpoint ]]; then
     echo "Checkpoint was not triggered on volume changes!"
     estat=2;
 fi
-
 
 slowjobid=$(grep 'Job queued. JobId=' "$backup_log" | sed -n -e 's/^.*JobId=//p')
 
@@ -100,9 +99,9 @@ expect_grep "Files Restored:         ${NumberOfBackedUpFiles}" \
             "Restore of canceled job did not go well!"
 
 # Certain systems do not support multiple types for find (-type f,l)
-NumberOfFilesRestored=$(find "$restore_directory"/"$tmp" -type f | wc -l)
-NumberOfLinksRestored=$(find "$restore_directory"/"$tmp" -type l | wc -l)
-NumberOfDirectoriesRestored=$(find "$restore_directory"/"$tmp" -type d | wc -l)
+NumberOfFilesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type f | wc -l)
+NumberOfLinksRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type l | wc -l)
+NumberOfDirectoriesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type d | wc -l)
 RestoredItems=$((NumberOfFilesRestored + NumberOfLinksRestored + NumberOfDirectoriesRestored))
 
 # Check that the restored files are actually there

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-kill
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-kill
@@ -33,7 +33,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $backup_log
-run job=$slowjob level=Full yes
+run job=$slowjob fileset=bigfileset level=Full yes
 quit
 END_OF_DATA
 

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-stop
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-stop
@@ -31,7 +31,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $backup_log
-run job=$slowjob level=Full yes
+run job=$slowjob fileset=bigfileset level=Full yes
 quit
 END_OF_DATA
 
@@ -99,9 +99,9 @@ expect_grep "Termination:            Restore OK" \
             "Restore job did not go well!"
 
 # Certain systems do not support multiple types for find (-type f,l)
-NumberOfFilesRestored=$(find "$restore_directory"/"$tmp" -type f | wc -l)
-NumberOfLinksRestored=$(find "$restore_directory"/"$tmp" -type l | wc -l)
-NumberOfDirectoriesRestored=$(find "$restore_directory"/"$tmp" -type d | wc -l)
+NumberOfFilesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type f | wc -l)
+NumberOfLinksRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type l | wc -l)
+NumberOfDirectoriesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type d | wc -l)
 RestoredItems=$((NumberOfFilesRestored + NumberOfLinksRestored + NumberOfDirectoriesRestored))
 
 # Check that the restored files are actually there

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-regular-backup
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-regular-backup
@@ -30,7 +30,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $backup_log
-run job=$slowjob yes
+run job=$slowjob fileset=SelfTest yes
 status director
 status client
 status storage=File


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

In this PR, `jobmedia` table entries are not updated anymore, and only new entries can be created. This change fixes a performance issue on restores of big volumes.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
