### PR TITLE
pr-tool: handling POEditor commits and optional github ci tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: remove openSUSE 15.3 and Univention 5.0 from test matrix [PR #1469]
 - cleanup: remove some unused functions and shrink number of includes in bareos.h [PR #1433]
 - core: fix schema public with PostgreSQL 15 [PR #1449]
+- pr-tool: handling POEditor commits and optional github ci tests [PR #1434]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -155,6 +156,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1429]: https://github.com/bareos/bareos/pull/1429
 [PR #1431]: https://github.com/bareos/bareos/pull/1431
 [PR #1433]: https://github.com/bareos/bareos/pull/1433
+[PR #1434]: https://github.com/bareos/bareos/pull/1434
 [PR #1437]: https://github.com/bareos/bareos/pull/1437
 [PR #1439]: https://github.com/bareos/bareos/pull/1439
 [PR #1440]: https://github.com/bareos/bareos/pull/1440

--- a/devtools/pip-tools/pr_tool/main.py
+++ b/devtools/pip-tools/pr_tool/main.py
@@ -216,7 +216,8 @@ class CommitAnalyzer:
         headline, *messageBody = commit.message.split("\n")
         issues = []
         if len(messageBody) == 0:
-            issues.append("missing newline at end of headline")
+            if not "(POEditor.com)" in commit.message:
+                issues.append("missing newline at end of headline")
         elif messageBody[0] == "":
             messageBody.pop(0)
         else:

--- a/devtools/pip-tools/pr_tool/main.py
+++ b/devtools/pip-tools/pr_tool/main.py
@@ -281,11 +281,16 @@ class Checklist:
         self.is_ok = False
         print("{} {}".format(Mark.FAIL, text))
 
-    def check(self, condition, ok_str, fail_str=None):
+    def softfail(self, text):
+        print("{} [optional] {}".format(Mark.FAIL, text))
+
+    def check(self, condition, ok_str, fail_str=None, optional=False):
         if not fail_str:
             fail_str = ok_str
         if condition:
             self.ok(ok_str)
+        elif optional:
+            self.softfail(fail_str)
         else:
             self.fail(fail_str)
 
@@ -332,11 +337,18 @@ def check_merge_prereq(repo, pr, ignore_status_checks=False):
 
     if not ignore_status_checks:
         for status_check in pr["statusCheckRollup"]:
+            optional = (
+                status_check["context"] != "continuous-integration/jenkins/pr-merge"
+            )
             cl.check(
                 status_check["state"] == "SUCCESS",
                 "Status check '{context}': {state}\n\t{targetUrl}".format(
                     **status_check
                 ),
+                "Status check '{context}': {state}\n\t{targetUrl}".format(
+                    **status_check
+                ),
+                optional,
             )
         cl.check(
             have_status_context(


### PR DESCRIPTION
Commit messages generated by the online tool https://POEditor.com don't contain a newline at the end of the headline. As we can't change this behavior, we don't emit a warning in this case.

POEditor.com commit message do look like:
"Update de_DE.mo (POEditor.com)"

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
