### PR TITLE
restore: fix failed restores showing Restore ok with warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: skip disabled clients in status command [PR #1367]
 - bsmtp: fix and update code, and change CLI parsing to CLI11 [PR #1316]
 - ua_restore: Add additional client info for restore report [PR #1374]
+- restore: fix failed restores showing Restore ok with warning [PR #1387]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -55,4 +56,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1367]: https://github.com/bareos/bareos/pull/1367
 [PR #1373]: https://github.com/bareos/bareos/pull/1373
 [PR #1374]: https://github.com/bareos/bareos/pull/1374
+[PR #1387]: https://github.com/bareos/bareos/pull/1387
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/restore.cc
+++ b/core/src/dird/restore.cc
@@ -423,10 +423,10 @@ void NativeRestoreCleanup(JobControlRecord* jcr, int TermCode)
   if (JobCanceled(jcr)) { CancelStorageDaemonJob(jcr); }
 
   if (jcr->dir_impl->ExpectedFiles != jcr->JobFiles) {
-    TermCode = JS_Warnings;
     Jmsg(jcr, M_WARNING, 0,
          _("File count mismatch: expected=%lu , restored=%lu\n"),
          jcr->dir_impl->ExpectedFiles, jcr->JobFiles);
+    if (TermCode == JS_Terminated) { TermCode = JS_Warnings; }
   }
 
   switch (TermCode) {


### PR DESCRIPTION
#### Description

This PR fixes an issue where failed restore jobs would show a `Restore ok -- with warnings` message instead of the proper failed message.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
