### PR TITLE
config parser: fix bad block size warning

### DIFF
--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -173,7 +173,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
   // Ensure that all required items are present
   for (i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {
-      if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
+      if (!items[i].IsPresent()) {
         Emsg2(M_ABORT, 0,
               _("%s item is required in %s resource, but not found.\n"),
               items[i].name, resources[type].name);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1011,9 +1011,8 @@ static void PropagateResource(ResourceItem* items,
   uint32_t offset;
 
   for (int i = 0; items[i].name; i++) {
-    if (!BitIsSet(i, dest->item_present_)
-        && BitIsSet(i, source->item_present_)) {
-      offset = items[i].offset;
+    offset = items[i].offset;
+    if (!dest->IsMemberPresent(offset) && source->IsMemberPresent(offset)) {
       switch (items[i].type) {
         case CFG_TYPE_STR:
         case CFG_TYPE_DIR:
@@ -1025,7 +1024,7 @@ static void PropagateResource(ResourceItem* items,
           svalue = (char**)((char*)dest + offset);
           if (*svalue) { free(*svalue); }
           *svalue = strdup(*def_svalue);
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1039,7 +1038,7 @@ static void PropagateResource(ResourceItem* items,
             Pmsg1(000, _("Hey something is wrong. p=0x%lu\n"), *svalue);
           }
           *svalue = *def_svalue;
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1060,7 +1059,7 @@ static void PropagateResource(ResourceItem* items,
 
             foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
 
-            SetBit(i, dest->item_present_);
+            dest->SetMemberPresent(offset);
             SetBit(i, dest->inherit_content_);
           }
           break;
@@ -1082,7 +1081,7 @@ static void PropagateResource(ResourceItem* items,
 
             foreach_alist (res, orig_list) { (*new_list)->append(res); }
 
-            SetBit(i, dest->item_present_);
+            dest->SetMemberPresent(offset);
             SetBit(i, dest->inherit_content_);
           }
           break;
@@ -1106,7 +1105,7 @@ static void PropagateResource(ResourceItem* items,
 
             foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
 
-            SetBit(i, dest->item_present_);
+            dest->SetMemberPresent(offset);
             SetBit(i, dest->inherit_content_);
           }
           break;
@@ -1127,7 +1126,7 @@ static void PropagateResource(ResourceItem* items,
           def_ivalue = (uint32_t*)((char*)(source) + offset);
           ivalue = (uint32_t*)((char*)dest + offset);
           *ivalue = *def_ivalue;
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1141,7 +1140,7 @@ static void PropagateResource(ResourceItem* items,
           def_lvalue = (int64_t*)((char*)(source) + offset);
           lvalue = (int64_t*)((char*)dest + offset);
           *lvalue = *def_lvalue;
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1152,7 +1151,7 @@ static void PropagateResource(ResourceItem* items,
           def_bvalue = (bool*)((char*)(source) + offset);
           bvalue = (bool*)((char*)dest + offset);
           *bvalue = *def_bvalue;
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1165,7 +1164,7 @@ static void PropagateResource(ResourceItem* items,
 
           d_pwd->encoding = s_pwd->encoding;
           d_pwd->value = strdup(s_pwd->value);
-          SetBit(i, dest->item_present_);
+          dest->SetMemberPresent(offset);
           SetBit(i, dest->inherit_content_);
           break;
         }
@@ -1192,7 +1191,7 @@ bool ValidateResource(int res_type, ResourceItem* items, BareosResource* res)
 
   for (int i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {
-      if (!BitIsSet(i, res->item_present_)) {
+      if (!res->IsMemberPresent(items[i].offset)) {
         Jmsg(NULL, M_ERROR, 0,
              _("\"%s\" directive in %s \"%s\" resource is required, but not "
                "found.\n"),
@@ -2473,7 +2472,7 @@ static void StorePooltype(LEX* lc, ResourceItem* item, int index, int pass)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2498,7 +2497,7 @@ static void StoreActiononpurge(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2547,7 +2546,7 @@ static void StoreDevice(LEX* lc,
     }
 
     ScanToEol(lc);
-    SetBit(index, (*item->allocated_resource)->item_present_);
+    item->SetPresent();
     ClearBit(index, (*item->allocated_resource)->inherit_content_);
   } else {
     my_config->StoreResource(CFG_TYPE_ALIST_RES, lc, item, index, pass);
@@ -2573,7 +2572,7 @@ static void StoreMigtype(LEX* lc, ResourceItem* item, int index)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2596,7 +2595,7 @@ static void StoreJobtype(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2619,7 +2618,7 @@ static void StoreProtocoltype(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2641,7 +2640,7 @@ static void StoreReplace(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2664,7 +2663,7 @@ static void StoreAuthprotocoltype(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2688,7 +2687,7 @@ static void StoreAuthtype(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2712,7 +2711,7 @@ static void StoreLevel(LEX* lc, ResourceItem* item, int index, int)
   }
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2797,7 +2796,7 @@ static void StoreAcl(LEX* lc, ResourceItem* item, int index, int pass)
     }
     token = LexGetToken(lc, BCT_ALL);
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -2823,7 +2822,7 @@ static void StoreAudit(LEX* lc, ResourceItem* item, int index, int pass)
     if (token == BCT_COMMA) { continue; }
     break;
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -3063,7 +3062,7 @@ bail_out:
   res_runscript = nullptr;
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -3991,7 +3990,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
       /* Check Job requirements after applying JobDefs
        * Ensure that the name item is present however. */
       if (items[0].flags & CFG_ITEM_REQUIRED) {
-        if (!BitIsSet(0, allocated_resource->item_present_)) {
+        if (!allocated_resource->IsMemberPresent(items[0].offset)) {
           Emsg2(M_ERROR, 0,
                 _("%s item is required in %s resource, but not found.\n"),
                 items[0].name, resources[type].name);

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -1001,7 +1001,7 @@ static void StoreNewinc(LEX* lc, ResourceItem* item, int index, int pass)
   ASSERT(!res_incexe);
 
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -317,10 +317,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
       }   /* end if Bstrcasecmp */
     }     /* end for RunFields */
 
-    /*
-     * At this point, it is not a keyword. Check for old syle
-     * Job Levels without keyword. This form is depreciated!!!
-     */
+    /* At this point, it is not a keyword. Check for old syle
+     * Job Levels without keyword. This form is depreciated!!! */
     if (!found) {
       for (j = 0; joblevels[j].level_name; j++) {
         if (Bstrcasecmp(lc->str, joblevels[j].level_name)) {
@@ -333,10 +331,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
     }
   } /* end for found */
 
-  /*
-   * Scan schedule times.
-   * Default is: daily at 0:0
-   */
+  /* Scan schedule times.
+   * Default is: daily at 0:0 */
   state = s_none;
   set_defaults(res_run);
 
@@ -464,12 +460,10 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
           scan_err0(lc, _("Bad time specification."));
           return;
         }
-        /*
-         * Note, according to NIST, 12am and 12pm are ambiguous and
+        /* Note, according to NIST, 12am and 12pm are ambiguous and
          *  can be defined to anything.  However, 12:01am is the same
          *  as 00:01 and 12:01pm is the same as 12:01, so we define
-         *  12am as 00:00 and 12pm as 12:00.
-         */
+         *  12am as 00:00 and 12pm as 12:00. */
         if (pm) {
           // Convert to 24 hour time
           if (code != 12) { code += 12; }
@@ -720,7 +714,7 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
   }
 
   lc->options = options; /* Restore scanner options */
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 } /* namespace directordaemon */

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -189,7 +189,7 @@ static void StoreCipher(LEX* lc, ResourceItem* item, int index, int)
     scan_err1(lc, _("Expected a Crypto Cipher option, got: %s"), lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -424,7 +424,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
   // Ensure that all required items are present
   for (i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {
-      if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
+      if (!items[i].IsPresent()) {
         Emsg2(M_ABORT, 0,
               _("%s item is required in %s resource, but not found.\n"),
               items[i].name, resources[type].name);

--- a/core/src/lib/bareos_resource.cc
+++ b/core/src/lib/bareos_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -49,7 +49,7 @@ BareosResource::BareosResource(const BareosResource& other)
   description_ = other.description_ ? strdup(other.description_) : nullptr;
   rcode_ = other.rcode_;
   refcnt_ = other.refcnt_;
-  ::memcpy(item_present_, other.item_present_, MAX_RES_ITEMS);
+  item_present_ = other.item_present_;
   ::memcpy(inherit_content_, other.inherit_content_, MAX_RES_ITEMS);
 }
 
@@ -62,7 +62,7 @@ BareosResource& BareosResource::operator=(const BareosResource& rhs)
   description_ = rhs.description_;
   rcode_ = rhs.rcode_;
   refcnt_ = rhs.refcnt_;
-  ::memcpy(item_present_, rhs.item_present_, MAX_RES_ITEMS);
+  item_present_ = rhs.item_present_;
   ::memcpy(inherit_content_, rhs.inherit_content_, MAX_RES_ITEMS);
   return *this;
 }

--- a/core/src/lib/bareos_resource.h
+++ b/core/src/lib/bareos_resource.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,7 @@
 #define BAREOS_LIB_BAREOS_RESOURCE_H_
 
 #include "include/bareos.h"
+#include <unordered_set>
 
 class PoolMem;
 class ConfigurationParser;
@@ -41,7 +42,9 @@ class BareosResource {
   uint32_t rcode_;       /* Resource id or type */
   int32_t refcnt_;       /* Reference count for releasing */
   std::string rcode_str_;
-  char item_present_[MAX_RES_ITEMS]; /* Set if item is present in conf file */
+  std::unordered_set<std::size_t>
+      item_present_; /* set of offsets into the resource where values were
+                        written */
   char inherit_content_[MAX_RES_ITEMS]; /* Set if item has inherited content */
   bool internal_{false};
 
@@ -62,6 +65,15 @@ class BareosResource {
                                  bool hide_sensitive_data,
                                  bool inherited,
                                  bool verbose);
+
+  bool IsMemberPresent(std::size_t member_offset) const
+  {
+    return item_present_.find(member_offset) != item_present_.end();
+  }
+  void SetMemberPresent(std::size_t member_offset)
+  {
+    item_present_.insert(member_offset);
+  }
 };
 
 const char* GetResourceName(const void* resource);

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -395,7 +395,7 @@ void ConfigurationParser::StoreMsgs(LEX* lc,
     }
   }
   ScanToEol(lc);
-  SetBit(index, message_resource->item_present_);
+  message_resource->SetMemberPresent(item->offset);
   ClearBit(index, message_resource->inherit_content_);
   Dmsg0(900, "Done StoreMsgs\n");
 }
@@ -422,7 +422,7 @@ void ConfigurationParser::StoreName(LEX* lc, ResourceItem* item, int index, int)
   }
   *p = strdup(lc->str);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -442,7 +442,7 @@ void ConfigurationParser::StoreStrname(LEX* lc,
     *p = strdup(lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -455,7 +455,7 @@ void ConfigurationParser::StoreStr(LEX* lc,
   LexGetToken(lc, BCT_STRING);
   if (pass == 1) { SetItemVariableFreeMemory<char*>(*item, strdup(lc->str)); }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -468,7 +468,7 @@ void ConfigurationParser::StoreStdstr(LEX* lc,
   LexGetToken(lc, BCT_STRING);
   if (pass == 1) { SetItemVariable<std::string>(*item, lc->str); }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -492,7 +492,7 @@ void ConfigurationParser::StoreDir(LEX* lc,
     *p = strdup(lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -509,7 +509,7 @@ void ConfigurationParser::StoreStdstrdir(LEX* lc,
     SetItemVariable<std::string>(*item, lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -565,7 +565,7 @@ void ConfigurationParser::StoreMd5Password(LEX* lc,
     }
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -593,7 +593,7 @@ void ConfigurationParser::StoreClearpassword(LEX* lc,
     pwd->value = strdup(lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -628,7 +628,7 @@ void ConfigurationParser::StoreRes(LEX* lc,
     *p = res;
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -670,7 +670,7 @@ void ConfigurationParser::StoreAlistRes(LEX* lc,
     }
     token = LexGetToken(lc, BCT_ALL);
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -695,7 +695,7 @@ void ConfigurationParser::StoreStdVectorStr(LEX* lc,
        *
        * We first check to see if the config item has the CFG_ITEM_DEFAULT
        * flag set and currently has exactly one entry. */
-      if (!BitIsSet(index, (*item->allocated_resource)->item_present_)) {
+      if (!item->IsPresent()) {
         if ((item->flags & CFG_ITEM_DEFAULT) && list->size() == 1) {
           if (list->at(0) == item->default_value) { list->clear(); }
         }
@@ -704,7 +704,7 @@ void ConfigurationParser::StoreStdVectorStr(LEX* lc,
     }
     token = LexGetToken(lc, BCT_ALL);
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -735,7 +735,7 @@ void ConfigurationParser::StoreAlistStr(LEX* lc,
        *
        * We first check to see if the config item has the CFG_ITEM_DEFAULT
        * flag set and currently has exactly one entry. */
-      if (!BitIsSet(index, (*item->allocated_resource)->item_present_)) {
+      if (!item->IsPresent()) {
         if ((item->flags & CFG_ITEM_DEFAULT) && list->size() == 1) {
           char* entry = (char*)list->first();
           if (bstrcmp(entry, item->default_value)) {
@@ -748,7 +748,7 @@ void ConfigurationParser::StoreAlistStr(LEX* lc,
     }
     token = LexGetToken(lc, BCT_ALL);
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -796,7 +796,7 @@ void ConfigurationParser::StoreAlistDir(LEX* lc,
     list->append(strdup(lc->str));
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -844,7 +844,7 @@ void ConfigurationParser::StorePluginNames(LEX* lc,
         break;
     }
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -884,7 +884,7 @@ void ConfigurationParser::store_int16(LEX* lc,
   LexGetToken(lc, BCT_INT16);
   SetItemVariable<int16_t>(*item, lc->u.int16_val);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -896,7 +896,7 @@ void ConfigurationParser::store_int32(LEX* lc,
   LexGetToken(lc, BCT_INT32);
   SetItemVariable<int32_t>(*item, lc->u.int32_val);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -909,7 +909,7 @@ void ConfigurationParser::store_pint16(LEX* lc,
   LexGetToken(lc, BCT_PINT16);
   SetItemVariable<uint16_t>(*item, lc->u.pint16_val);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -921,7 +921,7 @@ void ConfigurationParser::store_pint32(LEX* lc,
   LexGetToken(lc, BCT_PINT32);
   SetItemVariable<uint32_t>(*item, lc->u.pint32_val);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -934,7 +934,7 @@ void ConfigurationParser::store_int64(LEX* lc,
   LexGetToken(lc, BCT_INT64);
   SetItemVariable<int64_t>(*item, lc->u.int64_val);
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -1006,7 +1006,7 @@ void ConfigurationParser::store_int_unit(LEX* lc,
       return;
   }
   if (token != BCT_EOL) { ScanToEol(lc); }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
   Dmsg0(900, "Leave store_unit\n");
 }
@@ -1073,7 +1073,7 @@ void ConfigurationParser::StoreTime(LEX* lc, ResourceItem* item, int index, int)
       return;
   }
   if (token != BCT_EOL) { ScanToEol(lc); }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -1092,7 +1092,7 @@ void ConfigurationParser::StoreBit(LEX* lc, ResourceItem* item, int index, int)
     return;
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -1110,7 +1110,7 @@ void ConfigurationParser::StoreBool(LEX* lc, ResourceItem* item, int index, int)
     return;
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -1135,7 +1135,7 @@ void ConfigurationParser::StoreLabel(LEX* lc,
     return;
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -1275,7 +1275,7 @@ void ConfigurationParser::StoreAddresses(LEX* lc,
   if (token != BCT_EOB) {
     scan_err1(lc, _("Expected a end of block }, got: %s"), lc->str);
   }
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 

--- a/core/src/lib/resource_item.h
+++ b/core/src/lib/resource_item.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -40,18 +40,21 @@ struct ResourceItem {
   int32_t code;              /* Item code/additional info */
   uint32_t flags;            /* Flags: See CFG_ITEM_* */
   const char* default_value; /* Default value */
-  /*
-   * version string in format: [start_version]-[end_version]
+  /* version string in format: [start_version]-[end_version]
    * start_version: directive has been introduced in this version
-   * end_version:   directive is deprecated since this version
-   */
+   * end_version:   directive is deprecated since this version */
   const char* versions;
-  /*
-   * description of the directive, used for the documentation.
+  /* description of the directive, used for the documentation.
    * Full sentence.
-   * Every new directive should have a description.
-   */
+   * Every new directive should have a description. */
   const char* description;
+
+  void SetPresent() { (*allocated_resource)->SetMemberPresent(offset); }
+
+  bool IsPresent() const
+  {
+    return (*allocated_resource)->IsMemberPresent(offset);
+  }
 };
 
 static inline void* CalculateAddressOfMemberVariable(const ResourceItem& item)

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -279,7 +279,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
   // Ensure that all required items are present
   for (i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {
-      if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
+      if (!items[i].IsPresent()) {
         Emsg2(M_ERROR_TERM, 0,
               _("%s item is required in %s resource, but not found.\n"),
               items[i].name, resource_definitions[type].name);

--- a/core/src/stored/dev.cc
+++ b/core/src/stored/dev.cc
@@ -372,8 +372,10 @@ void Device::SetBlocksizes(DeviceControlRecord* dcr)
         "dev->max_block_size of %u, dcr->VolMaxBlocksize is %u\n",
         dev->print_name(), dev->device_resource->max_block_size,
         dev->max_block_size, dcr->VolMaxBlocksize);
-
-  if (dcr->VolMaxBlocksize == 0 && dev->device_resource->max_block_size != 0) {
+  if (dcr->VolMaxBlocksize != 0) {
+    dev->min_block_size = dcr->VolMinBlocksize;
+    dev->max_block_size = dcr->VolMaxBlocksize;
+  } else if (dev->device_resource->max_block_size != 0) {
     Dmsg2(100,
           "setting dev->max_block_size to "
           "dev->device_resource->max_block_size=%u "
@@ -381,9 +383,6 @@ void Device::SetBlocksizes(DeviceControlRecord* dcr)
           dev->device_resource->max_block_size, dev->print_name());
     dev->min_block_size = dev->device_resource->min_block_size;
     dev->max_block_size = dev->device_resource->max_block_size;
-  } else if (dcr->VolMaxBlocksize != 0) {
-    dev->min_block_size = dcr->VolMinBlocksize;
-    dev->max_block_size = dcr->VolMaxBlocksize;
   }
 
   // Sanity check

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -217,14 +217,15 @@ void DeviceResource::CreateAndAssignSerialNumber(uint16_t number)
   resource_name_ = strdup(tmp_name.c_str());
 }
 
-static void WarnOnNonZeroBlockSize(int max_block_size, std::string_view name)
+static void WarnOnSetMaxBlockSize(const DeviceResource& resource)
 {
-  if (max_block_size > 0) {
+  if (resource.IsMemberPresent(offsetof(
+          std::remove_pointer<decltype(&resource)>::type, max_block_size))) {
     my_config->AddWarning(fmt::format(
         FMT_STRING(
             "Device {:s}: Setting 'Maximum Block Size' is only supported on  "
             "tape devices"),
-        name));
+        resource.resource_name_));
   }
 }
 
@@ -264,7 +265,7 @@ static bool ValidateTapeDevice(const DeviceResource& resource)
 
 static bool ValidateGenericDevice(const DeviceResource& resource)
 {
-  WarnOnNonZeroBlockSize(resource.max_block_size, resource.resource_name_);
+  WarnOnSetMaxBlockSize(resource);
   WarnOnZeroMaxConcurrentJobs(resource.max_concurrent_jobs,
                               resource.resource_name_);
   WarnOnGtOneMaxConcurrentJobs(resource.max_concurrent_jobs,

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -28,6 +28,8 @@
 #include "stored/autoxflate.h"
 #include "lib/bareos_resource.h"
 
+#include <optional>
+
 namespace storagedaemon {
 
 class Device;
@@ -60,10 +62,10 @@ class DeviceResource : public BareosResource {
   utime_t max_rewind_wait{300};  /**< Maximum secs to wait for rewind */
   utime_t max_open_wait{300};    /**< Maximum secs to wait for open */
   uint32_t max_open_vols{1};     /**< Maximum simultaneous open volumes */
-  uint32_t label_block_size{64512};    /**< block size of the label block*/
-  uint32_t min_block_size{0};          /**< Current Minimum block size */
-  uint32_t max_block_size{1048576};    /**< Current Maximum block size */
-  uint32_t max_network_buffer_size{0}; /**< Max network buf size */
+  uint32_t label_block_size{64512};     /**< block size of the label block*/
+  uint32_t min_block_size{0};           /**< Current Minimum block size */
+  uint32_t max_block_size{1024 * 1024}; /**< Current Maximum block size */
+  uint32_t max_network_buffer_size{0};  /**< Max network buf size */
   uint32_t max_concurrent_jobs{0};   /**< Maximum concurrent jobs this drive */
   uint32_t autodeflate_algorithm{0}; /**< Compression algorithm to use for
                                      compression */

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -279,7 +279,7 @@ static void StoreAuthenticationType(LEX* lc, ResourceItem* item, int index, int)
               lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -339,7 +339,7 @@ static void StoreIoDirection(LEX* lc, ResourceItem* item, int index, int)
     scan_err1(lc, _("Expected a IO direction keyword, got: %s"), lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -365,7 +365,7 @@ static void StoreCompressionalgorithm(LEX* lc,
               lc->str);
   }
   ScanToEol(lc);
-  SetBit(index, (*item->allocated_resource)->item_present_);
+  item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
 }
 
@@ -736,7 +736,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
   // Ensure that all required items are present
   for (i = 0; items[i].name; i++) {
     if (items[i].flags & CFG_ITEM_REQUIRED) {
-      if (!BitIsSet(i, (*items[i].allocated_resource)->item_present_)) {
+      if (!items[i].IsPresent()) {
         Emsg2(M_ERROR_TERM, 0,
               _("\"%s\" item is required in \"%s\" resource, but not found.\n"),
               items[i].name, resources[type].name);


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR changes the way that the parser saves which members it set itself.  
Instead of remembering the items by index (from the resource item array),
they are instead remembered by offset of the member variable itself.  Since this is something everyone has access to -- as opposed to the private resource item arrays -- other parts of the code to easily query whether a member was set by the parser or not.

This is then used to only emit the block size warning if the block size was actually set inside the configuration (regardless of what is was set to).

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
