### PR TITLE
VMware Plugin: improve snapshot cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: re-add show update status for clients [PR #1371]
 - build: add Debian 12 [PR #1477]
 - pr-tool: Add options to be used in CI runs [PR #1488]
+- VMware Plugin: improve snapshot cleanup [PR #1484]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -187,5 +188,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1474]: https://github.com/bareos/bareos/pull/1474
 [PR #1477]: https://github.com/bareos/bareos/pull/1477
 [PR #1479]: https://github.com/bareos/bareos/pull/1479
+[PR #1484]: https://github.com/bareos/bareos/pull/1484
 [PR #1488]: https://github.com/bareos/bareos/pull/1488
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
If leftover snapshots exist from previous backups, they are now cleaned up before taking a new snapshot. Additionally, the snapshot cleanup after backup now works more reliable by reconnecting to the vCenter server if necessary. Code refactored to consequently use methods from pyVim.task. Also fixes a bug when folder=/ is used.

Fixes: #1533: Restoring vmware vms keeps failing, can't restore the data.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
