### PR TITLE
build: replace sprintf by snprintf due to upgraded MacOS compiler, change linking of googletest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - VMware Plugin: introduce pyVmomi 8.x compatibility [PR #1352]
 - devtools: add `pr-tool` to automate PR review and merge [PR #935]
+- build: replace sprintf by snprintf due to upgraded MacOS compiler, change linking of googletest [PR #1361]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -29,4 +30,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1351]: https://github.com/bareos/bareos/pull/1351
 [PR #1352]: https://github.com/bareos/bareos/pull/1352
 [PR #1354]: https://github.com/bareos/bareos/pull/1354
+[PR #1361]: https://github.com/bareos/bareos/pull/1361
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/findlib/bfile.cc
+++ b/core/src/findlib/bfile.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -214,7 +214,7 @@ const char* stream_to_ascii(int stream)
     case STREAM_XATTR_NETBSD:
       return _("NetBSD Specific Extended attribs");
     default:
-      sprintf(buf, "%d", stream);
+      snprintf(buf, 20, "%d", stream);
       return (const char*)buf;
   }
 }
@@ -733,17 +733,14 @@ int bopen(BareosFilePacket* bfd,
   Dmsg4(100, "bopen: fname %s, flags %08o, mode %04o, rdev %u\n", fname, flags,
         (mode & ~S_IFMT), rdev);
 
-  /*
-   * If the FILE_ATTRIBUTES_DEDUPED_ITEM bit is set this is a deduped file
+  /* If the FILE_ATTRIBUTES_DEDUPED_ITEM bit is set this is a deduped file
    * we let the bopen function know it should open the file without the
    * FILE_FLAG_OPEN_REPARSE_POINT flag by setting in the O_NOFOLLOW open flag.
    */
   if (rdev & FILE_ATTRIBUTES_DEDUPED_ITEM) { flags |= O_NOFOLLOW; }
 
-  /*
-   * If the FILE_ATTRIBUTE_ENCRYPTED bit is set this is an file on an EFS
-   * filesystem. For that we need some special handling.
-   */
+  /* If the FILE_ATTRIBUTE_ENCRYPTED bit is set this is an file on an EFS
+   * filesystem. For that we need some special handling. */
   if (rdev & FILE_ATTRIBUTE_ENCRYPTED) {
     return BopenEncrypted(bfd, fname, flags, mode);
   } else {
@@ -793,11 +790,9 @@ static inline int BcloseNonencrypted(BareosFilePacket* bfd)
     goto all_done;
   }
 
-  /*
-   * We need to tell the API to release the buffer it
+  /* We need to tell the API to release the buffer it
    *  allocated in lplugin_private_context.  We do so by calling the
-   *  API one more time, but with the Abort bit set.
-   */
+   *  API one more time, but with the Abort bit set. */
   if (bfd->use_backup_api && bfd->mode == BF_READ) {
     BYTE buf[10];
     if (bfd->lplugin_private_context

--- a/core/src/lib/attr.cc
+++ b/core/src/lib/attr.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -61,8 +61,7 @@ int UnpackAttributesRecord(JobControlRecord* jcr,
 {
   char* p;
   int object_len;
-  /*
-   * An Attributes record consists of:
+  /* An Attributes record consists of:
    *    File_index
    *    Type   (FT_types)
    *    Filename
@@ -71,8 +70,7 @@ int UnpackAttributesRecord(JobControlRecord* jcr,
    *    Extended attributes (Win32)
    *  plus optional values determined by AR_ flags in upper bits of Type
    *    Data_stream
-   *
-   */
+   * */
   attr->stream = stream;
   Dmsg1(debuglevel, "Attr: %s\n", rec);
   if (sscanf(rec, "%d %d", &attr->file_index, &attr->type) != 2) {
@@ -82,10 +80,8 @@ int UnpackAttributesRecord(JobControlRecord* jcr,
   }
   Dmsg2(debuglevel, "Got Attr: FilInx=%d type=%d\n", attr->file_index,
         attr->type);
-  /*
-   * Note AR_DATA_STREAM should never be set since it is encoded
-   *  at the end of the attributes.
-   */
+  /* Note AR_DATA_STREAM should never be set since it is encoded
+   *  at the end of the attributes. */
   if (attr->type & AR_DATA_STREAM) {
     attr->data_stream = 1;
   } else {
@@ -162,16 +158,14 @@ static void StripDoubleSlashes(char* fname)
  */
 void BuildAttrOutputFnames(JobControlRecord* jcr, Attributes* attr)
 {
-  /*
-   * Prepend the where directory so that the
+  /* Prepend the where directory so that the
    * files are put where the user wants.
    *
    * We do a little jig here to handle Win32 files with
    *   a drive letter -- we simply change the drive
    *   from, for example, c: to c/ for
    *   every filename if a prefix is supplied.
-   *
-   */
+   * */
 
   if (jcr->where_bregexp) {
     char* ret;
@@ -261,11 +255,11 @@ static const char* attr_stat_to_str(PoolMem& resultbuffer,
   if (!jcr->id_list) { jcr->id_list = new_guid_list(); }
   guid = jcr->id_list;
   p = encode_mode(attr->statp.st_mode, buf);
-  p += sprintf(p, "  %2d ", (uint32_t)attr->statp.st_nlink);
-  p += sprintf(p, "%-8.8s %-8.8s",
-               guid->uid_to_name(attr->statp.st_uid, en1, sizeof(en1)),
-               guid->gid_to_name(attr->statp.st_gid, en2, sizeof(en2)));
-  p += sprintf(p, "%12.12s ", edit_int64(attr->statp.st_size, ec1));
+  p += snprintf(p, 1000, "  %2d ", (uint32_t)attr->statp.st_nlink);
+  p += snprintf(p, 1000, "%-8.8s %-8.8s",
+                guid->uid_to_name(attr->statp.st_uid, en1, sizeof(en1)),
+                guid->gid_to_name(attr->statp.st_gid, en2, sizeof(en2)));
+  p += snprintf(p, 1000, "%12.12s ", edit_int64(attr->statp.st_size, ec1));
   p = encode_time(attr->statp.st_ctime, p);
 
   resultbuffer.strcat(buf);

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -280,10 +280,8 @@ void ConfigurationParser::StoreMsgs(LEX* lc,
         int cnt = 0;
         bool done = false;
 
-        /*
-         * See if this is an old style syslog definition.
-         * We count the number of = signs in the current config line.
-         */
+        /* See if this is an old style syslog definition.
+         * We count the number of = signs in the current config line. */
         p = lc->line;
         while (!done && *p) {
           switch (*p) {
@@ -301,10 +299,8 @@ void ConfigurationParser::StoreMsgs(LEX* lc,
           p++;
         }
 
-        /*
-         * If there is more then one = its the new format e.g.
-         * syslog = facility = filter
-         */
+        /* If there is more then one = its the new format e.g.
+         * syslog = facility = filter */
         if (cnt > 1) {
           dest = GetPoolMemory(PM_MESSAGE);
           // Pick up a single facility.
@@ -552,8 +548,9 @@ void ConfigurationParser::StoreMd5Password(LEX* lc,
                            &md5c, (unsigned char*)(lc->str), lc->str_len);
                        MD5_Final(digest, &md5c);)
       for (i = j = 0; i < sizeof(digest); i++) {
-        sprintf(&sig[j], "%02x", digest[i]);
+        snprintf(&sig[j], 3, "%02x", digest[i]);
         j += 2;
+        ASSERT(j < 100);
       }
       pwd->encoding = p_encoding_md5;
       pwd->value = strdup(sig);
@@ -686,12 +683,10 @@ void ConfigurationParser::StoreStdVectorStr(LEX* lc,
       Dmsg4(900, "Append %s to vector %p size=%d %s\n", lc->str, list,
             list->size(), item->name);
 
-      /*
-       * See if we need to drop the default value.
+      /* See if we need to drop the default value.
        *
        * We first check to see if the config item has the CFG_ITEM_DEFAULT
-       * flag set and currently has exactly one entry.
-       */
+       * flag set and currently has exactly one entry. */
       if (!BitIsSet(index, (*item->allocated_resource)->item_present_)) {
         if ((item->flags & CFG_ITEM_DEFAULT) && list->size() == 1) {
           if (list->at(0) == item->default_value) { list->clear(); }
@@ -728,12 +723,10 @@ void ConfigurationParser::StoreAlistStr(LEX* lc,
       Dmsg4(900, "Append %s to alist %p size=%d %s\n", lc->str, list,
             list->size(), item->name);
 
-      /*
-       * See if we need to drop the default value from the alist.
+      /* See if we need to drop the default value from the alist.
        *
        * We first check to see if the config item has the CFG_ITEM_DEFAULT
-       * flag set and currently has exactly one entry.
-       */
+       * flag set and currently has exactly one entry. */
       if (!BitIsSet(index, (*item->allocated_resource)->item_present_)) {
         if ((item->flags & CFG_ITEM_DEFAULT) && list->size() == 1) {
           char* entry = (char*)list->first();
@@ -778,12 +771,10 @@ void ConfigurationParser::StoreAlistDir(LEX* lc,
       DoShellExpansion(lc->str, SizeofPoolMemory(lc->str));
     }
 
-    /*
-     * See if we need to drop the default value from the alist.
+    /* See if we need to drop the default value from the alist.
      *
      * We first check to see if the config item has the CFG_ITEM_DEFAULT
-     * flag set and currently has exactly one entry.
-     */
+     * flag set and currently has exactly one entry. */
     if ((item->flags & CFG_ITEM_DEFAULT) && list->size() == 1) {
       char* entry;
 
@@ -1493,11 +1484,9 @@ std::string PrintConfigTime(ResourceItem* item)
   utime_t secs = GetItemVariable<utime_t>(*item);
   int factor;
 
-  /*
-   * Reverse time formatting: 1 Month, 1 Week, etc.
+  /* Reverse time formatting: 1 Month, 1 Week, etc.
    *
-   * convert default value string to numeric value
-   */
+   * convert default value string to numeric value */
   static const char* modifier[] = {"years", "months",  "weeks",   "days",
                                    "hours", "minutes", "seconds", NULL};
   static const int32_t multiplier[] = {60 * 60 * 24 * 365,
@@ -1822,10 +1811,8 @@ void BareosResource::PrintResourceItem(ResourceItem& item,
     Dmsg1(200, "%s: default value\n", item.name);
 
     if ((verbose) && (!(item.flags & CFG_ITEM_DEPRECATED))) {
-      /*
-       * If value has a expliciet default value and verbose mode is on,
-       * display directive as inherited.
-       */
+      /* If value has a expliciet default value and verbose mode is on,
+       * display directive as inherited. */
       print_item = true;
       inherited = true;
     }
@@ -1973,10 +1960,8 @@ void BareosResource::PrintResourceItem(ResourceItem& item,
       break;
     }
     case CFG_TYPE_MSGS:
-      /*
-       * We ignore these items as they are printed in a special way in
-       * MessagesResource::PrintConfig()
-       */
+      /* We ignore these items as they are printed in a special way in
+       * MessagesResource::PrintConfig() */
       break;
     case CFG_TYPE_ADDRESSES: {
       dlist<IPADDR>* addrs = GetItemVariable<dlist<IPADDR>*>(item);
@@ -1997,10 +1982,8 @@ void BareosResource::PrintResourceItem(ResourceItem& item,
       // Is stored in CFG_TYPE_ADDRESSES and printed there.
       break;
     default:
-      /*
-       * This is a non-generic type call back to the daemon to get things
-       * printed.
-       */
+      /* This is a non-generic type call back to the daemon to get things
+       * printed. */
       if (my_config.print_res_) {
         my_config.print_res_(item, send, hide_sensitive_data, inherited,
                              verbose);

--- a/core/src/lib/signal.cc
+++ b/core/src/lib/signal.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -169,7 +169,7 @@ extern "C" void SignalHandler(int sig)
     dbg_print_bareos();
 #  endif
 
-    sprintf(pid_buf, "%d", (int)main_pid);
+    snprintf(pid_buf, 20, "%d", (int)main_pid);
     Dmsg1(300, "Working=%s\n", working_directory);
     Dmsg1(300, "btpath=%s\n", btpath);
     Dmsg1(300, "exepath=%s\n", exepath);

--- a/core/src/lib/var.cc
+++ b/core/src/lib/var.cc
@@ -1284,7 +1284,7 @@ static int parse_operation(var_t* var,
       if (data->begin != NULL) {
         char buf[((sizeof(int) * 8) / 3)
                  + 10]; /* sufficient size: <#bits> x log_10(2) + safety */
-        sprintf(buf, "%d", (int)(data->end - data->begin));
+        snprintf(buf, sizeof(buf), "%d", (int)(data->end - data->begin));
         tokenbuf_free(data);
         if (!tokenbuf_assign(data, buf, strlen(buf))) {
           rc = VAR_ERR_OUT_OF_MEMORY;

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -165,9 +165,9 @@ endif()
 add_library(stored_objects STATIC ${SDSRCS})
 add_executable(bareos-sd stored.cc)
 
+target_link_libraries(stored_objects PRIVATE Threads::Threads)
 target_link_libraries(
-  bareos-sd PRIVATE stored_objects bareos bareossd bareosfind Threads::Threads
-                    CLI11::CLI11
+  bareos-sd PRIVATE stored_objects bareos bareossd bareosfind CLI11::CLI11
 )
 
 if(HAVE_WIN32)


### PR DESCRIPTION
Fix broken build due to MacOS deprecating `sprintf()` and missing dependency to Threads::Threads (that was uncovered when switching googletest from static to dynamic linking)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

