### PR TITLE
config: set device maxconcurrent jobs default to one

### DIFF
--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -290,11 +290,7 @@ static void WarnOnZeroMaxConcurrentJobs(int max_concurrent_jobs,
   if (max_concurrent_jobs == 0) {
     my_config->AddWarning(fmt::format(
         FMT_STRING("Device {:s}: unlimited (0) 'Maximum Concurrent Jobs' (the "
-                   "default) reduces the restore peformance."),
-        name));
-    my_config->AddWarning(fmt::format(
-        FMT_STRING("Device {:s}: the default value for 'Maximum Concurrent "
-                   "Jobs' will change from 0 (unlimited) to 1 in Bareos 23."),
+                   "default) reduces the restore performance."),
         name));
   }
 }

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -190,7 +190,7 @@ static ResourceItem dev_items[] = {
   {"MaximumBlockSize", CFG_TYPE_MAXBLOCKSIZE, ITEM(res_dev, max_block_size), 0, 0, NULL, NULL, NULL},
   {"MaximumFileSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_file_size), 0, CFG_ITEM_DEFAULT, "1000000000", NULL, NULL},
   {"VolumeCapacity", CFG_TYPE_SIZE64, ITEM(res_dev, volume_capacity), 0, 0, NULL, NULL, NULL},
-  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dev, max_concurrent_jobs), 0, 0, NULL, NULL, NULL},
+  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_dev, max_concurrent_jobs), 0, CFG_ITEM_DEFAULT, "1" ,NULL, NULL},
   {"SpoolDirectory", CFG_TYPE_DIR, ITEM(res_dev, spool_directory), 0, 0, NULL, NULL, NULL},
   {"MaximumSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_spool_size), 0, 0, NULL, NULL, NULL},
   {"MaximumJobSpoolSize", CFG_TYPE_SIZE64, ITEM(res_dev, max_job_spool_size), 0, 0, NULL, NULL, NULL},
@@ -796,7 +796,9 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
           p->device_resources = res_changer->device_resources;
 
           DeviceResource* q = nullptr;
-          foreach_alist (q, p->device_resources) { q->changer_res = p; }
+          foreach_alist (q, p->device_resources) {
+            q->changer_res = p;
+          }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-MaximumConcurrentJobs.rst.inc
@@ -7,4 +7,4 @@ This directive specifies the maximum number of Jobs that can run concurrently on
 .. warning::
 
 
-   When using devices that are *not* of type *tape*, it is highly recommended to set `Maximum Concurrent Jobs` to 1 to avoid intermixing jobs. Intermixed jobs on a Volume will significantly reduce performance during restore. Instead, define as many devices as required (e.g. multiply disk devices via :config:option:`sd/device/Count`) and parallelize by storing each job to an individual device at once.
+   When using devices that are *not* of type *tape*, it is highly recommended to set `Maximum Concurrent Jobs` to 1 {the default since Bareo 23) to avoid intermixing jobs. Intermixed jobs on a Volume will significantly reduce performance during restore. Instead, define as many devices as required (e.g. multiply disk devices via :config:option:`sd/device/Count`) and parallelize by storing each job to an individual device at once.


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

We have decided to set the maximum concurrent jobs value for devices to 1 in bareos 23.

This PR makes these changes to the code and removes the warning that states this change.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
