### PR TITLE
berrno_test.cc: accept both 271E and 273E

### DIFF
--- a/core/src/tests/berrno_test.cc
+++ b/core/src/tests/berrno_test.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,8 +22,10 @@
 #if defined(HAVE_MINGW)
 #  include "include/bareos.h"
 #  include "gtest/gtest.h"
+#  include "gmock/gmock.h"
 #else
 #  include "gtest/gtest.h"
+#  include "gmock/gmock.h"
 #endif
 
 #include "lib/berrno.h"
@@ -49,7 +51,7 @@ const char* socket_error_message
     = "No such file or directory (errno=2 | win_error=0x0000276D)";
 const char* win_socket_error_message = "Windows error 0x0000276D";
 const char* bind_error_message
-    = "No such file or directory (errno=2 | win_error=0x0000273F)";
+    = "No such file or directory (errno=2 | win_error=0x000027";
 #else
 #  error "error_messages for current OS undefined"
 #endif
@@ -98,6 +100,6 @@ TEST(berrno, errors)
   EXPECT_LT(operation_result, 0);
   if (operation_result < 0) {
     BErrNo be;
-    EXPECT_STREQ(be.bstrerror(), bind_error_message);
+    EXPECT_THAT(be.bstrerror(), testing::StartsWith(bind_error_message));
   }
 }


### PR DESCRIPTION
The error string for bind_error_message can be both "No such file or directory (errno=2 | win_error=0x0000271E)" and
"No such file or directory (errno=2 | win_error=0x0000273F)" depending on the windows cross chain.

We now allow both.

(cherry picked from commit 5394724ef6360c0727dbaa9bd2232158f33b9422)

### Thank you for contributing to the Bareos Project!

**Backport of PR #1407 to bareos-21** (remove this line, if it no backport)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
