### PR TITLE
dird: cats: adapt `purge` command to delete jobs with specific jobstatus and/or from specific pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - introduce php-cs-fixer and apply PSR-12 guidelines [PR #1403]
 - berrno_test.cc: accept both 271E and 273E [PR #1407]
 - Sanitizers: add ASAN options to avoid crashes [PR #1410]
+- dird: cats: adapt `purge` command to delete jobs with specific jobstatus and/or from specific pool [PR #1349]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -67,6 +68,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1345]: https://github.com/bareos/bareos/pull/1345
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
 [PR #1348]: https://github.com/bareos/bareos/pull/1348
+[PR #1349]: https://github.com/bareos/bareos/pull/1349
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
 [PR #1352]: https://github.com/bareos/bareos/pull/1352
 [PR #1354]: https://github.com/bareos/bareos/pull/1354

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -688,9 +688,8 @@ class BareosDb : public BareosDbQueryEnum {
                           int& JobLevel);
 
   /* sql_get.c */
-  bool GetVolumeJobids(JobControlRecord* jcr,
-                       MediaDbRecord* mr,
-                       db_list_ctx* lst);
+  bool GetVolumeJobids(MediaDbRecord* mr, db_list_ctx* lst);
+  bool GetVolumesInPool(PoolDbRecord* mr, db_list_ctx* lst);
   bool GetBaseFileList(JobControlRecord* jcr,
                        bool use_md5,
                        DB_RESULT_HANDLER* ResultHandler,

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -689,7 +689,7 @@ class BareosDb : public BareosDbQueryEnum {
 
   /* sql_get.c */
   bool GetVolumeJobids(MediaDbRecord* mr, db_list_ctx* lst);
-  bool GetVolumesInPool(PoolDbRecord* mr, db_list_ctx* lst);
+  bool GetMediaIdsInPool(PoolDbRecord* pool_record, std::vector<DBId_t>* lst);
   bool GetBaseFileList(JobControlRecord* jcr,
                        bool use_md5,
                        DB_RESULT_HANDLER* ResultHandler,

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -117,6 +117,14 @@ int DbListHandler(void* ctx, int num_fields, char** row)
   return 0;
 }
 
+// Use to build a vector of Ids from a query.
+int DbIdListHandler(void* ctx, int num_fields, char** row)
+{
+  std::vector<DBId_t>* lctx = (std::vector<DBId_t>*)ctx;
+  if (num_fields == 1 && row[0]) { lctx->push_back(std::stoul(row[0])); }
+  return 0;
+}
+
 /**
  * specific context passed from db_check_max_connections to
  * DbMaxConnectionsHandler.

--- a/core/src/cats/sql.h
+++ b/core/src/cats/sql.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/cats/sql.h
+++ b/core/src/cats/sql.h
@@ -23,6 +23,7 @@
 int db_int64_handler(void* ctx, int num_fields, char** row);
 int DbStrtimeHandler(void* ctx, int num_fields, char** row);
 int DbListHandler(void* ctx, int num_fields, char** row);
+int DbIdListHandler(void* ctx, int num_fields, char** row);
 void DbDebugPrint(JobControlRecord* jcr, FILE* fp);
 int DbIntHandler(void* ctx, int num_fields, char** row);
 

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1375,7 +1375,8 @@ bool BareosDb::AccurateGetJobids(JobControlRecord* jcr,
      *
      * If we are doing always incremental, we need to limit the search to
      * only include incrementals that are older than (now -
-     * AlwaysIncrementalInterval) and leave AlwaysIncrementalNumber incrementals */
+     * AlwaysIncrementalInterval) and leave AlwaysIncrementalNumber incrementals
+     */
     Mmsg(query,
          "INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, "
          "PurgedFiles) "
@@ -1486,12 +1487,14 @@ bool BareosDb::GetVolumeJobids(MediaDbRecord* mr, db_list_ctx* lst)
   return SqlQueryWithHandler(cmd, DbListHandler, lst);
 }
 
-bool BareosDb::GetVolumesInPool(PoolDbRecord* mr, db_list_ctx* lst)
+bool BareosDb::GetMediaIdsInPool(PoolDbRecord* pool_record,
+                                 std::vector<DBId_t>* lst)
 {
   DbLocker _{this};
-  Mmsg(cmd, "SELECT DISTINCT MediaId FROM Media WHERE PoolId=%lu", mr->PoolId);
+  Mmsg(cmd, "SELECT DISTINCT MediaId FROM Media WHERE PoolId=%lu",
+       pool_record->PoolId);
 
-  return SqlQueryWithHandler(cmd, DbListHandler, lst);
+  return SqlQueryWithHandler(cmd, DbIdListHandler, lst);
 }
 
 /**

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1375,8 +1375,7 @@ bool BareosDb::AccurateGetJobids(JobControlRecord* jcr,
      *
      * If we are doing always incremental, we need to limit the search to
      * only include incrementals that are older than (now -
-     * AlwaysIncrementalInterval) and leave AlwaysIncrementalNumber incrementals
-     */
+     * AlwaysIncrementalInterval) and leave AlwaysIncrementalNumber incrementals */
     Mmsg(query,
          "INSERT INTO btemp3%s (JobId, StartTime, EndTime, JobTDate, "
          "PurgedFiles) "

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1478,15 +1478,19 @@ bail_out:
   return retval;
 }
 
-bool BareosDb::GetVolumeJobids(JobControlRecord*,
-                               MediaDbRecord* mr,
-                               db_list_ctx* lst)
+bool BareosDb::GetVolumeJobids(MediaDbRecord* mr, db_list_ctx* lst)
 {
-  char ed1[50];
-
   DbLocker _{this};
-  Mmsg(cmd, "SELECT DISTINCT JobId FROM JobMedia WHERE MediaId=%s",
-       edit_int64(mr->MediaId, ed1));
+  Mmsg(cmd, "SELECT DISTINCT JobId FROM JobMedia WHERE MediaId=%lu",
+       mr->MediaId);
+
+  return SqlQueryWithHandler(cmd, DbListHandler, lst);
+}
+
+bool BareosDb::GetVolumesInPool(PoolDbRecord* mr, db_list_ctx* lst)
+{
+  DbLocker _{this};
+  Mmsg(cmd, "SELECT DISTINCT MediaId FROM Media WHERE PoolId=%lu", mr->PoolId);
 
   return SqlQueryWithHandler(cmd, DbListHandler, lst);
 }

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -346,6 +346,7 @@ static struct ua_cmdstruct commands[] = {
          "fileset [ filesetid=<filesetid> ] | fileset [ jobid=<jobid> ] |\n"
          "jobs [job=<job-name>] [client=<client-name>] [jobstatus=<status>] "
          "[jobtype=<jobtype>] [joblevel=<joblevel>] [volume=<volumename>] "
+         "[pool=<pool>] "
          "[days=<number>] [hours=<number>] [last] [count] |\n"
          "job=<job-name> [client=<client-name>] [jobstatus=<status>] "
          "[jobtype=<jobtype>] [volume=<volumename>] [days=<number>] "
@@ -382,7 +383,8 @@ static struct ua_cmdstruct commands[] = {
          "fileset jobid=<jobid> | fileset ujobid=<complete_name> |\n"
          "fileset [ filesetid=<filesetid> ] | fileset [ jobid=<jobid> ] |\n"
          "jobs [job=<job-name>] [client=<client-name>] [jobstatus=<status>] "
-         "[jobtype=<jobtype>][volume=<volumename>] [days=<number>] "
+         "[jobtype=<jobtype>] [volume=<volumename>] [pool=<pool>] "
+         "[days=<number>] "
          "[hours=<number>] [last] [count] |\n"
          "job=<job-name> [client=<client-name>] [jobstatus=<status>] "
          "[jobtype=<jobtype>] [joblevel=<joblevel>] [volume=<volumename>] "
@@ -400,11 +402,11 @@ static struct ua_cmdstruct commands[] = {
          "pool=<pool-name> |\n"
          "poolid=<poolid> |\n"
          "volumes [ jobid=<jobid> | ujobid=<complete_name> | pool=<pool-name> "
-         "| all ] |\n"
+         "| all ] [count] |\n"
          "volume=<volume-name> |\n"
          "volumeid=<volumeid> | mediaid=<volumeid> |\n"
-         "[ current ] | [ enabled ] | [disabled] |\n"
-         "[ limit=<num> [ offset=<number> ] ]"),
+         "[current] | [enabled | disabled] |\n"
+         "[limit=<num> [offset=<number>]]"),
      true, true},
     {NT_("messages"), MessagesCmd, _("Display pending messages"), NT_(""),
      false, false},
@@ -428,7 +430,8 @@ static struct ua_cmdstruct commands[] = {
     {NT_("purge"), PurgeCmd, _("Purge records from catalog"),
      NT_("[files [job=<job> | jobid=<jobid> | client=<client> | "
          "volume=<volume>]] |\n"
-         "[jobs [client=<client> | volume=<volume>]] |\n"
+         "[jobs [client=<client> | volume=<volume>] | pool=<pool>] "
+         "[jobstatus=<status>]] |\n"
          "[volume[=<volume>] [storage=<storage>] [pool=<pool> | allpools] "
          "[devicetype=<type>] [drive=<drivenum>] [action=<action>]] |\n"
          "[quota [client=<client>]]"),
@@ -2481,7 +2484,7 @@ static bool DeleteVolume(UaContext* ua)
 
   // If not purged, do it
   if (!bstrcmp(mr.VolStatus, "Purged")) {
-    if (!ua->db->GetVolumeJobids(ua->jcr, &mr, &lst)) {
+    if (!ua->db->GetVolumeJobids(&mr, &lst)) {
       ua->ErrorMsg(_("Can't list jobs on this volume\n"));
       return true;
     }

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,15 +92,13 @@ bool PurgeCmd(UaContext* ua, const char*)
         "PRUNE command, which respects retention periods.\n"
         "This command requires full access to all resources.\n"));
 
-  /*
-   * Check for console ACL permissions.
+  /* Check for console ACL permissions.
    * These permission might be harder than required.
    * However, otherwise it gets hard to figure out the correct permission.
    * E.g. when purging a volume, this volume can contain
    * different jobs from different client, stored in different pools and
    * storages. Instead of checking all of this, we require full permissions to
-   * all of these resources.
-   */
+   * all of these resources. */
   if (ua->AclHasRestrictions(Client_ACL)) {
     ua->ErrorMsg(permission_denied_message, "client");
     return false;
@@ -176,11 +174,9 @@ bool PurgeCmd(UaContext* ua, const char*)
         *ua->argk[i] = 0; /* zap keyword already seen */
         ua->SendMsg("\n");
 
-        /*
-         * Add volume=mr.VolumeName to cmd_holder if we have a new volume name
+        /* Add volume=mr.VolumeName to cmd_holder if we have a new volume name
          * from interactive selection. In certain cases this can produce
-         * duplicates, which we don't prevent as there are no side effects.
-         */
+         * duplicates, which we don't prevent as there are no side effects. */
         if (!bstrcmp(ua->cmd, cmd_holder.c_str())) {
           PmStrcat(cmd_holder, " volume=");
           PmStrcat(cmd_holder, mr.VolumeName);
@@ -600,10 +596,8 @@ static void do_truncate_on_purge(UaContext* ua,
     return;
   }
 
-  /*
-   * Send the command to truncate the volume after purge. If this feature
-   * is disabled for the specific device, this will be a no-op.
-   */
+  /* Send the command to truncate the volume after purge. If this feature
+   * is disabled for the specific device, this will be a no-op. */
 
   // Protect us from spaces
   BashSpaces(mr->VolumeName);
@@ -726,10 +720,8 @@ static bool ActionOnPurgeCmd(UaContext* ua, const char*)
     mr.PoolId = pr.PoolId;
   }
 
-  /*
-   * Look for all Purged volumes that can be recycled, are enabled and have
-   * more the 10,000 bytes.
-   */
+  /* Look for all Purged volumes that can be recycled, are enabled and have
+   * more the 10,000 bytes. */
   mr.Recycle = 1;
   mr.Enabled = VOL_ENABLED;
   mr.VolBytes = 10000;

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -319,6 +319,20 @@ static bool PurgeJobsFromPool(UaContext* ua, PoolDbRecord* pool_record)
     }
   }
 
+  std::vector<DBId_t> media_ids_in_pool;
+  if (ua->db->GetMediaIdsInPool(pool_record, &media_ids_in_pool)) {
+    ua->WarningMsg(_("No Medias found for pool %s.\n"), pool_record->Name,
+                   client->catalog->resource_name_);
+  }
+  for (auto mediaid : media_ids_in_pool) {
+    MediaDbRecord mr;
+    mr.MediaId = mediaid;
+    if (!ua->db->GetMediaRecord(ua->jcr, &mr)) {
+      ua->ErrorMsg("%s", ua->db->strerror());
+    }
+    IsVolumePurged(ua, &mr, false);
+  }
+
   return true;
 }
 

--- a/docs/manuals/source/DeveloperGuide/generaldevel.rst
+++ b/docs/manuals/source/DeveloperGuide/generaldevel.rst
@@ -155,6 +155,17 @@ Sourcecode Comments
 Use ``/* */`` for multi-line comments.
 Use ``//`` for single-line comments.
 
+SQL queries
+-----------
+
+Developers will have to use SQL queries to get data from the database. When you navigate the current code you might get a bit confused as there are different ways to do it:
+First, there are direct queries written within the functions that need them. Second, there are functions within the ``cats`` library containing ready made queries that get called. And finally there are the generated SQL files within the ``cats/dml`` folder that get invoked in certain situations.
+
+Until we decide on a unified way to handle sql queries, we advise the following:
+
+- If your queries are trivial, you can put them as a string within the code you are writing, make sure you wrap them in a function, and make sure it can be reused,
+- If you are dealing with long and convoluted queries, write them within the ``cats/dml`` folder and update the related files and enums.
+
 Do's
 ----
 

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -1052,26 +1052,30 @@ esac
 expect_grep()
 {
 
-local usage="Usage: ${FUNCNAME[0]} <expected_result> <log_file> [error message]\n    Find expected_result in log_file. Optionally display custom error_message if not found."
+local usage="Usage: ${FUNCNAME[0]} <expected_result> <log_file> [error message] [alternative result]\n    Find expected_result in log_file. Optionally, if not found, display custom error_message and/or grep for alternative that could be there instead."
 local expected_result="$1"
 local target_file="$2"
-local error_message="$3"
+local error_message=${3:-""}
+local possible_alternative=${4:-""}
 
-if [ $# -lt 2  ] || [ $# -gt 3  ]; then
+if [ $# -lt 2  ] || [ $# -gt 4  ]; then
     echo -e "${FUNCNAME[0]} : wrong number of parameters.\n${usage}"
     exit 1
 fi
 
 if [ ! -f ${target_file} ]; then
-    echo "\"${target_file}\" does not exist or is not a file."
+    echo "\"${target_file}\" does not exist or is not a file.\n"
     exit 1
 fi
 
 if ! grep -q "${expected_result}" "${target_file}"; then
-  echo "Fail: Expected line \"${expected_result}\" was not found in log file \"${target_file}\"." >&2
+  echo -e "\n*** Fail: Expected line \"${expected_result}\" was not found in log file \"${target_file}\"." >&2
   estat=1
   if [ "${error_message}" != "" ]; then
-    echo "-->${error_message}" >&2
+    echo "---Error--->${error_message}\n" >&2
+  fi
+  if [ "${possible_alternative}" != "" ]; then
+    echo -e "---Found instead--->$(grep "${possible_alternative}" ${target_file})\n" >&2
   fi
 fi
 }
@@ -1079,7 +1083,7 @@ fi
 expect_not_grep()
 {
 
-local usage="Usage: ${FUNCNAME[0]} <non_expected_result> <log_file> [error message]\n    Make sure non_expected_result is not in log_file. Optionally display custom error_message if not found."
+local usage="Usage: ${FUNCNAME[0]} <non_expected_result> <log_file> [error message]\n    Make sure non_expected_result is not in log_file. Optionally display custom error_message if found."
 local non_expected_result="$1"
 local target_file="$2"
 local error_message="$3"

--- a/systemtests/tests/multiplied-device/testrunner
+++ b/systemtests/tests/multiplied-device/testrunner
@@ -55,11 +55,11 @@ messages
 @# now purge and truncate
 @#
 @$out $tmp/log3.out
-purge volume=Full-0001
+purge volume=Full-0001 yes
 truncate volstatus=Purged drive=0 yes
-purge volume=Full-0002
+purge volume=Full-0002 yes
 truncate volstatus=Purged drive=1 yes
-purge volume=Full-0003
+purge volume=Full-0003 yes
 truncate volstatus=Purged drive=2 yes
 messages
 quit

--- a/systemtests/tests/pruning/etc/bareos/bareos-dir.d/job/failingjob.conf
+++ b/systemtests/tests/pruning/etc/bareos/bareos-dir.d/job/failingjob.conf
@@ -1,0 +1,12 @@
+Job {
+  Name = "failingjob"
+  Client = "bareos-fd"
+  RunScript {
+    Command = "/bin/false"
+    failjobonerror = yes
+    RunsWhen = After
+  }
+  JobDefs = "DefaultJob"
+  Pool = SmallFull
+  Full Backup Pool = SmallFull
+}

--- a/systemtests/tests/pruning/etc/bareos/bareos-dir.d/job/smallvoljob.conf
+++ b/systemtests/tests/pruning/etc/bareos/bareos-dir.d/job/smallvoljob.conf
@@ -1,0 +1,7 @@
+Job {
+  Name = "smallvoljob"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  Pool = SmallFull
+  Full Backup Pool = SmallFull
+}

--- a/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,10 +1,10 @@
 Pool {
   Name = Full
   Pool Type = Backup
-  Recycle = yes                       # Bareos can automatically recycle Volumes
-  AutoPrune = yes                     # Prune expired volumes
-  Volume Retention = 5 seconds         # How long should the Full Backups be kept? (#06)
-  Maximum Volume Bytes = 1M          # Limit Volume size to something reasonable
-  Maximum Volumes = 100               # Limit number of Volumes in Pool
-  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Recycle = yes
+  AutoPrune = yes
+  Volume Retention = 5 seconds
+  Maximum Volume Bytes = 1G
+  Maximum Volumes = 100
+  Label Format = "Full-"
 }

--- a/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/SmallFull.conf
+++ b/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/SmallFull.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = SmallFull
+  Pool Type = Backup
+  Recycle = yes
+  AutoPrune = yes
+  Volume Retention = 1 day
+  Maximum Volume Bytes = 69K
+  Maximum Volumes = 100
+  Label Format = "SmallFull-"
+}

--- a/systemtests/tests/pruning/testrunner
+++ b/systemtests/tests/pruning/testrunner
@@ -11,6 +11,8 @@ TestName="$(basename "$(pwd)")"
 export TestName
 
 regularjob_name=backup-bareos-fd
+failingjob_name=failingjob
+smallvoljob_name=smallvoljob
 
 #shellcheck source=../environment.in
 . ./environment
@@ -170,6 +172,44 @@ END_OF_DATA
 
 run_bconsole
 
+# Purging failed jobs
+
+purging_failed_jobs="$tmp"/purging_failed_jobs.out
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $purging_failed_jobs
+run job=$failingjob_name level=Full yes
+run job=$failingjob_name level=Full yes
+run job=$failingjob_name level=Full yes
+wait
+messages
+purge jobs client=bareos-fd jobstatus=E yes
+wait
+quit
+END_OF_DATA
+
+run_bconsole
+
+# Purging failed jobs in specific pool
+
+purging_pool_failed_jobs="$tmp"/purging_pool_failed_jobs.out
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $purging_pool_failed_jobs
+run job=$smallvoljob_name level=Full yes
+run job=$smallvoljob_name level=Full yes
+run job=$smallvoljob_name level=Full yes
+run job=$failingjob_name level=Full yes
+run job=$failingjob_name level=Full yes
+run job=$failingjob_name level=Full yes
+wait
+messages
+purge jobs jobstatus=E pool=SmallFull
+quit
+END_OF_DATA
+
+run_bconsole
+
 check_for_zombie_jobs storage=File
 check_two_logs "$label_backup_log" "$restore_log"
 
@@ -236,5 +276,26 @@ expect_grep "Pruned Files from 1 Jobs" \
 expect_grep "Most likely your retention policy pruned the files." \
             "$file_pruning_log" \
             "Restore command found files, when they should have been pruned"
+
+## Purging failed jobs
+expect_grep "Found 3 Jobs for client \"bareos-fd\" in catalog \"MyCatalog\"" \
+            "$purging_failed_jobs" \
+            "Correct number of failed jobs to prune was not found."
+
+expect_grep "Purging the following 3 JobIds: 12,13,14" \
+            "$purging_failed_jobs" \
+            "Expected pruned failed jobids not found" \
+            "Purging the"
+
+## Purging failed jobs from specific pool
+
+expect_grep "3 Jobs on Pool \"SmallFull\" purged from catalog" \
+            "$purging_pool_failed_jobs" \
+            "Correct number of jobs with warnings to purge on specific pool was not found."
+
+expect_grep "Purging the following 3 JobIds: 18,19,20" \
+            "$purging_pool_failed_jobs" \
+            "Expected purged jobids with warnings in specific pool not found" \
+            "Purging the"
 
 end_test

--- a/systemtests/tests/pruning/testrunner
+++ b/systemtests/tests/pruning/testrunner
@@ -10,28 +10,33 @@ set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 
-JobName=backup-bareos-fd
+regularjob_name=backup-bareos-fd
 
 #shellcheck source=../environment.in
 . ./environment
 
 #shellcheck source=../scripts/functions
 . "${rscripts}"/functions
+
 "${rscripts}"/cleanup
 "${rscripts}"/setup
-
-
 
 # Fill ${BackupDirectory} with data.
 setup_data
 
 start_test
 
+start_bareos
+
+label_backup_log="$tmp"/label_backup_log.out
+restore_log="$tmp"/restore_log.out
+prune_volume_log="$tmp"/prune_volume_log.out
+prune_all_log="$tmp"/prune_all_log.out
+
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
-@$out $tmp/log1.out
-setdebug level=100 storage=File
+@$out $label_backup_log
 label volume=TestVolume001 storage=File pool=Full
 label volume=TestVolume002 storage=File pool=Full
 label volume=TestVolume003 storage=File pool=Full
@@ -41,10 +46,11 @@ status director
 status client
 status storage=File
 wait
+run job=$regularjob_name Level=Full yes
+run job=$regularjob_name Level=Full yes
 messages
 
-run job=$JobName Level=Full yes
-run job=$JobName Level=Full yes
+@$out $restore_log
 @#
 @# now do a restore
 @#
@@ -54,7 +60,7 @@ yes
 wait
 messages
 
-@$out $tmp/log2.out
+@$out $prune_volume_log
 @#
 @# now prune using the commandline
 @#
@@ -62,60 +68,69 @@ messages
 update volume=TestVolume001 volstatus=Used
 prune volume=TestVolume001 yes
 wait
-messages
+quit
+END_OF_DATA
 
-@$out $tmp/log3.out
+run_bconsole
+
+## prune all volumes
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out $prune_all_log
 @#
 @# now do the same but using the prune all command
 @#
 @#
 
-run job=$JobName Level=Full yes
-run job=$JobName Level=Full yes
+run job=$regularjob_name Level=Full yes
+run job=$regularjob_name Level=Full yes
 wait
 update volume=TestVolume002 volstatus=Used
 
-run job=$JobName Level=Full yes
-run job=$JobName Level=Full yes
+run job=$regularjob_name Level=Full yes
+run job=$regularjob_name Level=Full yes
 wait
 update volume=TestVolume003 volstatus=Used
 
 @sleep 6
 
+messages
 prune volume all yes
 wait
-messages
 
-
-run job=$JobName Level=Full yes
+run job=$regularjob_name Level=Full yes
 wait
 
 quit
 END_OF_DATA
 
-run_bareos "$@"
+run_bconsole
+
+# Prune all volumes of specific pool
+
+prune_all_pool_log="$tmp"/prune_all_pool_log.out
 
 touch $tmp/data/weird-files/newfilecreatedjustforthistest
 
 cat <<END_OF_DATA >"$tmp/bconcmds"
-@$out $tmp/log4.out
+@$out $prune_all_pool_log
 @#
 @# Prune all volumes of a given pool
 @#
 @#
 
-run job=$JobName Level=Incremental yes
+run job=$regularjob_name Level=Incremental yes
 wait
 
 @sleep 6
 
+messages
 update volume=TestVolume004 volstatus=Used
 update volume=TestVolumeIncremental volstatus=Used
 
 prune volume all pool=Incremental yes
 
 wait
-messages
 quit
 END_OF_DATA
 
@@ -127,13 +142,13 @@ job_pruning_log="$tmp"/job_pruning_log.out
 
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out $job_pruning_log
-run job=$JobName Level=Full yes
-run job=$JobName Level=Full yes
+run job=$regularjob_name Level=Full yes
+run job=$regularjob_name Level=Full yes
 wait
 @sleep 2
+messages
 prune jobs yes
 wait
-messages
 quit
 END_OF_DATA
 
@@ -149,7 +164,6 @@ prune files yes
 wait
 restore jobid=11
 no
-
 messages
 quit
 END_OF_DATA
@@ -157,79 +171,70 @@ END_OF_DATA
 run_bconsole
 
 check_for_zombie_jobs storage=File
+check_two_logs "$label_backup_log" "$restore_log"
 
-check_two_logs
+## Prune volumes
+expect_grep "Purging the following 2 JobIds: 1,2" \
+            "$prune_volume_log" \
+            "Pruned jobs from volume pruning not found" \
+            "Purging the"
 
-if ! grep "Purging the following 2 JobIds: 1,2" "$tmp"/log2.out; then
-  echo "'Purging the following JobIds: 1,2' not found in $tmp/log2.out" >&2
-  grep 'Purging the' "$tmp"/log2.out >&2 || :
-  estat=1
-fi
+expect_grep "Volume \"TestVolume001\" contains no jobs after pruning." \
+            "$prune_volume_log" \
+            "Volume still contains jobs, or wrong volume pruned." \
+            "Volume.*contains no jobs after pruning."
 
-if ! grep -F 'Volume "TestVolume001" contains no jobs after pruning.' $tmp/log2.out; then
-  echo "'Volume \"TestVolume001\" contains no jobs after pruning.' not found in $tmp/log2.out" >&2
-  grep 'Volume.*contains no jobs after pruning.' $tmp/log2.out >&2 || :
-  estat=1
-fi
+## Prune all volumes
+expect_grep "Purging the following 2 JobIds: 4,5" \
+            "$prune_all_log" \
+            "Pruned jobs from volume all pruning not found" \
+            "Purging the"
 
-## prune all volumes checks
+expect_grep "Volume \"TestVolume002\" contains no jobs after pruning." \
+            "$prune_all_log" \
+            "Volume still contains jobs, or wrong volume pruned." \
+            "Volume.*contains no jobs after pruning."
 
-if ! grep "Purging the following 2 JobIds: 4,5" "$tmp"/log3.out; then
-  echo "'Purging the following JobIds: 4,5' not found in $tmp/log3.out" >&2
-  grep 'Purging the' "$tmp"/log3.out >&2 || :
-  estat=1
-fi
+expect_grep "Purging the following 2 JobIds: 6,7" \
+            "$prune_all_log" \
+            "Pruned jobs from volume all pruning not found" \
+            "Purging the"
 
-if ! grep -F 'Volume "TestVolume002" contains no jobs after pruning.' $tmp/log3.out; then
-  echo "'Volume \"TestVolume002\" contains no jobs after pruning.' not found in $tmp/log3.out" >&2
-  grep 'Volume.*contains no jobs after pruning.' $tmp/log3.out >&2 || :
-  estat=1
-fi
+expect_grep "Volume \"TestVolume003\" contains no jobs after pruning." \
+            "$prune_all_log" \
+            "Volume still contains jobs, or wrong volume pruned." \
+            "Volume.*contains no jobs after pruning."
 
-if ! grep "Purging the following 2 JobIds: 6,7" "$tmp"/log3.out; then
-  echo "'Purging the following JobIds: 6,7' not found in $tmp/log3.out" >&2
-  grep 'Purging the' "$tmp"/log3.out >&2 || :
-  estat=1
-fi
 
-if ! grep -F 'Volume "TestVolume003" contains no jobs after pruning.' $tmp/log3.out; then
-  echo "'Volume \"TestVolume003\" contains no jobs after pruning.' not found in $tmp/log3.out" >&2
-  grep 'Volume.*contains no jobs after pruning.' $tmp/log3.out >&2 || :
-  estat=1
-fi
+## Prune all volumes from specific pool
 
-# Prune all volumes of specific pool
+expect_grep "Purging the following 1 JobIds: 9" \
+            "$prune_all_pool_log" \
+            "Pruned jobs from volume all pool pruning not found" \
+            "Purging the"
 
-if ! grep "Purging the following 1 JobIds: 9" "$tmp"/log4.out; then
-  echo "'Purging the following JobIds: 9' not found in $tmp/log4.out" >&2
-  grep 'Purging the' "$tmp"/log3.out >&2 || :
-  estat=1
-fi
+expect_grep "Volume \"TestVolumeIncremental\" contains no jobs after pruning." \
+            "$prune_all_pool_log" \
+            "Volume still contains jobs, or wrong volume pruned." \
+            "Volume.*contains no jobs after pruning."
 
-if ! grep -F 'Volume "TestVolumeIncremental" contains no jobs after pruning.' $tmp/log4.out; then
-  echo "'Volume \"TestVolumeIncremental\" contains no jobs after pruning.' not found in $tmp/log4.out" >&2
-  grep 'Volume.*contains no jobs after pruning.' $tmp/log3.out >&2 || :
-  estat=1
-fi
-
-#job pruning
-
+## Pruning jobs
 expect_grep "Purging the following 3 JobIds: 3,8,10" \
             "$job_pruning_log" \
-            "job pruning went wrong"
+            "Expected pruned jobids not found" \
+            "Purging the"
 
 expect_grep "Pruned 3 Jobs for client bareos-fd from catalog." \
             "$job_pruning_log" \
-            "job pruning went wrong"
+            "Expected number of jobs pruned not found"
 
-#file pruning
-
+## Pruning files
 expect_grep "Pruned Files from 1 Jobs" \
             "$file_pruning_log" \
-            "file pruning went wrong"
+            "Expected number of files pruned not found"
 
 expect_grep "Most likely your retention policy pruned the files." \
             "$file_pruning_log" \
-            "file pruning went wrong"
+            "Restore command found files, when they should have been pruned"
 
 end_test

--- a/systemtests/tests/pruning/testrunner
+++ b/systemtests/tests/pruning/testrunner
@@ -204,7 +204,7 @@ run job=$failingjob_name level=Full yes
 run job=$failingjob_name level=Full yes
 wait
 messages
-purge jobs jobstatus=E pool=SmallFull
+purge jobs jobstatus=E pool=SmallFull yes
 quit
 END_OF_DATA
 

--- a/systemtests/tests/truncate-command/testrunner
+++ b/systemtests/tests/truncate-command/testrunner
@@ -60,7 +60,7 @@ fi
 
 cat <<END_OF_DATA >${tmp}/bconcmds2
 @$out ${tmp}/log2.out w
-purge volume=${VolumeName}
+purge volume=${VolumeName} yes
 truncate volstatus=Purged volume=${VolumeName} yes
 messages
 END_OF_DATA

--- a/systemtests/tests/virtualfull-basic/testrunner
+++ b/systemtests/tests/virtualfull-basic/testrunner
@@ -53,8 +53,8 @@ wait
 messages
 list jobs
 @# make sure we really restore the virtualfull
-purge volume=TestVolume001
-purge volume=TestVolume002
+purge volume=TestVolume001 yes
+purge volume=TestVolume002 yes
 status director
 status client
 status storage=File


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

This PR adds the ability for the `purge` command to delete jobs with a specific jobstatus and/or from specific pool.
The command used to only do so for specific volumes or clients.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- ~~Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.~~

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
