### PR TITLE
cats: fix issue where `startfile` field gets wrongly updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Changed
+- cats: fix issue where `startfile` field gets wrongly updated [PR #1347]
+
 ## [22.0.0] - 2022-12-21
 
 ### Breaking Changes
@@ -424,4 +427,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1333]: https://github.com/bareos/bareos/pull/1333
 [PR #1334]: https://github.com/bareos/bareos/pull/1334
 [PR #1337]: https://github.com/bareos/bareos/pull/1337
+[PR #1347]: https://github.com/bareos/bareos/pull/1347
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -109,12 +109,10 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
        "UPDATE JobMedia SET "
        "FirstIndex = (CASE WHEN firstindex=0 THEN %lu ELSE firstindex END), "
        "StartBlock = (CASE WHEN startblock=0 THEN %lu ELSE startblock END), "
-       "StartFile  = (CASE WHEN startfile=0 THEN %lu ELSE startfile END), "
        "LastIndex=%lu, EndFile=%lu, EndBlock=%lu, JobBytes=%llu "
        "WHERE JobId=%lu AND MediaId=%lu",
        jm->FirstIndex,
        jm->StartBlock,
-       jm->StartFile,
        jm->LastIndex,
        jm->EndFile,
        jm->EndBlock,
@@ -128,8 +126,8 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
   Dmsg0(300, cmd);
 
   if (UPDATE_DB(jcr, cmd) <= 0) {
-    Mmsg2(errmsg,
-          _("Update JobMedia record %s failed: ERR=%s\n Trying to insert: \n"),
+    Dmsg2(200,
+          "Update JobMedia record %s failed: ERR=%s. Trying now to insert: \n",
           cmd, sql_strerror());
 
     Mmsg(cmd, "SELECT count(*) from JobMedia WHERE JobId=%lu", jm->JobId);

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -494,10 +494,8 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
            dt, mr->MediaId);
       retval = UPDATE_DB(jcr, cmd) > 0;
     }
-    /*
-     * Make sure that if InChanger is non-zero any other identical slot
-     * has InChanger zero.
-     */
+    /* Make sure that if InChanger is non-zero any other identical slot
+     * has InChanger zero. */
     MakeInchangerUnique(jcr, mr);
   }
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

**Backport of PR #1346 to bareos-22**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems
