### PR TITLE
webui: make restore merge options configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - daemons: remove deprecated `Pid Directory` config option, and update `Maximum Concurrent Jobs` default value to 1 [PR #1426]
 - build: switch to FreeBSD 12.4 [PR #1440]
 - webui: create internal api module [PR #1447]
+- webui: make restore merge options configurable [PR #1445]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -143,5 +144,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1429]: https://github.com/bareos/bareos/pull/1429
 [PR #1439]: https://github.com/bareos/bareos/pull/1439
 [PR #1440]: https://github.com/bareos/bareos/pull/1440
+[PR #1445]: https://github.com/bareos/bareos/pull/1445
 [PR #1447]: https://github.com/bareos/bareos/pull/1447
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/BareosWebui.rst
@@ -519,6 +519,14 @@ Some parameters of the |webui| can be configured in :file:`/etc/bareos-webui/con
    ; Default:
    ;filetree_refresh_timeout=120000
 
+   ; Merge jobs on client selection
+   ; Default:
+   ;merge_jobs=true
+
+   ; Merge filesets on client selection
+   ; Default:
+   ;merge_filesets=true
+
    ;------------------------------------------------------------------------------
    ; THEME SETTINGS
    ;------------------------------------------------------------------------------

--- a/webui/config/autoload/global.php.in
+++ b/webui/config/autoload/global.php.in
@@ -85,6 +85,8 @@ function read_configuration_ini($configuration_ini)
         ),
         'restore' => array(
             'filetree_refresh_timeout' => 120000,
+            'merge_jobs' => true,
+            'merge_filesets' => true
         ),
         'theme' => array(
             'name' => "sunflower"
@@ -119,6 +121,12 @@ function read_configuration_ini($configuration_ini)
         }
         if (isset($configuration['restore']['filetree_refresh_timeout'])) {
             $result['restore']['filetree_refresh_timeout'] = $configuration['restore']['filetree_refresh_timeout'];
+        }
+        if (isset($configuration['restore']['merge_jobs'])) {
+            $result['restore']['merge_jobs'] = $configuration['restore']['merge_jobs'];
+        }
+        if (isset($configuration['restore']['merge_filesets'])) {
+            $result['restore']['merge_filesets'] = $configuration['restore']['merge_filesets'];
         }
         if (isset($configuration['theme']['name'])) {
             $result['theme']['name'] = $configuration['theme']['name'];

--- a/webui/install/configuration.ini.in
+++ b/webui/install/configuration.ini.in
@@ -51,6 +51,14 @@
 ; Default:
 ;filetree_refresh_timeout=120000
 
+; Merge jobs on client selection
+; Default:
+;merge_jobs=true
+
+; Merge filesets on client selection
+; Default:
+;merge_filesets=true
+
 ;------------------------------------------------------------------------------
 ; THEME SETTINGS
 ;------------------------------------------------------------------------------

--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -125,6 +125,8 @@ class AuthController extends AbstractActionController
         $session->offsetSet('dt_statesave', ($configuration['configuration']['tables']['save_previous_state']) ? 'true' : 'false');
         $session->offsetSet('dashboard_autorefresh_interval', $configuration['configuration']['dashboard']['autorefresh_interval']);
         $session->offsetSet('filetree_refresh_timeout', $configuration['configuration']['restore']['filetree_refresh_timeout']);
+        $session->offsetSet('merge_jobs', $configuration['configuration']['restore']['merge_jobs']);
+        $session->offsetSet('merge_filesets', $configuration['configuration']['restore']['merge_filesets']);
         $session->offsetSet('configuration_resource_graph', $configuration['configuration']['experimental']['configuration_resource_graph']);
 
         if (isset($configuration['configuration']['autochanger']['labelpooltype'])) {

--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -398,14 +398,10 @@ class RestoreController extends AbstractActionController
 
     private function handleJobMerge()
     {
-        if (isset($this->restore_params['mergejobs']) && $this->restore_params['mergejobs'] == 1) {
-            $this->restore_params['jobids'] = $this->restore_params['jobid'];
-        } else {
-            try {
-                $this->restore_params['jobids'] = $this->getRestoreModel()->getJobIds($this->bsock, $this->restore_params['jobid'], $this->restore_params['mergefilesets']);
-            } catch (Exception $e) {
-                echo $e->getMessage();
-            }
+        try {
+            $this->restore_params['jobids'] = $this->getRestoreModel()->getJobIds($this->bsock, $this->restore_params['jobid'], $this->restore_params['mergefilesets']);
+        } catch (Exception $e) {
+            echo $e->getMessage();
         }
     }
 
@@ -692,16 +688,16 @@ class RestoreController extends AbstractActionController
             $this->restore_params['jobids'] = null;
         }
 
-        if ($this->params()->fromQuery('mergefilesets')) {
+        if ($this->params()->fromQuery('mergefilesets') !== null) {
             $this->restore_params['mergefilesets'] = $this->params()->fromQuery('mergefilesets');
         } else {
-            $this->restore_params['mergefilesets'] = 0;
+            $this->restore_params['mergefilesets'] = $_SESSION['bareos']['merge_filesets'] ? 1 : 0;
         }
 
-        if ($this->params()->fromQuery('mergejobs')) {
+        if ($this->params()->fromQuery('mergejobs') !== null) {
             $this->restore_params['mergejobs'] = $this->params()->fromQuery('mergejobs');
         } else {
-            $this->restore_params['mergejobs'] = 0;
+            $this->restore_params['mergejobs'] = $_SESSION['bareos']['merge_jobs'] ? 1 : 0;
         }
 
         if ($this->params()->fromQuery('replace')) {
@@ -721,6 +717,7 @@ class RestoreController extends AbstractActionController
         } else {
             $this->restore_params['versions'] = null;
         }
+
     }
 
     /**

--- a/webui/module/Restore/src/Restore/Form/RestoreForm.php
+++ b/webui/module/Restore/src/Restore/Form/RestoreForm.php
@@ -261,8 +261,8 @@ class RestoreForm extends Form
                     'options' => array(
                         'label' => _('Merge all client filesets'),
                         'value_options' => array(
-                            '0' => _('Yes'),
-                            '1' => _('No')
+                            '1' => _('Yes'),
+                            '0' => _('No')
                         )
                     ),
                     'attributes' => array(
@@ -280,14 +280,14 @@ class RestoreForm extends Form
                     'options' => array(
                         'label' => _('Merge all client filesets'),
                         'value_options' => array(
-                            '0' => _('Yes'),
-                            '1' => _('No')
+                            '1' => _('Yes'),
+                            '0' => _('No')
                         )
                     ),
                     'attributes' => array(
                         'class' => 'form-control selectpicker show-tick',
                         'id' => 'mergefilesets',
-                        'value' => '0',
+                        'value' => $_SESSION['bareos']['merge_filesets'] ? 1 : 0,
                         'disabled' => true
                     )
                 )
@@ -303,8 +303,8 @@ class RestoreForm extends Form
                     'options' => array(
                         'label' => _('Merge all related jobs to last full backup of selected backup job'),
                         'value_options' => array(
-                            '0' => _('Yes'),
-                            '1' => _('No')
+                            '1' => _('Yes'),
+                            '0' => _('No')
                         )
                     ),
                     'attributes' => array(
@@ -322,14 +322,14 @@ class RestoreForm extends Form
                     'options' => array(
                         'label' => _('Merge jobs'),
                         'value_options' => array(
-                            '0' => _('Yes'),
-                            '1' => _('No')
+                            '1' => _('Yes'),
+                            '0' => _('No')
                         )
                     ),
                     'attributes' => array(
                         'class' => 'form-control selectpicker show-tick',
                         'id' => 'mergejobs',
-                        'value' => '0',
+                        'value' => $_SESSION['bareos']['merge_jobs'] ? 1 : 0,
                         'disabled' => true
                     )
                 )

--- a/webui/module/Restore/src/Restore/Model/RestoreModel.php
+++ b/webui/module/Restore/src/Restore/Model/RestoreModel.php
@@ -195,21 +195,21 @@ class RestoreModel
      *
      * @return array
      */
-    public function getJobIds(&$bsock = null, $jobid = null, $mergefilesets = 0, $mergejobs = 0)
+    public function getJobIds(&$bsock = null, $jobid = null, $mergefilesets = 1, $mergejobs = 1)
     {
-        if (isset($bsock)) {
-            if ($mergefilesets == 1 && $mergejobs == 1) {
+        if (isset($bsock) && isset($jobid)) {
+            if ($mergejobs == 0) {
                 return $jobid;
             }
-            if ($mergefilesets == 0) {
+            if ($mergefilesets == 1) {
                 $cmd = '.bvfs_get_jobids jobid=' . $jobid . ' all';
             } else {
-                $cmd = '.bvfs_get_jobids jobid=' . $jobid . '';
+                $cmd = '.bvfs_get_jobids jobid=' . $jobid;
             }
             $result = $bsock->send_command($cmd, 2);
             $jobids = \Zend\Json\Json::decode($result, \Zend\Json\Json::TYPE_ARRAY);
             $result = "";
-            if (!empty($jobids['result'])) {
+            if (isset($jobids['result']['jobids'])) {
                 $i = count($jobids['result']['jobids']);
                 foreach ($jobids['result']['jobids'] as $jobid) {
                     $result .= $jobid['id'];

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -337,21 +337,8 @@ $this->headTitle($title);
       p['where'] = '<?php echo $this->restore_params['where']; ?>';
       p['pluginoptions'] = '<?php echo $this->restore_params['pluginoptions']; ?>';
       p['fileset'] = '<?php echo $this->restore_params['fileset']; ?>';
-
-      if(k === 'mergejobs' && v === '1') {
-         p['mergefilesets'] = '1';
-      }
-      else {
-         p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
-      }
-
-      if(k === 'mergefilesets' && v === '0') {
-         p['mergejobs'] = '0';
-      }
-      else {
-         p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
-      }
-
+      p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
+      p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
       p['limit'] = '<?php echo $this->restore_params['limit']; ?>';
 
       p[k] = v;
@@ -411,7 +398,7 @@ $this->headTitle($title);
                'data' : function (node) {
                   return { 'id' : node.id };
                },
-               timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+               'timeout': <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
             },
          },
          'state' : {

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -487,19 +487,8 @@ function updateRestoreParams(k, v) {
    p['where'] = '<?php echo $this->restore_params['where']; ?>';
    p['pluginoptions'] = '<?php echo $this->restore_params['pluginoptions']; ?>';
    p['fileset'] = '<?php echo $this->restore_params['fileset']; ?>';
-
-   if (k === 'mergejobs' && v === '1') {
-      p['mergefilesets'] = '1';
-   } else {
-      p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
-   }
-
-   if (k === 'mergefilesets' && v === '0') {
-      p['mergejobs'] = '0';
-   } else {
-      p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
-   }
-
+   p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
+   p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
    p['limit'] = '<?php echo $this->restore_params['limit']; ?>';
 
    p[k] = v;
@@ -557,7 +546,7 @@ function showFileTree() {
                   'state': {'checkbox_disabled': true}
                };
             },
-            timeout: <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
+            'timeout': <?php echo $_SESSION['bareos']['filetree_refresh_timeout']; ?>,
          },
       },
       'state' : {

--- a/webui/public/js/bootstrap-table-formatter.js
+++ b/webui/public/js/bootstrap-table-formatter.js
@@ -512,7 +512,7 @@ function scheduleActionButtonsFormatter(value, row, index, basePath) {
 function jobActionButtonsFormatter(value, row, index, basePath) {
    let jobDetailsButton = '<a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top" href="' + basePath + '/job/details/' + row.jobid + '" title="' + iJS._("View Job Details") + '" id="btn-0"><span class="glyphicon glyphicon-search"></span></a>';
    let jobRerunButton = '<a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top" href="' + basePath + '/job/index?action=rerun&jobid=' + row.jobid + '" title="' + iJS._('Rerun') + '" id="btn-1" onclick="return confirm(\'Rerun Job ID ' + row.jobid + '?\')"><span class="glyphicon glyphicon-repeat"></span></a>';
-   let jobRestoreButton = '<a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top" href="' + basePath + '/restore/?mergefilesets=1&mergejobs=1&client=' + row.client + '&jobid=' + row.jobid + '" title="' + iJS._("Restore") + '" id="btn-1"><span class="glyphicon glyphicon-import"></span></a>';
+   let jobRestoreButton = '<a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top" href="' + basePath + '/restore/?mergefilesets=0&mergejobs=0&client=' + row.client + '&jobid=' + row.jobid + '" title="' + iJS._("Restore") + '" id="btn-1"><span class="glyphicon glyphicon-import"></span></a>';
    let jobCancelButton = '<a class="btn btn-default btn-xs" data-toggle="tooltip" data-placement="top" href="' + basePath + '/job/cancel/' + row.jobid + '" title="' + iJS._("Cancel") + '" id="btn-1" onclick="return confirm(\'Cancel Job ID ' + row.jobid + '?\')"><span class="glyphicon glyphicon-remove"></span></a>';
 
    switch(row.jobstatus) {


### PR DESCRIPTION
If you select a client in the webui restore module the default is that
according jobs and filesets get merged for the file tree presentation.

In larger environments you probably do not want this default behaviour.

Therefore, this commit introduces two new configuration.ini settings
to switch the default merge option behaviour in webui restore.

The newly introduced configuration.ini parameters are "merge_jobs"
and "merge_filesets" in the restore section.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
