### PR TITLE
stored: change default block size to 1 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - core: fix schema public with PostgreSQL 15 [PR #1449]
 - pr-tool: handling POEditor commits and optional github ci tests [PR #1434]
 - VMware Plugin: Backup and Restore of VMs using multiple datastores [PR #1473]
+- stored: change default block size to 1 MiB [PR #1396]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -140,6 +141,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1390]: https://github.com/bareos/bareos/pull/1390
 [PR #1392]: https://github.com/bareos/bareos/pull/1392
 [PR #1395]: https://github.com/bareos/bareos/pull/1395
+[PR #1396]: https://github.com/bareos/bareos/pull/1396
 [PR #1398]: https://github.com/bareos/bareos/pull/1398
 [PR #1401]: https://github.com/bareos/bareos/pull/1401
 [PR #1402]: https://github.com/bareos/bareos/pull/1402

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -371,6 +371,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   /* Check if we can still write. This may not be the case
    * if we are at the end of the tape or we got a fatal I/O error. */
   if (ok || dev->CanWrite()) {
+    jcr->JobFiles = file_currently_processed.GetFileIndex();
     if (!WriteSessionLabel(jcr->sd_impl->dcr, EOS_LABEL)) {
       // Print only if ok and not cancelled to avoid spurious messages
       if (ok && !jcr->IsJobCanceled()) {

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -29,62 +29,6 @@
 
 namespace storagedaemon {
 
-DeviceResource::DeviceResource()
-    : BareosResource()
-    , media_type(nullptr)
-    , archive_device_string(nullptr)
-    , device_options(nullptr)
-    , diag_device_name(nullptr)
-    , changer_name(nullptr)
-    , changer_command(nullptr)
-    , alert_command(nullptr)
-    , spool_directory(nullptr)
-    , device_type(DeviceType::B_UNKNOWN_DEV)
-    , label_type(B_BAREOS_LABEL)
-    , autoselect(true)
-    , norewindonclose(true)
-    , drive_tapealert_enabled(false)
-    , drive_crypto_enabled(false)
-    , query_crypto_status(false)
-    , collectstats(false)
-    , eof_on_error_is_eot(false)
-    , drive(0)
-    , drive_index(0)
-    , cap_bits{0}
-    , max_changer_wait(300)
-    , max_rewind_wait(300)
-    , max_open_wait(300)
-    , max_open_vols(1)
-    , label_block_size(64512)
-    , min_block_size(0)
-    , max_block_size(0)
-    , max_network_buffer_size(0)
-    , max_concurrent_jobs(0)
-    , autodeflate_algorithm(0)
-    , autodeflate_level(6)
-    , autodeflate(AutoXflateMode::IO_DIRECTION_NONE)
-    , autoinflate(AutoXflateMode::IO_DIRECTION_NONE)
-    , vol_poll_interval(300)
-    , max_file_size(1000000000)
-    , volume_capacity(0)
-    , max_spool_size(0)
-    , max_job_spool_size(0)
-
-    , mount_point(nullptr)
-    , mount_command(nullptr)
-    , unmount_command(nullptr)
-    , count(1)
-    , multiplied_device_resource(nullptr)
-
-    , dev(nullptr)
-    , changer_res(nullptr)
-
-    /* private: */
-    , temporarily_swapped_numbered_name(nullptr)
-{
-  return;
-}
-
 DeviceResource::DeviceResource(const DeviceResource& other)
     : BareosResource(other)
     , media_type(nullptr)

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -62,7 +62,7 @@ class DeviceResource : public BareosResource {
   uint32_t max_open_vols{1};     /**< Maximum simultaneous open volumes */
   uint32_t label_block_size{64512};    /**< block size of the label block*/
   uint32_t min_block_size{0};          /**< Current Minimum block size */
-  uint32_t max_block_size{0};          /**< Current Maximum block size */
+  uint32_t max_block_size{1048576};    /**< Current Maximum block size */
   uint32_t max_network_buffer_size{0}; /**< Max network buf size */
   uint32_t max_concurrent_jobs{0};   /**< Maximum concurrent jobs this drive */
   uint32_t autodeflate_algorithm{0}; /**< Compression algorithm to use for

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,50 +43,55 @@ class DeviceResource : public BareosResource {
   char* changer_command;       /**< Changer command  -- external program */
   char* alert_command;         /**< Alert command -- external program */
   char* spool_directory;       /**< Spool file directory */
-  std::string device_type;
-  uint32_t label_type;
-  bool autoselect;              /**< Automatically select from AutoChanger */
-  bool norewindonclose;         /**< Don't rewind tape drive on close */
-  bool drive_tapealert_enabled; /**< Enable Tape Alert monitoring */
-  bool drive_crypto_enabled;    /**< Enable hardware crypto */
-  bool query_crypto_status;     /**< Query device for crypto status */
-  bool collectstats;            /**< Set if statistics should be collected */
-  bool eof_on_error_is_eot;     /**< Interpret EOF during read error as EOT */
-  drive_number_t drive;         /**< Autochanger logical drive number */
-  drive_number_t drive_index;   /**< Autochanger physical drive index */
-  char cap_bits[CAP_BYTES];     /**< Capabilities of this device */
-  utime_t max_changer_wait;     /**< Changer timeout */
-  utime_t max_rewind_wait;      /**< Maximum secs to wait for rewind */
-  utime_t max_open_wait;        /**< Maximum secs to wait for open */
-  uint32_t max_open_vols;       /**< Maximum simultaneous open volumes */
-  uint32_t label_block_size;    /**< block size of the label block*/
-  uint32_t min_block_size;      /**< Current Minimum block size */
-  uint32_t max_block_size;      /**< Current Maximum block size */
-  uint32_t max_network_buffer_size; /**< Max network buf size */
-  uint32_t max_concurrent_jobs;     /**< Maximum concurrent jobs this drive */
-  uint32_t autodeflate_algorithm;   /**< Compression algorithm to use for
-                                       compression */
-  uint16_t autodeflate_level; /**< Compression level to use for compression
+  std::string device_type{DeviceType::B_UNKNOWN_DEV};
+  uint32_t label_type{B_BAREOS_LABEL};
+  bool autoselect{true};      /**< Automatically select from AutoChanger */
+  bool norewindonclose{true}; /**< Don't rewind tape drive on close */
+  bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */
+  bool drive_crypto_enabled{false};    /**< Enable hardware crypto */
+  bool query_crypto_status{false};     /**< Query device for crypto status */
+  bool collectstats{false}; /**< Set if statistics should be collected */
+  bool eof_on_error_is_eot{
+      false};                    /**< Interpret EOF during read error as EOT */
+  drive_number_t drive{0};       /**< Autochanger logical drive number */
+  drive_number_t drive_index{0}; /**< Autochanger physical drive index */
+  char cap_bits[CAP_BYTES]{0};   /**< Capabilities of this device */
+  utime_t max_changer_wait{300}; /**< Changer timeout */
+  utime_t max_rewind_wait{300};  /**< Maximum secs to wait for rewind */
+  utime_t max_open_wait{300};    /**< Maximum secs to wait for open */
+  uint32_t max_open_vols{1};     /**< Maximum simultaneous open volumes */
+  uint32_t label_block_size{64512};    /**< block size of the label block*/
+  uint32_t min_block_size{0};          /**< Current Minimum block size */
+  uint32_t max_block_size{0};          /**< Current Maximum block size */
+  uint32_t max_network_buffer_size{0}; /**< Max network buf size */
+  uint32_t max_concurrent_jobs{0};   /**< Maximum concurrent jobs this drive */
+  uint32_t autodeflate_algorithm{0}; /**< Compression algorithm to use for
+                                     compression */
+  uint16_t autodeflate_level{6}; /**< Compression level to use for compression
                                  algorithm which uses levels */
-  AutoXflateMode autodeflate; /**< auto deflation in this IO direction */
-  AutoXflateMode autoinflate; /**< auto inflation in this IO direction */
-  utime_t
-      vol_poll_interval;   /**< Interval between polling volume during mount */
-  int64_t max_file_size;   /**< Max file size in bytes */
-  int64_t volume_capacity; /**< Advisory capacity */
-  int64_t max_spool_size;  /**< Max spool size for all jobs */
-  int64_t max_job_spool_size; /**< Max spool size for any single job */
+  AutoXflateMode autodeflate{
+      AutoXflateMode::IO_DIRECTION_NONE}; /**< auto deflation in this IO
+                                             direction */
+  AutoXflateMode autoinflate{
+      AutoXflateMode::IO_DIRECTION_NONE}; /**< auto inflation in this IO
+                                             direction */
+  utime_t vol_poll_interval{
+      300}; /**< Interval between polling volume during mount */
+  int64_t max_file_size{1000000000}; /**< Max file size in bytes */
+  int64_t volume_capacity{0};        /**< Advisory capacity */
+  int64_t max_spool_size{0};         /**< Max spool size for all jobs */
+  int64_t max_job_spool_size{0};     /**< Max spool size for any single job */
 
   char* mount_point;     /**< Mount point for require mount devices */
   char* mount_command;   /**< Mount command */
   char* unmount_command; /**< Unmount command */
-  uint32_t count;        /**< Total number of multiplied devices */
+  uint32_t count{1};     /**< Total number of multiplied devices */
   DeviceResource* multiplied_device_resource; /**< Copied from this device */
 
   Device* dev; /* Pointer to physical dev -- set at runtime */
   AutochangerResource* changer_res; /* Pointer to changer res if any */
 
-  DeviceResource();
+  DeviceResource() = default;
   virtual ~DeviceResource() = default;
   DeviceResource(const DeviceResource& other);
   DeviceResource& operator=(const DeviceResource& rhs);

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -187,7 +187,7 @@ static ResourceItem dev_items[] = {
   {"LabelBlockSize", CFG_TYPE_PINT32, ITEM(res_dev, label_block_size), 0, CFG_ITEM_DEFAULT,
       "64512" /* DEFAULT_BLOCK_SIZE */, NULL, NULL},
   {"MinimumBlockSize", CFG_TYPE_PINT32, ITEM(res_dev, min_block_size), 0, 0, NULL, NULL, NULL},
-  {"MaximumBlockSize", CFG_TYPE_MAXBLOCKSIZE, ITEM(res_dev, max_block_size), 0, 0, NULL, NULL, NULL},
+  {"MaximumBlockSize", CFG_TYPE_MAXBLOCKSIZE, ITEM(res_dev, max_block_size), 0, CFG_ITEM_DEFAULT, "1048576", NULL, NULL},
   {"MaximumFileSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_file_size), 0, CFG_ITEM_DEFAULT, "1000000000", NULL, NULL},
   {"VolumeCapacity", CFG_TYPE_SIZE64, ITEM(res_dev, volume_capacity), 0, 0, NULL, NULL, NULL},
   {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dev, max_concurrent_jobs), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL},

--- a/core/src/tools/CMakeLists.txt
+++ b/core/src/tools/CMakeLists.txt
@@ -56,6 +56,10 @@ if(NOT HAVE_WIN32)
   target_link_libraries(bpluginfo bareos ${DL_LIBRARIES} CLI11::CLI11)
 endif()
 
+add_executable(gentestdata)
+target_sources(gentestdata PRIVATE gentestdata.cc)
+target_link_libraries(gentestdata PRIVATE CLI11::CLI11)
+
 set(TOOLS_BIN bsmtp bwild bregex)
 
 set(TOOLS_SBIN bscrypto bwild bregex)

--- a/core/src/tools/gentestdata.cc
+++ b/core/src/tools/gentestdata.cc
@@ -1,0 +1,56 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#include "CLI/App.hpp"
+#include "CLI/Formatter.hpp"
+#include "CLI/Config.hpp"
+#include <random>
+#include <cstring>
+
+static void print_random(long);
+
+int main(int argc, char** argv)
+{
+  CLI::App app{"Generate a stream of pseudo-random testdata"};
+
+  long bytes{1024};
+  app.add_option("-s,--size", bytes, "Number of bytes to create");
+
+  CLI11_PARSE(app, argc, argv);
+
+  print_random(bytes);
+  return 0;
+}
+
+
+void print_random(long bytes)
+{
+  std::mt19937_64 generator{};
+  using val_type = decltype(generator());
+
+  char buf[sizeof(val_type)];
+  for (auto remaining = bytes; remaining > 0; remaining -= sizeof(val_type)) {
+    auto value = generator();
+    memcpy(buf, &value, sizeof(val_type));
+    for (auto i = 0u; i < sizeof(val_type) && remaining - i > 0; i++) {
+      std::putchar(buf[i]);
+    }
+  }
+}

--- a/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
+++ b/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
@@ -505,6 +505,12 @@ Tapespeed and blocksizes
 :index:`\ <single: Tape; speed>`
 :index:`\ <single: Blocksize; optimize>`
 
+.. note::
+  As of Bareos 23, the default block size has been increased to 1 MiB (1.048.576 bytes).
+  This should provide optimal tape performance in the default configuration and remedy the need to tune block sizes.
+  The original chapter has been preserved in its original state for reference.
+
+
 The `Bareos Whitepaper Tape Speed Tuning <https://www.bareos.com/whitepapers/optimizing-the-tape-speed.pdf>`_ shows that the two parameters :strong:`Maximum File Size`\  and :strong:`Maximum Block Size`\  of the device have significant influence on the tape speed.
 
 While it is no problem to change the :config:option:`sd/device/MaximumFileSize`\  parameter, unfortunately it is not possible to change the :config:option:`sd/device/MaximumBlockSize`\  parameter, because the previously written tapes would become unreadable in the new setup. It would require that the :config:option:`sd/device/MaximumBlockSize`\  parameter is switched back to the old value to be able to read the old volumes, but of

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -711,6 +711,7 @@
         "MaximumBlockSize": {
           "datatype": "MAX_BLOCKSIZE",
           "code": 0,
+          "default_value": "1048576",
           "equals": true
         },
         "MaximumFileSize": {

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-pool-MaximumBlockSize.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-pool-MaximumBlockSize.rst.inc
@@ -1,4 +1,5 @@
-The :strong:`Maximum Block Size`\  can be defined here to define different block sizes per volume or statically for all volumes at :config:option:`sd/device/MaximumBlockSize`\ . If not defined, its default is 63 KB. Increasing this value could improve the throughput of writing to tapes.
+The :strong:`Maximum Block Size`\  can be defined here to define different block sizes per volume or statically for all volumes at :config:option:`sd/device/MaximumBlockSize`\ .
+Increasing this value may improve the throughput of writing to tapes.
 
 
 

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumBlockSize.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumBlockSize.rst.inc
@@ -3,7 +3,7 @@ As a consequence, this statement specifies both the default block size and the m
 The size written never exceeds the given size.
 If adding data to a block would cause it to exceed the given maximum size, the block will be written to the archive device, and the new data will begin a new block.
 
-If no value is specified or zero is specified, the Storage daemon will use a default block size of 64,512 bytes (126 \* 512).
+In Bareos :sinceVersion:`23.0.0: increase default block size` the default value is 1 MiB (1.048.576 bytes). Volumes written with older versions (and the smaller default block size) are still readable and will be rewritten with the larger block size.
 
 Please read chapter :ref:`Tapespeed and blocksizes`, to see how to tune this value in a safe manner.
 

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MinimumBlockSize.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MinimumBlockSize.rst.inc
@@ -1,6 +1,8 @@
 This statement applies only to non-random access devices (e.g. tape drives). Blocks written by the storage daemon to a non-random archive device will never be smaller than the given size. The Storage daemon will attempt to efficiently fill blocks with data received from active sessions but will, if necessary, add padding to a block to achieve the required minimum size.
 
-To force the block size to be fixed, as is the case for some non-random access devices (tape drives), set the Minimum block size and the Maximum block size to the same value. The default is that both the minimum and maximum block size are zero and the default block size is 64,512 bytes.
+To force the block size to be fixed, as is the case for some non-random access devices (tape drives), set the Minimum block size and the Maximum block size to the same value. This is usually not required.
+The default is that the minimum block size is zero and maximum block size is 1 MiB (1.048.576 bytes).
+This results in a default block size of 1 MiB (1.048.576 bytes).
 
 For example, suppose you want a fixed block size of 100K bytes, then you would specify:
 

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/pool/quickrecycle.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/pool/quickrecycle.conf
@@ -4,7 +4,7 @@ Pool {
   Recycle = yes                       # Bareos can automatically recycle Volumes
   AutoPrune = yes                     # Prune expired volumes
   Volume Retention = 2 seconds         # How long should the Full Backups be kept? (#06)
-  Maximum Volume Bytes = 70K          # Limit Volume size to something reasonable
+  Maximum Volume Bytes = 2M           # Limit Volume size to something reasonable
   Maximum Volumes = 100               # Limit number of Volumes in Pool
   Label Format = "recyclable-"              # Volumes will be labeled "Full-<volume-id>"
 }

--- a/systemtests/tests/bareos-basic/test-setup
+++ b/systemtests/tests/bareos-basic/test-setup
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -33,6 +33,11 @@ set -u
 
 # Fill ${BackupDirectory} with data.
 setup_data
+
+gentestdata="${CMAKE_BINARY_DIR}/core/src/tools/gentestdata"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  "$gentestdata" --size=1048576 >"$tmp/data/testfile$i.bin"
+done
 
 bin/bareos start
 bin/bareos status

--- a/systemtests/tests/block-size/create_autochanger_configs.sh.in
+++ b/systemtests/tests/block-size/create_autochanger_configs.sh.in
@@ -94,7 +94,6 @@ Device {
     AutomaticMount = yes
     MaximumFileSize = 10GB
     AlwaysOpen = Yes
-    MaximumBlockSize = 1M    # must be larger than real block size, otherwise bls crashes.
 }
 
 EOF

--- a/systemtests/tests/block-size/etc/bareos/bareos-sd.d/device/File1.conf
+++ b/systemtests/tests/block-size/etc/bareos/bareos-sd.d/device/File1.conf
@@ -7,5 +7,6 @@ Device {
   AutomaticMount = yes;               # when device opened, read it
   RemovableMedia = no;
   AlwaysOpen = no;
+  Maximum Block Size = 64512
   Description = "File device. A connecting Director must have the same Name and MediaType."
 }

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/bigfileset.conf.in
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/bigfileset.conf.in
@@ -14,6 +14,6 @@ FileSet {
       fstype = zfs
       fstype = btrfs
     }
-    File = "@PROJECT_SOURCE_DIR@/tests/"
+    File=<@tmpdir@/bigdata-list
   }
 }

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/job/slow-backup-bareos-fd.conf
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/job/slow-backup-bareos-fd.conf
@@ -8,5 +8,5 @@ Job {
   Messages = Standard
   Pool = SmallFull
   Full Backup Pool = SmallFull
-  Maximum Bandwidth = 30K
+  Maximum Bandwidth = 300K
 }

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/pool/FullSmallvolumes.conf
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/pool/FullSmallvolumes.conf
@@ -4,7 +4,7 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 365 days
-  Maximum Volume Bytes = 150k
+  Maximum Volume Bytes = 3M
   Maximum Volumes = 100
   Label Format = "SmallFull-"
 }

--- a/systemtests/tests/checkpoints/test-setup
+++ b/systemtests/tests/checkpoints/test-setup
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -33,6 +33,13 @@ set -u
 
 # Fill ${BackupDirectory} with data.
 setup_data
+
+gentestdata="${CMAKE_BINARY_DIR}/core/src/tools/gentestdata"
+mkdir -p "$tmp/bigdata"
+echo "$tmp/bigdata" >"$tmp/bigdata-list"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  "$gentestdata" --size=1048576 >"$tmp/bigdata/testfile$i.bin"
+done
 
 bin/bareos start
 bin/bareos status

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
@@ -99,9 +99,9 @@ expect_grep "Files Restored:         ${NumberOfBackedUpFiles}" \
             "Restore of canceled job did not go well!"
 
 # Certain systems do not support multiple types for find (-type f,l)
-NumberOfFilesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type f | wc -l)
-NumberOfLinksRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type l | wc -l)
-NumberOfDirectoriesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type d | wc -l)
+NumberOfFilesRestored=$(find "$restore_directory/$tmp/bigdata" -type f | wc -l)
+NumberOfLinksRestored=$(find "$restore_directory/$tmp/bigdata" -type l | wc -l)
+NumberOfDirectoriesRestored=$(find "$restore_directory/$tmp/bigdata" -type d | wc -l)
 RestoredItems=$((NumberOfFilesRestored + NumberOfLinksRestored + NumberOfDirectoriesRestored))
 
 # Check that the restored files are actually there

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-stop
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-stop
@@ -99,9 +99,9 @@ expect_grep "Termination:            Restore OK" \
             "Restore job did not go well!"
 
 # Certain systems do not support multiple types for find (-type f,l)
-NumberOfFilesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type f | wc -l)
-NumberOfLinksRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type l | wc -l)
-NumberOfDirectoriesRestored=$(find "$restore_directory"/"$PROJECT_SOURCE_DIR"/tests -type d | wc -l)
+NumberOfFilesRestored=$(find "$restore_directory/$tmp/bigdata" -type f | wc -l)
+NumberOfLinksRestored=$(find "$restore_directory/$tmp/bigdata" -type l | wc -l)
+NumberOfDirectoriesRestored=$(find "$restore_directory/$tmp/bigdata" -type d | wc -l)
 RestoredItems=$((NumberOfFilesRestored + NumberOfLinksRestored + NumberOfDirectoriesRestored))
 
 # Check that the restored files are actually there

--- a/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/SmallFull.conf
+++ b/systemtests/tests/pruning/etc/bareos/bareos-dir.d/pool/SmallFull.conf
@@ -4,7 +4,7 @@ Pool {
   Recycle = yes
   AutoPrune = yes
   Volume Retention = 1 day
-  Maximum Volume Bytes = 69K
+  Maximum Volume Bytes = 2M
   Maximum Volumes = 100
   Label Format = "SmallFull-"
 }

--- a/systemtests/tests/pruning/testrunner
+++ b/systemtests/tests/pruning/testrunner
@@ -25,6 +25,10 @@ smallvoljob_name=smallvoljob
 
 # Fill ${BackupDirectory} with data.
 setup_data
+gentestdata="${CMAKE_BINARY_DIR}/core/src/tools/gentestdata"
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  "$gentestdata" --size=1048576 >"$tmp/data/testfile$i.bin"
+done
 
 start_test
 


### PR DESCRIPTION
Historically Bareos uses a default block size of 63k (64.512 bytes). This usually works fine, until you use a modern tape drive. We already have a whilepaper on how to achieve good performance with tape drives, but you need to reconfigure the block sizes and there are a lot of ways you can break Bareos that way.
With the default block size set to 1M (1.048.576 bytes), there is no need to configure a custom block size for tapes anymore, as this new default now provides optimum performance for recent tape drives out of the box.
The default has been chosen carefully to provide optimum performance while retaining maximum interoperability. As there are still hostadapters (e.g. smartpqi) that cannot handle I/O larger than 1M and tape performance does not show significant increase when using a blocksize larger than 1M, this seems to be the reasonable choice.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
