### PR TITLE
stored: automatically increment tape block size in case the buffer is too small

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: add AccessMode SD->Device directive to reserve devices exclusively for reading or writing [PR #1464]
 - plugins: switch python-ldap plugin to  python3 [PR #1522]
 - build: switch from FreeBSD 13.1 to 13.2 [PR #1524]
+- stored: automatically increment tape block size in case the buffer is too small [PR #1496]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -219,6 +220,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1490]: https://github.com/bareos/bareos/pull/1490
 [PR #1493]: https://github.com/bareos/bareos/pull/1493
 [PR #1495]: https://github.com/bareos/bareos/pull/1495
+[PR #1496]: https://github.com/bareos/bareos/pull/1496
 [PR #1499]: https://github.com/bareos/bareos/pull/1499
 [PR #1502]: https://github.com/bareos/bareos/pull/1502
 [PR #1503]: https://github.com/bareos/bareos/pull/1503

--- a/core/src/stored/backends/unix_tape_device.cc
+++ b/core/src/stored/backends/unix_tape_device.cc
@@ -52,20 +52,16 @@
 #include "generic_tape_device.h"
 #include "unix_tape_device.h"
 
-namespace {
-static constexpr size_t size_increment = 1024 * 1024;
-static constexpr size_t max_size_increment = 16 * size_increment;
-static constexpr size_t next_size_increment(size_t count)
-{
-  if (count < size_increment) {
-    return size_increment;
-  } else {
-    return (count / size_increment) * 2 * size_increment;
-  }
-}
-}  // namespace
-
 namespace storagedaemon {
+
+static std::vector<std::size_t> bufsizes(std::size_t count)
+{
+  constexpr std::size_t mb = 1024 * 1024;
+  std::vector<std::size_t> sizes{1 * mb, 2 * mb, 4 * mb, 8 * mb, 16 * mb};
+  sizes.erase(sizes.begin(),
+              std::upper_bound(sizes.begin(), sizes.end(), count));
+  return sizes;
+}
 
 int unix_tape_device::d_ioctl(int fd, ioctl_req_t request, char* op)
 {
@@ -80,21 +76,33 @@ unix_tape_device::unix_tape_device()
 ssize_t unix_tape_device::d_read(int fd, void* buffer, size_t count)
 {
   ssize_t ret = ::read(fd, buffer, count);
-  /* when the driver fails to `read()` with `ENOMEM`, then the provided buffer
-   * was too small by re-reading with a temporary buffer that is enlarged
-   * step-by-step, we can read the block and returns its first `count` bytes.
+  /* If the driver fails to `read()` with `ENOMEM`, then the provided buffer
+   * was too small. By re-reading with a temporary buffer that is enlarged
+   * step-by-step, we can read the block and return the first `count` bytes.
    * This allows the calling code to read the block header and resize its buffer
    * according to the size recorded in that header.
    */
-  for (size_t bufsize = next_size_increment(count);
-       ret == -1 && errno == ENOMEM && bufsize <= max_size_increment;
-       bufsize = next_size_increment(bufsize)) {
-    std::vector<char> tmpbuf(bufsize);
-    bsr(1);       // go back one block so we can re-read
-    block_num++;  // re-increment the block counter that bsr() just incremented
-    if (auto tmpret = ::read(fd, tmpbuf.data(), tmpbuf.size()); tmpret != -1) {
-      memcpy(buffer, tmpbuf.data(), count);
-      ret = std::min(tmpret, static_cast<ssize_t>(count));
+  if (ret == -1 && errno == ENOMEM && HasCap(CAP_BSR)) {
+    for (auto bufsize : bufsizes(count)) {
+      // first go back one block so we can re-read
+      if (!bsr(1)) {
+        /* when backward-spacing fails for some reason, there's not much we
+         * can do, so we just return the original ENOMEM and hope that the
+         * caller knows the device is in a non well-defined state.
+         */
+        errno = ENOMEM;
+        return -1;
+      }
+      block_num++;  // re-increment the block counter bsr() just decremented
+      std::vector<char> tmpbuf(bufsize);
+      if (auto tmpret = ::read(fd, tmpbuf.data(), tmpbuf.size());
+          tmpret != -1) {
+        memcpy(buffer, tmpbuf.data(), count);
+        ret = std::min(tmpret, static_cast<ssize_t>(count));
+        break;  // successful read
+      } else if (errno != ENOMEM) {
+        break;  // some other error occured
+      }
     }
   }
   return ret;

--- a/core/src/stored/backends/unix_tape_device.h
+++ b/core/src/stored/backends/unix_tape_device.h
@@ -36,7 +36,7 @@ class unix_tape_device : public generic_tape_device {
   ~unix_tape_device() { close(nullptr); };
 
   int d_ioctl(int fd, ioctl_req_t request, char* op) override;
-  virtual ssize_t d_read(int fd, void* buffer, size_t count) override;
+  ssize_t d_read(int fd, void* buffer, size_t count) override;
 };
 
 } /* namespace storagedaemon */

--- a/core/src/stored/backends/unix_tape_device.h
+++ b/core/src/stored/backends/unix_tape_device.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2013-2013 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,6 +36,7 @@ class unix_tape_device : public generic_tape_device {
   ~unix_tape_device() { close(nullptr); };
 
   int d_ioctl(int fd, ioctl_req_t request, char* op) override;
+  virtual ssize_t d_read(int fd, void* buffer, size_t count) override;
 };
 
 } /* namespace storagedaemon */

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -1076,7 +1076,9 @@ reread:
     // Attempt to Reposition to re-read the block
     if (dev->IsTape()) {
       Dmsg0(250, "BootStrapRecord for reread; block too big for buffer.\n");
-      if (!dev->bsr(1)) {
+      if (dev->bsr(1)) {
+        dev->block_num++;  // re-increment what bsr() decremented
+      } else {
         Mmsg(dev->errmsg, "%s", dev->bstrerror());
         Jmsg(jcr, M_ERROR, 0, "%s", dev->errmsg);
         block->read_len = 0;

--- a/devtools/dist-tarball.sh
+++ b/devtools/dist-tarball.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -35,6 +35,12 @@ at_exit() {
   fi
 }
 trap at_exit EXIT
+
+add_prefix() {
+  while IFS= read -r -d $'\0' path; do
+    echo -ne "./$path\0"
+  done
+}
 
 git="${GIT:-$(command -v git)}"
 cmake="${CMAKE:-$(command -v cmake)}"
@@ -122,6 +128,7 @@ fi
 
 (echo -ne 'cmake/BareosVersion.cmake\0'; "$git" ls-files -z) | \
 "$sort" -u -z | \
+add_prefix | \
 "$tar" "${args[@]}" -cf - --files-from - | \
 "$xz" --threads=0 -c -6 > "${archive_file}"
 


### PR DESCRIPTION
This change allows Bareos to read tape volumes even if the configured `Maximum Block Size` is too small.
You will still see an error message like this to notify you that something is not right:
```
28-Jun 16:10 bareos-sd JobId 15: Error: stored/block.cc:1057 Block length 162132 is greater than buffer 64512. Attempting recovery.
28-Jun 16:10 bareos-sd JobId 15: stored/block.cc:1079 Setting block buffer size to 162132 bytes.
```
However, restore will not fail anymore.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
~~Required backport PRs have been created~~

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR