### PR TITLE
storage daemon: fix crash on volume swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - VMware Plugin: introduce pyVmomi 8.x compatibility [PR #1358]
 - build: replace sprintf by snprintf due to upgraded MacOS compiler, change linking of googletest [PR #1362]
+- storage daemon: fix crash on volume swap [PR #1360]
 
 ## [22.0.1] - 2023-01-02
 
@@ -436,5 +437,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1337]: https://github.com/bareos/bareos/pull/1337
 [PR #1347]: https://github.com/bareos/bareos/pull/1347
 [PR #1358]: https://github.com/bareos/bareos/pull/1358
+[PR #1360]: https://github.com/bareos/bareos/pull/1360
 [PR #1362]: https://github.com/bareos/bareos/pull/1362
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
Fix a problem introduced in Bareos 22 with commit
6c265ec52 replace volatile device pointers with actual variable

Due to an oversight in a refactoring, a swap would no longer move the volume to another device, but switch over to use the device that had the desired volume loaded.
As that device was not reserved, but was unreserved during acquire, the storage daemon would eventually crash in this case.

(cherry picked from commit c1de9e117cf9ef12c7be42aa808a7370a173151d)

### Thank you for contributing to the Bareos Project!

**Backport of PR #01356 to bareos-22** (remove this line, if it no backport)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)

##### General
- [x] PR name is meaningful
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Separate commit for CHANGELOG.md ("update CHANGELOG.md"). The PR number is correct.

##### Source code quality

- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] `bareos-check-sources --since-merge` does not report any problems

