### PR TITLE
systemd: improve restarting daemon

### DIFF
--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-dir
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the the maximum number of open file descriptors
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-director
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-filedaemon
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the maximum number of open file descriptors```
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-storage
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-sd.service


### PR DESCRIPTION
- add After=local-fs.target
- move StartLimitBurst=10 to service part (was wrongly put in unit)
- replace generic exit 1 by the specific configuration error exit code 42
- add comment about how to reset failed counter
- reformat debian filedaemon service file

Not sure we can backport this one before we finish the PR about the configuration exit code.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
