### PR TITLE
stored: revert removal of volatile keyword

### DIFF
--- a/core/src/stored/ansi_label.cc
+++ b/core/src/stored/ansi_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2005-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -57,6 +57,7 @@ static bool SameLabelNames(char* bareos_name, char* ansi_name);
  */
 int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
 {
+  Device* volatile dev = dcr->dev;
   JobControlRecord* jcr = dcr->jcr;
   char label[80]; /* tape label */
   int status, i;
@@ -68,36 +69,36 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
    * If tape read the following EOF mark, on disk do not read.
    */
   Dmsg0(100, "Read ansi label.\n");
-  if (!dcr->dev->IsTape()) { return VOL_OK; }
+  if (!dev->IsTape()) { return VOL_OK; }
 
-  dcr->dev->label_type = B_BAREOS_LABEL; /* assume Bareos label */
+  dev->label_type = B_BAREOS_LABEL; /* assume Bareos label */
 
   // Read a maximum of 5 records VOL1, HDR1, ... HDR4
   for (i = 0; i < 6; i++) {
     do {
-      status = dcr->dev->read(label, sizeof(label));
+      status = dev->read(label, sizeof(label));
     } while (status == -1 && errno == EINTR);
 
     if (status < 0) {
       BErrNo be;
-      dcr->dev->clrerror(-1);
+      dev->clrerror(-1);
       Dmsg1(100, "Read device got: ERR=%s\n", be.bstrerror());
       Mmsg2(jcr->errmsg, _("Read error on device %s in ANSI label. ERR=%s\n"),
-            dcr->dev->archive_device_string, be.bstrerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", dcr->dev->errmsg);
-      dcr->dev->VolCatInfo.VolCatErrors++;
+            dev->archive_device_string, be.bstrerror());
+      Jmsg(jcr, M_ERROR, 0, "%s", dev->errmsg);
+      dev->VolCatInfo.VolCatErrors++;
       return VOL_IO_ERROR;
     }
 
     if (status == 0) {
-      if (dcr->dev->AtEof()) {
-        dcr->dev->SetEot(); /* second eof, set eot bit */
+      if (dev->AtEof()) {
+        dev->SetEot(); /* second eof, set eot bit */
         Dmsg0(100, "EOM on ANSI label\n");
         Mmsg0(jcr->errmsg,
               _("Insane! End of tape while reading ANSI label.\n"));
         return VOL_LABEL_ERROR; /* at EOM this shouldn't happen */
       } else {
-        dcr->dev->SetAteof(); /* set eof state */
+        dev->SetAteof(); /* set eof state */
       }
     }
 
@@ -106,7 +107,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
         if (status == 80) {
           if (bstrncmp("VOL1", label, 4)) {
             ok = true;
-            dcr->dev->label_type = B_ANSI_LABEL;
+            dev->label_type = B_ANSI_LABEL;
             Dmsg0(100, "Got ANSI VOL1 label\n");
           } else {
             // Try EBCDIC
@@ -114,7 +115,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
             if (bstrncmp("VOL1", label, 4)) {
               ok = true;
               ;
-              dcr->dev->label_type = B_IBM_LABEL;
+              dev->label_type = B_IBM_LABEL;
               Dmsg0(100, "Found IBM label.\n");
               Dmsg0(100, "Got IBM VOL1 label\n");
             }
@@ -134,26 +135,26 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
             char* p = &label[4];
             char* q;
 
-            FreeVolume(dcr->dev);
+            FreeVolume(dev);
 
             // Store new Volume name
-            q = dcr->dev->VolHdr.VolumeName;
+            q = dev->VolHdr.VolumeName;
             for (int i = 0; *p != ' ' && i < 6; i++) { *q++ = *p++; }
             *q = 0;
             Dmsg0(100, "Call reserve_volume\n");
             //  why is this reserve_volume() needed???? KES
-            reserve_volume(dcr, dcr->dev->VolHdr.VolumeName);
-            dcr->dev = dcr->dev; /* may have changed in reserve_volume */
+            reserve_volume(dcr, dev->VolHdr.VolumeName);
+            dev = dcr->dev; /* may have changed in reserve_volume */
             Dmsg2(100, "Wanted ANSI Vol %s got %6s\n", VolName,
-                  dcr->dev->VolHdr.VolumeName);
+                  dev->VolHdr.VolumeName);
             Mmsg2(jcr->errmsg, _("Wanted ANSI Volume \"%s\" got \"%s\"\n"),
-                  VolName, dcr->dev->VolHdr.VolumeName);
+                  VolName, dev->VolHdr.VolumeName);
             return VOL_NAME_ERROR;
           }
         }
         break;
       case 1:
-        if (dcr->dev->label_type == B_IBM_LABEL) {
+        if (dev->label_type == B_IBM_LABEL) {
           EbcdicToAscii(label, label, sizeof(label));
         }
 
@@ -172,7 +173,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
                   &label[4]);
             Mmsg1(jcr->errmsg,
                   _("ANSI/IBM Volume \"%s\" does not belong to Bareos.\n"),
-                  dcr->dev->VolHdr.VolumeName);
+                  dev->VolHdr.VolumeName);
             return VOL_NAME_ERROR; /* Not a Bareos label */
           }
         } else {
@@ -181,14 +182,14 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
                   &label[4]);
             Mmsg1(jcr->errmsg,
                   _("ANSI/IBM Volume \"%s\" does not belong to Bareos.\n"),
-                  dcr->dev->VolHdr.VolumeName);
+                  dev->VolHdr.VolumeName);
             return VOL_NAME_ERROR; /* Not a Bareos label */
           }
         }
         Dmsg0(100, "Got HDR1 label\n");
         break;
       case 2:
-        if (dcr->dev->label_type == B_IBM_LABEL) {
+        if (dev->label_type == B_IBM_LABEL) {
           EbcdicToAscii(label, label, sizeof(label));
         }
 
@@ -206,7 +207,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
           return VOL_OK;
         }
 
-        if (dcr->dev->label_type == B_IBM_LABEL) {
+        if (dev->label_type == B_IBM_LABEL) {
           EbcdicToAscii(label, label, sizeof(label));
         }
 

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -123,10 +123,11 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
   slot_number_t wanted_slot;
   JobControlRecord* jcr = dcr->jcr;
   drive_number_t drive;
+  Device* volatile dev = dcr->dev;
 
-  if (!dcr->dev->AttachedToAutochanger()) {
+  if (!dev->AttachedToAutochanger()) {
     Dmsg1(100, "Device %s is not attached to an autochanger\n",
-          dcr->dev->print_name());
+          dev->print_name());
     return 0;
   }
 
@@ -137,7 +138,7 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
     return 1; /* nothing to load */
   }
 
-  drive = dcr->dev->drive_index;
+  drive = dev->drive_index;
   wanted_slot = dcr->VolCatInfo.InChanger ? dcr->VolCatInfo.Slot : 0;
   Dmsg3(100, "autoload: slot=%hd InChgr=%d Vol=%s\n", dcr->VolCatInfo.Slot,
         dcr->VolCatInfo.InChanger, dcr->getVolCatName());
@@ -161,31 +162,31 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
   changer = GetPoolMemory(PM_FNAME);
   if (!IsSlotNumberValid(wanted_slot)) {
     // Suppress info when polling
-    if (!dcr->dev->poll) {
+    if (!dev->poll) {
       Jmsg(
           jcr, M_INFO, 0,
           _("No slot defined in catalog (slot=%hd) for Volume \"%s\" on %s.\n"),
-          wanted_slot, dcr->getVolCatName(), dcr->dev->print_name());
+          wanted_slot, dcr->getVolCatName(), dev->print_name());
       Jmsg(jcr, M_INFO, 0,
            _("Cartridge change or \"update slots\" may be required.\n"));
     }
     rtn_stat = 0;
   } else if (!dcr->device_resource->changer_name) {
     // Suppress info when polling
-    if (!dcr->dev->poll) {
+    if (!dev->poll) {
       Jmsg(jcr, M_INFO, 0,
            _("No \"Changer Device\" for %s. Manual load of Volume may be "
              "required.\n"),
-           dcr->dev->print_name());
+           dev->print_name());
     }
     rtn_stat = 0;
   } else if (!dcr->device_resource->changer_command) {
     // Suppress info when polling
-    if (!dcr->dev->poll) {
+    if (!dev->poll) {
       Jmsg(jcr, M_INFO, 0,
            _("No \"Changer Command\" for %s. Manual load of Volume may be "
              "required.\n"),
-           dcr->dev->print_name());
+           dev->print_name());
     }
     rtn_stat = 0;
   } else {
@@ -217,7 +218,7 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
 
       // Load the desired volume.
       Dmsg2(100, "Doing changer load slot %hd %s\n", wanted_slot,
-            dcr->dev->print_name());
+            dev->print_name());
       Jmsg(
           jcr, M_INFO, 0,
           _("3304 Issuing autochanger \"load slot %hd, drive %hd\" command.\n"),
@@ -225,7 +226,7 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
       dcr->VolCatInfo.Slot = wanted_slot; /* slot to be loaded */
       changer = edit_device_codes(
           dcr, changer, dcr->device_resource->changer_command, "load");
-      dcr->dev->close(dcr);
+      dev->close(dcr);
       Dmsg1(200, "Run program=%s\n", changer);
       status = RunProgramFullOutput(changer, timeout, results.addr());
       if (status == 0) {
@@ -235,10 +236,10 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
             wanted_slot, drive);
         Dmsg2(100, "load slot %hd, drive %hd, status is OK.\n", wanted_slot,
               drive);
-        dcr->dev->SetSlotNumber(wanted_slot); /* set currently loaded slot */
-        if (dcr->dev->vol) {
+        dev->SetSlotNumber(wanted_slot); /* set currently loaded slot */
+        if (dev->vol) {
           // We just swapped this Volume so it cannot be swapping any more
-          dcr->dev->vol->ClearSwapping();
+          dev->vol->ClearSwapping();
         }
       } else {
         BErrNo be;
@@ -256,13 +257,13 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
              _("3992 Bad autochanger \"load slot %hd, drive %hd\": "
                "ERR=%s.\nResults=%s\n"),
              wanted_slot, drive, be.bstrerror(), results.c_str());
-        dcr->dev->SetSlotNumber(-1); /* mark unknown */
+        dev->SetSlotNumber(-1); /* mark unknown */
       }
       Dmsg2(100, "load slot %hd status=%d\n", wanted_slot, status);
       UnlockChanger(dcr);
     } else {
-      status = 0;                           /* we got what we want */
-      dcr->dev->SetSlotNumber(wanted_slot); /* set currently loaded slot */
+      status = 0;                      /* we got what we want */
+      dev->SetSlotNumber(wanted_slot); /* set currently loaded slot */
     }
 
     Dmsg1(100, "After changer, status=%d\n", status);

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -65,8 +65,6 @@
 #include "stored/volume_catalog_info.h"
 
 #include <vector>
-#include <atomic>
-
 template <typename T> class dlist;
 
 namespace storagedaemon {
@@ -212,7 +210,7 @@ class Device {
   Device& operator=(const Device&) = delete;
   Device(Device&&) = delete;
   Device& operator=(Device&&) = delete;
-  Device* swap_dev{};         /**< Swap vol from this device */
+  Device* volatile swap_dev{}; /**< Swap vol from this device */
   std::vector<DeviceControlRecord*> attached_dcrs;           /**< Attached DeviceControlRecords */
   pthread_mutex_t mutex_ = PTHREAD_MUTEX_INITIALIZER;        /**< Access control */
   pthread_mutex_t spool_mutex = PTHREAD_MUTEX_INITIALIZER;   /**< Mutex for updating spool_size */

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -72,7 +72,7 @@ class DeviceControlRecord {
   JobControlRecord* jcr{};         /**< Pointer to JobControlRecord */
   pthread_mutex_t mutex_ = PTHREAD_MUTEX_INITIALIZER;  /**< Access control */
   pthread_mutex_t r_mutex = PTHREAD_MUTEX_INITIALIZER; /**< rLock pre-mutex */
-  Device* dev{};          /**< Pointer to device */
+  Device* volatile dev{};          /**< Pointer to device */
   DeviceResource* device_resource{};    /**< Pointer to device resource */
   DeviceBlock* block{};            /**< Pointer to current block */
   DeviceRecord* rec{};             /**< Pointer to record being processed */


### PR DESCRIPTION
### Description


#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [ ] PR name is meaningful
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
- [ ] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
