### PR TITLE
scripts: config-lib improve setup_sd_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Improve handling of catalog requests that try to reduce VolFiles, VolBlocks and VolBytes [PR #1431]
 - filed: fix off-by-one error when resizing acl buffer [PR #1479]
 - Consolidate: fix for consolidate job's client name not being correctly shown [PR #1474]
+- scripts: config-lib improve setup_sd_user [PR #1448]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -170,6 +171,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1440]: https://github.com/bareos/bareos/pull/1440
 [PR #1445]: https://github.com/bareos/bareos/pull/1445
 [PR #1447]: https://github.com/bareos/bareos/pull/1447
+[PR #1448]: https://github.com/bareos/bareos/pull/1448
 [PR #1449]: https://github.com/bareos/bareos/pull/1449
 [PR #1450]: https://github.com/bareos/bareos/pull/1450
 [PR #1453]: https://github.com/bareos/bareos/pull/1453

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -317,6 +317,14 @@ setup_sd_user()
 
     getent group "${STORAGE_DAEMON_GROUP}" > /dev/null || groupadd -r "${STORAGE_DAEMON_GROUP}"
 
+    # Build list of additional groups the user should be in.
+    ADD_GROUPS=""
+    for sec_group in ${SEC_GROUPS}; do
+        if getent group "${sec_group}"; then
+            [ -z "${ADD_GROUPS}" ] && ADD_GROUPS="${sec_group}" || ADD_GROUPS="${ADD_GROUPS},${sec_group}"
+        fi
+    done
+
     #
     # If the user doesn't exist create a new one otherwise modify it to have the wanted secondary groups.
     #
@@ -328,64 +336,24 @@ setup_sd_user()
     if getent passwd "${STORAGE_DAEMON_USER}" > /dev/null; then
         if [ "${STORAGE_DAEMON_USER}" != "root" ]; then
             #
-            # Build a list of all groups the user is already in.
-            #
-            ADD_GROUPS=""
-            CUR_ADD_GROUPS=$(id -Gn "${STORAGE_DAEMON_USER}")
-            for sec_group in ${CUR_ADD_GROUPS}; do
-                [ -z "${USERMOD_CMDLINE}" ] && USERMOD_CMDLINE="usermod -G ${sec_group}" || USERMOD_CMDLINE="${USERMOD_CMDLINE},${sec_group}"
-            done
-
-            #
-            # See what secondary groups exist for the SD user to be added to.
-            #
-            for sec_group in ${SEC_GROUPS}; do
-                if getent group "${sec_group}" >/dev/null; then
-                    found=0
-                    for group in ${CUR_ADD_GROUPS}; do
-                        if [ "${group}" = "${sec_group}" ]; then
-                            found=1
-                        fi
-                    done
-
-                    if [ "${found}" = "0" ]; then
-                        [ -z "${ADD_GROUPS}" ] && ADD_GROUPS="${sec_group}" || ADD_GROUPS="${ADD_GROUPS} ${sec_group}"
-                        [ -z "${USERMOD_CMDLINE}" ] && USERMOD_CMDLINE="usermod -G ${sec_group}" || USERMOD_CMDLINE="${USERMOD_CMDLINE},${sec_group}"
-                    fi
-                fi
-            done
-
-            #
             # If the user was already created before,
             # Make sure the correct primary group is set otherwise fix it.
             #
             if [ "$(id -gn "${STORAGE_DAEMON_USER}")" != "${STORAGE_DAEMON_GROUP}" ]; then
                 usermod -g "${STORAGE_DAEMON_GROUP}" "${STORAGE_DAEMON_USER}" || warn "failed to add groups ${STORAGE_DAEMON_GROUP} to ${STORAGE_DAEMON_USER}"
             fi
-
             #
-            # Add the storage_daemon_user to additional groups (if needed)
+            # Add the storage_daemon_user to additional groups
             #
             if [ -n "${ADD_GROUPS}" ]; then
-                "${USERMOD_CMDLINE}" "${STORAGE_DAEMON_USER}" || warn "failed: ${USERMOD_CMDLINE} ${STORAGE_DAEMON_USER}"
+                usermod -a -G "${ADD_GROUPS}" "${STORAGE_DAEMON_USER}" || warn "failed: ${USERMOD_CMDLINE} ${STORAGE_DAEMON_USER}"
             fi
         fi
     else
         #
-        # User doesn't exist so create it.
-        # Determine additional groups the user should be in.
+        # User doesn't exist so create a new storage_daemon_user with additional groups
         #
-        NEW_ADD_GROUPS=""
-        for sec_group in ${SEC_GROUPS}; do
-            if getent group "${sec_group}"; then
-                [ -z "${NEW_ADD_GROUPS}" ] && NEW_ADD_GROUPS="-G ${sec_group}" || NEW_ADD_GROUPS="${NEW_ADD_GROUPS},${sec_group}"
-            fi
-        done
-
-        #
-        # Create a new storage_daemon_user
-        #
-        useradd -r --comment "bareos" --home "${BAREOS_WORKING_DIR}" -g "${STORAGE_DAEMON_GROUP}" "${NEW_ADD_GROUPS}" --shell /bin/false "${STORAGE_DAEMON_USER}" || warn "failed to create user ${STORAGE_DAEMON_USER}"
+        useradd -r --comment "bareos" --home "${BAREOS_WORKING_DIR}" -g "${STORAGE_DAEMON_GROUP}" -G "${ADD_GROUPS}" --shell /bin/false "${STORAGE_DAEMON_USER}" || warn "failed to create user ${STORAGE_DAEMON_USER}"
     fi
 }
 


### PR DESCRIPTION
With the current code, usermod -G .... call is done quoted generating a warning on several distribution when installing bareos-storage package. 
```
Running scriptlet: bareos-storage-22.0.4~pre51.ab585a79e-44.el8.x86_64                                                                                                                                                  19/39
/usr/lib/bareos/scripts/bareos-config-lib.sh: line 370: usermod -G bareos,tape,disk: command not found
Warning: failed: usermod -G bareos,tape,disk bareos
```

This PR propose to use simpler command construction by calling usermod -a -G group,group in all case.
usermod doesn't failed if the user already belong to the group, and with -a we preserve the already defined group.

- Use flag -a with -G on usermod command.
- Remove unneeded code for additional groups.

OP#5450

I propose to also create a backport to 22 for that one.

Result **Before**
```
id bareos
uid=988(bareos) gid=984(bareos) groups=984(bareos)
```

Result **After**
```
 id bareos
uid=988(bareos) gid=984(bareos) groups=984(bareos),6(disk),33(tape)
```

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR