### PR TITLE
check-sources: update check-sources ignores

### DIFF
--- a/.bareos-check-sources-ignore
+++ b/.bareos-check-sources-ignore
@@ -6,9 +6,16 @@ core/src/ndmp/*.h
 core/src/stored/crc32
 debian/control
 devtools/pip-tools/check_sources.egg-info/*
-webui/vendor
+webui/vendor/composer/*
+webui/vendor/container-interop/*
+webui/vendor/psr/*
+webui/vendor/zendframework/*
+webui/vendor/autoload.php
+webui/vendor/README.md
 webui/module/Application/language
+webui/public/fonts/*
 webui/public/js/*.min.*
+webui/public/js/jstree*
 webui/public/js/apexcharts.js
 webui/public/js/partials/*.min.*
 webui/public/js/bootstrap-select.js.map

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - docs: catalog maintenance improvements [PR #1379]
 - doc: improve plugin, webui, virtualfull chapters [PR #1401]
 - docs: move and update localization documentation [PR #1415]
+- check-sources: update check-sources ignores [PR #1439]
 
 [PR #935]: https://github.com/bareos/bareos/pull/935
 [PR #1011]: https://github.com/bareos/bareos/pull/1011
@@ -119,4 +120,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1422]: https://github.com/bareos/bareos/pull/1422
 [PR #1424]: https://github.com/bareos/bareos/pull/1424
 [PR #1429]: https://github.com/bareos/bareos/pull/1429
+[PR #1439]: https://github.com/bareos/bareos/pull/1439
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
The Bareos/BSock vendor module should not be ignored by check-sources as we developed and maintain it.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
