### PR TITLE
daemons: update network handling when IP protocols unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - vmware_cbt_tool.py: pyVmomi 8.x compatibility [PR #1386]
 - Fix problem with reoccuring files in always incremental [PR #1395]
 - bsmtp bls bextract: fixes for command line parsing [PR #1455]
+- daemons: update network handling when IP protocols unavailable [PR #1454]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -151,5 +152,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1445]: https://github.com/bareos/bareos/pull/1445
 [PR #1447]: https://github.com/bareos/bareos/pull/1447
 [PR #1453]: https://github.com/bareos/bareos/pull/1453
+[PR #1454]: https://github.com/bareos/bareos/pull/1454
 [PR #1455]: https://github.com/bareos/bareos/pull/1455
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -377,9 +377,9 @@ bool CheckIfFamilyEnabled(IpFamily family)
   do {
     ++tries;
     if ((fd = socket(GetFamily(family).value(), SOCK_STREAM, 0)) < 0) {
-      Bmicrosleep(5, 0);
+      Bmicrosleep(15, 0);
     }
-  } while (fd < 0 && tries < 2);
+  } while (fd < 0 && tries < 3);
 
   if (fd < 0) {
     BErrNo be;

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -37,9 +37,6 @@
 #ifdef HAVE_ARPA_NAMESER_H
 #  include <arpa/nameser.h>
 #endif
-#ifdef HAVE_RESOLV_H
-//#include <resolv.h>
-#endif
 
 IPADDR::IPADDR()
     : type(R_UNDEFINED), saddr(nullptr), saddr4(nullptr), saddr6(nullptr)

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -339,7 +339,17 @@ bool SetupPort(unsigned short& port,
   }
 }
 
-bool FamilyEnabled(int family)
+bool IsFamilyEnabled(int family)
+{
+  static bool ipv6_enabled = CheckIfFamilyEnabled(AF_INET6);
+  static bool ipv4_enabled = CheckIfFamilyEnabled(AF_INET);
+
+  if (family == AF_INET6) { return ipv6_enabled; }
+  if (family == AF_INET) { return ipv4_enabled; }
+  return false;
+}
+
+bool CheckIfFamilyEnabled(int family)
 {
   int tries = 0;
   int fd;
@@ -395,18 +405,18 @@ int AddAddress(dlist<IPADDR>** out,
   if (!SetupPort(port, defaultport, port_str, buf, buflen)) { return 0; }
 
   if (family == 0) {
-    bool ipv4_enabled = FamilyEnabled(AF_INET);
-    bool ipv6_enabled = FamilyEnabled(AF_INET6);
+    bool ipv4_enabled = IsFamilyEnabled(AF_INET);
+    bool ipv6_enabled = IsFamilyEnabled(AF_INET6);
     if (!ipv4_enabled && ipv6_enabled) { family = AF_INET6; }
     if (ipv4_enabled && !ipv6_enabled) { family = AF_INET; }
     if (!ipv4_enabled && !ipv6_enabled) {
       Bsnprintf(buf, buflen, _("Both IPv4 are IPv6 are disabled!"));
       return 0;
     }
-  } else if (family == AF_INET6 && !FamilyEnabled(AF_INET6)) {
+  } else if (family == AF_INET6 && !IsFamilyEnabled(AF_INET6)) {
     Bsnprintf(buf, buflen, _("IPv6 address wanted but IPv6 is disabled!"));
     return 0;
-  } else if (family == AF_INET && !FamilyEnabled(AF_INET)) {
+  } else if (family == AF_INET && !IsFamilyEnabled(AF_INET)) {
     Bsnprintf(buf, buflen, _("IPv4 address wanted but IPv4 is disabled!"));
     return 0;
   }

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -98,7 +98,7 @@ int AddAddress(dlist<IPADDR>** out,
                const char* port_str,
                char* buf,
                int buflen);
-bool FamilyEnabled(int family);
+bool CheckIfFamilyEnabled(int family);
 
 bool IsSameIpAddress(IPADDR* first, IPADDR* second);
 const char* BuildAddressesString(dlist<IPADDR>* addrs,

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -98,6 +98,7 @@ int AddAddress(dlist<IPADDR>** out,
                const char* port_str,
                char* buf,
                int buflen);
+bool FamilyEnabled(int family);
 
 bool IsSameIpAddress(IPADDR* first, IPADDR* second);
 const char* BuildAddressesString(dlist<IPADDR>* addrs,

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -32,6 +32,12 @@
 
 class OutputFormatterResource;
 
+enum class IpFamily
+{
+  V4,
+  V6
+};
+
 /* clang-format off */
 class IPADDR {
  public:
@@ -98,7 +104,7 @@ int AddAddress(dlist<IPADDR>** out,
                const char* port_str,
                char* buf,
                int buflen);
-bool CheckIfFamilyEnabled(int family);
+bool CheckIfFamilyEnabled(IpFamily family);
 
 bool IsSameIpAddress(IPADDR* first, IPADDR* second);
 const char* BuildAddressesString(dlist<IPADDR>* addrs,

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -47,9 +47,6 @@
 #ifdef HAVE_ARPA_NAMESER_H
 #  include <arpa/nameser.h>
 #endif
-#ifdef HAVE_RESOLV_H
-// #include <resolv.h>
-#endif
 
 #ifdef HAVE_POLL_H
 #  include <poll.h>

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -169,7 +169,7 @@ int OpenSocketAndBind(IPADDR* ipaddr,
     std::array<char, 256> buf1;
     std::vector<char> buf2(256 * addr_list->size());
 
-    Emsg3(M_ABORT, 0,
+    Emsg3(M_WARNING, 0,
           _("Cannot open stream socket. ERR=%s. Current %s All %s\n"),
           be.bstrerror(), ipaddr->build_address_str(buf1.data(), buf1.size()),
           BuildAddressesString(addr_list, buf2.data(), buf2.size()));

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -287,7 +287,7 @@ if(NOT client-only)
   bareos_add_test(sort_stringvector LINK_LIBRARIES bareos GTest::gtest_main)
   bareos_add_test(
     test_config_parser_dir LINK_LIBRARIES dird_objects bareos bareosfind
-                                          bareossql GTest::gtest_main
+                                          testing_common bareossql GTest::gtest_main
   )
   set_tests_properties(
     gtest:ConfigParser_Dir.bareos_configparser_tests

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -286,8 +286,9 @@ if(NOT client-only)
   )
   bareos_add_test(sort_stringvector LINK_LIBRARIES bareos GTest::gtest_main)
   bareos_add_test(
-    test_config_parser_dir LINK_LIBRARIES dird_objects bareos bareosfind
-                                          testing_common bareossql GTest::gtest_main
+    test_config_parser_dir
+    LINK_LIBRARIES dird_objects bareos bareosfind testing_common bareossql
+                   GTest::gtest_main
   )
   set_tests_properties(
     gtest:ConfigParser_Dir.bareos_configparser_tests

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -153,7 +153,13 @@ endif()
 # Keep alphabetically ordered
 if(NOT client-only)
   bareos_add_test(
-    addresses_and_ports
+    addresses_and_ports_config
+    LINK_LIBRARIES bareos dird_objects bareosfind bareossql testing_common
+                   $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}> GTest::gtest_main
+  )
+
+  bareos_add_test(
+    addresses_and_ports_functions
     LINK_LIBRARIES bareos dird_objects bareosfind bareossql testing_common
                    $<$<BOOL:HAVE_PAM>:${PAM_LIBRARIES}> GTest::gtest_main
   )

--- a/core/src/tests/addresses_and_ports_config.cc
+++ b/core/src/tests/addresses_and_ports_config.cc
@@ -157,12 +157,11 @@ static void check_addresses_list(std::string path_to_config,
   EXPECT_EQ(director_addresses, expected_addresses);
 }
 
-class AddressesAndPortsSetup : public ::testing::Test {
+class AddressesAndPortsConfigurationSetup : public ::testing::Test {
   void SetUp() override { InitDirGlobals(); }
 };
 
-
-TEST_F(AddressesAndPortsSetup, default_config_values)
+TEST_F(AddressesAndPortsConfigurationSetup, default_config_values)
 {
   std::string path_to_config
       = std::string(RELATIVE_PROJECT_SOURCE_DIR
@@ -175,7 +174,7 @@ TEST_F(AddressesAndPortsSetup, default_config_values)
   EXPECT_FALSE(try_binding_director_port(path_to_config, 0, 9101));
 }
 
-TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_port_set)
+TEST_F(AddressesAndPortsConfigurationSetup, OLD_STYLE_dir_port_set)
 {
   std::string path_to_config
       = std::string(RELATIVE_PROJECT_SOURCE_DIR
@@ -189,7 +188,7 @@ TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_port_set)
   EXPECT_FALSE(try_binding_director_port(path_to_config, 0, 29998));
 }
 
-TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, OLD_STYLE_dir_v4address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -200,7 +199,7 @@ TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4address_set)
   check_addresses_list(path_to_config, expected_addresses);
 }
 
-TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v6address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, OLD_STYLE_dir_v6address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -218,7 +217,8 @@ TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v6address_set)
  different when DirPort comes before DirAddress in the config file, and vice
  versa.*/
 
-TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4port_and_address_set)
+TEST_F(AddressesAndPortsConfigurationSetup,
+       OLD_STYLE_dir_v4port_and_address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -231,7 +231,8 @@ TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4port_and_address_set)
   EXPECT_FALSE(try_binding_director_port(path_to_config, AF_INET, 29997));
 }
 
-TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4address_and_port_set)
+TEST_F(AddressesAndPortsConfigurationSetup,
+       OLD_STYLE_dir_v4address_and_port_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -242,7 +243,7 @@ TEST_F(AddressesAndPortsSetup, OLD_STYLE_dir_v4address_and_port_set)
   check_addresses_list(path_to_config, expected_addresses);
 }
 
-TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_v6_address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, NEW_STYLE_dir_v6_address_set)
 {
   std::string path_to_config
       = std::string(RELATIVE_PROJECT_SOURCE_DIR
@@ -253,7 +254,7 @@ TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_v6_address_set)
   check_addresses_list(path_to_config, expected_addresses);
 }
 
-TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_v6_and_v4_address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, NEW_STYLE_dir_v6_and_v4_address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -265,7 +266,7 @@ TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_v6_and_v4_address_set)
   check_addresses_list(path_to_config, expected_addresses);
 }
 
-TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_ip_v4_address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, NEW_STYLE_dir_ip_v4_address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR
@@ -276,7 +277,7 @@ TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_ip_v4_address_set)
   check_addresses_list(path_to_config, expected_addresses);
 }
 
-TEST_F(AddressesAndPortsSetup, NEW_STYLE_dir_ip_v6_address_set)
+TEST_F(AddressesAndPortsConfigurationSetup, NEW_STYLE_dir_ip_v6_address_set)
 {
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR

--- a/core/src/tests/addresses_and_ports_functions.cc
+++ b/core/src/tests/addresses_and_ports_functions.cc
@@ -35,11 +35,10 @@ std::vector<std::string> CreateAddressesFromAddAddress(
 {
   std::vector<std::string> newaddresses{};
   char buf[1024];
-  dlist<IPADDR>* addresses = new dlist<IPADDR>();
+  dlist<IPADDR>* addresses = nullptr;
 
-  dlist<IPADDR>** fake_resource_pointer = &addresses;
-  AddAddress(fake_resource_pointer, type, htons(default_port), family,
-             hostname_str, port_str, buf, sizeof(buf));
+  AddAddress(&addresses, type, htons(default_port), family, hostname_str,
+             port_str, buf, sizeof(buf));
 
   IPADDR* addr = nullptr;
   foreach_dlist (addr, addresses) {

--- a/core/src/tests/addresses_and_ports_functions.cc
+++ b/core/src/tests/addresses_and_ports_functions.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
 
 This program is Free Software; you can redistribute it and/or
 modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/addresses_and_ports_functions.cc
+++ b/core/src/tests/addresses_and_ports_functions.cc
@@ -1,0 +1,111 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#include "testing_dir_common.h"
+
+#include "lib/address_conf.h"
+#include "lib/bnet.h"
+
+const unsigned short default_port = 9101;
+
+std::vector<std::string> CreateAddressesFromAddAddress(
+    IPADDR::i_type type,
+    int family,
+    unsigned short default_port,
+    const char* hostname_str,
+    const char* port_str)
+{
+  std::vector<std::string> newaddresses{};
+  char buf[1024];
+  dlist<IPADDR>* addresses = new dlist<IPADDR>();
+
+  dlist<IPADDR>** fake_resource_pointer = &addresses;
+  AddAddress(fake_resource_pointer, type, htons(default_port), family,
+             hostname_str, port_str, buf, sizeof(buf));
+
+  IPADDR* addr = nullptr;
+  foreach_dlist (addr, addresses) {
+    addr->build_address_str(buf, sizeof(buf), true);
+
+    std::string theaddress(buf);
+    theaddress.pop_back();
+
+    newaddresses.emplace_back(std::move(theaddress));
+  }
+  FreeAddresses(addresses);
+  return newaddresses;
+}
+
+class AddressesAndPortsFunctions : public ::testing::Test {
+  void SetUp() override { InitDirGlobals(); }
+};
+
+TEST_F(AddressesAndPortsFunctions, DefaultAddressesAreCorrectlyProcessed)
+{
+  std::vector<std::string> addresses = CreateAddressesFromAddAddress(
+      IPADDR::R_DEFAULT, 0, default_port, "", "");
+  std::vector<std::string> expected_addresses{"host[ipv4;0.0.0.0;9101]",
+                                              "host[ipv6;::;9101]"};
+  EXPECT_EQ(addresses, expected_addresses);
+}
+
+TEST_F(AddressesAndPortsFunctions, IPv4AddressesAreCorrectlyProcessed)
+{
+  std::vector<std::string> addresses = CreateAddressesFromAddAddress(
+      IPADDR::R_DEFAULT, AF_INET, default_port, "", "");
+  std::vector<std::string> expected_addresses{"host[ipv4;0.0.0.0;9101]"};
+  EXPECT_EQ(addresses, expected_addresses);
+
+  addresses = CreateAddressesFromAddAddress(IPADDR::R_MULTIPLE, AF_INET,
+                                            default_port, "1.2.3.4", "5000");
+  expected_addresses = {"host[ipv4;1.2.3.4;5000]"};
+  EXPECT_EQ(addresses, expected_addresses);
+
+  addresses = CreateAddressesFromAddAddress(IPADDR::R_MULTIPLE, AF_INET,
+                                            default_port, "257.2.3.4", "5000");
+  EXPECT_TRUE(addresses.empty());
+
+  addresses = CreateAddressesFromAddAddress(IPADDR::R_MULTIPLE, AF_INET,
+                                            default_port, "1.2.3.4", "70000");
+  EXPECT_TRUE(addresses.empty());
+}
+
+TEST_F(AddressesAndPortsFunctions, IPv6AddressesAreCorrectlyProcessed)
+{
+  std::vector<std::string> addresses = CreateAddressesFromAddAddress(
+      IPADDR::R_DEFAULT, AF_INET6, default_port, "", "");
+  std::vector<std::string> expected_addresses{"host[ipv6;::;9101]"};
+  EXPECT_EQ(addresses, expected_addresses);
+
+  addresses = CreateAddressesFromAddAddress(IPADDR::R_MULTIPLE, AF_INET6,
+                                            default_port, "", "");
+  expected_addresses = {"host[ipv6;::;9101]"};
+  EXPECT_EQ(addresses, expected_addresses);
+
+  addresses = CreateAddressesFromAddAddress(
+      IPADDR::R_MULTIPLE, AF_INET6, default_port, "1:2:3:4:5:6:7:8", "5000");
+  expected_addresses = {"host[ipv6;1:2:3:4:5:6:7:8;5000]"};
+  EXPECT_EQ(addresses, expected_addresses);
+
+  addresses = CreateAddressesFromAddAddress(IPADDR::R_MULTIPLE, AF_INET6,
+                                            default_port, "AAAA:AAAA:AAAA", "");
+  EXPECT_TRUE(addresses.empty());
+}

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -162,7 +162,7 @@ TEST(dlist, dynamic)
   FreeDlist(list);
 }
 
-TEST(dlist, dlist)
+TEST(dlist, RemoveAndReplacePrependedElement)
 {
   char buf[30];
   dlist<MYJCR>* jcr_chain;
@@ -197,6 +197,16 @@ TEST(dlist, dlist)
     free(jcr->buf);
   }
   delete jcr_chain;
+}
+
+TEST(dlist, RemoveAndReplaceAppendedElement)
+{
+  char buf[30];
+  dlist<MYJCR>* jcr_chain;
+  MYJCR* jcr = NULL;
+  MYJCR* save_jcr = NULL;
+  MYJCR* next_jcr;
+  int index = 0;
 
   /* The following may seem a bit odd, but we create a chaing
    *  of jcr objects.  Within a jcr object, there is a buf
@@ -227,7 +237,14 @@ TEST(dlist, dlist)
   }
 
   delete jcr_chain;
+}
 
+TEST(dlist, BinaryInsert)
+{
+  char buf[30];
+  dlist<MYJCR>* jcr_chain;
+  MYJCR* jcr = NULL;
+  MYJCR* jcr1;
 
   /* Now do a binary insert for the list */
   jcr_chain = new dlist<MYJCR>();
@@ -298,7 +315,6 @@ TEST(dlist, dlistString)
     buf[0]--;
   }
   dlistString* node;
-  foreach_dlist (node, chain) {
-  }
+  foreach_dlist (node, chain) {}
   chain->destroy();
 }

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -30,6 +30,7 @@
 #include "dird/dird_globals.h"
 #include "dird/dird_conf.h"
 #include "lib/output_formatter_resource.h"
+#include "testing_dir_common.h"
 
 #include <thread>
 #include <condition_variable>
@@ -53,10 +54,12 @@ bool sprintit(void*, const char* fmt, ...)
   return true;
 }
 
-TEST(ConfigParser_Dir, ParseSchedulerOddEvenDaysCorrectly)
-{
-  OSDependentInit();
+class ConfigParser_Dir : public ::testing::Test {
+  void SetUp() override { InitDirGlobals(); }
+};
 
+TEST_F(ConfigParser_Dir, ParseSchedulerOddEvenDaysCorrectly)
+{
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -96,9 +99,8 @@ TEST(ConfigParser_Dir, ParseSchedulerOddEvenDaysCorrectly)
   EXPECT_EQ(sprintoutput, expected_output);
 }
 
-TEST(ConfigParser_Dir, bareos_configparser_tests)
+TEST_F(ConfigParser_Dir, bareos_configparser_tests)
 {
-  OSDependentInit();
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -133,9 +135,8 @@ TEST(ConfigParser_Dir, bareos_configparser_tests)
   delete my_config;
 }
 
-TEST(ConfigParser_Dir, foreach_res_and_reload)
+TEST_F(ConfigParser_Dir, foreach_res_and_reload)
 {
-  OSDependentInit();
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -190,10 +191,8 @@ TEST(ConfigParser_Dir, foreach_res_and_reload)
   delete my_config;
 }  // namespace directordaemon
 
-TEST(ConfigParser_Dir, runscript_test)
+TEST_F(ConfigParser_Dir, runscript_test)
 {
-  OSDependentInit();
-
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/runscript-tests/bareos-dir.conf");
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
@@ -240,7 +239,7 @@ void test_CFG_TYPE_AUDIT(DirectorResource* me)
   EXPECT_EQ(me->audit_events->size(), 8);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_AUDIT)
+TEST_F(ConfigParser_Dir, CFG_TYPE_AUDIT)
 {
   test_config_directive_type(test_CFG_TYPE_AUDIT);
 }
@@ -253,7 +252,7 @@ void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* me)
   EXPECT_EQ(me->plugin_names->size(), 16);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_PLUGIN_NAMES)
+TEST_F(ConfigParser_Dir, CFG_TYPE_PLUGIN_NAMES)
 {
   test_config_directive_type(test_CFG_TYPE_PLUGIN_NAMES);
 }
@@ -264,7 +263,7 @@ void test_CFG_TYPE_STR_VECTOR(DirectorResource* me)
   EXPECT_EQ(me->tls_cert_.allowed_certificate_common_names_.size(), 8);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_STR_VECTOR)
+TEST_F(ConfigParser_Dir, CFG_TYPE_STR_VECTOR)
 {
   test_config_directive_type(test_CFG_TYPE_STR_VECTOR);
 }
@@ -285,7 +284,7 @@ void test_CFG_TYPE_ALIST_STR(DirectorResource*)
   EXPECT_EQ(job2->run_cmds->size(), 8);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_ALIST_STR)
+TEST_F(ConfigParser_Dir, CFG_TYPE_ALIST_STR)
 {
   test_config_directive_type(test_CFG_TYPE_ALIST_STR);
 }
@@ -299,7 +298,7 @@ void test_CFG_TYPE_ALIST_RES(DirectorResource*)
   EXPECT_EQ(job1->base->size(), 8);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_ALIST_RES)
+TEST_F(ConfigParser_Dir, CFG_TYPE_ALIST_RES)
 {
   test_config_directive_type(test_CFG_TYPE_ALIST_RES);
 }
@@ -312,7 +311,7 @@ void test_CFG_TYPE_STR(DirectorResource* me)
   EXPECT_STREQ(me->description_, "item31");
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_STR)
+TEST_F(ConfigParser_Dir, CFG_TYPE_STR)
 {
   test_config_directive_type(test_CFG_TYPE_STR);
 }
@@ -332,7 +331,7 @@ void test_CFG_TYPE_FNAME(DirectorResource*)
   foreach_alist (val, files) { printf("Files = %s\n", val); }
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_FNAME)
+TEST_F(ConfigParser_Dir, CFG_TYPE_FNAME)
 {
   test_config_directive_type(test_CFG_TYPE_FNAME);
 }
@@ -345,7 +344,7 @@ void test_CFG_TYPE_TIME(DirectorResource* me)
   EXPECT_EQ(me->heartbeat_interval, 38898367);
 }
 
-TEST(ConfigParser_Dir, CFG_TYPE_TIME)
+TEST_F(ConfigParser_Dir, CFG_TYPE_TIME)
 {
   test_config_directive_type(test_CFG_TYPE_TIME);
 }

--- a/core/src/tests/test_config_parser_fd.cc
+++ b/core/src/tests/test_config_parser_fd.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/test_config_parser_fd.cc
+++ b/core/src/tests/test_config_parser_fd.cc
@@ -36,6 +36,10 @@ TEST(ConfigParser, test_filed_config)
 {
   OSDependentInit();
 
+#if HAVE_WIN32
+  WSA_Init();
+#endif
+
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
   my_config = InitFdConfig(path_to_config_file.c_str(), M_ERROR_TERM);

--- a/core/src/win32/compat/include/mingwconfig.h
+++ b/core/src/win32/compat/include/mingwconfig.h
@@ -75,9 +75,6 @@
 /* Define to 1 if you have the `Readdir_r' function. */
 /* #undef HAVE_READDIR_R */
 
-/* Define to 1 if you have the <resolv.h> header file. */
-/* #undef HAVE_RESOLV_H */
-
 /* Define to 1 if translation of program messages to the user's native
    language is requested. */
 #if (defined _MSC_VER) && (_MSC_VER >= 1400)  // VC8+


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Description

Even though IPv6 has been widely available across platforms, there can be situations where it can be outright disabled. In that case, Bareos wouldn't be able to create IPv6 sockets and would abort, dumping core files along the way.

The above issue prompted this PR, which updates how Bareos daemons handle this kind of situation.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
