### PR TITLE
stored: add AccessMode SD->Device directive to reserve devices exclusively for reading or writing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: show current and allowed console connections [PR #1487]
 - dird: add prev and new jobid variables [PR #1499]
 - improve default configuration [PR #1508]
+- stored: add AccessMode SD->Device directive to reserve devices exclusively for reading or writing [PR #1464]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -201,6 +202,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1455]: https://github.com/bareos/bareos/pull/1455
 [PR #1459]: https://github.com/bareos/bareos/pull/1459
 [PR #1460]: https://github.com/bareos/bareos/pull/1460
+[PR #1464]: https://github.com/bareos/bareos/pull/1464
 [PR #1466]: https://github.com/bareos/bareos/pull/1466
 [PR #1468]: https://github.com/bareos/bareos/pull/1468
 [PR #1469]: https://github.com/bareos/bareos/pull/1469

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -115,15 +115,13 @@ static int const debuglevel = 200;
 // Does the mode contain OUT
 static bool AutoxflateModeContainsOut(IODirection mode)
 {
-  return (mode == IODirection::WRITE
-          || mode == IODirection::READ_WRITE);
+  return (mode == IODirection::WRITE || mode == IODirection::READ_WRITE);
 }
 
 // Does the mode contain IN
 static bool AutoxflateModeContainsIn(IODirection mode)
 {
-  return (mode == IODirection::READ
-          || mode == IODirection::READ_WRITE);
+  return (mode == IODirection::READ || mode == IODirection::READ_WRITE);
 }
 
 // what streams can be decompressed by the plugin

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -113,17 +113,17 @@ static int const debuglevel = 200;
 
 
 // Does the mode contain OUT
-static bool AutoxflateModeContainsOut(AutoXflateMode mode)
+static bool AutoxflateModeContainsOut(IODirection mode)
 {
-  return (mode == AutoXflateMode::IO_DIRECTION_OUT
-          || mode == AutoXflateMode::IO_DIRECTION_INOUT);
+  return (mode == IODirection::WRITE
+          || mode == IODirection::READ_WRITE);
 }
 
 // Does the mode contain IN
-static bool AutoxflateModeContainsIn(AutoXflateMode mode)
+static bool AutoxflateModeContainsIn(IODirection mode)
 {
-  return (mode == AutoXflateMode::IO_DIRECTION_IN
-          || mode == AutoXflateMode::IO_DIRECTION_INOUT);
+  return (mode == IODirection::READ
+          || mode == IODirection::READ_WRITE);
 }
 
 // what streams can be decompressed by the plugin
@@ -312,8 +312,8 @@ static bRC setup_record_translation(PluginContext* ctx, void* value)
       && dcr->jcr->is_JobType(JT_RESTORE)
       && (AutoxflateModeContainsIn(dcr->autodeflate)
           || !AutoxflateModeContainsIn(dcr->autoinflate))) {
-    dcr->autoinflate = AutoXflateMode::IO_DIRECTION_IN;
-    dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
+    dcr->autoinflate = IODirection::READ;
+    dcr->autodeflate = IODirection::NONE;
     Jmsg(ctx, M_INFO,
          _("autoxflate-sd: overriding settings on %s for NDMP restore\n"),
          dcr->dev_name);
@@ -321,19 +321,19 @@ static bRC setup_record_translation(PluginContext* ctx, void* value)
 
   // Give jobmessage info what is configured
   switch (dcr->autodeflate) {
-    case AutoXflateMode::IO_DIRECTION_NONE:
+    case IODirection::NONE:
       deflate_in = SETTING_NO;
       deflate_out = SETTING_NO;
       break;
-    case AutoXflateMode::IO_DIRECTION_IN:
+    case IODirection::READ:
       deflate_in = SETTING_YES;
       deflate_out = SETTING_NO;
       break;
-    case AutoXflateMode::IO_DIRECTION_OUT:
+    case IODirection::WRITE:
       deflate_in = SETTING_NO;
       deflate_out = SETTING_YES;
       break;
-    case AutoXflateMode::IO_DIRECTION_INOUT:
+    case IODirection::READ_WRITE:
       deflate_in = SETTING_YES;
       deflate_out = SETTING_YES;
       break;
@@ -345,19 +345,19 @@ static bRC setup_record_translation(PluginContext* ctx, void* value)
   }
 
   switch (dcr->autoinflate) {
-    case AutoXflateMode::IO_DIRECTION_NONE:
+    case IODirection::NONE:
       inflate_in = SETTING_NO;
       inflate_out = SETTING_NO;
       break;
-    case AutoXflateMode::IO_DIRECTION_IN:
+    case IODirection::READ:
       inflate_in = SETTING_YES;
       inflate_out = SETTING_NO;
       break;
-    case AutoXflateMode::IO_DIRECTION_OUT:
+    case IODirection::WRITE:
       inflate_in = SETTING_NO;
       inflate_out = SETTING_YES;
       break;
-    case AutoXflateMode::IO_DIRECTION_INOUT:
+    case IODirection::READ_WRITE:
       inflate_in = SETTING_YES;
       inflate_out = SETTING_YES;
       break;

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -179,8 +179,7 @@ static void InitiateDevice(JobControlRecord* jcr, Device* dev)
   dev->max_spool_size = dev->device_resource->max_spool_size;
   dev->drive = dev->device_resource->drive;
   dev->drive_index = dev->device_resource->drive_index;
-  dev->read_only = dev->device_resource->read_only;
-  dev->write_only = dev->device_resource->write_only;
+  dev->access_mode = dev->device_resource->access_mode;
   dev->autoselect = dev->device_resource->autoselect;
   dev->norewindonclose = dev->device_resource->norewindonclose;
   dev->device_type = dev->device_resource->device_type;

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -179,6 +179,8 @@ static void InitiateDevice(JobControlRecord* jcr, Device* dev)
   dev->max_spool_size = dev->device_resource->max_spool_size;
   dev->drive = dev->device_resource->drive;
   dev->drive_index = dev->device_resource->drive_index;
+  dev->read_only = dev->device_resource->read_only;
+  dev->write_only = dev->device_resource->write_only;
   dev->autoselect = dev->device_resource->autoselect;
   dev->norewindonclose = dev->device_resource->norewindonclose;
   dev->device_type = dev->device_resource->device_type;

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -231,6 +231,8 @@ class Device {
   int oflags{};               /**< Read/write flags */
   DeviceMode open_mode{DeviceMode::kUndefined};
   std::string device_type{};
+  bool read_only{};           /**< Select for reading only */
+  bool write_only{};          /**< Select for writing only */
   bool autoselect{};          /**< Autoselect in autochanger */
   bool norewindonclose{};     /**< Don't rewind tape drive on close */
   bool initiated{};           /**< Set when FactoryCreateDevice() called */

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -232,7 +232,7 @@ class Device {
   int oflags{};               /**< Read/write flags */
   DeviceMode open_mode{DeviceMode::kUndefined};
   std::string device_type{};
-  IODirection access_mode{};  /**< Allowed access mode(s) for reservation */
+  IODirection access_mode{IODirection::READ_WRITE};  /**< Allowed access mode(s) for reservation */
   bool autoselect{};          /**< Autoselect in autochanger */
   bool norewindonclose{};     /**< Don't rewind tape drive on close */
   bool initiated{};           /**< Set when FactoryCreateDevice() called */

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -63,7 +63,7 @@
 #include "include/bareos.h"
 #include "stored/record.h"
 #include "stored/volume_catalog_info.h"
-#include "stored/autoxflate.h"
+#include "stored/io_direction.h"
 #include "lib/btimers.h"
 
 #include <vector>
@@ -232,7 +232,7 @@ class Device {
   int oflags{};               /**< Read/write flags */
   DeviceMode open_mode{DeviceMode::kUndefined};
   std::string device_type{};
-  AutoXflateMode access_mode{}; /**< Allowed access mode(s) for reservation */
+  IODirection access_mode{};  /**< Allowed access mode(s) for reservation */
   bool autoselect{};          /**< Autoselect in autochanger */
   bool norewindonclose{};     /**< Don't rewind tape drive on close */
   bool initiated{};           /**< Set when FactoryCreateDevice() called */

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -63,6 +63,7 @@
 #include "include/bareos.h"
 #include "stored/record.h"
 #include "stored/volume_catalog_info.h"
+#include "stored/autoxflate.h"
 #include "lib/btimers.h"
 
 #include <vector>
@@ -231,8 +232,7 @@ class Device {
   int oflags{};               /**< Read/write flags */
   DeviceMode open_mode{DeviceMode::kUndefined};
   std::string device_type{};
-  bool read_only{};           /**< Select for reading only */
-  bool write_only{};          /**< Select for writing only */
+  AutoXflateMode access_mode{}; /**< Allowed access mode(s) for reservation */
   bool autoselect{};          /**< Autoselect in autochanger */
   bool norewindonclose{};     /**< Don't rewind tape drive on close */
   bool initiated{};           /**< Set when FactoryCreateDevice() called */

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -39,7 +39,7 @@
 #ifndef BAREOS_STORED_DEVICE_CONTROL_RECORD_H_
 #define BAREOS_STORED_DEVICE_CONTROL_RECORD_H_
 
-#include "stored/autoxflate.h"
+#include "stored/io_direction.h"
 #include "stored/volume_catalog_info.h"
 
 namespace storagedaemon {
@@ -97,8 +97,8 @@ class DeviceControlRecord {
   bool any_volume{};         /**< Any OK for dir_find_next... */
   bool attached_to_dev{};    /**< Set when attached to dev */
   bool keep_dcr{};           /**< Do not free dcr in release_dcr */
-  AutoXflateMode autodeflate{AutoXflateMode::IO_DIRECTION_NONE};
-  AutoXflateMode autoinflate{AutoXflateMode::IO_DIRECTION_NONE};
+  IODirection autodeflate{IODirection::NONE};
+  IODirection autoinflate{IODirection::NONE};
   uint32_t VolFirstIndex{};        /**< First file index this Volume */
   uint32_t VolLastIndex{};         /**< Last file index this Volume */
   uint32_t FileIndex{};            /**< Current File Index */

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -22,7 +22,6 @@
 */
 
 #include "lib/parse_conf.h"
-#include "stored/autoxflate.h"
 #include "stored/device_resource.h"
 #include "stored/stored_globals.h"
 #include <fmt/format.h>

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -62,8 +62,7 @@ DeviceResource::DeviceResource(const DeviceResource& other)
   }
   device_type = other.device_type;
   label_type = other.label_type;
-  read_only = other.read_only;
-  write_only = other.write_only;
+  access_mode = other.access_mode;
   autoselect = other.autoselect;
   norewindonclose = other.norewindonclose;
   drive_tapealert_enabled = other.drive_tapealert_enabled;
@@ -119,8 +118,7 @@ DeviceResource& DeviceResource::operator=(const DeviceResource& rhs)
   spool_directory = rhs.spool_directory;
   device_type = rhs.device_type;
   label_type = rhs.label_type;
-  read_only = rhs.read_only;
-  write_only = rhs.write_only;
+  access_mode = rhs.access_mode;
   autoselect = rhs.autoselect;
   norewindonclose = rhs.norewindonclose;
   drive_tapealert_enabled = rhs.drive_tapealert_enabled;

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -62,6 +62,8 @@ DeviceResource::DeviceResource(const DeviceResource& other)
   }
   device_type = other.device_type;
   label_type = other.label_type;
+  read_only = other.read_only;
+  write_only = other.write_only;
   autoselect = other.autoselect;
   norewindonclose = other.norewindonclose;
   drive_tapealert_enabled = other.drive_tapealert_enabled;
@@ -117,6 +119,8 @@ DeviceResource& DeviceResource::operator=(const DeviceResource& rhs)
   spool_directory = rhs.spool_directory;
   device_type = rhs.device_type;
   label_type = rhs.label_type;
+  read_only = rhs.read_only;
+  write_only = rhs.write_only;
   autoselect = rhs.autoselect;
   norewindonclose = rhs.norewindonclose;
   drive_tapealert_enabled = rhs.drive_tapealert_enabled;

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -25,7 +25,7 @@
 #define BAREOS_STORED_DEVICE_RESOURCE_H_
 
 #include "stored/dev.h"
-#include "stored/autoxflate.h"
+#include "stored/io_direction.h"
 #include "lib/bareos_resource.h"
 
 namespace storagedaemon {
@@ -45,7 +45,7 @@ class DeviceResource : public BareosResource {
   char* spool_directory;       /**< Spool file directory */
   std::string device_type{DeviceType::B_UNKNOWN_DEV};
   uint32_t label_type{B_BAREOS_LABEL};
-  AutoXflateMode access_mode{AutoXflateMode::IO_DIRECTION_INOUT};   /**< Allowed access mode(s) for reservation */
+  IODirection access_mode{IODirection::READ_WRITE}; /**< Allowed access mode(s) for reservation */
   bool autoselect{true};      /**< Automatically select from AutoChanger */
   bool norewindonclose{true}; /**< Don't rewind tape drive on close */
   bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */
@@ -70,11 +70,11 @@ class DeviceResource : public BareosResource {
                                      compression */
   uint16_t autodeflate_level{6}; /**< Compression level to use for compression
                                  algorithm which uses levels */
-  AutoXflateMode autodeflate{
-      AutoXflateMode::IO_DIRECTION_NONE}; /**< auto deflation in this IO
+  IODirection autodeflate{
+      IODirection::NONE}; /**< auto deflation in this IO
                                              direction */
-  AutoXflateMode autoinflate{
-      AutoXflateMode::IO_DIRECTION_NONE}; /**< auto inflation in this IO
+  IODirection autoinflate{
+      IODirection::NONE}; /**< auto inflation in this IO
                                              direction */
   utime_t vol_poll_interval{
       300}; /**< Interval between polling volume during mount */

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -45,9 +45,10 @@ class DeviceResource : public BareosResource {
   char* spool_directory;       /**< Spool file directory */
   std::string device_type{DeviceType::B_UNKNOWN_DEV};
   uint32_t label_type{B_BAREOS_LABEL};
-  IODirection access_mode{IODirection::READ_WRITE}; /**< Allowed access mode(s) for reservation */
-  bool autoselect{true};      /**< Automatically select from AutoChanger */
-  bool norewindonclose{true}; /**< Don't rewind tape drive on close */
+  IODirection access_mode{
+      IODirection::READ_WRITE}; /**< Allowed access mode(s) for reservation */
+  bool autoselect{true};        /**< Automatically select from AutoChanger */
+  bool norewindonclose{true};   /**< Don't rewind tape drive on close */
   bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */
   bool drive_crypto_enabled{false};    /**< Enable hardware crypto */
   bool query_crypto_status{false};     /**< Query device for crypto status */
@@ -70,12 +71,10 @@ class DeviceResource : public BareosResource {
                                      compression */
   uint16_t autodeflate_level{6}; /**< Compression level to use for compression
                                  algorithm which uses levels */
-  IODirection autodeflate{
-      IODirection::NONE}; /**< auto deflation in this IO
-                                             direction */
-  IODirection autoinflate{
-      IODirection::NONE}; /**< auto inflation in this IO
-                                             direction */
+  IODirection autodeflate{IODirection::NONE}; /**< auto deflation in this IO
+                                                                 direction */
+  IODirection autoinflate{IODirection::NONE}; /**< auto inflation in this IO
+                                                                 direction */
   utime_t vol_poll_interval{
       300}; /**< Interval between polling volume during mount */
   int64_t max_file_size{1000000000}; /**< Max file size in bytes */

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -45,8 +45,7 @@ class DeviceResource : public BareosResource {
   char* spool_directory;       /**< Spool file directory */
   std::string device_type{DeviceType::B_UNKNOWN_DEV};
   uint32_t label_type{B_BAREOS_LABEL};
-  bool read_only{false};       /**< Select for reading only */
-  bool write_only{false};      /**< Select for writing only */
+  AutoXflateMode access_mode{AutoXflateMode::IO_DIRECTION_INOUT};   /**< Allowed access mode(s) for reservation */
   bool autoselect{true};      /**< Automatically select from AutoChanger */
   bool norewindonclose{true}; /**< Don't rewind tape drive on close */
   bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -45,6 +45,8 @@ class DeviceResource : public BareosResource {
   char* spool_directory;       /**< Spool file directory */
   std::string device_type{DeviceType::B_UNKNOWN_DEV};
   uint32_t label_type{B_BAREOS_LABEL};
+  bool read_only{false};       /**< Select for reading only */
+  bool write_only{false};      /**< Select for writing only */
   bool autoselect{true};      /**< Automatically select from AutoChanger */
   bool norewindonclose{true}; /**< Don't rewind tape drive on close */
   bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */

--- a/core/src/stored/io_direction.h
+++ b/core/src/stored/io_direction.h
@@ -21,21 +21,21 @@
    02110-1301, USA.
 */
 
-#ifndef BAREOS_STORED_AUTOXFLATE_H_
-#define BAREOS_STORED_AUTOXFLATE_H_
+#ifndef BAREOS_STORED_IO_DIRECTION_H_
+#define BAREOS_STORED_IO_DIRECTION_H_
 
 #include "include/bareos.h"
 
 namespace storagedaemon {
 
-enum class AutoXflateMode : uint16_t
+enum class IODirection : uint16_t
 {
-  IO_DIRECTION_NONE = 0,
-  IO_DIRECTION_IN,
-  IO_DIRECTION_OUT,
-  IO_DIRECTION_INOUT
+  NONE = 0,
+  READ,
+  WRITE,
+  READ_WRITE
 };
 
 }  // namespace storagedaemon
 
-#endif  // BAREOS_STORED_AUTOXFLATE_H_
+#endif  // BAREOS_STORED_IO_DIRECTION_H_

--- a/core/src/stored/io_direction.h
+++ b/core/src/stored/io_direction.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -381,10 +381,10 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
 
   // Check autodeflation.
   switch (jcr->sd_impl->read_dcr->autodeflate) {
-    case AutoXflateMode::IO_DIRECTION_IN:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
+    case IODirection::READ:
+    case IODirection::READ_WRITE:
       Dmsg0(200, "Clearing autodeflate on read_dcr\n");
-      jcr->sd_impl->read_dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
+      jcr->sd_impl->read_dcr->autodeflate = IODirection::NONE;
       break;
     default:
       break;
@@ -392,10 +392,10 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
 
   if (jcr->sd_impl->dcr) {
     switch (jcr->sd_impl->dcr->autodeflate) {
-      case AutoXflateMode::IO_DIRECTION_OUT:
-      case AutoXflateMode::IO_DIRECTION_INOUT:
+      case IODirection::WRITE:
+      case IODirection::READ_WRITE:
         Dmsg0(200, "Clearing autodeflate on write dcr\n");
-        jcr->sd_impl->dcr->autodeflate = AutoXflateMode::IO_DIRECTION_NONE;
+        jcr->sd_impl->dcr->autodeflate = IODirection::NONE;
         break;
       default:
         break;
@@ -404,10 +404,10 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
 
   // Check autoinflation.
   switch (jcr->sd_impl->read_dcr->autoinflate) {
-    case AutoXflateMode::IO_DIRECTION_IN:
-    case AutoXflateMode::IO_DIRECTION_INOUT:
+    case IODirection::READ:
+    case IODirection::READ_WRITE:
       Dmsg0(200, "Clearing autoinflate on read_dcr\n");
-      jcr->sd_impl->read_dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
+      jcr->sd_impl->read_dcr->autoinflate = IODirection::NONE;
       break;
     default:
       break;
@@ -415,10 +415,10 @@ static inline void CheckAutoXflation(JobControlRecord* jcr)
 
   if (jcr->sd_impl->dcr) {
     switch (jcr->sd_impl->dcr->autoinflate) {
-      case AutoXflateMode::IO_DIRECTION_OUT:
-      case AutoXflateMode::IO_DIRECTION_INOUT:
+      case IODirection::WRITE:
+      case IODirection::READ_WRITE:
         Dmsg0(200, "Clearing autoinflate on write dcr\n");
-        jcr->sd_impl->dcr->autoinflate = AutoXflateMode::IO_DIRECTION_NONE;
+        jcr->sd_impl->dcr->autoinflate = IODirection::NONE;
         break;
       default:
         break;

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -645,13 +645,13 @@ static int ReserveDevice(ReserveContext& rctx)
   }
 
   // Make sure device access mode matches
-  Dmsg3(debuglevel,
-        "chk AccessMode append=%d access_mode=%d\n",
-        rctx.append, rctx.device_resource->access_mode);
+  Dmsg3(debuglevel, "chk AccessMode append=%d access_mode=%d\n", rctx.append,
+        rctx.device_resource->access_mode);
   if (rctx.append && rctx.device_resource->access_mode == IODirection::READ) {
     // Trying to write but access mode is readonly
     return -1;
-  } else if (!rctx.append && rctx.device_resource->access_mode == IODirection::WRITE) {
+  } else if (!rctx.append
+             && rctx.device_resource->access_mode == IODirection::WRITE) {
     // Trying to read but access mode is writeonly
     return -1;
   }

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -438,7 +438,7 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
           rctx.device_name = device_name;
           rctx.device_resource = vol->dev->device_resource;
 
-          if (rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
+          if (rctx.device_resource->access_mode == IODirection::READ) {
             Dmsg1(debuglevel,
                   "device=%s not suitable because it is read only\n",
                   vol->dev->device_resource->resource_name_);
@@ -547,11 +547,11 @@ int SearchResForDevice(ReserveContext& rctx)
           Dmsg1(100, "Device %s not autoselect skipped.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
-        } else if (rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
+        } else if (rctx.append && rctx.device_resource->access_mode == IODirection::READ) {
           Dmsg1(debuglevel, "Device %s is read only.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
-        } else if (!rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_OUT) {
+        } else if (!rctx.append && rctx.device_resource->access_mode == IODirection::WRITE) {
           Dmsg1(debuglevel, "Device %s is write only.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
@@ -661,9 +661,9 @@ static int ReserveDevice(ReserveContext& rctx)
   Dmsg3(debuglevel,
         "chk AccessMode append=%d access_mode=%d\n",
         rctx.append, rctx.device_resource->access_mode);
-  if (rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
+  if (rctx.append && rctx.device_resource->access_mode == IODirection::READ) {
     return -1;
-  } else if (!rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_OUT) {
+  } else if (!rctx.append && rctx.device_resource->access_mode == IODirection::WRITE) {
     return -1;
   }
 

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -438,7 +438,7 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
           rctx.device_name = device_name;
           rctx.device_resource = vol->dev->device_resource;
 
-          if (rctx.device_resource->read_only) {
+          if (rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
             Dmsg1(debuglevel,
                   "device=%s not suitable because it is read only\n",
                   vol->dev->device_resource->resource_name_);
@@ -547,11 +547,11 @@ int SearchResForDevice(ReserveContext& rctx)
           Dmsg1(100, "Device %s not autoselect skipped.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
-        } else if (rctx.append && rctx.device_resource->read_only) {
+        } else if (rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
           Dmsg1(debuglevel, "Device %s is read only.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
-        } else if (!rctx.append && rctx.device_resource->write_only) {
+        } else if (!rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_OUT) {
           Dmsg1(debuglevel, "Device %s is write only.\n",
                 rctx.device_resource->resource_name_);
           continue; /* Device is not available */
@@ -657,14 +657,13 @@ static int ReserveDevice(ReserveContext& rctx)
     return -1;
   }
 
-  // Make sure device read_only and write_only match
+  // Make sure device access mode matches
   Dmsg3(debuglevel,
-        "chk ReadOnly/WriteOnly append=%d read_only=%d write_only=%d\n",
-        rctx.append, rctx.device_resource->read_only,
-        rctx.device_resource->write_only);
-  if (rctx.append && rctx.device_resource->read_only) {
+        "chk AccessMode append=%d access_mode=%d\n",
+        rctx.append, rctx.device_resource->access_mode);
+  if (rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_IN) {
     return -1;
-  } else if (!rctx.append && rctx.device_resource->write_only) {
+  } else if (!rctx.append && rctx.device_resource->access_mode == AutoXflateMode::IO_DIRECTION_OUT) {
     return -1;
   }
 

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -649,11 +649,11 @@ static int ReserveDevice(ReserveContext& rctx)
         "chk AccessMode append=%d access_mode=%d\n",
         rctx.append, rctx.device_resource->access_mode);
   if (rctx.append && rctx.device_resource->access_mode == IODirection::READ) {
-	// Trying to write but access mode is readonly
+    // Trying to write but access mode is readonly
     return -1;
   } else if (!rctx.append && rctx.device_resource->access_mode == IODirection::WRITE) {
     // Trying to read but access mode is writeonly
-	return -1;
+    return -1;
   }
 
   // Make sure device_resource exists -- i.e. we can stat() it

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -253,15 +253,12 @@ struct s_io_kw {
   IODirection token;
 };
 
-static s_io_kw io_directions[] = {{"in", IODirection::READ},
-                                  {"read", IODirection::READ},
-                                  {"readonly", IODirection::READ},
-                                  {"out", IODirection::WRITE},
-                                  {"write", IODirection::WRITE},
-                                  {"writeonly", IODirection::WRITE},
-                                  {"both", IODirection::READ_WRITE},
-                                  {"readwrite", IODirection::READ_WRITE},
-                                  {nullptr, IODirection::READ_WRITE}};
+static s_io_kw io_directions[] = {
+    {"in", IODirection::READ},         {"read", IODirection::READ},
+    {"readonly", IODirection::READ},   {"out", IODirection::WRITE},
+    {"write", IODirection::WRITE},     {"writeonly", IODirection::WRITE},
+    {"both", IODirection::READ_WRITE}, {"readwrite", IODirection::READ_WRITE},
+    {nullptr, IODirection::READ_WRITE}};
 
 static s_kw compression_algorithms[]
     = {{"gzip", COMPRESS_GZIP},   {"lzo", COMPRESS_LZO1X},

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -172,8 +172,8 @@ static ResourceItem dev_items[] = {
   {"RequiresMount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_REQMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"OfflineOnUnmount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_OFFLINEUNMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"BlockChecksum", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_BLOCKCHECKSUM, CFG_ITEM_DEFAULT, "on", NULL, NULL},
-  {"AccessMode", CFG_TYPE_IODIRECTION, ITEM(res_dev, access_mode), 0, CFG_ITEM_DEFAULT, "readwrite", NULL, "Access mode specifies whether"
-  "this device can be used for reading, writing or for both modes."},
+  {"AccessMode", CFG_TYPE_IODIRECTION, ITEM(res_dev, access_mode), 0, CFG_ITEM_DEFAULT, "readwrite", NULL, "Access mode specifies whether "
+  "this device can be reserved for reading, writing or for both modes (default)."},
   {"AutoSelect", CFG_TYPE_BOOL, ITEM(res_dev, autoselect), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL},
   {"ChangerDevice", CFG_TYPE_STRNAME, ITEM(res_dev, changer_name), 0, 0, NULL, NULL, NULL},
   {"ChangerCommand", CFG_TYPE_STRNAME, ITEM(res_dev, changer_command), 0, 0, NULL, NULL, NULL},

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -172,6 +172,8 @@ static ResourceItem dev_items[] = {
   {"RequiresMount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_REQMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"OfflineOnUnmount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_OFFLINEUNMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"BlockChecksum", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_BLOCKCHECKSUM, CFG_ITEM_DEFAULT, "on", NULL, NULL},
+  {"ReadOnly", CFG_TYPE_BOOL, ITEM(res_dev, read_only), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
+  {"WriteOnly", CFG_TYPE_BOOL, ITEM(res_dev, write_only), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
   {"AutoSelect", CFG_TYPE_BOOL, ITEM(res_dev, autoselect), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL},
   {"ChangerDevice", CFG_TYPE_STRNAME, ITEM(res_dev, changer_name), 0, 0, NULL, NULL, NULL},
   {"ChangerCommand", CFG_TYPE_STRNAME, ITEM(res_dev, changer_command), 0, 0, NULL, NULL, NULL},

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -172,8 +172,8 @@ static ResourceItem dev_items[] = {
   {"RequiresMount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_REQMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"OfflineOnUnmount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_OFFLINEUNMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"BlockChecksum", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_BLOCKCHECKSUM, CFG_ITEM_DEFAULT, "on", NULL, NULL},
-  {"ReadOnly", CFG_TYPE_BOOL, ITEM(res_dev, read_only), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
-  {"WriteOnly", CFG_TYPE_BOOL, ITEM(res_dev, write_only), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
+  {"AccessMode", CFG_TYPE_IODIRECTION, ITEM(res_dev, access_mode), 0, CFG_ITEM_DEFAULT, "readwrite", NULL, "Access mode specifies whether"
+  "this device can be used for reading, writing or for both modes."},
   {"AutoSelect", CFG_TYPE_BOOL, ITEM(res_dev, autoselect), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL},
   {"ChangerDevice", CFG_TYPE_STRNAME, ITEM(res_dev, changer_name), 0, 0, NULL, NULL, NULL},
   {"ChangerCommand", CFG_TYPE_STRNAME, ITEM(res_dev, changer_command), 0, 0, NULL, NULL, NULL},
@@ -254,8 +254,13 @@ struct s_io_kw {
 };
 
 static s_io_kw io_directions[] = {{"in", AutoXflateMode::IO_DIRECTION_IN},
+                                  {"read", AutoXflateMode::IO_DIRECTION_IN},
+                                  {"readonly", AutoXflateMode::IO_DIRECTION_IN},
                                   {"out", AutoXflateMode::IO_DIRECTION_OUT},
+                                  {"write", AutoXflateMode::IO_DIRECTION_OUT},
+                                  {"writeonly", AutoXflateMode::IO_DIRECTION_OUT},
                                   {"both", AutoXflateMode::IO_DIRECTION_INOUT},
+                                  {"readwrite", AutoXflateMode::IO_DIRECTION_INOUT},
                                   {nullptr, AutoXflateMode::IO_DIRECTION_NONE}};
 
 static s_kw compression_algorithms[]

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -250,18 +250,18 @@ static struct s_kw authentication_methods[]
 
 struct s_io_kw {
   const char* name;
-  AutoXflateMode token;
+  IODirection token;
 };
 
-static s_io_kw io_directions[] = {{"in", AutoXflateMode::IO_DIRECTION_IN},
-                                  {"read", AutoXflateMode::IO_DIRECTION_IN},
-                                  {"readonly", AutoXflateMode::IO_DIRECTION_IN},
-                                  {"out", AutoXflateMode::IO_DIRECTION_OUT},
-                                  {"write", AutoXflateMode::IO_DIRECTION_OUT},
-                                  {"writeonly", AutoXflateMode::IO_DIRECTION_OUT},
-                                  {"both", AutoXflateMode::IO_DIRECTION_INOUT},
-                                  {"readwrite", AutoXflateMode::IO_DIRECTION_INOUT},
-                                  {nullptr, AutoXflateMode::IO_DIRECTION_NONE}};
+static s_io_kw io_directions[] = {{"in", IODirection::READ},
+                                  {"read", IODirection::READ},
+                                  {"readonly", IODirection::READ},
+                                  {"out", IODirection::WRITE},
+                                  {"write", IODirection::WRITE},
+                                  {"writeonly", IODirection::WRITE},
+                                  {"both", IODirection::READ_WRITE},
+                                  {"readwrite", IODirection::READ_WRITE},
+                                  {nullptr, IODirection::READ_WRITE}};
 
 static s_kw compression_algorithms[]
     = {{"gzip", COMPRESS_GZIP},   {"lzo", COMPRESS_LZO1X},
@@ -337,7 +337,7 @@ static void StoreIoDirection(LEX* lc, ResourceItem* item, int index, int)
   LexGetToken(lc, BCT_NAME);
   for (i = 0; io_directions[i].name; i++) {
     if (Bstrcasecmp(lc->str, io_directions[i].name)) {
-      SetItemVariable<AutoXflateMode>(*item, io_directions[i].token);
+      SetItemVariable<IODirection>(*item, io_directions[i].token);
       i = 0;
       break;
     }

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly1.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly1.conf
@@ -3,5 +3,5 @@ Device {
   Name = readonly1
   Media Type = FileRWOnly
   Archive Device = .
-  Read Only = yes
+  Access Mode = readonly
 }

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly1.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly1.conf
@@ -1,0 +1,7 @@
+Device {
+  Device Type = File
+  Name = readonly1
+  Media Type = FileRWOnly
+  Archive Device = .
+  Read Only = yes
+}

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly2.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly2.conf
@@ -3,5 +3,5 @@ Device {
   Name = readonly2
   Media Type = FileRWOnly
   Archive Device = .
-  Read Only = yes
+  Access Mode = readonly
 }

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly2.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/readonly2.conf
@@ -1,0 +1,7 @@
+Device {
+  Device Type = File
+  Name = readonly2
+  Media Type = FileRWOnly
+  Archive Device = .
+  Read Only = yes
+}

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly1.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly1.conf
@@ -3,5 +3,5 @@ Device {
   Name = writeonly1
   Media Type = FileRWOnly
   Archive Device = .
-  Write Only = yes
+  Access Mode = writeonly
 }

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly1.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly1.conf
@@ -1,0 +1,7 @@
+Device {
+  Device Type = File
+  Name = writeonly1
+  Media Type = FileRWOnly
+  Archive Device = .
+  Write Only = yes
+}

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly2.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly2.conf
@@ -3,5 +3,5 @@ Device {
   Name = writeonly2
   Media Type = FileRWOnly
   Archive Device = .
-  Write Only = yes
+  Access Mode = writeonly
 }

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly2.conf
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/device/writeonly2.conf
@@ -1,0 +1,7 @@
+Device {
+  Device Type = File
+  Name = writeonly2
+  Media Type = FileRWOnly
+  Archive Device = .
+  Write Only = yes
+}

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -74,10 +74,8 @@ void ReservationTest::SetUp()
   configfile = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/sd_reservation/");
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);
-  /*
-   * we do not run CheckResources() here, so take care the test configration
-   * is not broken. Also autochangers will not work.
-   */
+  /* we do not run CheckResources() here, so take care the test configration
+   * is not broken. Also autochangers will not work. */
 
   InitReservationsLock();
   CreateVolumeLists();
@@ -301,16 +299,19 @@ TEST_F(ReservationTest, use_cmd_append_reserves_write_only)
   job1->jcr->dir_bsock = bsock.get();
 
   EXPECT_CALL(*bsock, recv())
-      .WillOnce(BSOCK_RECV(bsock.get(),
-                           "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
-                           "pool_type=ptptp append=1 copy=0 stripe=0"))
+      .WillOnce(
+          BSOCK_RECV(bsock.get(),
+                     "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
+                     "pool_type=ptptp append=1 copy=0 stripe=0"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly2"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly2"))
-      .WillOnce(Return(BNET_EOD))                            // end of device commands
-      .WillOnce(Return(BNET_EOD))                            // end of storage command
-      .WillOnce(BSOCK_RECV(bsock.get(), "1901 No Media."));  // response to DirFindNextAppendableVolume
+      .WillOnce(Return(BNET_EOD))  // end of device commands
+      .WillOnce(Return(BNET_EOD))  // end of storage command
+      .WillOnce(BSOCK_RECV(
+          bsock.get(),
+          "1901 No Media."));  // response to DirFindNextAppendableVolume
 
   EXPECT_CALL(*bsock, send()).WillRepeatedly(Return(true));
 
@@ -327,9 +328,10 @@ TEST_F(ReservationTest, use_cmd_non_append_reserves_read_only)
   job1->jcr->dir_bsock = bsock.get();
 
   EXPECT_CALL(*bsock, recv())
-      .WillOnce(BSOCK_RECV(bsock.get(),
-                           "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
-                           "pool_type=ptptp append=0 copy=0 stripe=0"))
+      .WillOnce(
+          BSOCK_RECV(bsock.get(),
+                     "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
+                     "pool_type=ptptp append=0 copy=0 stripe=0"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly2"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly1"))
@@ -352,30 +354,34 @@ TEST_F(ReservationTest, use_cmd_non_append_reserves_read_only_with_wait)
   auto job1 = std::make_unique<TestJob>(111u);
   auto job2 = std::make_unique<TestJob>(222u);
   auto job3 = std::make_unique<TestJob>(333u);
-  job1->jcr->dir_bsock = job2->jcr->dir_bsock = job3->jcr->dir_bsock = bsock.get();
+  job1->jcr->dir_bsock = job2->jcr->dir_bsock = job3->jcr->dir_bsock
+      = bsock.get();
 
   EXPECT_CALL(*bsock, recv())
-      .WillOnce(BSOCK_RECV(bsock.get(),
-                           "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
-                           "pool_type=ptptp append=0 copy=0 stripe=0"))
+      .WillOnce(
+          BSOCK_RECV(bsock.get(),
+                     "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
+                     "pool_type=ptptp append=0 copy=0 stripe=0"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly2"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly2"))
-      .WillOnce(Return(BNET_EOD))   // end of device commands
-      .WillOnce(Return(BNET_EOD))   // end of storage command
-      .WillOnce(BSOCK_RECV(bsock.get(),
-                           "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
-                           "pool_type=ptptp append=0 copy=0 stripe=0"))
+      .WillOnce(Return(BNET_EOD))  // end of device commands
+      .WillOnce(Return(BNET_EOD))  // end of storage command
+      .WillOnce(
+          BSOCK_RECV(bsock.get(),
+                     "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
+                     "pool_type=ptptp append=0 copy=0 stripe=0"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly2"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly2"))
-      .WillOnce(Return(BNET_EOD))   // end of device commands
-      .WillOnce(Return(BNET_EOD))   // end of storage command
-      .WillOnce(BSOCK_RECV(bsock.get(),
-                           "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
-                           "pool_type=ptptp append=0 copy=0 stripe=0"))
+      .WillOnce(Return(BNET_EOD))  // end of device commands
+      .WillOnce(Return(BNET_EOD))  // end of storage command
+      .WillOnce(
+          BSOCK_RECV(bsock.get(),
+                     "use storage=sssss media_type=FileRWOnly pool_name=ppppp "
+                     "pool_type=ptptp append=0 copy=0 stripe=0"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly1"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=readonly2"))
       .WillOnce(BSOCK_RECV(bsock.get(), "use device=writeonly1"))
@@ -403,6 +409,6 @@ TEST_F(ReservationTest, use_cmd_non_append_reserves_read_only_with_wait)
 
   // Unreserve job1 and readonly1 after waiting for a bit
   auto _ = std::async(std::launch::async, [&job1] { WaitThenUnreserve(job1); });
-  
+
   future.wait();
 }

--- a/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
+++ b/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
@@ -744,6 +744,23 @@ When parsing the resource directives, Bareos classifies the data according to th
    :values: **in** | **out** | **both**
 
    String indicating sens of IO can be `in` or `out` or `both`
+   Following aliases are also valid:
+
+   read
+        Alias for `in`.
+
+   readonly
+        Alias for `in`.
+
+   write
+        Alias for `out`.
+
+   writeonly
+        Alias for `out`.
+
+   readwrite
+        Alias for `both`.
+
 
 
 .. config:datatype:: JOB_TYPE

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -642,6 +642,13 @@
           "default_value": "on",
           "equals": true
         },
+        "AccessMode": {
+          "datatype": "IO_DIRECTION",
+          "code": 0,
+          "default_value": "readwrite",
+          "equals": true,
+          "description": "Access mode specifies whether this device can be reserved for reading, writing or for both modes (default)."
+        },
         "AutoSelect": {
           "datatype": "BOOLEAN",
           "code": 0,

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-AccessMode.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-AccessMode.rst.inc
@@ -1,7 +1,7 @@
-This parameter specifies for which access modes (i.e. reading or writing) this device can be reserved.
+The following values are valid:
 
--  readonly - this device can only be used for reading.
+-  readonly - this device can be reserved only for reading.
 
--  writeonly - this device can only be used for writing.
+-  writeonly - this device can be reserved only for writing.
 
--  readwrite - this device can be used for both reading and writing.
+-  readwrite - this device can be reserved for both reading and writing.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-AccessMode.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/sd-device-AccessMode.rst.inc
@@ -1,0 +1,7 @@
+This parameter specifies for which access modes (i.e. reading or writing) this device can be reserved.
+
+-  readonly - this device can only be used for reading.
+
+-  writeonly - this device can only be used for writing.
+
+-  readwrite - this device can be used for both reading and writing.


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Hello, I'm proposing to add a new config directive to SD->Device: AccessMode. The purpose of this directives is to make it possible to reserve devices exclusively for read or write jobs.
My use case is the following: I would like to have a pool which can both be written to (e.g. via virtualfull) and migrated/copied from to another pool at the same time. By reserving at least one device for write jobs only and others for read jobs only, I can ensure that the virtualfull jobs and migration/copy jobs can always run concurrently and don't block each other (unless they want to use same volume).
As far as I can tell, this is currently not possible. Simply adding more devices to the pool would not ensure that there is always a device free for the migration or copy jobs.

Is there interest for such a feature? If so I'd also look into adding tests, updating the relevant docs and diagrams if necessary.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
