### PR TITLE
vmware_cbt_tool.py: pyVmomi 8.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - filed: avoid reading from ephemeral buffer [PR #1373]
 - checkpoints: fix performance drop on big volume restores [PR #1345]
 - VMware Plugin: fix restore to different vmname [PR #1390]
+- vmware_cbt_tool.py: pyVmomi 8.x compatibility [PR #1386]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -68,6 +69,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1374]: https://github.com/bareos/bareos/pull/1374
 [PR #1377]: https://github.com/bareos/bareos/pull/1377
 [PR #1378]: https://github.com/bareos/bareos/pull/1378
+[PR #1386]: https://github.com/bareos/bareos/pull/1386
 [PR #1387]: https://github.com/bareos/bareos/pull/1387
 [PR #1389]: https://github.com/bareos/bareos/pull/1389
 [PR #1390]: https://github.com/bareos/bareos/pull/1390

--- a/core/src/vmware/vmware_cbt_tool/vmware_cbt_tool.py
+++ b/core/src/vmware/vmware_cbt_tool/vmware_cbt_tool.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2023 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -27,7 +27,7 @@ Python program for enabling/disabling/resetting CBT on a VMware VM
 
 from __future__ import print_function
 
-from pyVim.connect import SmartConnect, SmartConnectNoSSL, Disconnect
+from pyVim.connect import SmartConnect, Disconnect
 from pyVmomi import vim, vmodl
 
 import argparse
@@ -149,7 +149,6 @@ def main():
         )
 
     try:
-
         si = None
         retry_no_ssl_verify = False
         try:
@@ -172,8 +171,12 @@ def main():
 
         if retry_no_ssl_verify:
             try:
-                si = SmartConnectNoSSL(
-                    host=args.host, user=args.user, pwd=password, port=int(args.port)
+                si = SmartConnect(
+                    host=args.host,
+                    user=args.user,
+                    pwd=password,
+                    port=int(args.port),
+                    disableSslCertValidation=True,
                 )
             except IOError as e:
                 print(
@@ -211,7 +214,6 @@ def main():
         vm = None
 
         for vm in get_vm_list(args, dcftree):
-
             print(
                 "INFO: VM %s CBT supported: %s"
                 % (


### PR DESCRIPTION
This PR backport the fix #da94e4df3 to fix pyVmomi 8.0 compatibility to the tool 

It would be great to have both backported to 21.

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

