### PR TITLE
docs: release note remove warning about binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,13 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - Fix gcc warnings in ndmjob program [PR #1343]
 
+### Documentation
+- add explanation about binary version numbers [PR #1354]
+
 [PR #1335]: https://github.com/bareos/bareos/pull/1335
 [PR #1343]: https://github.com/bareos/bareos/pull/1343
 [PR #1346]: https://github.com/bareos/bareos/pull/1346
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
 [PR #1352]: https://github.com/bareos/bareos/pull/1352
+[PR #1354]: https://github.com/bareos/bareos/pull/1354
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/Appendix/ReleaseNotes.rst
+++ b/docs/manuals/source/Appendix/ReleaseNotes.rst
@@ -5,12 +5,11 @@ Release Notes
 
 .. index:: Releases
 
-.. warning::
-
-      While all the source code is published on `GitHub <https://github.com/bareos/bareos/>`_, the releases of packages on https://download.bareos.org/ is limited to the initial versions of a major release. Later maintenance releases are only published on https://download.bareos.com/.
-
-
 This information is also available as ``CHANGELOG.md`` in the corresponding branch of the `Bareos GitHub project`_
+
+.. note::
+
+   You can consult our :ref:`section-BareosBinaryReleasePolicy` section to get more information about version available.
 
 .. _Bareos GitHub project: https://github.com/bareos/bareos/
 

--- a/docs/manuals/source/Appendix/ReleaseNotes.rst
+++ b/docs/manuals/source/Appendix/ReleaseNotes.rst
@@ -9,7 +9,7 @@ This information is also available as ``CHANGELOG.md`` in the corresponding bran
 
 .. note::
 
-   You can consult our :ref:`section-BareosBinaryReleasePolicy` section to get more information about version available.
+   See :ref:`section-BareosBinaryReleasePolicy` for more information about available versions.
 
 .. _Bareos GitHub project: https://github.com/bareos/bareos/
 

--- a/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
@@ -164,8 +164,6 @@ Not all packages are required to run Bareos.
 
 .. _section-BareosBinaryReleasePolicy:
 
-.. _section-BareosRepositoryTypes:
-
 Bareos Binary Release Policy
 ----------------------------
 
@@ -180,13 +178,13 @@ There are different types of Bareos binaries:
 
       * Only the latest build is available.
       * Packages may be marked as pre-releases (``<next-version-number>~pre``) and are published after passing an automated testing process.
-      * When a new Bareos major version gets released, the version in this repository will also change to the new version.
+      * When a new Bareos major version gets released, this repository will also change to the new **current** version.
 
    * Latest build of the Bareos master branch at https://download.bareos.org/next/
 
       * Only the latest build is available.
       * Packages are marked as pre-releases (``<next-major-version-number>.0.0~pre``) and are only published after passing an automated testing process.
-      * When a new Bareos major version gets released, the version in this repository will also change to the new version.
+      * When the development of a new Bareos major version starts, this repository will also change to the new **next** version.
 
 #. Bareos Subscription binaries on https://download.bareos.com/
 
@@ -197,6 +195,17 @@ There are different types of Bareos binaries:
    * While the repository can be browsed, accessing the binaries requires a Bareos Subscription.
 
 The software in both types of repositories is based on the same source code freely available in https://github.com/bareos/bareos/. There are no hidden nor open core components.
+
+.. note::
+
+   About ``<next-version-number>~pre`` version numbers:
+
+   Assume the current major release is ``22`` and the latest stable release is ``22.0.1``.
+   As soon as some code gets backported to Bareos 22,
+   packages with ``22.0.2~pre`` version will get published.
+   It means the latest stable current ``22.0.1`` release + newer backported feature that will appear in ``22.0.2``.
+   Thus your Bareos installation will always run stable tested current software.
+
 
 For a simple comparison of the two editions, please see the following table:
 


### PR DESCRIPTION
This PR remove the warning section of release note page and add a note to new Binary Policy page to explain more deeply what `<next-version-number>~pre` is with example.

OP #5373

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Required documentation changes are present and part of the PR

