### PR TITLE
build: remove EOL distros from build matrix

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -36,68 +36,19 @@ OS:
     "Leap_15.3":
       TYPE: rpm
       IMAGE: opensuse-leap153
+      CUSTOM_TEST_IMAGES: [ openSUSE-Leap_15.4 ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:
        x86_64:
           - bareos
           - python-bareos
-
-    "Leap_15.2":
-      TYPE: rpm
-      IMAGE: opensuse-leap152
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-       x86_64:
-          - bareos
-          - bareos-webui
-          - libfastlz
-          - python-bareos
-
-  Univention:
-    "4.3":
-      TYPE: deb
-      IMAGE: univention4.3
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-
-    "4.4":
-      TYPE: deb
-      IMAGE: univention4.4
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-
 
   SLE:
 
     "15_SP3":
       TYPE: rpm
       IMAGE: sle153
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-
-    "15_SP2":
-      TYPE: rpm
-      IMAGE: sle152
       ARCH:
       - x86_64
       PROJECTPACKAGES:
@@ -147,39 +98,6 @@ OS:
            - libfastlz
            - python-bareos
 
-  Fedora:
-    "33":
-      TYPE: rpm
-      IMAGE: fedora33
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - python-bareos
-    "32":
-      TYPE: rpm
-      IMAGE: fedora32
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - python-bareos
-
-    "31":
-      TYPE: rpm
-      IMAGE: fedora31
-      ARCH:
-      - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-webui
-           - python-bareos
-
   Debian:
     "11":
       TYPE: deb
@@ -201,24 +119,6 @@ OS:
         x86_64:
            - bareos
            - bareos-vmware
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-    "9.0":
-      TYPE: deb
-      IMAGE: "debian9.0"
-      ARCH:
-        - i586
-        - x86_64
-      PROJECTPACKAGES:
-        x86_64:
-           - bareos
-           - bareos-vmware
-           - bareos-webui
-           - libfastlz
-           - python-bareos
-        i586:
-           - bareos
            - bareos-webui
            - libfastlz
            - python-bareos

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -127,6 +127,7 @@ OS:
     "8":
       TYPE: rpm
       IMAGE: centos8
+      CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream ]
       ARCH:
       - x86_64
       PROJECTPACKAGES:

--- a/.quality-gates.yml
+++ b/.quality-gates.yml
@@ -92,8 +92,8 @@ Fedora_33:
 
 FreeBSD:
   ctest_unstable: 0
-  warnings_unhealthy: 191
-  warnings_healthy: 190
+  warnings_unhealthy: 201
+  warnings_healthy: 200
 
 MacOS:
   ctest_unstable: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - FreeBSD: build cleanup [PR #1382]
 - build: switch to FreeBSD 12.4 [PR #1444]
+- build: remove EOL distros from build matrix [PR #1472]
 
 ## [20.0.8] - 2022-11-09
 
@@ -547,4 +548,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1304]: https://github.com/bareos/bareos/pull/1304
 [PR #1382]: https://github.com/bareos/bareos/pull/1382
 [PR #1444]: https://github.com/bareos/bareos/pull/1444
+[PR #1472]: https://github.com/bareos/bareos/pull/1472
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -413,6 +413,7 @@ if(NOT client-only)
     bool_string LINK_LIBRARIES bareos ${GTEST_LIBRARIES}
                                ${GTEST_MAIN_LIBRARIES}
   )
+  set_tests_properties(gtest:bsock.console_director_connection_test_cleartext PROPERTIES LABELS broken)
 
 endif() # NOT client-only
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -21,13 +21,11 @@ message("Entering ${CMAKE_CURRENT_SOURCE_DIR}")
 include_directories(${OPENSSL_INCLUDE_DIR})
 
 # clang 11.0.1 on FreBSD 13  fails to skip suggest-override for gtest
-if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION
-                                         VERSION_EQUAL 11.0.1
+if(CMAKE_C_COMPILER_ID MATCHES Clang AND CMAKE_C_COMPILER_VERSION VERSION_EQUAL
+                                         11.0.1
 )
   add_compile_options(-Wno-suggest-override)
 endif()
-
-
 
 macro(bareos_gtest_add_tests testname)
   gtest_add_tests(
@@ -345,7 +343,9 @@ endif() # NOT client-only
 bareos_add_test(
   thread_list LINK_LIBRARIES bareos ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES}
 )
-set_tests_properties(gtest:thread_list.thread_list_startup_and_shutdown PROPERTIES LABELS broken)
+set_tests_properties(
+  gtest:thread_list.thread_list_startup_and_shutdown PROPERTIES LABELS broken
+)
 
 bareos_add_test(
   thread_specific_data LINK_LIBRARIES bareos ${GTEST_LIBRARIES}
@@ -413,7 +413,10 @@ if(NOT client-only)
     bool_string LINK_LIBRARIES bareos ${GTEST_LIBRARIES}
                                ${GTEST_MAIN_LIBRARIES}
   )
-  set_tests_properties(gtest:bsock.console_director_connection_test_cleartext PROPERTIES LABELS broken)
+  set_tests_properties(
+    gtest:bsock.console_director_connection_test_cleartext PROPERTIES LABELS
+                                                                      broken
+  )
 
 endif() # NOT client-only
 

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -154,7 +154,7 @@ static void CheckEncryption(const BareosSocket* UA_sock, TlsPolicy tls_policy)
 
 static bool do_connection_test(std::string path_to_config, TlsPolicy tls_policy)
 {
-  debug_level = 10; // set debug level high enough so we can see error messages
+  debug_level = 10;  // set debug level high enough so we can see error messages
   InitSignalHandler();
   InitGlobals();
 
@@ -185,6 +185,176 @@ static bool do_connection_test(std::string path_to_config, TlsPolicy tls_policy)
 
   return true;
 }
+
+static void test_socket(int family, int port)
+{
+  int test_fd;
+  int option = 1;
+
+  EXPECT_TRUE((test_fd = socket(family, SOCK_STREAM, 0)) >= 0);
+
+  switch (family) {
+    case AF_INET:;
+      struct sockaddr_in v4_address;
+      v4_address.sin_family = family;
+      v4_address.sin_port = htons(port);
+      v4_address.sin_addr.s_addr = INADDR_ANY;
+
+
+      EXPECT_FALSE(
+          bind(test_fd, (struct sockaddr*)&v4_address, sizeof(v4_address))
+          == 0);
+
+      break;
+
+#ifdef HAVE_IPV6
+    case AF_INET6:
+      struct sockaddr_in6 v6_address;
+      v6_address.sin6_family = family;
+      v6_address.sin6_port = htons(port);
+      inet_pton(AF_INET6, "::", &v6_address.sin6_addr);
+
+      EXPECT_TRUE(setsockopt(test_fd, IPPROTO_IPV6, IPV6_V6ONLY,
+                             (sockopt_val_t)&option, sizeof(option))
+                  == 0);
+
+      EXPECT_FALSE(
+          bind(test_fd, (struct sockaddr*)&v6_address, sizeof(v6_address))
+          == 0);
+
+      break;
+#endif
+
+    default:
+      EXPECT_TRUE(false);
+      break;
+  }
+
+  close(test_fd);
+}
+
+static bool do_binding_test(std::string path_to_config, int family, int port)
+{
+  debug_level = 10;  // set debug level high enough so we can see error messages
+  InitSignalHandler();
+  InitGlobals();
+
+  PConfigParser director_config(DirectorPrepareResources(path_to_config));
+  if (!director_config) { return false; }
+
+  bool start_socket_server_ok
+      = directordaemon::StartSocketServer(directordaemon::me->DIRaddrs);
+  EXPECT_TRUE(start_socket_server_ok) << "Could not start SocketServer";
+  if (!start_socket_server_ok) { return false; }
+
+  test_socket(family, port);
+
+  directordaemon::StopSocketServer();
+  StopWatchdog();
+
+  return true;
+}
+
+static void check_addresses_list(std::string path_to_config,
+                                 std::vector<std::string> expected_addresses)
+{
+  char buff[1024];
+  IPADDR* addr;
+
+  std::vector<std::string> director_addresses;
+
+  debug_level = 10;  // set debug level high enough so we can see error messages
+  InitSignalHandler();
+  InitGlobals();
+
+  PConfigParser director_config(DirectorPrepareResources(path_to_config));
+  EXPECT_TRUE(director_config);
+
+  EXPECT_TRUE(directordaemon::me->DIRaddrs->size()
+              == static_cast<int>(expected_addresses.size()));
+
+  foreach_dlist (addr, directordaemon::me->DIRaddrs) {
+    addr->build_address_str(buff, sizeof(buff), true);
+
+    std::string theaddress = std::string(buff);
+    theaddress.pop_back();
+
+    director_addresses.push_back(theaddress);
+  }
+
+  std::sort(director_addresses.begin(), director_addresses.end());
+  std::sort(expected_addresses.begin(), expected_addresses.end());
+  EXPECT_EQ(director_addresses, expected_addresses);
+}
+
+TEST(port_and_addresses_setup, default_config_values)
+{
+  std::string path_to_config = std::string(
+      RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/default_dir_values/");
+
+  std::vector<std::string> expected_addresses{"host[ipv6;::;9101]",
+                                              "host[ipv4;0.0.0.0;9101]"};
+
+  check_addresses_list(path_to_config, expected_addresses);
+
+  do_binding_test(path_to_config, AF_INET, 9101);
+
+#ifdef HAVE_IPV6
+  do_binding_test(path_to_config, AF_INET6, 9101);
+#endif
+}
+
+TEST(port_and_addresses_setup, dir_port_set)
+{
+  std::string path_to_config = std::string(
+      RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/dir_port_set/");
+
+  std::vector<std::string> expected_addresses{"host[ipv4;0.0.0.0;30013]",
+                                              "host[ipv6;::;30013]"};
+
+  check_addresses_list(path_to_config, expected_addresses);
+
+  do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
+                              "/configs/dual_stacking/dir_port_set/"),
+                  AF_INET, 30013);
+
+#ifdef HAVE_IPV6
+  do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
+                              "/configs/dual_stacking/dir_port_set/"),
+                  AF_INET6, 30013);
+#endif
+}
+
+TEST(port_and_addresses_setup, dir_v4address_set)
+{
+  std::string path_to_config = std::string(
+      RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/dir_v4address_set/");
+
+  std::vector<std::string> expected_addresses{"host[ipv4;127.0.0.1;9101]"};
+
+  check_addresses_list(path_to_config, expected_addresses);
+
+  do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
+                              "/configs/dual_stacking/dir_v4address_set/"),
+                  AF_INET, 9101);
+}
+
+TEST(port_and_addresses_setup, dir_v4address_and_port_set)
+{
+  std::string path_to_config
+      = std::string(RELATIVE_PROJECT_SOURCE_DIR
+                    "/configs/dual_stacking/dir_v4address_and_port_set/");
+
+  std::vector<std::string> expected_addresses{"host[ipv4;127.0.0.1;30012]"};
+
+  check_addresses_list(path_to_config, expected_addresses);
+
+  do_binding_test(
+      std::string(RELATIVE_PROJECT_SOURCE_DIR
+                  "/configs/dual_stacking/dir_v4address_and_port_set/"),
+      AF_INET, 30012);
+}
+
 
 TEST(bsock, console_director_connection_test_tls_psk)
 {

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -154,6 +154,7 @@ static void CheckEncryption(const BareosSocket* UA_sock, TlsPolicy tls_policy)
 
 static bool do_connection_test(std::string path_to_config, TlsPolicy tls_policy)
 {
+  debug_level = 10; // set debug level high enough so we can see error messages
   InitSignalHandler();
   InitGlobals();
 

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -292,15 +292,15 @@ TEST(port_and_addresses_setup, default_config_values)
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/default_dir_values/");
 
-  std::vector<std::string> expected_addresses{"host[ipv6;::;9101]",
-                                              "host[ipv4;0.0.0.0;9101]"};
+  std::vector<std::string> expected_addresses{"host[ipv6;::;29999]",
+                                              "host[ipv4;0.0.0.0;29999]"};
 
   check_addresses_list(path_to_config, expected_addresses);
 
-  do_binding_test(path_to_config, AF_INET, 9101);
+  do_binding_test(path_to_config, AF_INET, 29999);
 
 #ifdef HAVE_IPV6
-  do_binding_test(path_to_config, AF_INET6, 9101);
+  do_binding_test(path_to_config, AF_INET6, 29999);
 #endif
 }
 
@@ -330,13 +330,13 @@ TEST(port_and_addresses_setup, dir_v4address_set)
   std::string path_to_config = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/dir_v4address_set/");
 
-  std::vector<std::string> expected_addresses{"host[ipv4;127.0.0.1;9101]"};
+  std::vector<std::string> expected_addresses{"host[ipv4;127.0.0.1;29998]"};
 
   check_addresses_list(path_to_config, expected_addresses);
 
   do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
                               "/configs/dual_stacking/dir_v4address_set/"),
-                  AF_INET, 9101);
+                  AF_INET, 29998);
 }
 
 TEST(port_and_addresses_setup, dir_v4address_and_port_set)

--- a/core/src/tests/bsock_test_connection_setup.cc
+++ b/core/src/tests/bsock_test_connection_setup.cc
@@ -25,6 +25,8 @@
 #  include "gtest/gtest.h"
 #endif
 
+#include <algorithm>
+
 #include "console/console_conf.h"
 #include "console/console_globals.h"
 #include "console/connect_to_director.h"
@@ -285,44 +287,6 @@ static void check_addresses_list(std::string path_to_config,
   std::sort(director_addresses.begin(), director_addresses.end());
   std::sort(expected_addresses.begin(), expected_addresses.end());
   EXPECT_EQ(director_addresses, expected_addresses);
-}
-
-TEST(port_and_addresses_setup, default_config_values)
-{
-  std::string path_to_config = std::string(
-      RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/default_dir_values/");
-
-  std::vector<std::string> expected_addresses{"host[ipv6;::;29999]",
-                                              "host[ipv4;0.0.0.0;29999]"};
-
-  check_addresses_list(path_to_config, expected_addresses);
-
-  do_binding_test(path_to_config, AF_INET, 29999);
-
-#ifdef HAVE_IPV6
-  do_binding_test(path_to_config, AF_INET6, 29999);
-#endif
-}
-
-TEST(port_and_addresses_setup, dir_port_set)
-{
-  std::string path_to_config = std::string(
-      RELATIVE_PROJECT_SOURCE_DIR "/configs/dual_stacking/dir_port_set/");
-
-  std::vector<std::string> expected_addresses{"host[ipv4;0.0.0.0;30013]",
-                                              "host[ipv6;::;30013]"};
-
-  check_addresses_list(path_to_config, expected_addresses);
-
-  do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
-                              "/configs/dual_stacking/dir_port_set/"),
-                  AF_INET, 30013);
-
-#ifdef HAVE_IPV6
-  do_binding_test(std::string(RELATIVE_PROJECT_SOURCE_DIR
-                              "/configs/dual_stacking/dir_port_set/"),
-                  AF_INET6, 30013);
-#endif
 }
 
 TEST(port_and_addresses_setup, dir_v4address_set)

--- a/core/src/tests/configs/dual_stacking/default_dir_values/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/default_dir_values/bareos-dir.d/director/bareos-dir.conf
@@ -1,4 +1,5 @@
 Director {                            # define myself
   Name = bareos-dir
   Password = "dir_password"         # Console password
+  DirPort =  29999
 }

--- a/core/src/tests/configs/dual_stacking/default_dir_values/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/default_dir_values/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,4 @@
+Director {                            # define myself
+  Name = bareos-dir
+  Password = "dir_password"         # Console password
+}

--- a/core/src/tests/configs/dual_stacking/dir_port_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_port_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,6 +1,5 @@
 Director {                            # define myself
   Name = bareos-dir
   Password = "dir_password"         # Console password
-  
   DirPort = 30013
 }

--- a/core/src/tests/configs/dual_stacking/dir_port_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_port_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,6 @@
+Director {                            # define myself
+  Name = bareos-dir
+  Password = "dir_password"         # Console password
+  
+  DirPort = 30013
+}

--- a/core/src/tests/configs/dual_stacking/dir_v4address_and_port_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_v4address_and_port_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,7 +1,6 @@
 Director {                            # define myself
   Name = bareos-dir
   Password = "dir_password"         # Console password
-
   DirPort = 30012
   DirAddress = 127.0.0.1
 }

--- a/core/src/tests/configs/dual_stacking/dir_v4address_and_port_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_v4address_and_port_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,7 @@
+Director {                            # define myself
+  Name = bareos-dir
+  Password = "dir_password"         # Console password
+
+  DirPort = 30012
+  DirAddress = 127.0.0.1
+}

--- a/core/src/tests/configs/dual_stacking/dir_v4address_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_v4address_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,6 +1,6 @@
-Director {                            
+Director {
   Name = bareos-dir
   Password = "dir_password"         # Console password
-  
+  DirPort = 29998
   DirAddress = 127.0.0.1
 }

--- a/core/src/tests/configs/dual_stacking/dir_v4address_set/bareos-dir.d/director/bareos-dir.conf
+++ b/core/src/tests/configs/dual_stacking/dir_v4address_set/bareos-dir.d/director/bareos-dir.conf
@@ -1,0 +1,6 @@
+Director {                            
+  Name = bareos-dir
+  Password = "dir_password"         # Console password
+  
+  DirAddress = 127.0.0.1
+}


### PR DESCRIPTION
**Backport of PR #1469 to bareos-20**

This is not 100% a backport, but heavily related. It achieves the same thing on an older branch.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

