### PR TITLE
stored: fix crashes of storage tools when autoxflate plugin is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - json generation: Fix some leaks and an integer overflow [PR #1130]
 - tray-monitor: build against Qt6 when present [PR #1011]
 - systemtests: `rename virtualfull` -> `virtualfull-basic` ,`bareos` -> `bareos-basic`, `bconsole` -> `bconsole-basic` [PR #1339]
+- stored: fix crashes of storage tools when autoxflate plugin is loaded [PR #1348]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -36,6 +37,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1339]: https://github.com/bareos/bareos/pull/1339
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
+[PR #1348]: https://github.com/bareos/bareos/pull/1348
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
 [PR #1352]: https://github.com/bareos/bareos/pull/1352
 [PR #1354]: https://github.com/bareos/bareos/pull/1354

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -198,15 +198,13 @@ static bRC newPlugin(PluginContext* ctx)
   memset(p_ctx, 0, sizeof(struct plugin_ctx));
   ctx->plugin_private_context = (void*)p_ctx; /* set our context pointer */
 
-  /*
-   * Only register plugin events we are interested in.
+  /* Only register plugin events we are interested in.
    *
    * bSdEventJobEnd - SD Job finished.
    * bSdEventSetupRecordTranslation - Setup the buffers for doing record
    * translation. bSdEventReadRecordTranslation - Perform read-side record
    * translation. bSdEventWriteRecordTranslation - Perform write-side record
-   * translation.
-   */
+   * translation. */
   bareos_core_functions->registerBareosEvents(
       ctx, 4, bSdEventJobEnd, bSdEventSetupRecordTranslation,
       bSdEventReadRecordTranslation, bSdEventWriteRecordTranslation);
@@ -598,9 +596,17 @@ static bool AutoDeflateRecord(PluginContext* ctx, DeviceControlRecord* dcr)
   nrec = bareos_core_functions->new_record(/* with_data = */ false);
   bareos_core_functions->CopyRecordState(nrec, rec);
 
+  if (!dcr->jcr->compress.deflate_buffer) {
+    Jmsg(ctx, M_FATAL,
+         _("autoxflate-sd: compress.deflate_buffer was not setup "
+           "missing bSdEventSetupRecordTranslation call?\n"));
+    goto bail_out;
+  }
   // Setup the converted DeviceRecord to point with its data buffer to the
   // compression buffer.
   nrec->data = dcr->jcr->compress.deflate_buffer;
+
+
   switch (rec->maskedStream) {
     case STREAM_FILE_DATA:
     case STREAM_WIN32_DATA:

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -200,6 +200,14 @@ int main(int argc, char* argv[])
   in_dev = in_jcr->sd_impl->dcr->dev;
   if (!in_dev) { exit(1); }
 
+  // Let SD plugins setup the record translation
+  if (GeneratePluginEvent(in_jcr, bSdEventSetupRecordTranslation, in_dcr)
+      != bRC_OK) {
+    Jmsg(in_jcr, M_FATAL, 0,
+         _("bSdEventSetupRecordTranslation call for input failed!\n"));
+  }
+
+
   // Setup output device for writing
   Dmsg0(100, "About to setup output jcr\n");
 
@@ -210,6 +218,13 @@ int main(int argc, char* argv[])
 
   out_dev = out_jcr->sd_impl->dcr->dev;
   if (!out_dev) { exit(1); }
+
+  // Let SD plugins setup the record translation
+  if (GeneratePluginEvent(out_jcr, bSdEventSetupRecordTranslation, out_dcr)
+      != bRC_OK) {
+    Jmsg(in_jcr, M_FATAL, 0,
+         _("bSdEventSetupRecordTranslation call for output failed!\n"));
+  }
 
   Dmsg0(100, "About to acquire device for writing\n");
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -253,11 +253,17 @@ int main(int argc, char* argv[])
   Pmsg2(000, _("%u Jobs copied. %u records copied.\n"), jobs, records);
 
 
+  CleanupCompression(in_jcr);
+  CleanupCompression(out_jcr);
+  FreePlugins(out_jcr);
+  FreePlugins(in_jcr);
+  UnloadSdPlugins();
   FreeJcr(in_jcr);
   FreeJcr(out_jcr);
 
   delete in_dev;
   delete out_dev;
+
 
   return 0;
 }

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -233,6 +233,7 @@ int main(int argc, char* argv[])
 
   LoadSdPlugins(me->plugin_directory, me->plugin_names);
 
+
   ReadCryptoCache(me->working_directory, "bareos-sd",
                   GetFirstPortHostOrder(me->SDaddrs));
 
@@ -265,9 +266,7 @@ static inline void DropDelayedDataStreams()
 
   if (!delayed_streams || delayed_streams->empty()) { return; }
 
-  foreach_alist (dds, delayed_streams) {
-    free(dds->content);
-  }
+  foreach_alist (dds, delayed_streams) { free(dds->content); }
 
   delayed_streams->destroy();
 }
@@ -306,8 +305,7 @@ static inline void PopDelayedDataStreams()
   // See if there is anything todo.
   if (!delayed_streams || delayed_streams->empty()) { return; }
 
-  /*
-   * Only process known delayed data streams here.
+  /* Only process known delayed data streams here.
    * If you start using more delayed data streams
    * be sure to add them in this loop and add the
    * proper calls here.
@@ -315,8 +313,7 @@ static inline void PopDelayedDataStreams()
    * Currently we support delayed data stream
    * processing for the following type of streams:
    * - *_ACL_*
-   * - *_XATTR_*
-   */
+   * - *_XATTR_* */
   foreach_alist (dds, delayed_streams) {
     switch (dds->stream) {
       case STREAM_UNIX_ACCESS_ACL:
@@ -400,6 +397,11 @@ static void DoExtract(char* devname,
   if (!dev) { exit(1); }
   dcr = jcr->sd_impl->read_dcr;
 
+  // Let SD plugins setup the record translation
+  if (GeneratePluginEvent(jcr, bSdEventSetupRecordTranslation, dcr) != bRC_OK) {
+    Jmsg(jcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
+  }
+
   // Make sure where directory exists and that it is a directory
   if (stat(where, &statp) < 0) {
     BErrNo be;
@@ -428,10 +430,8 @@ static void DoExtract(char* devname,
 
   ReadRecords(dcr, RecordCb, MountNextReadVolume);
 
-  /*
-   * If output file is still open, it was the last one in the
-   * archive since we just hit an end of file, so close the file.
-   */
+  /* If output file is still open, it was the last one in the
+   * archive since we just hit an end of file, so close the file. */
   if (IsBopen(&bfd)) { ClosePreviousStream(); }
   FreeAttr(attr);
 

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -385,7 +385,7 @@ static void DoExtract(char* devname,
                       DirectorResource* director)
 {
   struct stat statp;
-  uint32_t decompress_buf_size;
+  /* uint32_t decompress_buf_size; */
 
   EnableBackupPrivileges(nullptr, 1);
 
@@ -417,13 +417,13 @@ static void DoExtract(char* devname,
   attr = new_attr(jcr);
 
   jcr->buf_size = DEFAULT_NETWORK_BUFFER_SIZE;
-  SetupDecompressionBuffers(jcr, &decompress_buf_size);
+  /* SetupDecompressionBuffers(jcr, &decompress_buf_size); */
 
-  if (decompress_buf_size > 0) {
-    jcr->compress = CompressionContext{};
-    jcr->compress.inflate_buffer = GetMemory(decompress_buf_size);
-    jcr->compress.inflate_buffer_size = decompress_buf_size;
-  }
+  /* if (decompress_buf_size > 0) { */
+  /*   jcr->compress = CompressionContext{}; */
+  /*   jcr->compress.inflate_buffer = GetMemory(decompress_buf_size); */
+  /*   jcr->compress.inflate_buffer_size = decompress_buf_size; */
+  /* } */
 
   acl_data.last_fname = GetPoolMemory(PM_FNAME);
   xattr_data.last_fname = GetPoolMemory(PM_FNAME);
@@ -443,12 +443,18 @@ static void DoExtract(char* devname,
     delete delayed_streams;
   }
 
-  CleanupCompression(jcr);
 
   CleanDevice(jcr->sd_impl->dcr);
+
   delete dev;
+
   FreeDeviceControlRecord(dcr);
+
+  CleanupCompression(jcr);
+  FreePlugins(jcr);
   FreeJcr(jcr);
+  UnloadSdPlugins();
+
 
   printf(_("%u files restored.\n"), num_files);
 

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -238,16 +238,22 @@ int main(int argc, char* argv[])
     jcr = SetupJcr("bls", device.data(), bsr, director, dcr, VolumeNames,
                    true); /* read device */
     if (!jcr) { exit(1); }
+
+
+    // Let SD plugins setup the record translation
+    if (GeneratePluginEvent(jcr, bSdEventSetupRecordTranslation, dcr)
+        != bRC_OK) {
+      Jmsg(jcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
+    }
+
     jcr->sd_impl->ignore_label_errors = ignore_label_errors;
     dev = jcr->sd_impl->dcr->dev;
     if (!dev) { exit(1); }
     dcr = jcr->sd_impl->dcr;
     rec = new_record();
     attr = new_attr(jcr);
-    /*
-     * Assume that we have already read the volume label.
-     * If on second or subsequent volume, adjust buffer pointer
-     */
+    /* Assume that we have already read the volume label.
+     * If on second or subsequent volume, adjust buffer pointer */
     if (dev->VolHdr.PrevVolumeName[0] != 0) { /* second volume */
       Pmsg1(0,
             _("\n"

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -283,7 +283,11 @@ static void do_close(JobControlRecord* jcr)
   CleanDevice(jcr->sd_impl->dcr);
   delete dev;
   FreeDeviceControlRecord(jcr->sd_impl->dcr);
+
+  CleanupCompression(jcr);
+  FreePlugins(jcr);
   FreeJcr(jcr);
+  UnloadSdPlugins();
 }
 
 /* List just block information */

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -355,11 +355,13 @@ int main(int argc, char* argv[])
   }
   db->CloseDatabase(bjcr);
   DbFlushBackends();
-
   CleanDevice(bjcr->sd_impl->dcr);
   delete dev;
   FreeDeviceControlRecord(bjcr->sd_impl->dcr);
+  FreePlugins(bjcr);
+  CleanupCompression(bjcr);
   FreeJcr(bjcr);
+  UnloadSdPlugins();
 
   return 0;
 }

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -305,6 +305,13 @@ int main(int argc, char* argv[])
                   true);
   if (!bjcr) { exit(1); }
   dev = bjcr->sd_impl->read_dcr->dev;
+
+  // Let SD plugins setup the record translation
+  if (GeneratePluginEvent(bjcr, bSdEventSetupRecordTranslation, dcr)
+      != bRC_OK) {
+    Jmsg(bjcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
+  }
+
 
   if (showProgress) {
     char ed1[50];
@@ -635,12 +642,10 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
           bstrncpy(dcr->pool_type, label.PoolType, sizeof(dcr->pool_type));
           bstrncpy(dcr->pool_name, label.PoolName, sizeof(dcr->pool_name));
 
-          /*
-           * Look for existing Job Media records for this job.  If there are
+          /* Look for existing Job Media records for this job.  If there are
            * any, no new ones need be created.  This may occur if File
            * Retention has expired before Job Retention, or if the volume
-           * has already been bscan'd
-           */
+           * has already been bscan'd */
           Mmsg(sql_buffer, "SELECT count(*) from JobMedia where JobId=%d",
                jr.JobId);
           db->SqlQuery(sql_buffer.c_str(), db_int64_handler, &jmr_count);
@@ -819,10 +824,8 @@ static bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec)
     case STREAM_ENCRYPTED_FILE_DATA:
     case STREAM_ENCRYPTED_WIN32_DATA:
     case STREAM_ENCRYPTED_MACOS_FORK_DATA:
-      /*
-       * For encrypted stream, this is an approximation.
-       * The data must be decrypted to know the correct length.
-       */
+      /* For encrypted stream, this is an approximation.
+       * The data must be decrypted to know the correct length. */
       mjcr->JobBytes += rec->data_len;
       if (rec->maskedStream == STREAM_SPARSE_DATA) {
         mjcr->JobBytes -= sizeof(uint64_t);
@@ -1130,10 +1133,8 @@ static bool CreatePoolRecord(BareosDb* db, PoolDbRecord* pr)
 // Called from SOS to create a client for the current Job
 static bool CreateClientRecord(BareosDb* db, ClientDbRecord* cr)
 {
-  /*
-   * Note, update_db can temporarily be set false while
-   * updating the database, so we must ensure that ClientId is non-zero.
-   */
+  /* Note, update_db can temporarily be set false while
+   * updating the database, so we must ensure that ClientId is non-zero. */
   if (!update_db) {
     cr->ClientId = 0;
     if (!db->GetClientRecord(bjcr, cr)) {
@@ -1419,10 +1420,8 @@ static JobControlRecord* create_jcr(JobDbRecord* jr,
                                     uint32_t JobId)
 {
   JobControlRecord* jobjcr;
-  /*
-   * Transfer as much as possible to the Job JobControlRecord. Most important is
-   *   the JobId and the ClientId.
-   */
+  /* Transfer as much as possible to the Job JobControlRecord. Most important is
+   *   the JobId and the ClientId. */
   jobjcr = new_jcr(BscanFreeJcr);
   jobjcr->sd_impl = new StoredJcrImpl;
   jobjcr->setJobType(jr->JobType);

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -328,6 +328,11 @@ int main(int margc, char* margv[])
   if (!dev->IsTape()) {
     Pmsg0(000, _("btape only works with tape storage.\n"));
     exit(1);
+  }
+
+  // Let SD plugins setup the record translation
+  if (GeneratePluginEvent(jcr, bSdEventSetupRecordTranslation, dcr) != bRC_OK) {
+    Jmsg(jcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
   }
 
   if (!open_the_device()) { exit(1); }
@@ -1067,10 +1072,8 @@ static bool write_two_files()
   bool rc = false; /* bad return code */
   Device* dev = dcr->dev;
 
-  /*
-   * Set big max_file_size so that write_record_to_block
-   * doesn't insert any additional EOF marks
-   */
+  /* Set big max_file_size so that write_record_to_block
+   * doesn't insert any additional EOF marks */
   if (dev->max_block_size) {
     dev->max_file_size = 2LL * num_recs * (uint64_t)dev->max_block_size;
   } else {
@@ -1493,10 +1496,8 @@ try_again:
   }
 
   if (!open_the_device()) { goto bail_out; }
-  /*
-   * Start with sleep_time 0 then increment by 30 seconds if we get
-   * a failure.
-   */
+  /* Start with sleep_time 0 then increment by 30 seconds if we get
+   * a failure. */
   Bmicrosleep(sleep_time, 0);
   if (!dev->rewind(dcr) || !dev->weof(1)) {
     Pmsg1(0, _("Bad status from rewind. ERR=%s\n"), dev->bstrerror());
@@ -2134,11 +2135,9 @@ static void fillcmd()
   dcr->DirAskSysopToCreateAppendableVolume();
   dev->SetAppend(); /* force volume to be relabeled */
 
-  /*
-   * Acquire output device for writing.  Note, after acquiring a
+  /* Acquire output device for writing.  Note, after acquiring a
    *   device, we MUST release it, which is done at the end of this
-   *   subroutine.
-   */
+   *   subroutine. */
   Dmsg0(100, "just before acquire_device\n");
   if (!AcquireDeviceForAppend(dcr)) {
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
@@ -2445,11 +2444,9 @@ static bool do_unfill()
     Pmsg1(-1, "%s", dev->errmsg);
     goto bail_out;
   }
-  /*
-   * We now have the first tape mounted.
+  /* We now have the first tape mounted.
    * Note, re-reading last block may have caused us to
-   *   loose track of where we are (block number unknown).
-   */
+   *   loose track of where we are (block number unknown). */
   Pmsg0(-1, _("Rewinding.\n"));
   if (!dev->rewind(dcr)) { /* get to a known place on tape */
     goto bail_out;
@@ -2628,10 +2625,8 @@ static int FlushBlock(DeviceBlock* block)
     Pmsg3(000, _("Last block at: %u:%u this_dev_block_num=%d\n"), last_file,
           last_block_num, this_block_num);
     if (vol_num == 1) {
-      /*
-       * This is 1st tape, so save first tape info separate
-       *  from second tape info
-       */
+      /* This is 1st tape, so save first tape info separate
+       *  from second tape info */
       last_block_num1 = last_block_num;
       last_file1 = last_file;
       last_block1 = dup_block(last_block);
@@ -2680,12 +2675,10 @@ static int FlushBlock(DeviceBlock* block)
   /* Save contents after write so that the header is serialized */
   memcpy(this_block->buf, block->buf, this_block->buf_len);
 
-  /*
-   * Note, we always read/write to block, but we toggle
+  /* Note, we always read/write to block, but we toggle
    *  copying it to one or another of two allocated blocks.
    * Switch blocks so that the block just successfully written is
-   *  always in last_block.
-   */
+   *  always in last_block. */
   tblock = last_block;
   last_block = this_block;
   this_block = tblock;

--- a/systemtests/scripts/cleanup
+++ b/systemtests/scripts/cleanup
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -u
-
 #shellcheck source=../environment.in
 . ./environment
 

--- a/systemtests/tests/bareos-basic/CMakeLists.txt
+++ b/systemtests/tests/bareos-basic/CMakeLists.txt
@@ -31,22 +31,26 @@ set_tests_properties(
     "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )
 set_tests_properties(
-  system:bareos:bls-autoxflate
-  PROPERTIES FIXTURES_REQUIRED
-             "system:bareos:backup-job-fixture;system:bareos-fixture"
+  system:bareos-basic:bls-autoxflate
+  PROPERTIES
+    FIXTURES_REQUIRED
+    "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )
 set_tests_properties(
-  system:bareos:bextract-autoxflate
-  PROPERTIES FIXTURES_REQUIRED
-             "system:bareos:backup-job-fixture;system:bareos-fixture"
+  system:bareos-basic:bextract-autoxflate
+  PROPERTIES
+    FIXTURES_REQUIRED
+    "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )
 set_tests_properties(
-  system:bareos:bscan-autoxflate
-  PROPERTIES FIXTURES_REQUIRED
-             "system:bareos:backup-job-fixture;system:bareos-fixture"
+  system:bareos-basic:bscan-autoxflate
+  PROPERTIES
+    FIXTURES_REQUIRED
+    "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )
 set_tests_properties(
-  system:bareos:bcopy-autoxflate
-  PROPERTIES FIXTURES_REQUIRED
-             "system:bareos:backup-job-fixture;system:bareos-fixture"
+  system:bareos-basic:bcopy-autoxflate
+  PROPERTIES
+    FIXTURES_REQUIRED
+    "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )

--- a/systemtests/tests/bareos-basic/CMakeLists.txt
+++ b/systemtests/tests/bareos-basic/CMakeLists.txt
@@ -45,3 +45,8 @@ set_tests_properties(
   PROPERTIES FIXTURES_REQUIRED
              "system:bareos:backup-job-fixture;system:bareos-fixture"
 )
+set_tests_properties(
+  system:bareos:bcopy-autoxflate
+  PROPERTIES FIXTURES_REQUIRED
+             "system:bareos:backup-job-fixture;system:bareos-fixture"
+)

--- a/systemtests/tests/bareos-basic/CMakeLists.txt
+++ b/systemtests/tests/bareos-basic/CMakeLists.txt
@@ -30,3 +30,18 @@ set_tests_properties(
     FIXTURES_REQUIRED
     "system:bareos-basic:backup-job-fixture;system:bareos-basic-fixture"
 )
+set_tests_properties(
+  system:bareos:bls-autoxflate
+  PROPERTIES FIXTURES_REQUIRED
+             "system:bareos:backup-job-fixture;system:bareos-fixture"
+)
+set_tests_properties(
+  system:bareos:bextract-autoxflate
+  PROPERTIES FIXTURES_REQUIRED
+             "system:bareos:backup-job-fixture;system:bareos-fixture"
+)
+set_tests_properties(
+  system:bareos:bscan-autoxflate
+  PROPERTIES FIXTURES_REQUIRED
+             "system:bareos:backup-job-fixture;system:bareos-fixture"
+)

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage2.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage2.conf
@@ -1,0 +1,15 @@
+Device {
+  Name = FileStorage2
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+  Auto Inflate = both
+  Auto Deflate = both
+  Auto Deflate Algorithm = gzip
+
+}

--- a/systemtests/tests/bareos-basic/testrunner-bcopy-autoxflate
+++ b/systemtests/tests/bareos-basic/testrunner-bcopy-autoxflate
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+set -x
+
+# run bls and make sure it works (with autoxflate plugin)
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+JobName=backup-bareos-fd
+
+run_bcopy -v -i TestVolume001  -o TestVolume002  FileStorage FileStorage2
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bcopy exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+if ! grep -q "bcopy: stored/bcopy.cc:253-0 . Jobs copied. .*records copied." "$tmp/bcopy.out"; then
+  echo 'Expected string \"weird-files/dangling-link\" not found in bcopy output'
+  stop_bareos
+  exit 1
+fi
+
+
+end_test

--- a/systemtests/tests/bareos-basic/testrunner-bextract-autoxflate
+++ b/systemtests/tests/bareos-basic/testrunner-bextract-autoxflate
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+# run bextract and check it works
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+
+start_test
+
+JobName=backup-bareos-fd
+
+rm -rf "$tmp/bareos-restores"
+mkdir -p  "$tmp/bareos-restores"
+run_bextract -vv -V TestVolume001 FileStorage "$tmp/bareos-restores"
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bextract exit code: $ret"
+  stop_bareos
+  exit $ret
+else
+  find "$tmp/bareos-restores"
+  check_restore_diff "${BackupDirectory}" # check extracted files
+  mv "$tmp/bareos-restores" "$tmp/bextract-restores" # move extracted files away
+  mkdir -p  "$tmp/bareos-restores"
+fi
+
+
+end_test

--- a/systemtests/tests/bareos-basic/testrunner-bls-autoxflate
+++ b/systemtests/tests/bareos-basic/testrunner-bls-autoxflate
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# run bls and make sure it works (with autoxflate plugin)
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+JobName=backup-bareos-fd
+
+run_bls -vv -V TestVolume001 FileStorage
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bls exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+if ! grep -q "weird-files/dangling-link" "$tmp/bls.out"; then
+  echo 'Expected string \"weird-files/dangling-link\" not found in  bls output'
+  stop_bareos
+  exit 1
+fi
+
+
+end_test

--- a/systemtests/tests/bareos-basic/testrunner-bscan-autoxflate
+++ b/systemtests/tests/bareos-basic/testrunner-bscan-autoxflate
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# run bscan and make sure it does not crash
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+JobName=backup-bareos-fd
+
+run_bscan_db -vv -s -V TestVolume001 FileStorage
+ret=$?
+if [ $ret -ne 0 ]; then
+  echo "bscan exit code: $ret"
+  stop_bareos
+  exit $ret
+fi
+
+end_test

--- a/systemtests/tests/bareos-basic/testrunner-simple-backup-and-restore
+++ b/systemtests/tests/bareos-basic/testrunner-simple-backup-and-restore
@@ -25,6 +25,7 @@ messages
 @$out $tmp/log1.out
 setdebug level=100 storage=File
 label volume=TestVolume001 storage=File pool=Full
+label volume=TestVolume002 storage=File pool=Full
 run job=$JobName yes
 status director
 status client


### PR DESCRIPTION
The low level storage tools bcopy, bextract, bls, bscan and btape load sd plugins if they are configured.

Unfortunately, the plugin event `bSdEventSetupRecordTranslation` was not emitted before, so that the autoxflate plugin did not setup the compression buffers.

Now, all these tools do emit the plugin event, and the autoxflate-sd plugin also checks for the buffer before using it and emits an message otherwise.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
