### PR TITLE
docs: replace GZIP compression by LZ4 and MD5/SHA1 signature by XXH128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - doc: improve plugin, webui, virtualfull chapters [PR #1401]
 - docs: move and update localization documentation [PR #1415]
 - check-sources: update check-sources ignores [PR #1439]
+- docs: replace GZIP compression by LZ4 and MD5/SHA1 signature by XXH128 [PR #1453]
 
 [PR #935]: https://github.com/bareos/bareos/pull/935
 [PR #1011]: https://github.com/bareos/bareos/pull/1011
@@ -146,4 +147,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1440]: https://github.com/bareos/bareos/pull/1440
 [PR #1445]: https://github.com/bareos/bareos/pull/1445
 [PR #1447]: https://github.com/bareos/bareos/pull/1447
+[PR #1453]: https://github.com/bareos/bareos/pull/1453
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/DeveloperGuide/Webui.rst
+++ b/docs/manuals/source/DeveloperGuide/Webui.rst
@@ -12,7 +12,7 @@ Translation
 Where do I find the translation?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The localization files are located in file:`webui/module/Application/language`.
+The localization files are located in :file:`webui/module/Application/language`.
 You can find the languages that are currently
 in translation in our online project, which is addressed in the next section.
 

--- a/docs/manuals/source/DeveloperGuide/pluginAPI.rst
+++ b/docs/manuals/source/DeveloperGuide/pluginAPI.rst
@@ -69,8 +69,8 @@ a:
         Name = TestFS
         Include {
            Options {
-              Compression = GZIP1
-              Signature = MD5
+              Compression = LZ4
+              Signature = XXH128
               Wild = "*.txt"
               Plugin = <command-string>
            }

--- a/docs/manuals/source/TasksAndConcepts/AutomatedDiskBackup.rst
+++ b/docs/manuals/source/TasksAndConcepts/AutomatedDiskBackup.rst
@@ -52,7 +52,9 @@ The decision was to use three Pools: one for Full saves, one for Differential sa
 Full Pool
 ~~~~~~~~~
 
-:index:`\ <single: Pool; Full>`\  :index:`\ <single: Full Pool>`\
+.. index::
+   single: Pool; Full
+   single: Full Pool
 
 Putting a single Full backup on each Volume, will require six Full save Volumes, and a retention period of six months. The Pool needed to do that is:
 
@@ -85,7 +87,9 @@ If you have two clients, you would want to set Maximum Volume Jobs to 2 instead 
 Differential Pool
 ~~~~~~~~~~~~~~~~~
 
-:index:`\ <single: Pool; Differential>`\  :index:`\ <single: Differential Pool>`\
+.. index::
+   single: Pool; Differential
+   single: Differential Pool
 
 For the Differential backup Pool, we choose a retention period of a bit longer than a month and ensure that there is at least one Volume for each of the maximum of five weeks in a month. So the following works:
 
@@ -118,7 +122,9 @@ See the discussion above concering the Full pool for how to handle multiple clie
 Incremental Pool
 ~~~~~~~~~~~~~~~~
 
-:index:`\ <single: Incremental Pool>`\  :index:`\ <single: Pool; Incremental>`\
+.. index::
+   single: Incremental Pool
+   single: Pool; Incremental
 
 Finally, here is the resource for the Incremental Pool:
 
@@ -219,8 +225,8 @@ The Director’s configuration file is as follows:
      Name = "Full Set"
      Include = {
        Options {
-         signature=SHA1;
-         compression=GZIP9
+         Signature = XXH128
+         Compression = LZ4
        }
        File = /
        File = /usr

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
@@ -108,8 +108,8 @@ Now include the plugin as command-plugin in the fileset resource and define a jo
        Name = "postgres"
        Include  {
            Options {
-               compression=GZIP
-               signature = MD5
+               Compression = LZ4
+               Signature = XXH128
            }
            Plugin = "python"
                     ":module_name=bareos-fd-postgres"

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -97,8 +97,8 @@ To define the backup of a VM in Bareos, a job definition and a fileset resource 
 
      Include {
        Options {
-            signature = MD5
-            Compression = GZIP
+            Signature = XXH128
+            Compression = LZ4
        }
        Plugin = "python"
                 ":module_name=bareos-fd-vmware"
@@ -202,8 +202,8 @@ Since :sinceVersion:`17.2.8: VMware Plugin: non-ascii characters` it is possible
 
      Include {
        Options {
-            signature = MD5
-            Compression = GZIP
+            Signature = XXH128
+            Compression = LZ4
        }
        Plugin = "python"
                 ":module_name=bareos-fd-vmware"
@@ -221,8 +221,8 @@ Since :sinceVersion:`17.2.8: VMware Plugin: non-ascii characters` it is possible
 
      Include {
        Options {
-            signature = MD5
-            Compression = GZIP
+            Signature = XXH128
+            Compression = LZ4
        }
        Plugin = "python"
                 ":module_name=bareos-fd-vmware"
@@ -247,8 +247,8 @@ Since :sinceVersion:`20: VMware Plugin: config file` it is optionally possible t
 
      Include {
        Options {
-            signature = MD5
-            Compression = GZIP
+            Signature = XXH128
+            Compression = LZ4
        }
        Plugin = "python"
                 ":module_name=bareos-fd-vmware"

--- a/docs/manuals/source/TasksAndConcepts/VolumeManagement.rst
+++ b/docs/manuals/source/TasksAndConcepts/VolumeManagement.rst
@@ -3,7 +3,9 @@
 Volume Management
 =================
 
-:index:`\ <single: Volume; Management>`\  :index:`\ <single: Disk Volumes>`\
+.. index::
+   single: Volume; Management
+   single: Disk Volumes
 
 This chapter presents most all the features needed to do Volume management. Most of the concepts apply equally well to both tape and disk Volumes. However, the chapter was originally written to explain backing up to disk, so you will see it is slanted in that direction, but all the directives presented here apply equally well whether your volume is disk or tape.
 
@@ -12,7 +14,8 @@ If you have a lot of hard disk storage or you absolutely must have your backups 
 Key Concepts and Resource Records
 ---------------------------------
 
-:index:`\ <single: Volume; Management; Key Concepts and Resource Records>`\
+.. index::
+   single: Volume; Management; Key Concepts and Resource Records
 
 Getting Bareos to write to disk rather than tape in the simplest case is rather easy. In the Storage daemon’s configuration file, you simply define an :config:option:`sd/device/ArchiveDevice`\  to be a directory. The default directory to store backups on disk is :file:`/var/lib/bareos/storage`:
 
@@ -58,7 +61,8 @@ In addition, if you want to use concurrent jobs that write to several different 
 Pool Options to Limit the Volume Usage
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:index:`\ <single: Pool; Options to Limit the Volume Usage>`\
+.. index::
+   single: Pool; Options to Limit the Volume Usage
 
 Some of the options you have, all of which are specified in the Pool record, are:
 
@@ -213,8 +217,8 @@ The |dir| configuration is as follows:
      Name = "Example FileSet"
      Include {
        Options {
-         compression=GZIP
-         signature=SHA1
+         Compression = LZ4
+         Signature = XXH128
        }
        File = /etc
      }


### PR DESCRIPTION
This PR propose to update our documentation by replacing the slowest compression algorithm we have (GZIP) by a modern and well supported format LZ4.
We also replaced the oldest MD5 or SHA1 signature exemple by the XXH128

OP#5451
#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
