### PR TITLE
daemons: remove deprecated `Pid Directory` config option, and update `Maximum Concurrent Jobs` default value to 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: keep copy and migration control/administrative jobs [PR #1421]
 - scripts: config-lib improve get_local_hostname fallback [PR #1402]
 - dird: deprecate client `Autoprune`, `JobRetention`, and `FileRetention` [PR #1425]
+- daemons: remove deprecated `Pid Directory` config option, and update `Maximum Concurrent Jobs` default value to 1 [PR #1426]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -136,6 +137,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1422]: https://github.com/bareos/bareos/pull/1422
 [PR #1424]: https://github.com/bareos/bareos/pull/1424
 [PR #1425]: https://github.com/bareos/bareos/pull/1425
+[PR #1426]: https://github.com/bareos/bareos/pull/1426
 [PR #1429]: https://github.com/bareos/bareos/pull/1429
 [PR #1439]: https://github.com/bareos/bareos/pull/1439
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Breaking changes
+- The following deprecated configuration options have been removed, make sure to update your configuration accordingly:
+   * Director daemon
+     * Pid Directory
+     
+   * File daemon
+     * Pid Directory
+     * Compatible
+     
+   * Storage daemon
+     * Pid Directory
+     * Compatible
+
 ### Changed
 - VMware Plugin: introduce pyVmomi 8.x compatibility [PR #1352]
 - devtools: add `pr-tool` to automate PR review and merge [PR #935]

--- a/core/platforms/packaging/bareos-aix.spec
+++ b/core/platforms/packaging/bareos-aix.spec
@@ -33,7 +33,6 @@ Vendor: 	The Bareos Team
 %define plugin_dir     /opt/freeware/lib/plugins
 %define script_dir     /opt/freeware/bareos/scripts
 %define working_dir    /opt/freeware/var/bareos/working
-%define pid_dir        /var/run
 %define bsr_dir        /opt/freeware/var/bareos/working
 # TODO: use /run ?
 %define _subsysdir     /var/lock

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -19,7 +19,6 @@ Vendor:     The Bareos Team
 %define plugin_dir     %{_libdir}/%{name}/plugins
 %define script_dir     /usr/lib/%{name}/scripts
 %define working_dir    /var/lib/%{name}
-%define pid_dir        /var/lib/%{name}
 %define bsr_dir        /var/lib/%{name}
 # TODO: use /run ?
 %define _subsysdir     /var/lock

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -122,7 +122,6 @@ static ResourceItem dir_items[] = {
   { "DirSourceAddress", CFG_TYPE_ADDRESSES_ADDRESS, ITEM(res_dir,  DIRsrc_addr), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
   { "QueryFile", CFG_TYPE_DIR, ITEM(res_dir, query_file), 0, CFG_ITEM_REQUIRED, NULL, NULL, NULL },
   { "WorkingDirectory", CFG_TYPE_DIR, ITEM(res_dir, working_directory), 0, CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_WORKINGDIR, NULL, NULL },
-  { "PidDirectory", CFG_TYPE_DIR, ITEM(res_dir, pid_directory), 0, CFG_ITEM_DEPRECATED, NULL, NULL, NULL },
   { "PluginDirectory", CFG_TYPE_DIR, ITEM(res_dir, plugin_directory), 0, 0, NULL,
      "14.2.0-", "Plugins are loaded from this directory. To load only specific plugins, use 'Plugin Names'." },
   { "PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_dir, plugin_names), 0, 0, NULL,
@@ -3767,7 +3766,6 @@ static void FreeResource(BareosResource* res, int type)
       if (p->scripts_directory) { free(p->scripts_directory); }
       if (p->plugin_directory) { free(p->plugin_directory); }
       if (p->plugin_names) { delete p->plugin_names; }
-      if (p->pid_directory) { free(p->pid_directory); }
       if (p->password_.value) { free(p->password_.value); }
       if (p->query_file) { free(p->query_file); }
       if (p->DIRaddrs) { FreeAddresses(p->DIRaddrs); }

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -116,7 +116,6 @@ class DirectorResource
   char* scripts_directory = nullptr;    /* ScriptsDirectory */
   char* plugin_directory = nullptr;     /* Plugin Directory */
   alist<const char*>* plugin_names = nullptr; /* Plugin names to load */
-  char* pid_directory = nullptr;              /* PidDirectory */
   MessagesResource* messages = nullptr;       /* Daemon message handler */
   uint32_t MaxConcurrentJobs = 0; /* Max concurrent jobs for whole director */
   uint32_t MaxConsoleConnections = 0; /* Max concurrent console connections */

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -88,7 +88,6 @@ static ResourceItem cli_items[] = {
   {"FdSourceAddress", CFG_TYPE_ADDRESSES_ADDRESS, ITEM(res_client, FDsrc_addr), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL},
   {"WorkingDirectory", CFG_TYPE_DIR, ITEM(res_client, working_directory), 0,
       CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_WORKINGDIR, NULL, NULL},
-  {"PidDirectory", CFG_TYPE_DIR, ITEM(res_client, pid_directory), 0, CFG_ITEM_DEPRECATED, NULL, NULL, NULL},
   {"PluginDirectory", CFG_TYPE_DIR, ITEM(res_client, plugin_directory), 0, 0, NULL, NULL, NULL},
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_client, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_client, scripts_directory), 0, 0, NULL, NULL, NULL},
@@ -370,7 +369,6 @@ static void FreeResource(BareosResource* res, int type)
       ClientResource* p = dynamic_cast<ClientResource*>(res);
       assert(p);
       if (p->working_directory) { free(p->working_directory); }
-      if (p->pid_directory) { free(p->pid_directory); }
       if (p->scripts_directory) { free(p->scripts_directory); }
       if (p->plugin_directory) { free(p->plugin_directory); }
       if (p->plugin_names) { delete p->plugin_names; }

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -91,7 +91,6 @@ class ClientResource
   dlist<IPADDR>* FDaddrs = nullptr;
   dlist<IPADDR>* FDsrc_addr = nullptr; /* Address to source connections from */
   char* working_directory = nullptr;
-  char* pid_directory = nullptr;
   char* plugin_directory = nullptr; /* Plugin directory */
   alist<const char*>* plugin_names = nullptr;
   char* scripts_directory = nullptr;

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -288,14 +288,10 @@ static void WarnOnZeroMaxConcurrentJobs(int max_concurrent_jobs,
                                         std::string_view name)
 {
   if (max_concurrent_jobs == 0) {
-    my_config->AddWarning(fmt::format(
-        FMT_STRING("Device {:s}: unlimited (0) 'Maximum Concurrent Jobs' (the "
-                   "default) reduces the restore peformance."),
-        name));
-    my_config->AddWarning(fmt::format(
-        FMT_STRING("Device {:s}: the default value for 'Maximum Concurrent "
-                   "Jobs' will change from 0 (unlimited) to 1 in Bareos 23."),
-        name));
+    my_config->AddWarning(
+        fmt::format(FMT_STRING("Device {:s}: unlimited (0) 'Maximum Concurrent "
+                               "Jobs' reduces the restore peformance."),
+                    name));
   }
 }
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -79,7 +79,6 @@ static ResourceItem store_items[] = {
   {"SdSourceAddress", CFG_TYPE_ADDRESSES_ADDRESS, ITEM(res_store, SDsrc_addr), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL},
   {"WorkingDirectory", CFG_TYPE_DIR, ITEM(res_store, working_directory), 0,
       CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_WORKINGDIR, NULL, NULL},
-  {"PidDirectory", CFG_TYPE_DIR, ITEM(res_store, pid_directory), 0, CFG_ITEM_DEPRECATED, NULL, NULL, NULL},
 #if defined(HAVE_DYNAMIC_SD_BACKENDS)
   {"BackendDirectory", CFG_TYPE_STR_VECTOR_OF_DIRS, ITEM(res_store, backend_directories), 0,
       CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_BACKENDDIR, NULL, NULL},
@@ -920,7 +919,6 @@ static void FreeResource(BareosResource* res, int type)
       if (p->SDsrc_addr) { FreeAddresses(p->SDsrc_addr); }
       if (p->NDMPaddrs) { FreeAddresses(p->NDMPaddrs); }
       if (p->working_directory) { free(p->working_directory); }
-      if (p->pid_directory) { free(p->pid_directory); }
       if (p->plugin_directory) { free(p->plugin_directory); }
       if (p->plugin_names) { delete p->plugin_names; }
       if (p->scripts_directory) { free(p->scripts_directory); }

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -189,7 +189,7 @@ static ResourceItem dev_items[] = {
   {"MaximumBlockSize", CFG_TYPE_MAXBLOCKSIZE, ITEM(res_dev, max_block_size), 0, 0, NULL, NULL, NULL},
   {"MaximumFileSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_file_size), 0, CFG_ITEM_DEFAULT, "1000000000", NULL, NULL},
   {"VolumeCapacity", CFG_TYPE_SIZE64, ITEM(res_dev, volume_capacity), 0, 0, NULL, NULL, NULL},
-  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dev, max_concurrent_jobs), 0, 0, NULL, NULL, NULL},
+  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dev, max_concurrent_jobs), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL},
   {"SpoolDirectory", CFG_TYPE_DIR, ITEM(res_dev, spool_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_spool_size), 0, 0, NULL, NULL, NULL},
   {"MaximumJobSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_job_spool_size), 0, 0, NULL, NULL, NULL},

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -101,8 +101,7 @@ class StorageResource
       = nullptr; /**< Address to source connections from */
   dlist<IPADDR>* NDMPaddrs = nullptr;
   char* working_directory = nullptr; /**< Working directory for checkpoints */
-  char* pid_directory = nullptr;
-  char* plugin_directory = nullptr; /**< Plugin directory */
+  char* plugin_directory = nullptr;  /**< Plugin directory */
   alist<const char*>* plugin_names = nullptr;
   char* scripts_directory = nullptr;
   std::vector<std::string> backend_directories;

--- a/debian/rules
+++ b/debian/rules
@@ -29,7 +29,6 @@ define CONFIGURE_COMMON
   -Dscriptdir=/usr/lib/bareos/scripts \
   -Dplugindir=/usr/lib/bareos/plugins \
   -Dworkingdir=/var/lib/bareos \
-  -Dpiddir=/var/lib/bareos \
   -Dbsrdir=/var/lib/bareos \
   -Dlogdir=/var/log/bareos \
   -Dsubsysdir=/var/lock \

--- a/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/systemtests.rst
+++ b/docs/manuals/source/DeveloperGuide/BuildAndTestBareos/systemtests.rst
@@ -334,7 +334,6 @@ Directory Structure (Build)
       |           |-- monitor
       |           `-- storage
       |-- log
-      |-- piddir
       |-- python-modules
       |-- sbin
       |-- storage

--- a/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
@@ -314,11 +314,11 @@ To do so you can use the `-t` flag:
 .. code-block:: shell-session
    :caption: Shell example to check the Bareos configuration
 
-   root@host:~# su - bareos -s /bin/sh -c "bareos-dir -t"
-   root@host:~# su - bareos -s /bin/sh -c "bareos-sd -t"
    root@host:~# bareos-fd -t
+   root@host:~# su - bareos -s /bin/sh -c "bareos-sd -t"
+   root@host:~# su - bareos -s /bin/sh -c "bareos-dir -t"
    There are configuration warnings:
-      * using deprecated keyword PidDirectory on line 19 of file /etc/bareos/bareos-fd.d/client/myself.conf
+    * using deprecated keyword CollectStatistics on line 8 of file /etc/bareos/bareos-dir.d/storage/File.conf
 
 The same warnings are also shown on a regular start of the daemons.
 

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -58,12 +58,6 @@
           "platform_specific": true,
           "equals": true
         },
-        "PidDirectory": {
-          "datatype": "DIRECTORY",
-          "code": 0,
-          "deprecated": true,
-          "equals": true
-        },
         "PluginDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -202,12 +202,6 @@
           "platform_specific": true,
           "equals": true
         },
-        "PidDirectory": {
-          "datatype": "DIRECTORY",
-          "code": 0,
-          "deprecated": true,
-          "equals": true
-        },
         "PluginDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,
@@ -473,12 +467,6 @@
           "code": 0,
           "default_value": "/var/lib/bareos",
           "platform_specific": true,
-          "equals": true
-        },
-        "PidDirectory": {
-          "datatype": "DIRECTORY",
-          "code": 0,
-          "deprecated": true,
           "equals": true
         },
         "PluginDirectory": {

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -727,6 +727,7 @@
         "MaximumConcurrentJobs": {
           "datatype": "PINT32",
           "code": 0,
+          "default_value": "1",
           "equals": true
         },
         "SpoolDirectory": {

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -202,12 +202,6 @@
           "platform_specific": true,
           "equals": true
         },
-        "PidDirectory": {
-          "datatype": "DIRECTORY",
-          "code": 0,
-          "deprecated": true,
-          "equals": true
-        },
         "BackendDirectory": {
           "datatype": "DIRECTORY_LIST",
           "code": 0,

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-director-PidDirectory.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-director-PidDirectory.rst.inc
@@ -1,1 +1,0 @@
-Since :sinceVersion:`21.0.0: Pid file handling` this directive has no effect anymore. The way to set up a pid file is to do it as an option to the Director binary with the ``-p <file>`` option, where <file> is the path to a pidfile of your choosing. By default, no pidfile is created.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-PidDirectory.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-PidDirectory.rst.inc
@@ -1,1 +1,0 @@
-Since :sinceVersion:`21.0.0: Pid file handling` this directive has no effect anymore. The way to set up a pid file is to do it as an option to the Client binary with the ``-p <file>`` option, where <file> is the path to a pidfile of your choosing. By default, no pidfile is created.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-storage-PidDirectory.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-storage-PidDirectory.rst.inc
@@ -1,1 +1,0 @@
-Since :sinceVersion:`21.0.0: Pid file handling` this directive has no effect anymore. The way to set up a pid file is to do it as an option to the Storage binary with the ``-p <file>`` option, where <file> is the path to a pidfile of your choosing. By default, no pidfile is created.

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -332,7 +332,6 @@ macro(prepare_testdir_for_daemon_run)
   set(tmpdir ${current_test_directory}/tmp)
   set(tmp ${tmpdir})
   set(working_dir ${current_test_directory}/working)
-  set(piddir ${current_test_directory}/piddir)
 
   set(sd_backenddir ${SD_BACKEND_DIR_TO_TEST})
   # the SD will not suppot the BackendDirectory setting if it was not built with
@@ -370,7 +369,6 @@ macro(prepare_testdir_for_daemon_run)
     )
   endif()
 
-  file(MAKE_DIRECTORY ${piddir})
   file(MAKE_DIRECTORY ${tmpdir})
   file(MAKE_DIRECTORY ${archivedir})
   file(MAKE_DIRECTORY ${logdir})

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -69,9 +69,6 @@ export BAREOS_BEXTRACT_BINARY=@BEXTRACT_BINARY@
 export BAREOS_DBCHECK_BINARY=@BAREOS_DBCHECK_BINARY@
 export BAREOS_BCOPY_BINARY=@BCOPY_BINARY@
 
-
-export PIDDIR=@piddir@
-
 export archivedir
 
 export scripts

--- a/systemtests/scripts/cleanup
+++ b/systemtests/scripts/cleanup
@@ -15,7 +15,6 @@ rm -rf "${working:?}"/CLEANUPMARKER
 rm -rf "${working:?}"/plugins/*
 rm -rf "${archivedir:?}"/*
 rm -f  "${config_directory_dir_additional_test_config}"/*
-rm -f  "${PIDDIR}"/*
 find . -name "gigaslam.gif" -exec rm -f {} \;
 
 # cleanup chrome user data (selenium tests)

--- a/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -7,6 +7,5 @@ Director {
   Auditing = yes
 
   Working Directory =  "@working_dir@"
-  Pid Directory =  "@piddir@"
   DirPort = @dir_port@
 }

--- a/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -10,6 +10,5 @@ Client {
   Plugin Names = "@python_module_name@"
 
   Working Directory =  "@working_dir@"
-  Pid Directory =  "@piddir@"
   FD Port = @fd_port@
 }

--- a/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py2plug-fd-mariabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -9,7 +9,6 @@ Storage {
   # Plugin Directory = "@python_plugin_module_src_sd@"
   # Plugin Names = ""
   Working Directory =  "@working_dir@"
-  Pid Directory =  "@piddir@"
   SD Port = @sd_port@
   @sd_backend_config@
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

This PR removes the already deprecated `Pid Directory` config option from all daemons, and updates the `Maximum Concurrent Jobs` config option default value to 1.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
