### PR TITLE
build: fix for gcc 13.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: create internal api module [PR #1447]
 - webui: make restore merge options configurable [PR #1445]
 - webui: update German translation [PR #1437]
+- build: fix for gcc 13.1.1 [PR #1459]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -154,4 +155,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1453]: https://github.com/bareos/bareos/pull/1453
 [PR #1454]: https://github.com/bareos/bareos/pull/1454
 [PR #1455]: https://github.com/bareos/bareos/pull/1455
+[PR #1459]: https://github.com/bareos/bareos/pull/1459
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

We previously merged a PR that fixes some issues raised by `gcc 13`, but those fixes were only for `gcc 13.0.1`.
The updated `gcc 13.1.1` raises another issue that this PR tries to fix.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
