### PR TITLE
dird: allow to disable TLS-PSK downgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: cats: adapt `purge` command to delete jobs with specific jobstatus and/or from specific pool [PR #1349]
 - filed: stored: remove deprecated `compatible` option from configuration  [PR #1341]
 - webui: remove some development leftovers and artefacts [PR #1422]
+- dird: allow to disable TLS-PSK downgrades [PR #1398]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -99,6 +100,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1390]: https://github.com/bareos/bareos/pull/1390
 [PR #1392]: https://github.com/bareos/bareos/pull/1392
 [PR #1395]: https://github.com/bareos/bareos/pull/1395
+[PR #1398]: https://github.com/bareos/bareos/pull/1398
 [PR #1401]: https://github.com/bareos/bareos/pull/1401
 [PR #1403]: https://github.com/bareos/bareos/pull/1403
 [PR #1407]: https://github.com/bareos/bareos/pull/1407

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -213,7 +213,7 @@ static ResourceItem user_items[] = {
   {nullptr, 0, 0, nullptr, 0, 0, nullptr, nullptr, nullptr}
 };
 
-static ResourceItem cli_items[] = {
+static ResourceItem client_items[] = {
   { "Name", CFG_TYPE_NAME, ITEM(res_client, resource_name_), 0, CFG_ITEM_REQUIRED, NULL, NULL,
      "The name of the resource." },
   { "Description", CFG_TYPE_STR, ITEM(res_client, description_), 0, 0, NULL, NULL, NULL },
@@ -510,7 +510,7 @@ static ResourceItem counter_items[] = {
 static ResourceTable resources[] = {
   { "Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       [] (){ res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir) },
-  { "Client", "Clients", cli_items, R_CLIENT, sizeof(ClientResource),
+  { "Client", "Clients", client_items, R_CLIENT, sizeof(ClientResource),
       [] (){ res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)  },
   { "JobDefs", "JobDefs", job_items, R_JOBDEFS, sizeof(JobResource),
       [] (){ res_job = new JobResource(); }, reinterpret_cast<BareosResource**>(&res_job) },

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -210,25 +210,40 @@ static void SendInfoSuccess(JobControlRecord* jcr, UaContext* ua)
   }
 }
 
-bool ConnectToFileDaemon(JobControlRecord* jcr,
-                         int retry_interval,
-                         int max_retry_time,
-                         bool verbose,
-                         UaContext* ua)
+void UpdateFailedConnectionHandshakeMode(JobControlRecord* jcr)
 {
-  if (!IsConnectingToClientAllowed(jcr) && !IsConnectFromClientAllowed(jcr)) {
-    Emsg1(M_WARNING, 0, _("Connecting to %s is not allowed.\n"),
-          jcr->dir_impl->res.client->resource_name_);
-    return false;
+  switch (jcr->dir_impl->connection_handshake_try_) {
+    case ClientConnectionHandshakeMode::kTlsFirst:
+      if (jcr->file_bsock) {
+        jcr->file_bsock->close();
+        delete jcr->file_bsock;
+        jcr->file_bsock = nullptr;
+      }
+      jcr->setJobStatus(JS_Running);
+      if (!IsClientTlsRequired(jcr)) {
+        jcr->dir_impl->connection_handshake_try_
+            = ClientConnectionHandshakeMode::kCleartextFirst;
+      } else {
+        jcr->dir_impl->connection_handshake_try_
+            = ClientConnectionHandshakeMode::kFailed;
+      }
+      break;
+    case ClientConnectionHandshakeMode::kCleartextFirst:
+      jcr->dir_impl->connection_handshake_try_
+          = ClientConnectionHandshakeMode::kFailed;
+      break;
+    case ClientConnectionHandshakeMode::kFailed:
+    default: /* should be one of class ClientConnectionHandshakeMode */
+      ASSERT(false);
+      break;
   }
-  bool success = false;
-  bool tcp_connect_failed = false;
-  int connect_tries
-      = 3; /* as a finish-hook for the UseWaitingClient mechanism */
+}
 
-  /* try the connection modes starting with tls directly,
-   * in case there is a client that cannot do Tls immediately then
-   * fall back to cleartext md5-handshake */
+/* try the connection modes starting with tls directly,
+ * in case there is a client that cannot do Tls immediately then
+ * fall back to cleartext md5-handshake */
+void SetConnectionHandshakeMode(JobControlRecord* jcr, UaContext* ua)
+{
   OutputMessageForConnectionTry(jcr, ua);
   if (jcr->dir_impl->res.client->connection_successful_handshake_
           == ClientConnectionHandshakeMode::kUndefined
@@ -248,6 +263,25 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
         = jcr->dir_impl->res.client->connection_successful_handshake_;
     jcr->is_passive_client_connection_probing = false;
   }
+}
+
+bool ConnectToFileDaemon(JobControlRecord* jcr,
+                         int retry_interval,
+                         int max_retry_time,
+                         bool verbose,
+                         UaContext* ua)
+{
+  if (!IsConnectingToClientAllowed(jcr) && !IsConnectFromClientAllowed(jcr)) {
+    Emsg1(M_WARNING, 0, _("Connecting to %s is not allowed.\n"),
+          jcr->dir_impl->res.client->resource_name_);
+    return false;
+  }
+  bool success = false;
+  bool tcp_connect_failed = false;
+  int connect_tries
+      = 3; /* as a finish-hook for the UseWaitingClient mechanism */
+
+  SetConnectionHandshakeMode(jcr, ua);
 
   do { /* while (tcp_connect_failed ...) */
     /* connect the tcp socket */
@@ -278,31 +312,7 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
          * - tls mismatch or
          * - if an old client cannot do tls- before md5-handshake
          * */
-        switch (jcr->dir_impl->connection_handshake_try_) {
-          case ClientConnectionHandshakeMode::kTlsFirst:
-            if (jcr->file_bsock) {
-              jcr->file_bsock->close();
-              delete jcr->file_bsock;
-              jcr->file_bsock = nullptr;
-            }
-            jcr->setJobStatus(JS_Running);
-            if (!IsClientTlsRequired(jcr)) {
-              jcr->dir_impl->connection_handshake_try_
-                  = ClientConnectionHandshakeMode::kCleartextFirst;
-            } else {
-              jcr->dir_impl->connection_handshake_try_
-                  = ClientConnectionHandshakeMode::kFailed;
-            }
-            break;
-          case ClientConnectionHandshakeMode::kCleartextFirst:
-            jcr->dir_impl->connection_handshake_try_
-                = ClientConnectionHandshakeMode::kFailed;
-            break;
-          case ClientConnectionHandshakeMode::kFailed:
-          default: /* should be one of class ClientConnectionHandshakeMode */
-            ASSERT(false);
-            break;
-        }
+        UpdateFailedConnectionHandshakeMode(jcr);
       }
     } else {
       Jmsg(jcr, M_FATAL, 0, "\nFailed to connect to client \"%s\".\n",

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -286,15 +286,20 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
               jcr->file_bsock = nullptr;
             }
             jcr->setJobStatus(JS_Running);
-            jcr->dir_impl->connection_handshake_try_
-                = ClientConnectionHandshakeMode::kCleartextFirst;
+            if (!IsClientTlsRequired(jcr)) {
+              jcr->dir_impl->connection_handshake_try_
+                  = ClientConnectionHandshakeMode::kCleartextFirst;
+            } else {
+              jcr->dir_impl->connection_handshake_try_
+                  = ClientConnectionHandshakeMode::kFailed;
+            }
             break;
           case ClientConnectionHandshakeMode::kCleartextFirst:
             jcr->dir_impl->connection_handshake_try_
                 = ClientConnectionHandshakeMode::kFailed;
             break;
           case ClientConnectionHandshakeMode::kFailed:
-          default: /* should bei one of class ClientConnectionHandshakeMode */
+          default: /* should be one of class ClientConnectionHandshakeMode */
             ASSERT(false);
             break;
         }

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -33,7 +33,7 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
                          bool verbose,
                          UaContext* ua = nullptr);
 void UpdateFailedConnectionHandshakeMode(JobControlRecord* jcr);
-void SetConnectionHandshakeMode(JobControlRecord* jcr, UaContext *ua);
+void SetConnectionHandshakeMode(JobControlRecord* jcr, UaContext* ua);
 int SendJobInfoToFileDaemon(JobControlRecord* jcr);
 bool SendIncludeExcludeLists(JobControlRecord* jcr);
 bool SendLevelCommand(JobControlRecord* jcr);

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -60,6 +60,7 @@ void* HandleFiledConnection(ConnectionPool* connections,
 ConnectionPool* get_client_connections();
 bool IsConnectingToClientAllowed(ClientResource* res);
 bool IsConnectingToClientAllowed(JobControlRecord* jcr);
+bool IsClientTlsRequired(JobControlRecord* jcr);
 bool IsConnectFromClientAllowed(ClientResource* res);
 bool IsConnectFromClientAllowed(JobControlRecord* jcr);
 bool UseWaitingClient(JobControlRecord* jcr_job, int timeout);

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -32,6 +32,8 @@ bool ConnectToFileDaemon(JobControlRecord* jcr,
                          int max_retry_time,
                          bool verbose,
                          UaContext* ua = nullptr);
+void UpdateFailedConnectionHandshakeMode(JobControlRecord* jcr);
+void SetConnectionHandshakeMode(JobControlRecord* jcr, UaContext *ua);
 int SendJobInfoToFileDaemon(JobControlRecord* jcr);
 bool SendIncludeExcludeLists(JobControlRecord* jcr);
 bool SendLevelCommand(JobControlRecord* jcr);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -381,6 +381,11 @@ bool IsConnectFromClientAllowed(ClientResource* res)
   return res->conn_from_fd_to_dir;
 }
 
+bool IsClientTlsRequired(JobControlRecord* jcr)
+{
+  return jcr->dir_impl->res.client->GetPolicy() == TlsPolicy::kBnetTlsRequired;
+}
+
 bool IsConnectFromClientAllowed(JobControlRecord* jcr)
 {
   return IsConnectFromClientAllowed(jcr->dir_impl->res.client);

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -115,7 +115,7 @@ static ResourceItem dir_items[] = {
  *
  * name handler value code flags default_value
  */
-static ResourceItem cli_items[] = {
+static ResourceItem client_items[] = {
   {"Name", CFG_TYPE_NAME, ITEM(res_client,resource_name_), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL},
   {"Description", CFG_TYPE_STR, ITEM(res_client,description_), 0, 0, NULL, NULL, NULL},
   {"Address", CFG_TYPE_STR, ITEM(res_client,address), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL},
@@ -170,7 +170,7 @@ static ResourceTable resource_definitions[] = {
       []() { res_monitor = new MonitorResource(); }, reinterpret_cast<BareosResource**>(&res_monitor)},
   {"Director", "Directors", dir_items, R_DIRECTOR, sizeof(DirectorResource),
       []() { res_dir = new DirectorResource(); }, reinterpret_cast<BareosResource**>(&res_dir)},
-  {"Client", "Clients", cli_items, R_CLIENT, sizeof(ClientResource),
+  {"Client", "Clients", client_items, R_CLIENT, sizeof(ClientResource),
       []() { res_client = new ClientResource(); }, reinterpret_cast<BareosResource**>(&res_client)},
   {"Storage", "Storages", store_items, R_STORAGE, sizeof(StorageResource),
       []() { res_store = new StorageResource(); }, reinterpret_cast<BareosResource**>(&res_store)},

--- a/core/src/tests/configs/dir_fd_connection/dir_fd_allow_tls_downgrade/bareos-dir.d/client/fd-no-downgrade.conf
+++ b/core/src/tests/configs/dir_fd_connection/dir_fd_allow_tls_downgrade/bareos-dir.d/client/fd-no-downgrade.conf
@@ -1,0 +1,6 @@
+Client {
+  Name = fd-allow-downgrade
+  Address = localhost
+  Password = ""
+  tls require = no
+}

--- a/core/src/tests/configs/dir_fd_connection/dir_fd_allow_tls_downgrade/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dir_fd_connection/dir_fd_allow_tls_downgrade/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Password = "dir_password"
+}

--- a/core/src/tests/configs/dir_fd_connection/dir_fd_no_tls_downgrade/bareos-dir.d/client/fd-no-downgrade.conf
+++ b/core/src/tests/configs/dir_fd_connection/dir_fd_no_tls_downgrade/bareos-dir.d/client/fd-no-downgrade.conf
@@ -1,0 +1,6 @@
+Client {
+  Name = fd-no-downgrade
+  Address = localhost
+  Password = ""
+  tls require = yes
+}

--- a/core/src/tests/configs/dir_fd_connection/dir_fd_no_tls_downgrade/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dir_fd_connection/dir_fd_no_tls_downgrade/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,4 @@
+Director {
+  Name = bareos-dir
+  Password = "dir_password"
+}

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -62,9 +62,9 @@ TEST(DirectorToClientConnection, DoesNotDowngradeToClearTextWhenTlsRequired)
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
                                                 "fd-no-downgrade"));
-  jcr->file_bsock = new BareosSocketTCP;
 
-  EXPECT_FALSE(directordaemon::ConnectToFileDaemon(jcr, 0, 0, false, nullptr));
+  directordaemon::SetConnectionHandshakeMode(jcr, nullptr);
+  directordaemon::UpdateFailedConnectionHandshakeMode(jcr);
   EXPECT_TRUE(jcr->dir_impl->connection_handshake_try_
               == directordaemon::ClientConnectionHandshakeMode::kFailed);
   FreeJcr(jcr);
@@ -86,9 +86,9 @@ TEST(DirectorToClientConnection, DowngradesToClearTextWhenTlsNotRequired)
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
                                                 "fd-allow-downgrade"));
-  jcr->file_bsock = new BareosSocketTCP;
 
-  EXPECT_FALSE(directordaemon::ConnectToFileDaemon(jcr, 0, 0, false, nullptr));
+  directordaemon::SetConnectionHandshakeMode(jcr, nullptr);
+  directordaemon::UpdateFailedConnectionHandshakeMode(jcr);
   EXPECT_TRUE(
       jcr->dir_impl->connection_handshake_try_
       == directordaemon::ClientConnectionHandshakeMode::kCleartextFirst);

--- a/systemtests/tests/testfind/testrunner
+++ b/systemtests/tests/testfind/testrunner
@@ -46,4 +46,6 @@ if [ ! -r "$unopenable_dir" ]; then
                 "Error on faulty directory not detected."
 fi
 
+rmdir "${unopenable_dir}"
+
 end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

This PR disables TLS-PSK downgrades and allows to manually enable them in the configuration.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
