### PR TITLE
Python Plugins: Avoid pop(0) performance impact

### DIFF
--- a/core/src/plugins/filed/python/ldap/BareosFdPluginLDAP.py
+++ b/core/src/plugins/filed/python/ldap/BareosFdPluginLDAP.py
@@ -37,6 +37,7 @@ import ldap.resiter
 import ldap.modlist
 import time
 from calendar import timegm
+import collections
 
 
 def _safe_encode(data):
@@ -397,7 +398,7 @@ class BareosLDAPWrapper:
                 # if there is nothing return an error.
                 try:
                     res_type, res_data, res_msgid, res_controls = self.resultset.next()
-                    self.ldap_entries = res_data
+                    self.ldap_entries = collections.deque(res_data)
                 except ldap.NO_SUCH_OBJECT:
                     return bareosfd.bRC_Error
                 except StopIteration:
@@ -405,7 +406,7 @@ class BareosLDAPWrapper:
 
             # Get the next entry from the result set.
             if self.ldap_entries:
-                self.dn, self.entry = self.ldap_entries.pop(0)
+                self.dn, self.entry = self.ldap_entries.popleft()
 
                 if self.dn:
                     # Extract the createTimestamp and modifyTimestamp and
@@ -483,7 +484,7 @@ class BareosLDAPWrapper:
                 try:
                     # Get the next result set
                     res_type, res_data, res_msgid, res_controls = self.resultset.next()
-                    self.ldap_entries = res_data
+                    self.ldap_entries = collections.deque(res_data)
 
                     # We expect something to be in the result set but better check
                     if self.ldap_entries:

--- a/docs/manuals/source/DeveloperGuide/PythonPluginAPI.rst
+++ b/docs/manuals/source/DeveloperGuide/PythonPluginAPI.rst
@@ -200,6 +200,13 @@ To let the plugin do the I/O, just set `IOP.status` to
                 #  do io in plugin
                 IOP.status = bareosfd.iostat_do_in_plugin
 
+Using large lists may cause performance issues
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Using large lists in Python can have a significant performance impact as it incurs O(n) memory movement costs for ``pop(0)`` and ``insert(0, v)`` operations. Plugins which use large lists should use ``collections.deque`` instead as its ``popleft()`` and ``appendleft()`` functions perform well. If possible it is even better to use a generator to also decrease the memory footprint.
+
+For more details see `Python collections.deque documentation <https://docs.python.org/3/library/collections.html#collections.deque>`
+
 
 Description of the Bareos Python plugin API for Bareos < 20
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Python plugins should use collections.deque with popleft() instead of lists with pop(0) as it incurs O(n) memory movement costs which causes performance issues on large lists.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
