### PR TITLE
bareos-fd-postgres: added support for PostgreSQL 15 and later

### DIFF
--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2022 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2023 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -393,10 +393,10 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
 
     def parseBackupStopResult(self, result):
         try:
-            for (key, value) in re.findall("([A-Z ]+): (.*)\n", result):
-                if key == 'START WAL LOCATION':
+            for key, value in re.findall("([A-Z ]+): (.*)\n", result):
+                if key == "START WAL LOCATION":
                     value, _ = value.split(" ", 1)
-        
+
                 self.labelItems.update({key.strip(): value.strip()})
             bareosfd.DebugMessage(150, "Labels read: %s\n" % str(self.labelItems))
         except Exception as e:
@@ -404,7 +404,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 bareosfd.M_ERROR,
                 "Could not parse stop result %s: %s\n" % (result, e),
             )
-        
+
     def start_backup_file(self, savepkt):
         """
         For normal files we call the super method
@@ -493,16 +493,16 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         # self.execute_SQL("SELECT pg_backup_start_time()")
         # self.backupStartTime = self.dbCursor.fetchone()[0]
         # Tell Postgres we are done
-        
+
         pgMajorVersion = self.pgVersion // 10000
         if pgMajorVersion >= 15:
-            stopStmt = "pg_backup_stop"
+            stopStmt = "pg_backup_stop(wait_for_archive => true)"
         else:
-            stopStmt = "pg_stop_backup"
+            stopStmt = "pg_stop_backup()"
             self.parseBackupLabelFile()
-        
+
         try:
-            results = self.dbCon.run("SELECT %s();" % stopStmt)
+            results = self.dbCon.run("SELECT %s;" % stopStmt)
             if pgMajorVersion >= 15:
                 self.parseBackupStopResult(results[0][0])
                 self.lastLSN = self.formatLSN(self.labelItems["START WAL LOCATION"])

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -555,7 +555,9 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 self.writeAndAppendLabelFile(firstRow[1])
                 if len(firstRow) > 2 and len(firstRow[2]) > 0:
                     self.writeAndAppendTablespaceMapFile(firstRow[2])
-                self.lastLSN = self.formatLSN(self.labelItems["START WAL LOCATION"])
+                
+                if "START WAL LOCATION" in self.labelItems:
+                    self.lastLSN = self.formatLSN(self.labelItems["START WAL LOCATION"])
             else:
                 self.lastLSN = self.formatLSN(firstRow)
 

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -391,7 +391,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 "Could not read Label File %s: %s\n" % (self.labelFileName, e),
             )
 
-    def parseBackupStopResult(self, result: str):
+    def parseBackupStopResult(self, result):
         try:
             for (key, value) in re.findall("([A-Z ]+): (.*)\n", result):
                 if key == 'START WAL LOCATION':

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -565,12 +565,13 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 bareosfd.M_ERROR, "%s statement failed: %s\n" % (stopStmt, e)
             )
 
-        bareosfd.JobMessage(
-            bareosfd.M_INFO,
-            "Database connection closed. "
-            + "CHECKPOINT LOCATION: %s, " % self.labelItems["CHECKPOINT LOCATION"]
-            + "START WAL LOCATION: %s\n" % self.labelItems["START WAL LOCATION"],
-        )
+        message = "Database connection closed. "
+        for key, value in self.labelItems:
+            message = message + "%s: %s, " % (key, value)
+        message = message[:-2] + "\n"
+
+        bareosfd.JobMessage(bareosfd.M_INFO, message)
+
         self.close_db_connection()
         self.PostgressFullBackupRunning = False
 

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -364,7 +364,8 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         )
         try:
             result = self.dbCon.run(
-                "SELECT %s('%s');" % (startStmt, self.backupLabelString)
+                #TODO make fast => True an option
+                "SELECT %s('%s', fast => True);" % (startStmt, self.backupLabelString)
             )
         except Exception as e:
             bareosfd.JobMessage(
@@ -552,10 +553,11 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 # pg_backup_stop will return one row with three values. The second of these fields should be written
                 # to a file named backup_label in the root directory of the backup. The third field should be written
                 # to a file named tablespace_map unless the field is empty
-                self.writeAndAppendLabelFile(firstRow[1])
-                if len(firstRow) > 2 and len(firstRow[2]) > 0:
-                    self.writeAndAppendTablespaceMapFile(firstRow[2])
-                
+                if  chr(self.level) == "F":
+                    self.writeAndAppendLabelFile(firstRow[1])
+                    if len(firstRow) > 2 and len(firstRow[2]) > 0:
+                        self.writeAndAppendTablespaceMapFile(firstRow[2])
+
                 if "START WAL LOCATION" in self.labelItems:
                     self.lastLSN = self.formatLSN(self.labelItems["START WAL LOCATION"])
             else:

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -70,7 +70,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         self.labelFileName = None
         self.recoverySignalFileName = None
         self.tablespaceMapFileName = None
-        self.lastLSN = None
+        self.lastLSN = 0
         self.dbCon = None
         # This will be set to True between SELECT pg_start_backup
         # and SELECT pg_stop_backup. We backup database file during
@@ -256,7 +256,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                         "Could not get current LSN, last LSN was: %s : %s \n"
                         % (self.lastLSN, e),
                     )
-                if currentLSN > self.lastLSN and self.switchWal:
+                if self.switchWal and str(currentLSN) > str(self.lastLSN):
                     # Let Postgres write latest transaction into a new WAL file now
                     try:
                         result = self.dbCon.run(switchLsnStmt)
@@ -481,7 +481,7 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
                 "Got lastBackupStopTime %d from restore object of job %d\n"
                 % (self.lastBackupStopTime, ROP.jobid),
             )
-        if "lastLSN" in self.rop_data[ROP.jobid]:
+        if "lastLSN" in self.rop_data[ROP.jobid] and self.rop_data[ROP.jobid]["lastLSN"] is not None:
             self.lastLSN = self.rop_data[ROP.jobid]["lastLSN"]
             bareosfd.JobMessage(
                 bareosfd.M_INFO,

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -368,12 +368,22 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
             )
             return bareosfd.bRC_Error
 
+        if pgMajorVersion >= 15:
+            recoverySignalFileName = self.options["postgresDataDir"] + "recovery.signal"
+            with open(recoverySignalFileName, 'w') as recoverySignalFile:
+                recoverySignalFile.write("Created by bareos\n")
+            bareosfd.DebugMessage(150, "Did write recovery.signal file at %s\n" % recoverySignalFileName)
+            self.files_to_backup.append(recoverySignalFileName)
+
+            with open(self.labelFileName, 'w') as labelFile:
+                labelFile.write("TODO\n")
+            bareosfd.DebugMessage(150, "Did write backup_label file at %s\n" % self.labelFileName)
+
         bareosfd.DebugMessage(150, "Start response: %s\n" % str(result))
-        if pgMajorVersion < 15:
-            bareosfd.DebugMessage(
-                150, "Adding label file %s to fileset\n" % self.labelFileName
-            )
-            self.files_to_backup.append(self.labelFileName)
+        bareosfd.DebugMessage(
+            150, "Adding label file %s to fileset\n" % self.labelFileName
+        )
+        self.files_to_backup.append(self.labelFileName)
         bareosfd.DebugMessage(150, "Filelist: %s\n" % (self.files_to_backup))
         self.PostgressFullBackupRunning = True
         return bareosfd.bRC_OK

--- a/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -68,9 +68,9 @@ local_db_prepare_files() {
 local_db_start_server() {
   echo "start db server"
   if [ $UID -eq 0 ]; then
-    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl  -w --pgdata=data --log=log/logfile start"
+    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl --timeout=10 --wait --pgdata=data --log=log/logfile start"
   else
-    ${POSTGRES_BIN_PATH}/pg_ctl -w --pgdata=data --log=log/logfile start
+    ${POSTGRES_BIN_PATH}/pg_ctl --timeout=10 --wait --pgdata=data --log=log/logfile start
   fi
 #  tries=60
 #  while ! ${POSTGRES_BIN_PATH}/psql --host="$1" --list > /dev/null 2>&1; do
@@ -90,7 +90,6 @@ local_db_start_server() {
 #    sleep 1
 #  done
 
-  return 0
 }
 
 local_db_create_superuser_role() {

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -28,6 +28,8 @@ mkdir -p "$TESTPGHOST"
 
 pushd database > /dev/null
 setup_local_db "$TESTPGHOST"
+# PG_VERSION will be pick from backuped PG data dir
+PG_VERSION="$(cut -d '.' -f1 data/PG_VERSION)"
 popd > /dev/null
 
 #shellcheck source=../scripts/functions
@@ -42,7 +44,6 @@ CREATE TABLE t(id serial PRIMARY KEY, text VARCHAR(20), created_on TIMESTAMP);
 INSERT INTO t (text, created_on) values ('test for FULL backup', current_timestamp);
 SELECT * FROM t;
 "
-PSQL_VERSION=$(${PSQL} -qtAX ${DBNAME} <<< "SHOW server_version;" | sed 's/\..*//g')
 
 start_test
 
@@ -76,12 +77,15 @@ wait
 END_OF_DATA
 
 run_bconsole
+
 # run another Incr without db changes - should result in empty backup job (only restore object)
 run_bconsole
 
 # Now stop database and try a restore
 pushd database/ > /dev/null
 local_db_stop_server "$TESTPGHOST"
+# Save previous log
+cp -a data/log/* log/
 rm -Rf data
 rm -Rf wal_archive
 echo "------------ stopped"
@@ -90,8 +94,7 @@ popd > /dev/null
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
-messages
-@$out $tmp/log1.out
+@$out $tmp/log2.out
 restore client=bareos-fd where=/ select all done yes
 wait
 messages
@@ -102,27 +105,30 @@ check_for_zombie_jobs storage=File
 stop_bareos
 sleep 1
 
+pushd database > /dev/null
 #sometimes the pid file remains
-rm -f database/data/postmaster.pid
+rm -f data/postmaster.pid
+# reset log file
+rm -f data/log/*
+rm -f data/pg_wall/* ||:
 
-# Create a recovery.conf
+# Create a recovery.conf or recovery.signal
 # This may become a plugin feature later on
 # postgres 11 and lower
-# bc returns 1 if true, 0 if false so we need to negate
-if [ $(bc -l <<< "${PSQL_VERSION} < 12") -eq "1" ]; then
-  echo "PSQL is ${PSQL_VERSION} so lower than 12, using recovery.conf"
-  echo "restore_command = 'cp $current_test_directory/database/wal_archive/%f %p'" > $current_test_directory/database/data/recovery.conf
-  [ $EUID -eq 0 ] &&  chown postgres database/data/recovery.conf
+if (( ${PG_VERSION} < 12 )); then
+  echo "PG_VERSION is ${PG_VERSION} so lower than 12, using recovery.conf"
+  echo "restore_command = 'cp $current_test_directory/database/wal_archive/%f %p'" > ${current_test_directory}/database/data/recovery.conf
+  [ $EUID -eq 0 ] && chmod 0600 data/recovery.conf
+  [ $EUID -eq 0 ] && chown postgres data/recovery.conf
 else
   # postgres 12+
-  echo "PSQL is ${PSQL_VERSION} so 12+, using postgresql.conf and recovery.signal"
-  touch $current_test_directory/database/data/recovery.signal
-  echo "restore_command = 'cp $current_test_directory/database/wal_archive/%f %p'" >> database/data/postgresql.conf
-  [ $EUID -eq 0 ] &&  chown postgres database/data/postgresql.conf
+  echo "PG_VERSION is ${PG_VERSION} so 12+, using postgresql.conf and recovery.signal"
+  touch "${current_test_directory}/database/data/recovery.signal"
+  echo "restore_command = 'cp ${current_test_directory}/database/wal_archive/%f %p'" >> ${current_test_directory}/database/data/postgresql.conf
+  [ $EUID -eq 0 ] && chmod 0600 data/postgresql.conf data/recovery.signal
+  [ $EUID -eq 0 ] && chown postgres:postgres data/postgresql.conf data/recovery.signal
 fi
-# start DB again - shall recover to latest possible state
-pushd database > /dev/null
-local_db_start_server "$TESTPGHOST" || exit 1
+local_db_start_server "${TESTPGHOST}"
 popd > /dev/null
 
 i=0
@@ -130,7 +136,7 @@ until ${PSQL} ${DBNAME} <<< "SELECT * FROM t" | grep "for INCR"  > $tmp/sql.log 
 	echo "waiting for query to succeed"
 	sleep 1
   i=$((i+1))
-  if [ $i -gt 30 ]; then echo "timeout waiting for query after recovery"; exit 1; fi
+  if [ $i -gt 10 ]; then echo "timeout waiting for query after recovery"; exit 1; fi
 done
 
 pushd database/ > /dev/null

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -52,7 +52,7 @@ cat <<END_OF_DATA >$tmp/bconcmds
 messages
 @$out $tmp/log1.out
 label volume=TestVolume001 storage=File pool=Full
-setdebug level=100 trace=1 timestamp=1 client=bareos-fd
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
 run job=$JobName yes
 wait
 setdebug level=0 client=bareos-fd
@@ -64,6 +64,9 @@ messages
 END_OF_DATA
 
 run_bareos "$@"
+expect_grep "Backup OK" "$tmp/log1.out" "Full Backup not found!" 
+
+exit 1
 
 # Now add data to the database and run an incremental job
 echo "INSERT INTO t (text, created_on) values ('test for INCR backup', current_timestamp)" | ${PSQL} ${DBNAME}
@@ -71,15 +74,26 @@ echo "INSERT INTO t (text, created_on) values ('test for INCR backup', current_t
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
-@$out $tmp/log1.out
+@$out $tmp/log2.out
 run job=$JobName Level=Incremental yes
 wait
+messages
 END_OF_DATA
 
 run_bconsole
+expect_grep "Backup OK" "$tmp/log2.out" "First Incremental Backup not found!"
 
 # run another Incr without db changes - should result in empty backup job (only restore object)
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/log3.out
+run job=$JobName Level=Incremental yes
+wait
+messages
+END_OF_DATA
 run_bconsole
+expect_grep "Backup OK" "$tmp/log3.out" "2nd Incremental Backup not found!" 
 
 # Now stop database and try a restore
 pushd database/ > /dev/null
@@ -94,13 +108,14 @@ popd > /dev/null
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages
-@$out $tmp/log2.out
+@$out $tmp/log4.out
 restore client=bareos-fd where=/ select all done yes
 wait
 messages
 END_OF_DATA
 run_bconsole
 
+expect_grep "Restore OK" "$tmp/log4.out" "Restore Backup not ok!"
 check_for_zombie_jobs storage=File
 stop_bareos
 sleep 1
@@ -117,14 +132,14 @@ rm -f data/pg_wall/* ||:
 # postgres 11 and lower
 if (( ${PG_VERSION} < 12 )); then
   echo "PG_VERSION is ${PG_VERSION} so lower than 12, using recovery.conf"
-  echo "restore_command = 'cp $current_test_directory/database/wal_archive/%f %p'" > ${current_test_directory}/database/data/recovery.conf
+  echo "restore_command = 'cp ../wal_archive/%f %p'" > ${current_test_directory}/database/data/recovery.conf
   [ $EUID -eq 0 ] && chmod 0600 data/recovery.conf
   [ $EUID -eq 0 ] && chown postgres data/recovery.conf
 else
   # postgres 12+
   echo "PG_VERSION is ${PG_VERSION} so 12+, using postgresql.conf and recovery.signal"
   touch "${current_test_directory}/database/data/recovery.signal"
-  echo "restore_command = 'cp ${current_test_directory}/database/wal_archive/%f %p'" >> ${current_test_directory}/database/data/postgresql.conf
+  echo "restore_command = 'cp ../wal_archive/%f %p'" >> ${current_test_directory}/database/data/postgresql.conf
   [ $EUID -eq 0 ] && chmod 0600 data/postgresql.conf data/recovery.signal
   [ $EUID -eq 0 ] && chown postgres:postgres data/postgresql.conf data/recovery.signal
 fi

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -66,8 +66,6 @@ END_OF_DATA
 run_bareos "$@"
 expect_grep "Backup OK" "$tmp/log1.out" "Full Backup not found!" 
 
-exit 1
-
 # Now add data to the database and run an incremental job
 echo "INSERT INTO t (text, created_on) values ('test for INCR backup', current_timestamp)" | ${PSQL} ${DBNAME}
 

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -85,7 +85,7 @@ run_bconsole
 pushd database/ > /dev/null
 local_db_stop_server "$TESTPGHOST"
 # Save previous log
-cp -a data/log/* log/
+[ -d "data/log" ] && cp -a data/log/* log/
 rm -Rf data
 rm -Rf wal_archive
 echo "------------ stopped"


### PR DESCRIPTION
After upgrading to Debian bookworm I realized that the bareos-fd-postgres plugin is no longer compatible with version 15 of PostgreSQL as it

1. no longer creates the `backup_label` file
2. renames `pg_start_backup` to `pg_backup_start`
3. renames `pg_stop_backup` to `pg_backup_stop`

See https://www.postgresql.org/docs/current/release-15.html (look for the non-exclusive backup mode feature).

This PR ignores the `backup_label` file for PostgreSQL 15 and later and uses the result of the `pg_backup_stop` SELECT statement. It also uses the new function names when starting/stoping the backup.

**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
