### PR TITLE
add missing include to fix compilation with gcc 13

### DIFF
--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -81,6 +81,7 @@
 #include "lib/btimers.h"
 #include "include/jcr.h"
 #include "lib/berrno.h"
+#include <stdexcept>
 
 #ifndef HAVE_DYNAMIC_SD_BACKENDS
 #  ifdef HAVE_GFAPI


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Fix compilation error with gcc 13
