### PR TITLE
Improve handling of catalog requests that try to reduce VolFiles, VolBlocks and VolBytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Fix problem with reoccuring files in always incremental [PR #1395]
 - bsmtp bls bextract: fixes for command line parsing [PR #1455]
 - daemons: update network handling when IP protocols unavailable [PR #1454]
+- Improve handling of catalog requests that try to reduce VolFiles, VolBlocks and VolBytes [PR #1431]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -151,6 +152,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1425]: https://github.com/bareos/bareos/pull/1425
 [PR #1426]: https://github.com/bareos/bareos/pull/1426
 [PR #1429]: https://github.com/bareos/bareos/pull/1429
+[PR #1431]: https://github.com/bareos/bareos/pull/1431
 [PR #1433]: https://github.com/bareos/bareos/pull/1433
 [PR #1437]: https://github.com/bareos/bareos/pull/1437
 [PR #1439]: https://github.com/bareos/bareos/pull/1439

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -249,15 +249,31 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
       if (mr.InitialWrite == 0) { mr.InitialWrite = jcr->start_time; }
       Dmsg2(400, "label=%d labeldate=%d\n", label, mr.LabelDate);
     } else {
-      // Insanity check for VolFiles get set to a smaller value
+      // Sanity check for VolFiles to be increasing
       if (sdmr.VolFiles < mr.VolFiles) {
-        Jmsg(jcr, M_FATAL, 0,
-             _("Volume Files at %u being set to %u"
-               " for Volume \"%s\". This is incorrect.\n"),
+        Jmsg(jcr, M_INFO, 0,
+             _("Ignoring Volume Files at %u being set to %u"
+               " for Volume \"%s\".\n"),
              mr.VolFiles, sdmr.VolFiles, mr.VolumeName);
-        bs->fsend(_("1992 Update Media error. VolFiles=%u, CatFiles=%u\n"),
-                  sdmr.VolFiles, mr.VolFiles);
-        goto bail_out;
+        sdmr.VolFiles = mr.VolFiles;
+      }
+
+      // Sanity check for VolBlocks to be increasing
+      if (sdmr.VolBlocks < mr.VolBlocks) {
+        Jmsg(jcr, M_INFO, 0,
+             _("Ignoring Volume Blocks at %u being set to %u"
+               " for Volume \"%s\".\n"),
+             mr.VolBlocks, sdmr.VolBlocks, mr.VolumeName);
+        sdmr.VolBlocks = mr.VolBlocks;
+      }
+
+      // Sanity check for VolBytes to be increasing
+      if (sdmr.VolBytes < mr.VolBytes) {
+        Jmsg(jcr, M_INFO, 0,
+             _("Ignoring Volume Bytes at %lld being set to %lld"
+               " for Volume \"%s\".\n"),
+             mr.VolBytes, sdmr.VolBytes, mr.VolumeName);
+        sdmr.VolBytes = mr.VolBytes;
       }
     }
     Dmsg2(400, "Update media: BefVolJobs=%u After=%u\n", mr.VolJobs,
@@ -351,7 +367,6 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
       Jmsg(jcr, M_WARNING, 0,
            _("Batch database connection not found. Cannot update file list\n"));
     }
-
   } else if (sscanf(bs->msg, Update_jobrecord, &Job, &update_jobfiles,
                     &update_jobbytes)
              == 3) {

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -479,7 +479,8 @@ DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr)
   dev->VolCatInfo.VolCatJobs++; /* increment number of jobs on vol */
   Dmsg4(100, "=== nwriters=%d nres=%d vcatjob=%d dev=%s\n", dev->num_writers,
         dev->NumReserved(), dev->VolCatInfo.VolCatJobs, dev->print_name());
-  dcr->DirUpdateVolumeInfo(false, false); /* send Volume info to Director */
+  dcr->DirUpdateVolumeInfo(
+      is_labeloperation::False); /* send Volume info to Director */
   retval = true;
 
 get_out:
@@ -547,7 +548,8 @@ bool ReleaseDevice(DeviceControlRecord* dcr)
     Dmsg2(150, "dir_update_vol_info. label=%d Vol=%s\n", dev->IsLabeled(),
           vol->VolCatName);
     if (dev->IsLabeled() && vol->VolCatName[0] != 0) {
-      dcr->DirUpdateVolumeInfo(false, false); /* send Volume info to Director */
+      dcr->DirUpdateVolumeInfo(
+          is_labeloperation::False); /* send Volume info to Director */
       RemoveReadVolume(jcr, dcr->VolumeName);
       VolumeUnused(dcr);
     }
@@ -575,8 +577,8 @@ bool ReleaseDevice(DeviceControlRecord* dcr)
         dev->VolCatInfo.VolCatFiles = dev->file; /* set number of files */
 
         // Note! do volume update before close, which zaps VolCatInfo
-        dcr->DirUpdateVolumeInfo(false,
-                                 false); /* send Volume info to Director */
+        dcr->DirUpdateVolumeInfo(
+            is_labeloperation::False); /* send Volume info to Director */
         Dmsg2(200, "dir_update_vol_info. Release vol=%s dev=%s\n",
               dev->getVolCatName(), dev->print_name());
       }

--- a/core/src/stored/askdir.cc
+++ b/core/src/stored/askdir.cc
@@ -273,7 +273,8 @@ get_out:
  * back to the director. The information comes from the
  * dev record.
  */
-bool StorageDaemonDeviceControlRecord::DirUpdateVolumeInfo(bool label, bool)
+bool StorageDaemonDeviceControlRecord::DirUpdateVolumeInfo(
+    is_labeloperation label)
 {
   BareosSocket* dir = jcr->dir_bsock;
   VolumeCatalogInfo* vol = &dev->VolCatInfo;
@@ -296,7 +297,7 @@ bool StorageDaemonDeviceControlRecord::DirUpdateVolumeInfo(bool label, bool)
   Dmsg1(debuglevel, "Update cat VolBytes=%lld\n", vol->VolCatBytes);
 
   // Just labeled or relabeled the tape
-  if (label) {
+  if (label == is_labeloperation::True) {
     bstrncpy(vol->VolCatStatus, "Append", sizeof(vol->VolCatStatus));
   }
   vol->VolLastWritten = time(NULL);

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -463,7 +463,7 @@ static bool TerminateWritingVolume(DeviceControlRecord* dcr)
            sizeof(dev->VolCatInfo.VolCatStatus));
   dev->VolCatInfo.VolCatFiles = dev->file; /* set number of files */
 
-  if (!dcr->DirUpdateVolumeInfo(false, true)) {
+  if (!dcr->DirUpdateVolumeInfo(is_labeloperation::False)) {
     Mmsg(dev->errmsg, _("Error sending Volume info to Director.\n"));
     ok = false;
     Dmsg0(50, "Error updating volume info.\n");
@@ -514,7 +514,7 @@ static bool DoNewFileBookkeeping(DeviceControlRecord* dcr)
     return false;
   }
   dev->VolCatInfo.VolCatFiles = dev->file;
-  if (!dcr->DirUpdateVolumeInfo(false, false)) {
+  if (!dcr->DirUpdateVolumeInfo(is_labeloperation::False)) {
     Dmsg0(50, "Error from update_vol_info.\n");
     TerminateWritingVolume(dcr);
     dev->dev_errno = EIO;

--- a/core/src/stored/device.cc
+++ b/core/src/stored/device.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -130,19 +130,18 @@ bool FixupDeviceBlockWriteError(DeviceControlRecord* dcr, int retries)
   Dmsg2(050, "MustUnload=%d dev=%s\n", dev->MustUnload(), dev->print_name());
   dev->Lock(); /* lock again */
 
-  dev->VolCatInfo.VolCatJobs++;           /* increment number of jobs on vol */
-  dcr->DirUpdateVolumeInfo(false, false); /* send Volume info to Director */
+  dev->VolCatInfo.VolCatJobs++; /* increment number of jobs on vol */
+  dcr->DirUpdateVolumeInfo(
+      is_labeloperation::False); /* send Volume info to Director */
 
   Jmsg(jcr, M_INFO, 0, _("New volume \"%s\" mounted on device %s at %s.\n"),
        dcr->VolumeName, dev->print_name(),
        bstrftime(dt, sizeof(dt), time(NULL)));
 
-  /*
-   * If this is a new tape, the label_blk will contain the
+  /* If this is a new tape, the label_blk will contain the
    *  label, so write it now. If this is a previously
    *  used tape, MountNextWriteVolume() will return an
-   *  empty label_blk, and nothing will be written.
-   */
+   *  empty label_blk, and nothing will be written. */
   Dmsg0(190, "write label block to dev\n");
   if (!dcr->WriteBlockToDev()) {
     BErrNo be;
@@ -190,11 +189,9 @@ bool FixupDeviceBlockWriteError(DeviceControlRecord* dcr, int retries)
   ok = true;
 
 bail_out:
-  /*
-   * At this point, the device is locked and blocked.
+  /* At this point, the device is locked and blocked.
    * Unblock the device, restore any entry blocked condition, then
-   *   return leaving the device locked (as it was on entry).
-   */
+   *   return leaving the device locked (as it was on entry). */
   UnblockDevice(dev);
   if (blocked != BST_NOT_BLOCKED) { BlockDevice(dev, blocked); }
   return ok; /* device locked */
@@ -301,10 +298,8 @@ BootStrapRecord* PositionDeviceToFirstFile(JobControlRecord* jcr,
   BootStrapRecord* bsr = NULL;
   Device* dev = dcr->dev;
   uint32_t file, block;
-  /*
-   * Now find and position to first file and block
-   *   on this tape.
-   */
+  /* Now find and position to first file and block
+   *   on this tape. */
   if (jcr->sd_impl->read_session.bsr) {
     jcr->sd_impl->read_session.bsr->Reposition = true;
     bsr = find_next_bsr(jcr->sd_impl->read_session.bsr, dev);
@@ -346,11 +341,9 @@ bool TryDeviceRepositioning(JobControlRecord* jcr,
     return true;
   }
   if (bsr) {
-    /*
-     * ***FIXME*** gross kludge to make disk seeking work.  Remove
+    /* ***FIXME*** gross kludge to make disk seeking work.  Remove
      *   when find_next_bsr() is fixed not to return a bsr already
-     *   completed.
-     */
+     *   completed. */
     uint32_t block, file;
     /* TODO: use dev->file_addr ? */
     uint64_t dev_addr = (((uint64_t)dev->file) << 32) | dev->block_num;

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -59,6 +59,12 @@ struct DeviceBlock;
 struct DeviceRecord;
 
 /* clang-format off */
+
+enum class is_labeloperation : bool
+{
+  True = true,
+  False = false
+};
 
 class DeviceControlRecord {
  private:
@@ -144,7 +150,7 @@ class DeviceControlRecord {
   // Methods in askdir.c
   virtual DeviceControlRecord* get_new_spooling_dcr();
   virtual bool DirFindNextAppendableVolume() { return true; }
-  virtual bool DirUpdateVolumeInfo(bool /* label */, bool /* update_LastWritten */)
+  virtual bool DirUpdateVolumeInfo(is_labeloperation)
   {
     return true;
   }

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -1119,7 +1119,8 @@ bool DeviceControlRecord::RewriteVolumeLabel(bool recycle)
   bstrncpy(dev->VolCatInfo.VolCatStatus, "Append",
            sizeof(dev->VolCatInfo.VolCatStatus));
   dev->setVolCatName(dcr->VolumeName);
-  if (!dcr->DirUpdateVolumeInfo(true, true)) { /* indicate doing relabel */
+  if (!dcr->DirUpdateVolumeInfo(
+          is_labeloperation::True)) { /* indicate doing relabel */
     return false;
   }
   if (recycle) {

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -331,7 +331,7 @@ read_volume:
 
     dev->VolCatInfo.VolCatMounts++; /* Update mounts */
     Dmsg1(150, "update volinfo mounts=%d\n", dev->VolCatInfo.VolCatMounts);
-    if (!dcr->DirUpdateVolumeInfo(false, false)) { goto bail_out; }
+    if (!dcr->DirUpdateVolumeInfo(is_labeloperation::False)) { goto bail_out; }
 
     /* Return an empty block */
     EmptyBlock(block); /* we used it for reading so set for write */
@@ -641,7 +641,7 @@ bool DeviceControlRecord::is_eod_valid()
              VolumeName, dev->GetFile(), dev->VolCatInfo.VolCatFiles);
         dev->VolCatInfo.VolCatFiles = dev->GetFile();
         dev->VolCatInfo.VolCatBlocks = dev->GetBlockNum();
-        if (!DirUpdateVolumeInfo(false, true)) {
+        if (!DirUpdateVolumeInfo(is_labeloperation::False)) {
           Jmsg(jcr, M_WARNING, 0, _("Error updating Catalog\n"));
           MarkVolumeInError();
           return false;
@@ -674,7 +674,7 @@ bool DeviceControlRecord::is_eod_valid()
              edit_uint64(dev->VolCatInfo.VolCatBytes, ed2));
         dev->VolCatInfo.VolCatBytes = (uint64_t)pos;
         dev->VolCatInfo.VolCatFiles = (uint32_t)(pos >> 32);
-        if (!DirUpdateVolumeInfo(false, true)) {
+        if (!DirUpdateVolumeInfo(is_labeloperation::False)) {
           Jmsg(jcr, M_WARNING, 0, _("Error updating Catalog\n"));
           MarkVolumeInError();
           return false;
@@ -738,8 +738,9 @@ int DeviceControlRecord::TryAutolabel(bool opened)
     }
     Dmsg0(150, "dir_update_vol_info. Set Append\n");
     /* Copy Director's info into the device info */
-    dev->VolCatInfo = VolCatInfo;                /* structure assignment */
-    if (!dcr->DirUpdateVolumeInfo(true, true)) { /* indicate tape labeled */
+    dev->VolCatInfo = VolCatInfo; /* structure assignment */
+    if (!dcr->DirUpdateVolumeInfo(
+            is_labeloperation::True)) { /* indicate tape labeled */
       return try_error;
     }
     Jmsg(dcr->jcr, M_INFO, 0, _("Labeled new Volume \"%s\" on device %s.\n"),
@@ -772,7 +773,7 @@ void DeviceControlRecord::MarkVolumeInError()
   bstrncpy(dev->VolCatInfo.VolCatStatus, "Error",
            sizeof(dev->VolCatInfo.VolCatStatus));
   Dmsg0(150, "dir_update_vol_info. Set Error.\n");
-  dcr->DirUpdateVolumeInfo(false, false);
+  dcr->DirUpdateVolumeInfo(is_labeloperation::False);
   VolumeUnused(dcr);
   Dmsg0(50, "SetUnload\n");
   dev->SetUnload(); /* must get a new volume */
@@ -794,7 +795,7 @@ void DeviceControlRecord::mark_volume_not_inchanger()
   VolCatInfo.InChanger = false;
   dev->VolCatInfo.InChanger = false;
   Dmsg0(400, "update vol info in mount\n");
-  dcr->DirUpdateVolumeInfo(true, false); /* set new status */
+  dcr->DirUpdateVolumeInfo(is_labeloperation::True); /* set new status */
 }
 
 /**

--- a/core/src/stored/sd_device_control_record.h
+++ b/core/src/stored/sd_device_control_record.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,7 +31,7 @@ namespace storagedaemon {
 class StorageDaemonDeviceControlRecord : public DeviceControlRecord {
  public:
   bool DirFindNextAppendableVolume() override;
-  bool DirUpdateVolumeInfo(bool label, bool update_LastWritten) override;
+  bool DirUpdateVolumeInfo(is_labeloperation label) override;
   bool DirCreateJobmediaRecord(bool zero) override;
   bool DirUpdateFileAttributes(DeviceRecord* record) override;
   bool DirAskSysopToMountVolume(int mode) override;


### PR DESCRIPTION
We have the effect that at the end of restores, we get catalog requests that try to reduce the VolFiles.
Instead of emitting a fatal error, we now log the event and keep the current value.

We do the same for VolBytes and for VolBlocks.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR