### PR TITLE
filed: fix off-by-one error when resizing acl buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bsmtp bls bextract: fixes for command line parsing [PR #1455]
 - daemons: update network handling when IP protocols unavailable [PR #1454]
 - Improve handling of catalog requests that try to reduce VolFiles, VolBlocks and VolBytes [PR #1431]
+- filed: fix off-by-one error when resizing acl buffer [PR #1479]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -172,4 +173,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1460]: https://github.com/bareos/bareos/pull/1460
 [PR #1469]: https://github.com/bareos/bareos/pull/1469
 [PR #1473]: https://github.com/bareos/bareos/pull/1473
+[PR #1479]: https://github.com/bareos/bareos/pull/1479
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1331,7 +1331,7 @@ bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
       case bRC_OK:
         if (ap.content_length && ap.content) {
           acl_data->u.build->content = CheckPoolMemorySize(
-              acl_data->u.build->content, ap.content_length);
+              acl_data->u.build->content, ap.content_length + 1);
           memcpy(acl_data->u.build->content, ap.content, ap.content_length);
           acl_data->u.build->content_length = ap.content_length;
           free(ap.content);


### PR DESCRIPTION
When retrieving ACL data from a plugin, the buffer was not resized correctly, which might result in a buffer that is one byte to short so the null-termination could produce an overflow.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)


### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

