### PR TITLE
packaging: systemd unit: set a limit of restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: make restore merge options configurable [PR #1445]
 - webui: update German translation [PR #1437]
 - build: fix for gcc 13.1.1 [PR #1459]
+- packaging: systemd unit: set a limit of restart [PR #1450]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -152,6 +153,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1440]: https://github.com/bareos/bareos/pull/1440
 [PR #1445]: https://github.com/bareos/bareos/pull/1445
 [PR #1447]: https://github.com/bareos/bareos/pull/1447
+[PR #1450]: https://github.com/bareos/bareos/pull/1450
 [PR #1453]: https://github.com/bareos/bareos/pull/1453
 [PR #1454]: https://github.com/bareos/bareos/pull/1454
 [PR #1455]: https://github.com/bareos/bareos/pull/1455

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -13,8 +13,6 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 
@@ -29,6 +27,12 @@ ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
 # Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
+
 
 [Install]
 Alias=bareos-director.service

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -12,6 +12,11 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist and is a directory
 ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -22,15 +27,8 @@ ExecStart=@sbindir@/bareos-dir -f
 SuccessExitStatus=0 15
 ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
-#Restart=on-failure
-# Allow unlimited restarts,
-# required for automatic restarting on Univention Corporate Servers (UCS).
-# Since systemd >= 230 this is a deprecated in favor for:
-# [Unit]
-# StartLimitIntervalSec=0
-# However, as this also have to work for systems with older version of systemd,
-# we stick to this old setting.
-StartLimitInterval=0
+# Increase the maximum number of open file descriptors
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-director.service

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -10,8 +10,8 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -7,8 +7,8 @@ Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
@@ -7,6 +7,13 @@ Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+# Check if working dir exist and is a directory
+ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -15,8 +22,9 @@ Group=@fd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-fd -f
 SuccessExitStatus=0 15
-Restart=on-failure
 # IOSchedulingClass=idle
+# Increase the maximum number of open file descriptors
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-filedaemon.service

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -10,8 +10,6 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 
@@ -25,6 +23,12 @@ SuccessExitStatus=0 15
 # IOSchedulingClass=idle
 # Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
+
 
 [Install]
 Alias=bareos-filedaemon.service

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -10,8 +10,6 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 
@@ -24,6 +22,12 @@ ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
 # Increase the the maximum number of open file descriptors
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
+
 
 [Install]
 Alias=bareos-storage.service

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -7,8 +7,8 @@ Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
@@ -7,6 +7,13 @@ Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+# Check if working dir exist and is a directory
+ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -15,7 +22,8 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-Restart=on-failure
+# Increase the the maximum number of open file descriptors
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-storage.service

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -13,8 +13,6 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 
@@ -29,6 +27,11 @@ ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
 # Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -10,8 +10,8 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
@@ -12,6 +12,11 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target 
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist and is a directory
 ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -22,15 +27,8 @@ ExecStart=@sbindir@/bareos-dir -f
 SuccessExitStatus=0 15
 ExecReload=@sbindir@/bareos-dir -t -f
 ExecReload=/bin/kill -HUP $MAINPID
-#Restart=on-failure
-# Allow unlimited restarts,
-# required for automatic restarting on Univention Corporate Servers (UCS).
-# Since systemd >= 230 this is a deprecated in favor for:
-# [Unit]
-# StartLimitIntervalSec=0
-# However, as this also have to work for systems with older version of systemd,
-# we stick to this old setting.
-StartLimitInterval=0
+# Increase the maximum number of open file descriptors
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -6,8 +6,8 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -9,8 +9,6 @@ Requires=network.target nss-lookup.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
@@ -25,6 +23,12 @@ SuccessExitStatus=0 15
 # IOSchedulingClass=idle
 # Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
+
 
 [Install]
 Alias=bareos-fd.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -1,11 +1,18 @@
 #
-# Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
+# Check if working dir exist and is a directory
+ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
@@ -15,8 +22,9 @@ Group=@fd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-fd -f
 SuccessExitStatus=0 15
-Restart=on-failure
 # IOSchedulingClass=idle
+# Increase the maximum number of open file descriptors
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-fd.service

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -10,8 +10,6 @@ After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
-# wait 3 minutes between each restart
-RestartSec=180
 StartLimitIntervalSec=1d
 StartLimitBurst=10
 
@@ -24,6 +22,11 @@ ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
 # Increase the maximum number of open file descriptors```
 LimitNOFILE=8192:524288
+# Restart on failure, wait 30 seconds
+Restart=on-failure
+RestartSec=30
+# Don't restart on wrong exec arguments and configuration errors.
+RestartPreventExitStatus=109 1
 
 [Install]
 Alias=bareos-sd.service

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -7,8 +7,8 @@ Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
-# Check if working dir exist and is a directory
-ConditionPathIsDirectory=@working_dir@
+# Check if working dir exist
+ConditionPathExists=@working_dir@
 # Limit the number of restart per day to 10
 # wait 3 minutes between each restart
 RestartSec=180

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 # Copyright (c) 2011 Free Software Foundation Europe e.V., Author: Bruno Friedmann
 #
 [Unit]
@@ -7,6 +7,13 @@ Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
 After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+# Check if working dir exist and is a directory
+ConditionPathIsDirectory=@working_dir@
+# Limit the number of restart per day to 10
+# wait 3 minutes between each restart
+RestartSec=180
+StartLimitIntervalSec=1d
+StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -15,7 +22,8 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-Restart=on-failure
+# Increase the maximum number of open file descriptors```
+LimitNOFILE=8192:524288
 
 [Install]
 Alias=bareos-sd.service

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Thank you for contributing to the Bareos Project!
 
-**Backport of PR #0000 to bareos-2x** (remove this line, if it no backport)
+**Backport of PR #0000 to bareos-2x** (remove this line, if it no backport, for backport use cherry-pick -x)
 
 #### Please check
 

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Thank you for contributing to the Bareos Project!
 
-**Backport of PR #0000 to bareos-2x** (remove this line, if it no backport, for backport use cherry-pick -x)
+**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)
 
 #### Please check
 


### PR DESCRIPTION
We want to enable automatic restart of daemon, but with a certain limit.
This will avoid constant crashing of daemon, which need an administrative review of their configuration.
We insert a limit burst of ten restart per day after a three minutes wait.

We also insert an increase in nb of open files
We add the conditional test for working directory on all daemons

OP#5453 OP#5461

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

