### PR TITLE
build: remove EOL distros from build matrix

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -182,6 +182,7 @@ OS:
     "9":
       TYPE: rpm
       IMAGE: centos9
+      CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:
@@ -192,6 +193,7 @@ OS:
     "8":
       TYPE: rpm
       IMAGE: rocky8
+      CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -68,19 +68,6 @@ OS:
           - bareos
           - python-bareos
 
-  Univention:
-    "4.4":
-      TYPE: deb
-      IMAGE: univention4.4
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - python-bareos
-
-
   SLE:
     "15_SP4":
       TYPE: rpm

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -67,26 +67,6 @@ OS:
           - bareos
           - python-bareos
 
-    "Leap_15.3":
-      TYPE: rpm
-      IMAGE: opensuse-leap153
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-       x86_64:
-          - bareos
-          - python-bareos
-
-    "Leap_15.2":
-      TYPE: rpm
-      IMAGE: opensuse-leap152
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-       x86_64:
-          - bareos
-          - python-bareos
-
   Univention:
     "4.4":
       TYPE: deb
@@ -170,24 +150,6 @@ OS:
         x86_64:
            - bareos
            - python-bareos
-    "35":
-      TYPE: rpm
-      IMAGE: fedora35
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - python-bareos
-    "34":
-      TYPE: rpm
-      IMAGE: fedora34
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - python-bareos
   Debian:
     "11":
       TYPE: deb
@@ -210,22 +172,6 @@ OS:
            - bareos
            - bareos-webui
            - bareos-vmware
-           - python-bareos
-    "9.0":
-      TYPE: deb
-      IMAGE: "debian9.0"
-      ARCH:
-        - i586
-        - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - bareos-vmware
-           - python-bareos
-        i586:
-           - bareos
-           - bareos-webui
            - python-bareos
 
   EL:
@@ -292,8 +238,6 @@ OS:
         - sparc
       PROJECTPACKAGES:
         i386:
-           - bareos
-        sparc:
            - bareos
 
   win:

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -60,6 +60,7 @@ OS:
     "Leap_15.4":
       TYPE: rpm
       IMAGE: opensuse-leap154
+      CUSTOM_TEST_IMAGES: [ openSUSE-Leap_15.4 ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:
@@ -84,6 +85,7 @@ OS:
     "15_SP4":
       TYPE: rpm
       IMAGE: sle154
+      CUSTOM_TEST_IMAGES: [ SLE-15_SP4 ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:
@@ -93,6 +95,7 @@ OS:
     "15_SP3":
       TYPE: rpm
       IMAGE: sle153
+      CUSTOM_TEST_IMAGES: [ SLE-15_SP4 ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:
@@ -102,6 +105,7 @@ OS:
     "15_SP2":
       TYPE: rpm
       IMAGE: sle152
+      CUSTOM_TEST_IMAGES: [ SLE-15_SP4 ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - build: switch to FreeBSD 12.4 [PR #1443]
 - build: fix for gcc 13.1.1 [PR #1462]
+- build: remove EOL distros from build matrix [PR #1471]
 
 ## [21.1.7] - 2023-03-24
 
@@ -673,4 +674,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1417]: https://github.com/bareos/bareos/pull/1417
 [PR #1443]: https://github.com/bareos/bareos/pull/1443
 [PR #1462]: https://github.com/bareos/bareos/pull/1462
+[PR #1471]: https://github.com/bareos/bareos/pull/1471
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
**Backport of PR #1469 to bareos-21**

This is not 100% a backport, but heavily related. It achieves the same thing on an older branch.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

