### PR TITLE
default config: use virtual disk changer as `FileStorage`

### DIFF
--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
@@ -6,6 +6,7 @@
 @dir(bareos,bareos,0750) %%ETCDIR%%/bareos-sd.d/messages
 @dir(bareos,bareos,0750) %%ETCDIR%%/bareos-sd.d/storage
 @sample(bareos,bareos,0640) %%ETCDIR%%/bareos-sd.d/device/FileStorage.conf.sample
+@sample(bareos,bareos,0640) %%ETCDIR%%/bareos-sd.d/autochanger/filechanger.conf.sample
 @sample(bareos,bareos,0640) %%ETCDIR%%/bareos-sd.d/director/bareos-dir.conf.sample
 @sample(bareos,bareos,0640) %%ETCDIR%%/bareos-sd.d/director/bareos-mon.conf.sample
 @sample(bareos,bareos,0640) %%ETCDIR%%/bareos-sd.d/messages/Standard.conf.sample

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1260,6 +1260,7 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %attr(0750, %{storage_daemon_user}, %{daemon_group}) %dir %{_sysconfdir}/%{name}/bareos-sd.d/ndmp
 %attr(0750, %{storage_daemon_user}, %{daemon_group}) %dir %{_sysconfdir}/%{name}/bareos-sd.d/messages
 %attr(0750, %{storage_daemon_user}, %{daemon_group}) %dir %{_sysconfdir}/%{name}/bareos-sd.d/storage
+%attr(0640, %{storage_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/autochanger/filechanger.conf
 %attr(0640, %{storage_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/FileStorage.conf
 %attr(0640, %{storage_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/director/bareos-dir.conf
 %attr(0640, %{storage_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/director/bareos-mon.conf

--- a/core/src/defaultconfigs/bareos-sd.d/autochanger/filechanger.conf
+++ b/core/src/defaultconfigs/bareos-sd.d/autochanger/filechanger.conf
@@ -1,0 +1,6 @@
+Autochanger {
+  Name = "FileStorage"
+  Changer Device = /dev/null # required for virtual disk changer
+  Changer Command = ""       # required for virtual disk changer
+  Device = FileStorage  # basename of the multidevice devices
+}

--- a/core/src/defaultconfigs/bareos-sd.d/device/FileStorage.conf.in
+++ b/core/src/defaultconfigs/bareos-sd.d/device/FileStorage.conf.in
@@ -1,4 +1,5 @@
 Device {
+  Description = "Multiplied file device. A connecting Director must have the same Name and MediaType."
   Name = FileStorage
   Media Type = File
   Archive Device = @archivedir@
@@ -7,5 +8,6 @@ Device {
   AutomaticMount = yes;               # when device opened, read it
   RemovableMedia = no;
   AlwaysOpen = no;
-  Description = "File device. A connecting Director must have the same Name and MediaType."
+  Count = 10                          # Number of instances
+  MaximumConcurrentJobs = 1
 }

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -278,7 +278,7 @@ static void WarnOnNonZeroBlockSize(int max_block_size, std::string_view name)
   if (max_block_size > 0) {
     my_config->AddWarning(fmt::format(
         FMT_STRING(
-            "Device {:s}: Setting 'Maximum Block Size' is only supported on  "
+            "Device {:s}: Setting 'Maximum Block Size' is only supported on "
             "tape devices"),
         name));
   }
@@ -290,7 +290,7 @@ static void WarnOnZeroMaxConcurrentJobs(int max_concurrent_jobs,
   if (max_concurrent_jobs == 0) {
     my_config->AddWarning(
         fmt::format(FMT_STRING("Device {:s}: unlimited (0) 'Maximum Concurrent "
-                               "Jobs' reduces the restore peformance."),
+                               "Jobs' reduces the restore performance."),
                     name));
   }
 }

--- a/debian/bareos-storage.install.in
+++ b/debian/bareos-storage.install.in
@@ -2,6 +2,7 @@
 @backenddir@/libbareossd-file.so*
 @scriptdir@/disk-changer
 @configtemplatedir@/bareos-sd.d/device/FileStorage.conf
+@configtemplatedir@/bareos-sd.d/autochanger/filechanger.conf
 @configtemplatedir@/bareos-sd.d/director/bareos-dir.conf
 @configtemplatedir@/bareos-sd.d/director/bareos-mon.conf
 @configtemplatedir@/bareos-sd.d/messages/Standard.conf


### PR DESCRIPTION
This PR changes the existing single storage device "FileStorage" into a multiple device disk autochanger.
This should make the default config better suitable to scale on customer installations compared to the old configuration.


**Backport of PR #0000 to bareos-2x** (remove this line, if it no backport)

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
