### PR TITLE
dird: enable default options in `fileset` config when no options are explicitly specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: remove warning for maximum block size for tapes [PR #1375]
 - ua_restore: enable restore from archive [PR #1372]
 - testfind: reuse filedaemon logic [PR #1234]
+- dird: enable default options in `fileset` config when no options are explicitly specified [PR #1357]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -65,6 +66,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1352]: https://github.com/bareos/bareos/pull/1352
 [PR #1354]: https://github.com/bareos/bareos/pull/1354
 [PR #1356]: https://github.com/bareos/bareos/pull/1356
+[PR #1357]: https://github.com/bareos/bareos/pull/1357
 [PR #1359]: https://github.com/bareos/bareos/pull/1359
 [PR #1361]: https://github.com/bareos/bareos/pull/1361
 [PR #1365]: https://github.com/bareos/bareos/pull/1365

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -442,7 +442,7 @@ static void ScanIncludeOptions(LEX* lc, int keyword, char* opts, int optlen)
 }
 
 // Store regex info
-static void StoreRegex(LEX* lc, ResourceItem* item, int, int pass)
+static void StoreRegex(LEX* lc, ResourceItem* item, int pass)
 {
   int token, rc;
   regex_t preg{};
@@ -491,7 +491,7 @@ static void StoreRegex(LEX* lc, ResourceItem* item, int, int pass)
 }
 
 // Store Base info
-static void StoreBase(LEX* lc, ResourceItem*, int, int pass)
+static void StoreBase(LEX* lc, ResourceItem*, int pass)
 {
   LexGetToken(lc, BCT_NAME);
   if (pass == 1) {
@@ -502,7 +502,7 @@ static void StoreBase(LEX* lc, ResourceItem*, int, int pass)
 }
 
 // Store reader info
-static void StorePlugin(LEX* lc, ResourceItem*, int, int pass)
+static void StorePlugin(LEX* lc, ResourceItem*, int pass)
 {
   LexGetToken(lc, BCT_NAME);
   if (pass == 1) {
@@ -513,7 +513,7 @@ static void StorePlugin(LEX* lc, ResourceItem*, int, int pass)
 }
 
 // Store Wild-card info
-static void StoreWild(LEX* lc, ResourceItem* item, int, int pass)
+static void StoreWild(LEX* lc, ResourceItem* item, int pass)
 {
   int token;
   const char* type;
@@ -557,7 +557,7 @@ static void StoreWild(LEX* lc, ResourceItem* item, int, int pass)
 }
 
 // Store fstype info
-static void StoreFstype(LEX* lc, ResourceItem*, int, int pass)
+static void StoreFstype(LEX* lc, ResourceItem*, int pass)
 {
   int token;
 
@@ -581,7 +581,7 @@ static void StoreFstype(LEX* lc, ResourceItem*, int, int pass)
 }
 
 // Store Drivetype info
-static void StoreDrivetype(LEX* lc, ResourceItem*, int, int pass)
+static void StoreDrivetype(LEX* lc, ResourceItem*, int pass)
 {
   int token;
 
@@ -604,7 +604,7 @@ static void StoreDrivetype(LEX* lc, ResourceItem*, int, int pass)
   ScanToEol(lc);
 }
 
-static void StoreMeta(LEX* lc, ResourceItem*, int, int pass)
+static void StoreMeta(LEX* lc, ResourceItem*, int pass)
 {
   int token;
 
@@ -631,7 +631,6 @@ static void StoreMeta(LEX* lc, ResourceItem*, int, int pass)
 static void StoreOption(
     LEX* lc,
     ResourceItem* item,
-    int,
     int pass,
     std::map<int, options_default_value_s>& option_default_values)
 {
@@ -689,7 +688,7 @@ static void SetupCurrentOpts(void)
 }
 
 // Come here when Options seen in Include/Exclude
-static void StoreOptionsRes(LEX* lc, ResourceItem*, int, int pass, bool exclude)
+static void StoreOptionsRes(LEX* lc, ResourceItem*, int pass, bool exclude)
 {
   int token, i;
   std::map<int, options_default_value_s> option_default_values
@@ -725,28 +724,28 @@ static void StoreOptionsRes(LEX* lc, ResourceItem*, int, int pass, bool exclude)
         /* Call item handler */
         switch (options_items[i].type) {
           case CFG_TYPE_OPTION:
-            StoreOption(lc, &options_items[i], i, pass, option_default_values);
+            StoreOption(lc, &options_items[i], pass, option_default_values);
             break;
           case CFG_TYPE_REGEX:
-            StoreRegex(lc, &options_items[i], i, pass);
+            StoreRegex(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_BASE:
-            StoreBase(lc, &options_items[i], i, pass);
+            StoreBase(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_WILD:
-            StoreWild(lc, &options_items[i], i, pass);
+            StoreWild(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_PLUGIN:
-            StorePlugin(lc, &options_items[i], i, pass);
+            StorePlugin(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_FSTYPE:
-            StoreFstype(lc, &options_items[i], i, pass);
+            StoreFstype(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_DRIVETYPE:
-            StoreDrivetype(lc, &options_items[i], i, pass);
+            StoreDrivetype(lc, &options_items[i], pass);
             break;
           case CFG_TYPE_META:
-            StoreMeta(lc, &options_items[i], i, pass);
+            StoreMeta(lc, &options_items[i], pass);
             break;
           default:
             break;
@@ -792,7 +791,7 @@ static FilesetResource* GetStaticFilesetResource()
  * always increase the name buffer by 10 items because we expect
  * to add more entries.
  */
-static void StoreFname(LEX* lc, ResourceItem*, int, int pass, bool)
+static void StoreFname(LEX* lc, ResourceItem*, int pass, bool)
 {
   int token;
 
@@ -838,7 +837,7 @@ static void StoreFname(LEX* lc, ResourceItem*, int, int pass, bool)
  * always increase the name buffer by 10 items because we expect
  * to add more entries.
  */
-static void StorePluginName(LEX* lc, ResourceItem*, int, int pass, bool exclude)
+static void StorePluginName(LEX* lc, ResourceItem*, int pass, bool exclude)
 {
   int token;
 
@@ -883,7 +882,7 @@ static void StorePluginName(LEX* lc, ResourceItem*, int, int pass, bool exclude)
 }
 
 // Store exclude directory containing info
-static void StoreExcludedir(LEX* lc, ResourceItem*, int, int pass, bool exclude)
+static void StoreExcludedir(LEX* lc, ResourceItem*, int pass, bool exclude)
 {
   if (exclude) {
     scan_err0(lc,
@@ -941,16 +940,16 @@ static void StoreNewinc(LEX* lc, ResourceItem* item, int index, int pass)
         }
         switch (newinc_items[i].type) {
           case CFG_TYPE_FNAME:
-            StoreFname(lc, &newinc_items[i], i, pass, item->code);
+            StoreFname(lc, &newinc_items[i], pass, item->code);
             break;
           case CFG_TYPE_PLUGINNAME:
-            StorePluginName(lc, &newinc_items[i], i, pass, item->code);
+            StorePluginName(lc, &newinc_items[i], pass, item->code);
             break;
           case CFG_TYPE_EXCLUDEDIR:
-            StoreExcludedir(lc, &newinc_items[i], i, pass, item->code);
+            StoreExcludedir(lc, &newinc_items[i], pass, item->code);
             break;
           case CFG_TYPE_OPTIONS:
-            StoreOptionsRes(lc, &newinc_items[i], i, pass, item->code);
+            StoreOptionsRes(lc, &newinc_items[i], pass, item->code);
             break;
           default:
             break;

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -1440,9 +1440,17 @@ FileSet {
   Name = "FsMultiInclude"
   Description = "fileset with multiple blocks."
   Include {
+    Options {
+      AclSupport = Yes
+      XattrSupport = Yes
+    }
     File = "/tmp/dir11"
   }
   Include {
+    Options {
+      AclSupport = Yes
+      XattrSupport = Yes
+    }
     File = "/tmp/dir22"
   }
 }
@@ -1471,6 +1479,10 @@ FileSet {
     File = "/tmp/data"
   }
   Include {
+    Options {
+      AclSupport = Yes
+      XattrSupport = Yes
+    }
     File = "/tmp/dir22"
   }
 }


### PR DESCRIPTION
#### Description

When a fileset configuration does not include an `options` section, the default values would not be applied. Defaults would only apply when the config parser finds an `options` section.

This PR makes sure default options are set even when no options section is specified.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

##### Tests

- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
