### PR TITLE
python-bareos: add missing `dirname` variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: update German translation [PR #1437]
 - build: fix for gcc 13.1.1 [PR #1459]
 - packaging: systemd unit: set a limit of restart [PR #1450]
+- python-bareos: add missing `dirname` variable [PR #1460]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -158,4 +159,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1454]: https://github.com/bareos/bareos/pull/1454
 [PR #1455]: https://github.com/bareos/bareos/pull/1455
 [PR #1459]: https://github.com/bareos/bareos/pull/1459
+[PR #1460]: https://github.com/bareos/bareos/pull/1460
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/filedaemon.py
+++ b/python-bareos/bareos/bsock/filedaemon.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -100,6 +100,7 @@ class FileDaemon(LowLevel):
         self,
         address="localhost",
         port=9102,
+        dirname=None,
         name=None,
         password=None,
         tls_psk_enable=True,

--- a/python-bareos/bareos/bsock/filedaemon.py
+++ b/python-bareos/bareos/bsock/filedaemon.py
@@ -137,20 +137,20 @@ class FileDaemon(LowLevel):
             self.tls_version = tls_version
         # Well, we are not really a Director,
         # but using the interface provided for Directors.
-        self.identity_prefix = u"R_DIRECTOR"
+        self.identity_prefix = "R_DIRECTOR"
         self.connect(address, port, dirname, ConnectionType.FILEDAEMON, name, password)
         self._init_connection()
 
     def _finalize_authentication(self):
         code, text = self.receive_and_evaluate_response_message()
 
-        self.logger.debug(u"code: {0}".format(code))
+        self.logger.debug("code: {0}".format(code))
 
         #
         # Test if authentication has been accepted.
         #
         if code == ProtocolMessageIds.FdOk:
-            self.logger.info(u"Authentication: {0}".format(text))
+            self.logger.info("Authentication: {0}".format(text))
             self.auth_credentials_valid = True
         else:
             raise bareos.exceptions.AuthenticationError(


### PR DESCRIPTION
- fix systemtest failure system:python-bareos:filedaemon `dirname is not defined`

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
