### PR TITLE
Sanitizers: add ASAN options to avoid crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: enable default options in `fileset` config when no options are explicitly specified [PR #1357]
 - introduce php-cs-fixer and apply PSR-12 guidelines [PR #1403]
 - berrno_test.cc: accept both 271E and 273E [PR #1407]
+- Sanitizers: add ASAN options to avoid crashes [PR #1410]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -89,4 +90,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1390]: https://github.com/bareos/bareos/pull/1390
 [PR #1403]: https://github.com/bareos/bareos/pull/1403
 [PR #1407]: https://github.com/bareos/bareos/pull/1407
+[PR #1410]: https://github.com/bareos/bareos/pull/1410
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/devtools/build-and-test-with-sanitize.sh
+++ b/devtools/build-and-test-with-sanitize.sh
@@ -1,4 +1,23 @@
 #!/bin/bash
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 set -u
 set -e
 set -x

--- a/devtools/build-and-test-with-sanitize.sh
+++ b/devtools/build-and-test-with-sanitize.sh
@@ -28,6 +28,10 @@ cmake \
   -Dpostgresql=yes
 cmake --build cmake-build
 
+# avoid problems in containers with sanitizers
+# see https://github.com/google/sanitizers/issues/1322
+export ASAN_OPTIONS=intercept_tls_get_addr=0
+
 cd cmake-build
 export REGRESS_DEBUG=1
 ctest \


### PR DESCRIPTION
Set `ASAN_OPTIONS=intercept_tls_get_addr=0` to avoid problems with sanitizers running in containers.
see: https://github.com/google/sanitizers/issues/1322

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR