### PR TITLE
dird: add prev and new jobid variables

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -173,6 +173,7 @@ Rudolf Cejka
 Russel Howe
 Ruth Ivimey-Cook
 Sam Verstraete
+Samuel Börlin
 Scott Bailey
 Sebastian Lederer
 Sebastian Sura

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bsmtp: make mailhost and port message info a debug message [PR #1507]
 - dird: cats: abort purge when there are no eligible jobids [PR #1512]
 - dird: show current and allowed console connections [PR #1487]
+- dird: add prev and new jobid variables [PR #1499]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -208,6 +209,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1490]: https://github.com/bareos/bareos/pull/1490
 [PR #1493]: https://github.com/bareos/bareos/pull/1493
 [PR #1495]: https://github.com/bareos/bareos/pull/1495
+[PR #1499]: https://github.com/bareos/bareos/pull/1499
 [PR #1502]: https://github.com/bareos/bareos/pull/1502
 [PR #1503]: https://github.com/bareos/bareos/pull/1503
 [PR #1507]: https://github.com/bareos/bareos/pull/1507

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3083,33 +3083,32 @@ bail_out:
  * %m = Prev Backup JobId
  * %M = New Backup JobId
  */
-extern "C" char* job_code_callback_director(JobControlRecord* jcr,
+extern "C" std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
                                             const char* param)
 {
-  static char yes[] = "yes";
-  static char no[] = "no";
-  
-  static char str[50];
+  static const std::string yes = "yes";
+  static const std::string no = "no";
+  static const std::string none = "*None*";
 
   switch (param[0]) {
     case 'f':
       if (jcr->dir_impl->res.fileset) {
-        return jcr->dir_impl->res.fileset->resource_name_;
+        return std::string(jcr->dir_impl->res.fileset->resource_name_);
       }
       break;
     case 'h':
       if (jcr->dir_impl->res.client) {
-        return jcr->dir_impl->res.client->address;
+        return std::string(jcr->dir_impl->res.client->address);
       }
       break;
     case 'p':
       if (jcr->dir_impl->res.pool) {
-        return jcr->dir_impl->res.pool->resource_name_;
+        return std::string(jcr->dir_impl->res.pool->resource_name_);
       }
       break;
     case 'w':
       if (jcr->dir_impl->res.write_storage) {
-        return jcr->dir_impl->res.write_storage->resource_name_;
+        return std::string(jcr->dir_impl->res.write_storage->resource_name_);
       }
       break;
     case 'x':
@@ -3117,7 +3116,7 @@ extern "C" char* job_code_callback_director(JobControlRecord* jcr,
     case 'C':
       return jcr->dir_impl->cloned ? yes : no;
     case 'D':
-      return my_name;
+      return std::string(my_name);
     case 'V':
       if (jcr) {
         /* If this is a migration/copy we need the volume name from the
@@ -3125,34 +3124,32 @@ extern "C" char* job_code_callback_director(JobControlRecord* jcr,
         if (jcr->dir_impl->mig_jcr) { jcr = jcr->dir_impl->mig_jcr; }
 
         if (jcr->VolumeName) {
-          return jcr->VolumeName;
+          return std::string(jcr->VolumeName);
         } else {
-          return (char*)_("*None*");
+          return none;
         }
       } else {
-        return (char*)_("*None*");
+        return none;
       }
       break;
     case 'm': /* Migration/copy job prev jobid */
       if (jcr && jcr->dir_impl && jcr->dir_impl->previous_jr.JobId) {
-        Bsnprintf(str, sizeof(str), "%d", jcr->dir_impl->previous_jr.JobId);
-        return str;
+        return std::to_string(jcr->dir_impl->previous_jr.JobId);
       } else {
-        return (char*)_("*None*");
+        return none;
       }
       break;
     case 'M': /* Migration/copy job new jobid */
       if (jcr && jcr->dir_impl && jcr->dir_impl->mig_jcr && jcr->dir_impl->mig_jcr->dir_impl
 	      && jcr->dir_impl->mig_jcr->dir_impl->jr.JobId) {
-        Bsnprintf(str, sizeof(str), "%d", jcr->dir_impl->mig_jcr->dir_impl->jr.JobId);
-        return str;
+        return std::to_string(jcr->dir_impl->mig_jcr->dir_impl->jr.JobId);
       } else {
-        return (char*)_("*None*");
+        return none;
       }
       break;
   }
 
-  return NULL;
+  return std::nullopt;
 }
 
 /**

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3080,8 +3080,8 @@ bail_out:
  * %C = Cloning (yes/no)
  * %D = Director name
  * %V = Volume name(s) (Destination)
- * %m = Prev Backup JobId
- * %M = New Backup JobId
+ * %O = Prev Backup JobId
+ * %N = New Backup JobId
  */
 std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
                                             const char* param)
@@ -3132,14 +3132,14 @@ std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
         return none;
       }
       break;
-    case 'm': /* Migration/copy job prev jobid */
+    case 'O': /* Migration/copy job prev jobid */
       if (jcr && jcr->dir_impl && jcr->dir_impl->previous_jr.JobId) {
         return std::to_string(jcr->dir_impl->previous_jr.JobId);
       } else {
         return none;
       }
       break;
-    case 'M': /* Migration/copy job new jobid */
+    case 'N': /* Migration/copy job new jobid */
       if (jcr && jcr->dir_impl && jcr->dir_impl->mig_jcr && jcr->dir_impl->mig_jcr->dir_impl
 	      && jcr->dir_impl->mig_jcr->dir_impl->jr.JobId) {
         return std::to_string(jcr->dir_impl->mig_jcr->dir_impl->jr.JobId);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3084,7 +3084,7 @@ bail_out:
  * %N = New Backup JobId
  */
 std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
-                                            const char* param)
+                                                      const char* param)
 {
   static const std::string yes = "yes";
   static const std::string no = "no";
@@ -3140,8 +3140,9 @@ std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
       }
       break;
     case 'N': /* Migration/copy job new jobid */
-      if (jcr && jcr->dir_impl && jcr->dir_impl->mig_jcr && jcr->dir_impl->mig_jcr->dir_impl
-	      && jcr->dir_impl->mig_jcr->dir_impl->jr.JobId) {
+      if (jcr && jcr->dir_impl && jcr->dir_impl->mig_jcr
+          && jcr->dir_impl->mig_jcr->dir_impl
+          && jcr->dir_impl->mig_jcr->dir_impl->jr.JobId) {
         return std::to_string(jcr->dir_impl->mig_jcr->dir_impl->jr.JobId);
       } else {
         return none;

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3093,22 +3093,22 @@ extern "C" std::optional<std::string> job_code_callback_director(JobControlRecor
   switch (param[0]) {
     case 'f':
       if (jcr->dir_impl->res.fileset) {
-        return std::string(jcr->dir_impl->res.fileset->resource_name_);
+        return jcr->dir_impl->res.fileset->resource_name_;
       }
       break;
     case 'h':
       if (jcr->dir_impl->res.client) {
-        return std::string(jcr->dir_impl->res.client->address);
+        return jcr->dir_impl->res.client->address;
       }
       break;
     case 'p':
       if (jcr->dir_impl->res.pool) {
-        return std::string(jcr->dir_impl->res.pool->resource_name_);
+        return jcr->dir_impl->res.pool->resource_name_;
       }
       break;
     case 'w':
       if (jcr->dir_impl->res.write_storage) {
-        return std::string(jcr->dir_impl->res.write_storage->resource_name_);
+        return jcr->dir_impl->res.write_storage->resource_name_;
       }
       break;
     case 'x':
@@ -3116,7 +3116,7 @@ extern "C" std::optional<std::string> job_code_callback_director(JobControlRecor
     case 'C':
       return jcr->dir_impl->cloned ? yes : no;
     case 'D':
-      return std::string(my_name);
+      return my_name;
     case 'V':
       if (jcr) {
         /* If this is a migration/copy we need the volume name from the
@@ -3124,7 +3124,7 @@ extern "C" std::optional<std::string> job_code_callback_director(JobControlRecor
         if (jcr->dir_impl->mig_jcr) { jcr = jcr->dir_impl->mig_jcr; }
 
         if (jcr->VolumeName) {
-          return std::string(jcr->VolumeName);
+          return jcr->VolumeName;
         } else {
           return none;
         }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3083,7 +3083,7 @@ bail_out:
  * %m = Prev Backup JobId
  * %M = New Backup JobId
  */
-extern "C" std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
+std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
                                             const char* param)
 {
   static const std::string yes = "yes";

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3080,12 +3080,16 @@ bail_out:
  * %C = Cloning (yes/no)
  * %D = Director name
  * %V = Volume name(s) (Destination)
+ * %m = Prev Backup JobId
+ * %M = New Backup JobId
  */
 extern "C" char* job_code_callback_director(JobControlRecord* jcr,
                                             const char* param)
 {
   static char yes[] = "yes";
   static char no[] = "no";
+  
+  static char str[50];
 
   switch (param[0]) {
     case 'f':
@@ -3125,6 +3129,23 @@ extern "C" char* job_code_callback_director(JobControlRecord* jcr,
         } else {
           return (char*)_("*None*");
         }
+      } else {
+        return (char*)_("*None*");
+      }
+      break;
+    case 'm': /* Migration/copy job prev jobid */
+      if (jcr && jcr->dir_impl && jcr->dir_impl->previous_jr.JobId) {
+        Bsnprintf(str, sizeof(str), "%d", jcr->dir_impl->previous_jr.JobId);
+        return str;
+      } else {
+        return (char*)_("*None*");
+      }
+      break;
+    case 'M': /* Migration/copy job new jobid */
+      if (jcr && jcr->dir_impl && jcr->dir_impl->mig_jcr && jcr->dir_impl->mig_jcr->dir_impl
+	      && jcr->dir_impl->mig_jcr->dir_impl->jr.JobId) {
+        Bsnprintf(str, sizeof(str), "%d", jcr->dir_impl->mig_jcr->dir_impl->jr.JobId);
+        return str;
       } else {
         return (char*)_("*None*");
       }

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -679,7 +679,7 @@ bool print_datatype_schema_json(PoolMem& buffer,
 json_t* json_datatype(const int type, ResourceItem items[]);
 const char* AuthenticationProtocolTypeToString(uint32_t auth_protocol);
 const char* JobLevelToString(int level);
-extern "C" std::optional<std::string> job_code_callback_director(JobControlRecord* jcr, const char*);
+std::optional<std::string> job_code_callback_director(JobControlRecord* jcr, const char*);
 const char* GetUsageStringForConsoleConfigureCommand();
 void DestroyConfigureUsageString();
 bool PopulateDefs();

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -679,7 +679,7 @@ bool print_datatype_schema_json(PoolMem& buffer,
 json_t* json_datatype(const int type, ResourceItem items[]);
 const char* AuthenticationProtocolTypeToString(uint32_t auth_protocol);
 const char* JobLevelToString(int level);
-extern "C" char* job_code_callback_director(JobControlRecord* jcr, const char*);
+extern "C" std::optional<std::string> job_code_callback_director(JobControlRecord* jcr, const char*);
 const char* GetUsageStringForConsoleConfigureCommand();
 void DestroyConfigureUsageString();
 bool PopulateDefs();

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -679,7 +679,8 @@ bool print_datatype_schema_json(PoolMem& buffer,
 json_t* json_datatype(const int type, ResourceItem items[]);
 const char* AuthenticationProtocolTypeToString(uint32_t auth_protocol);
 const char* JobLevelToString(int level);
-std::optional<std::string> job_code_callback_director(JobControlRecord* jcr, const char*);
+std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
+                                                      const char*);
 const char* GetUsageStringForConsoleConfigureCommand();
 void DestroyConfigureUsageString();
 bool PopulateDefs();

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -94,7 +94,7 @@ static alist<pthread_t*>* client_initiated_connection_threads = nullptr;
 extern bool AccurateCmd(JobControlRecord* jcr);
 extern bool StatusCmd(JobControlRecord* jcr);
 extern bool QstatusCmd(JobControlRecord* jcr);
-extern "C" char* job_code_callback_filed(JobControlRecord* jcr,
+extern "C" std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
                                          const char* param);
 
 /* Forward referenced functions */

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -94,8 +94,6 @@ static alist<pthread_t*>* client_initiated_connection_threads = nullptr;
 extern bool AccurateCmd(JobControlRecord* jcr);
 extern bool StatusCmd(JobControlRecord* jcr);
 extern bool QstatusCmd(JobControlRecord* jcr);
-extern "C" std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
-                                         const char* param);
 
 /* Forward referenced functions */
 static bool BackupCmd(JobControlRecord* jcr);

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -54,7 +54,7 @@ namespace filedaemon {
  * %D = Director
  * %m = Modification time (for incremental and differential)
  */
-extern "C" std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
+std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
                                          const char* param)
 {
   switch (param[0]) {

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -55,7 +55,7 @@ namespace filedaemon {
  * %m = Modification time (for incremental and differential)
  */
 std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
-                                         const char* param)
+                                                   const char* param)
 {
   switch (param[0]) {
     case 'D':

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -60,7 +60,7 @@ extern "C" std::optional<std::string> job_code_callback_filed(JobControlRecord* 
   switch (param[0]) {
     case 'D':
       if (jcr->fd_impl->director) {
-        return std::string(jcr->fd_impl->director->resource_name_);
+        return jcr->fd_impl->director->resource_name_;
       }
       break;
     case 'm':

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -54,22 +54,20 @@ namespace filedaemon {
  * %D = Director
  * %m = Modification time (for incremental and differential)
  */
-extern "C" char* job_code_callback_filed(JobControlRecord* jcr,
+extern "C" std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
                                          const char* param)
 {
-  static char str[50];
-
   switch (param[0]) {
     case 'D':
       if (jcr->fd_impl->director) {
-        return jcr->fd_impl->director->resource_name_;
+        return std::string(jcr->fd_impl->director->resource_name_);
       }
       break;
     case 'm':
-      return edit_uint64(jcr->fd_impl->since_time, str);
+      return std::to_string(jcr->fd_impl->since_time);
   }
 
-  return NULL;
+  return std::nullopt;
 }
 
 bool InitFileset(JobControlRecord* jcr)

--- a/core/src/filed/fileset.h
+++ b/core/src/filed/fileset.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,7 +39,7 @@ int AddOptionsFlagsToFileset(JobControlRecord* jcr, const char* item);
 void AddFileset(JobControlRecord* jcr, const char* item);
 bool TermFileset(JobControlRecord* jcr);
 std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
-                                         const char*);
+                                                   const char*);
 
 } /* namespace filedaemon */
 

--- a/core/src/filed/fileset.h
+++ b/core/src/filed/fileset.h
@@ -38,6 +38,8 @@ int AddWildToFileset(JobControlRecord* jcr, const char* item, int type);
 int AddOptionsFlagsToFileset(JobControlRecord* jcr, const char* item);
 void AddFileset(JobControlRecord* jcr, const char* item);
 bool TermFileset(JobControlRecord* jcr);
+std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
+                                         const char*);
 
 } /* namespace filedaemon */
 

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -38,11 +38,12 @@
 #include <functional>
 #include <string>
 #include <vector>
+#include <optional>
 
 class JobControlRecord;
 
 extern "C" {
-typedef char* (*job_code_callback_t)(JobControlRecord*, const char*);
+typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*, const char*);
 }
 
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -42,9 +42,7 @@
 
 class JobControlRecord;
 
-extern "C" {
 typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*, const char*);
-}
 
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -42,7 +42,8 @@
 
 class JobControlRecord;
 
-typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*, const char*);
+typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*,
+                                                          const char*);
 
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -924,7 +924,13 @@ POOLMEM* edit_job_codes(JobControlRecord* jcr,
           break;
         default:
           str = NULL;
-          if (callback != NULL) { str = callback(jcr, p); }
+          if (callback != NULL) {
+            auto callback_result = callback(jcr, p);
+            if (callback_result) {
+              Bsnprintf(add, sizeof(add), "%s", callback_result->c_str());
+              str = add;
+            }
+          }
 
           if (!str) {
             add[0] = '%';

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -927,7 +927,7 @@ POOLMEM* edit_job_codes(JobControlRecord* jcr,
           if (callback != NULL) {
             auto callback_result = callback(jcr, p);
             if (callback_result) {
-              Bsnprintf(add, sizeof(add), "%s", callback_result->c_str());
+              snprintf(add, sizeof(add), "%s", callback_result->c_str());
               str = add;
             }
           }

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
@@ -62,6 +62,7 @@ Before executing the specified command, Bareos performs character substitution o
 %j Unique Job Id
 %l Job Level
 %n Job name
+%m Modification time (only on |fd| side for incremental and differential)
 %N New Job Id (only on director side during migration/copy jobs)
 %O Previous Job Id (only on director side during migration/copy jobs)
 %p Pool name (only on director side)

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
@@ -61,8 +61,8 @@ Before executing the specified command, Bareos performs character substitution o
 %i Job Id
 %j Unique Job Id
 %l Job Level
-%n Job name
 %m Modification time (only on |fd| side for incremental and differential)
+%n Job name
 %N New Job Id (only on director side during migration/copy jobs)
 %O Previous Job Id (only on director side during migration/copy jobs)
 %p Pool name (only on director side)

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-RunScript.rst.inc
@@ -62,6 +62,8 @@ Before executing the specified command, Bareos performs character substitution o
 %j Unique Job Id
 %l Job Level
 %n Job name
+%N New Job Id (only on director side during migration/copy jobs)
+%O Previous Job Id (only on director side during migration/copy jobs)
 %p Pool name (only on director side)
 %P Daemon PID
 %s Since time

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy.conf
@@ -9,11 +9,11 @@ Job {
   Run Script {
     Runs On Client = No
     Runs When = Before
-    Command = "echo 'prevjobid=%m newjobid=%M'"
+    Command = "echo 'prevjobid=%O newjobid=%N'"
   }
   Run Script {
     Runs On Client = No
     Runs When = After
-    Command = "echo 'prevjobid=%m newjobid=%M'"
+    Command = "echo 'prevjobid=%O newjobid=%N'"
   }
 }

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy.conf
@@ -6,4 +6,14 @@ Job {
   Selection Pattern = "."
   Client = "bareos-fd"
   Messages = Standard
+  Run Script {
+    Runs On Client = No
+    Runs When = Before
+    Command = "echo 'prevjobid=%m newjobid=%M'"
+  }
+  Run Script {
+    Runs On Client = No
+    Runs When = After
+    Command = "echo 'prevjobid=%m newjobid=%M'"
+  }
 }

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/migrate.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/migrate.conf
@@ -9,11 +9,11 @@ Job {
   Run Script {
     Runs On Client = No
     Runs When = Before
-    Command = "echo 'prevjobid=%m newjobid=%M'"
+    Command = "echo 'prevjobid=%O newjobid=%N'"
   }
   Run Script {
     Runs On Client = No
     Runs When = After
-    Command = "echo 'prevjobid=%m newjobid=%M'"
+    Command = "echo 'prevjobid=%O newjobid=%N'"
   }
 }

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/migrate.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/migrate.conf
@@ -6,4 +6,14 @@ Job {
   Selection Pattern = "."
   Client = "bareos-fd"
   Messages = Standard
+  Run Script {
+    Runs On Client = No
+    Runs When = Before
+    Command = "echo 'prevjobid=%m newjobid=%M'"
+  }
+  Run Script {
+    Runs On Client = No
+    Runs When = After
+    Command = "echo 'prevjobid=%m newjobid=%M'"
+  }
 }

--- a/systemtests/tests/copy-migrate/testrunner-02-copy
+++ b/systemtests/tests/copy-migrate/testrunner-02-copy
@@ -44,19 +44,19 @@ expect_grep "|.*C.*|" \
 
 expect_grep "JobId 2: BeforeJob: prevjobid=\*None\* newjobid=\*None\*" \
             "$copy_log" \
-            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "Before runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 expect_grep "JobId 2: AfterJob: prevjobid=\*None\* newjobid=\*None\*" \
             "$copy_log" \
-            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "After runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 expect_grep "JobId 3: BeforeJob: prevjobid=1 newjobid=4" \
             "$copy_log" \
-            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "Before runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 expect_grep "JobId 3: AfterJob: prevjobid=1 newjobid=4" \
             "$copy_log" \
-            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "After runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out $query_results

--- a/systemtests/tests/copy-migrate/testrunner-02-copy
+++ b/systemtests/tests/copy-migrate/testrunner-02-copy
@@ -42,6 +42,22 @@ expect_grep "|.*C.*|" \
             "$query_results" \
             "Copy job does not have the expected type."
 
+expect_grep "JobId 2: BeforeJob: prevjobid=\*None\* newjobid=\*None\*" \
+            "$copy_log" \
+            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
+expect_grep "JobId 2: AfterJob: prevjobid=\*None\* newjobid=\*None\*" \
+            "$copy_log" \
+            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
+expect_grep "JobId 3: BeforeJob: prevjobid=1 newjobid=4" \
+            "$copy_log" \
+            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
+expect_grep "JobId 3: AfterJob: prevjobid=1 newjobid=4" \
+            "$copy_log" \
+            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out $query_results
 prune volume=TestVolume001 yes

--- a/systemtests/tests/copy-migrate/testrunner-05-migrate
+++ b/systemtests/tests/copy-migrate/testrunner-05-migrate
@@ -48,19 +48,19 @@ expect_grep "The following 3 JobIds were chosen to be migrated: 11,12,13" \
 
 expect_grep "JobId 14: BeforeJob: prevjobid=\*None\* newjobid=\*None\*" \
             "$log" \
-            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "Before runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 expect_grep "JobId 14: AfterJob: prevjobid=\*None\* newjobid=\*None\*" \
             "$log" \
-            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "After runscript does not return expected previous jobid (%O) and new jobid (%N)."
 
 expect_grep "JobId 19: BeforeJob: prevjobid=13 newjobid=20" \
             "$log" \
-            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "Before runscript does not return expected previous jobid (%O) and new jobid (%N)."
 			
 expect_grep "JobId 19: AfterJob: prevjobid=13 newjobid=20" \
             "$log" \
-            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+            "After runscript does not return expected previous jobid (%O) and new jobid (%N)."
 
 # 1 administrative job that spawns 3 migration jobs
 if [[ $(grep -c "Termination:.*Migration OK" "$log") -ne "4" ]]; then

--- a/systemtests/tests/copy-migrate/testrunner-05-migrate
+++ b/systemtests/tests/copy-migrate/testrunner-05-migrate
@@ -46,6 +46,22 @@ expect_grep "The following 3 JobIds were chosen to be migrated: 11,12,13" \
             "$log" \
             "Expected jobs to be migrated do not match."
 
+expect_grep "JobId 14: BeforeJob: prevjobid=\*None\* newjobid=\*None\*" \
+            "$log" \
+            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
+expect_grep "JobId 14: AfterJob: prevjobid=\*None\* newjobid=\*None\*" \
+            "$log" \
+            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+
+expect_grep "JobId 19: BeforeJob: prevjobid=13 newjobid=20" \
+            "$log" \
+            "Before runscript does not return expected previous jobid (%m) and new jobid (%M)."
+			
+expect_grep "JobId 19: AfterJob: prevjobid=13 newjobid=20" \
+            "$log" \
+            "After runscript does not return expected previous jobid (%m) and new jobid (%M)."
+
 # 1 administrative job that spawns 3 migration jobs
 if [[ $(grep -c "Termination:.*Migration OK" "$log") -ne "4" ]]; then
     echo "Not all migration jobs finished successfully."


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR adds two new RunScript variables %O and %N which contain the previous and new jobid of a migration/copy job.
Currently there is no convenient way to retrieve this information in RunScripts. This would be useful to e.g. easily archive copied or migrated jobs (especially with always incremental and in combination with https://github.com/bareos/bareos/pull/1372):
```
  Run Script {
        console = "update jobid=%N jobtype=A"
        Runs When = After
        Runs On Client = No
        Runs On Failure = No
  }
```

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
