### PR TITLE
doc: improve plugin, webui, virtualfull chapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - add explanation about binary version numbers [PR #1354]
 - docs: improve bareos-webui documentation [PR #1366]
 - docs: catalog maintenance improvements [PR #1379]
+- doc: improve plugin, webui, virtualfull chapters [PR #1401]
 
 [PR #935]: https://github.com/bareos/bareos/pull/935
 [PR #1011]: https://github.com/bareos/bareos/pull/1011
@@ -90,6 +91,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1389]: https://github.com/bareos/bareos/pull/1389
 [PR #1390]: https://github.com/bareos/bareos/pull/1390
 [PR #1395]: https://github.com/bareos/bareos/pull/1395
+[PR #1401]: https://github.com/bareos/bareos/pull/1401
 [PR #1403]: https://github.com/bareos/bareos/pull/1403
 [PR #1407]: https://github.com/bareos/bareos/pull/1407
 [PR #1410]: https://github.com/bareos/bareos/pull/1410

--- a/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
+++ b/docs/manuals/source/Appendix/Howtos/BackupOfThirdPartyDatabases.rst.inc
@@ -880,7 +880,7 @@ Following settings must be done on the Bareos client (|fd|):
    Client {
      ...
      Plugin Directory = /usr/lib64/bareos/plugins
-     Plugin Names = "python"
+     Plugin Names = "python3"
    }
 
 Configure the plugin in the |dir|:

--- a/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
@@ -106,6 +106,18 @@ After adding the repository simply install the bareos-webui package via your pac
 
       apt-get install bareos-webui
 
+Because php-fpm support is not automatically added to Apache2 on Debian like platforms, you have to issue those commands to enable it.
+Replace :command:`php8.1-fpm` by the version you have installed.
+
+.. code-block:: shell-session
+   :caption: Debian, Ubuntu enabling php8-fpm support on Apache2 example
+
+   a2enmod proxy_fcgi setenvif
+   a2enconf php8.1-fpm
+   systemctl reload apache2
+
+
+
 Minimal Configuration
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -163,6 +175,7 @@ Debian, Ubuntu, Univention
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Please use `apt` instead of `apt-get` to upgrade automatically.
+
 
 SUSE Linux Enterprise Server (SLES), openSUSE
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
@@ -65,7 +65,7 @@ System Requirements
 
 -  PHP 7 or newer is recommended.
 
--  On SUSE Linux Enterprise 12 you need the additional SUSE Linux Enterprise Module for Web Scripting 12.
+-  On SUSE Linux Enterprise 12 you need the additional SUSE Linux Enterprise Module for Web Scripting 12 and additional repository :strong:`Package Hub` to satisfy apache2-mod-fcgid requirement.
 
 .. _section-install-webui:
 

--- a/docs/manuals/source/TasksAndConcepts/AlwaysIncrementalBackupScheme.rst
+++ b/docs/manuals/source/TasksAndConcepts/AlwaysIncrementalBackupScheme.rst
@@ -407,6 +407,7 @@ Usually, it is desired to be able to store a certain backup for a longer time, e
 
 There are two options to achieve this goal.
 
+
 Copy Jobs
 ~~~~~~~~~
 
@@ -467,3 +468,7 @@ To make sure the longterm :config:option:`dir/job/Level = VirtualFull`\  is not 
 As can be seen on the plot, the :config:option:`dir/job/Level = VirtualFull`\  archives the current data, i.e. it consolidates the full and all incrementals that are currently available.
 
 .. image:: /include/images/always-incremental-virtualfull-job-archiving.*
+
+.. warning::
+
+   With Virtual Full, you are restricted to use the same |sd| for the source and the destination, because the restore bsr file created for the job can only be read by one storage daemon at a time.

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/MariaDBmariabackupPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/MariaDBmariabackupPlugin.rst.inc
@@ -39,7 +39,7 @@ Activate your plugin directory in the |fd| configuration. See :ref:`fdPlugins` f
    Client {
      ...
      Plugin Directory = /usr/lib64/bareos/plugins
-     Plugin Names = "python"
+     Plugin Names = "python3"
    }
 
 Now include the plugin as command-plugin in the Fileset resource:

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PerconaXtraBackupPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PerconaXtraBackupPlugin.rst.inc
@@ -51,7 +51,7 @@ Activate your plugin directory in the |fd| configuration. See :ref:`fdPlugins` f
    Client {
      ...
      Plugin Directory = /usr/lib64/bareos/plugins
-     Plugin Names = "python"
+     Plugin Names = "python3"
    }
 
 Now include the plugin as command-plugin in the Fileset resource:

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -75,7 +75,7 @@ Make sure to add or enable the following settings in your |fd| configuration:
    Client {
      ...
      Plugin Directory = /usr/lib/bareos/plugins
-     Plugin Names = python
+     Plugin Names = python3
      ...
    }
 

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-Level.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-Level.rst.inc
@@ -5,11 +5,15 @@ Backup
    For a Backup Job, the Level may be one of the following:
 
    Full
-      :index:`\ <single: Full>`
+      .. index::
+         single: Full
+
       When the Level is set to Full all files in the FileSet whether or not they have changed will be backed up.
 
    Incremental
-      :index:`\ <single: Incremental>`
+      .. index::
+         single: Incremental
+
       When the Level is set to Incremental all files specified in the FileSet that have changed since the last successful backup of the the same Job using the same FileSet and Client, will be backed up. If the Director cannot find a previous valid Full backup then the job will be upgraded into a Full backup. When the Director looks for a valid backup record in the catalog database, it looks for a previous Job with:
 
       -  The same Job name.
@@ -38,7 +42,9 @@ Backup
       However, to manage deleted files or directories changes in the catalog during an Incremental backup you can use :ref:`Accurate mode <accuratemode>`. This is quite memory consuming process.
 
    Differential
-      :index:`\ <single: Differential>`
+      .. index::`
+         single: Differential
+
       When the Level is set to Differential all files specified in the FileSet that have changed since the last successful Full backup of the same Job will be backed up. If the Director cannot find a valid previous Full backup for the same Job, FileSet, and Client, backup, then the Differential job will be upgraded into a Full backup. When the Director looks for a valid Full backup record in the catalog database, it looks for a previous Job with:
 
       -  The same Job name.
@@ -72,15 +78,17 @@ Backup
    VirtualFull
       .. _VirtualFull:
 
-      :index:`\ <single: VirtualFull Backup>`
+      .. index::
+         single: VirtualFull Backup
+
       When the Level is set to VirtualFull, a new Full backup is generated from the last existing Full backup and the matching Differential- and Incremental-Backups. It matches this according the :config:option:`dir/client/Name`\  and :config:option:`dir/fileset/Name`\ . This means, a new Full backup get created without transfering all the data from the client to the backup
       server again. The new Full backup will be stored in the pool defined in :config:option:`dir/pool/NextPool`\ .
-
 
 
       .. warning::
 
          Opposite to the other backup levels, VirtualFull may require read and write access to multiple volumes. In most cases you have to make sure, that Bareos does not try to read and write to the same Volume.
+         With Virtual Full, you are restricted to use the same |sd| for the source and the destination, because the restore bsr file created for the job can only be read by one storage daemon at a time.
 
 Restore
    For a Restore Job, no level needs to be specified.
@@ -89,13 +97,17 @@ Verify
    For a Verify Job, the Level may be one of the following:
 
    InitCatalog
-      :index:`\ <single: InitCatalog>`
+      .. index::
+         single: InitCatalog
+
       does a scan of the specified FileSet and stores the file attributes in the Catalog database. Since no file data is saved, you might ask why you would want to do this. It turns out to be a very simple and easy way to have a Tripwire like feature using Bareos. In other words, it allows you to save the state of a set of files defined by the FileSet and later check to see if those files have been modified or deleted and if any new files have been added.
       This can be used to detect system intrusion. Typically you would specify a FileSet that contains the set of system files that should not change (e.g. /sbin, /boot, /lib, /bin, ...). Normally, you run the InitCatalog level verify one time when your system is first setup, and then once again after each modification (upgrade) to your system. Thereafter, when your want to check the state of your system files, you use a Verify level = Catalog. This compares the results of your InitCatalog
       with the current state of the files.
 
    Catalog
-      :index:`\ <single: Catalog>`
+      .. index::
+         single: Catalog
+
       Compares the current state of the files against the state previously saved during an InitCatalog. Any discrepancies are reported. The items reported are determined by the verify options specified on the Include directive in the specified FileSet (see the FileSet resource below for more details). Typically this command will be run once a day (or night) to check for any changes to your system files.
 
       .. warning::
@@ -106,7 +118,9 @@ Verify
          track new files.
 
    VolumeToCatalog
-      :index:`\ <single: VolumeToCatalog>`
+      .. index::
+         single: VolumeToCatalog
+
       This level causes Bareos to read the file attribute data written to the Volume from the last backup Job for the job specified on the VerifyJob directive. The file attribute data are compared to the values saved in the Catalog database and any differences are reported. This is similar to the DiskToCatalog level except that instead of comparing the disk file attributes to the catalog database, the attribute data written to the Volume is read and
       compared to the catalog database. Although the attribute data including the signatures (MD5 or SHA1) are compared, the actual file data is not compared (it is not in the catalog).
 
@@ -130,7 +144,9 @@ Verify
 
 
    DiskToCatalog
-      :index:`\ <single: DiskToCatalog>`
+      .. index::
+         single: DiskToCatalog
+
       This level causes Bareos to read the files as they currently are on disk, and to compare the current file attributes with the attributes saved in the catalog from the last backup for the job specified on the VerifyJob directive. This level differs from the VolumeToCatalog level described above by the fact that it doesn’t compare against a previous Verify job but against a previous backup. When you run this level, you must supply the verify options
       on your Include statements. Those options determine what attribute fields are compared.
 

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-VirtualFullBackupPool.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-VirtualFullBackupPool.rst.inc
@@ -1,0 +1,1 @@
+The Virtual Full Backup Pool specifies a Pool to be used for Virtual Full backups. It will override any :config:option:`dir/job/Pool`\  specification during a Virtual Full backup.


### PR DESCRIPTION
This PR is a composite PR for several documentation changes. It is proposed to also backport this to branch-22

This PR propose to change `Plugin Names = "python"` samples to `Plugin Names = "python3"` in documentation: making it clear to everyone that parameter need to be adjusted depending on the python version you use.

This PR contain also the additional how-to enable php-fpm for apache in debian like distributions.

This PR contain the documentation changes about Virtual Full Backup can only be run on the same bareos-sd daemon.

This PR contain the documentation changes for bareos-webui installation under SLE12SP5 adding the PackageHub repository.

OP#5425
OP#5426
OP#5433
OP#5431

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

