### PR TITLE
utils: add a thread-safe single-producer/single-consumer queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bareos-check-sources: ignore bootstrap*.css [PR #1556]
 - daemons: set CLI11 error exit code to `41` and bareos config parsing error exit code to `42` [PR #1515]
 - database: improve subscription view [PR #1542]
+- utils: add a thread-safe single-producer/single-consumer queue [PR #1504]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -235,6 +236,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1499]: https://github.com/bareos/bareos/pull/1499
 [PR #1502]: https://github.com/bareos/bareos/pull/1502
 [PR #1503]: https://github.com/bareos/bareos/pull/1503
+[PR #1504]: https://github.com/bareos/bareos/pull/1504
 [PR #1505]: https://github.com/bareos/bareos/pull/1505
 [PR #1506]: https://github.com/bareos/bareos/pull/1506
 [PR #1507]: https://github.com/bareos/bareos/pull/1507

--- a/core/src/lib/channel.h
+++ b/core/src/lib/channel.h
@@ -72,13 +72,14 @@ template <typename T> class queue {
         : locked{std::move(locked)}, update(update)
     {
     }
+    handle(const handle&) = delete;
+    handle& operator=(const handle&) = delete;
+    handle(handle&&) = delete;
+    handle& operator=(handle&&) = delete;
 
     std::vector<T>& data() { return locked->data; }
 
-    ~handle()
-    {
-      if (update) { update->notify_one(); }
-    }
+    ~handle() { update->notify_one(); }
   };
 
   /* the *_lock functions return std::nullopt only if the channel is closed

--- a/core/src/lib/channel.h
+++ b/core/src/lib/channel.h
@@ -1,0 +1,309 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_CHANNEL_H_
+#define BAREOS_LIB_CHANNEL_H_
+
+#include <condition_variable>
+#include <optional>
+#include <deque>
+#include <utility>
+#include <variant>
+
+#include "thread_util.h"
+
+namespace channel {
+// a simple single consumer/ single producer queue
+// Its composed of three parts: the input, the output and the
+// actual queue data.
+// Instead of directly interacting with the queue itself you instead
+// interact with either the input or the output.
+// This ensures that there is only one producer (who writes to the input)
+// and one consumer (who reads from the output).
+
+struct failed_to_acquire_lock {};
+struct channel_closed {};
+
+template <typename T> class queue {
+  struct internal {
+    std::deque<T> data;
+    bool in_dead;
+    bool out_dead;
+  };
+
+  synchronized<internal> shared{};
+  std::condition_variable in_update{};
+  std::condition_variable out_update{};
+  std::size_t max_size;
+
+ public:
+  explicit queue(std::size_t max_size) : max_size(max_size) {}
+  queue(const queue&) = delete;
+  queue& operator=(const queue&) = delete;
+  queue(queue&&) = delete;
+  queue& operator=(queue&&) = delete;
+
+  using locked_type = decltype(shared.lock());
+
+  class handle {
+    locked_type locked;
+    std::condition_variable* update;
+
+   public:
+    handle(locked_type locked, std::condition_variable* update)
+        : locked{std::move(locked)}, update(update)
+    {
+    }
+
+    std::deque<T>& data() { return locked->data; }
+
+    ~handle()
+    {
+      if (update) { update->notify_one(); }
+    }
+  };
+
+  std::optional<handle> output_lock()
+  {
+    auto locked = shared.lock();
+    locked.wait(in_update, [](const auto& intern) {
+      return intern.data.size() > 0 || intern.in_dead;
+    });
+    if (locked->data.size() == 0) {
+      return std::nullopt;
+    } else {
+      return std::make_optional<handle>(std::move(locked), &out_update);
+    }
+  }
+
+  std::optional<handle> input_lock()
+  {
+    auto locked = shared.lock();
+    locked.wait(out_update, [max_size = max_size](const auto& intern) {
+      return intern.data.size() < max_size || intern.out_dead;
+    });
+    if (locked->out_dead) {
+      return std::nullopt;
+    } else {
+      return std::make_optional<handle>(std::move(locked), &in_update);
+    }
+  }
+
+  using try_result
+      = std::variant<handle, failed_to_acquire_lock, channel_closed>;
+
+  try_result try_output_lock()
+  {
+    auto locked = shared.try_lock();
+    if (!locked) { return failed_to_acquire_lock{}; }
+    if (locked.value()->data.size() == 0) {
+      if (locked.value()->in_dead) {
+        return channel_closed{};
+      } else {
+        return failed_to_acquire_lock{};
+      }
+    }
+
+    return try_result(std::in_place_type<handle>, std::move(locked).value(),
+                      &out_update);
+  }
+
+  try_result try_input_lock()
+  {
+    auto locked = shared.try_lock();
+    if (!locked) { return failed_to_acquire_lock{}; }
+    if (locked.value()->out_dead) { return channel_closed{}; }
+    if (locked.value()->data.size() >= max_size) {
+      return failed_to_acquire_lock{};
+    }
+
+    return try_result(std::in_place_type<handle>, std::move(locked).value(),
+                      &in_update);
+  }
+
+  void close_in()
+  {
+    shared.lock()->in_dead = true;
+    in_update.notify_one();
+  }
+
+  void close_out()
+  {
+    shared.lock()->out_dead = true;
+    out_update.notify_one();
+  }
+};
+
+template <typename T> class input {
+  std::shared_ptr<queue<T>> shared;
+  bool did_close{false};
+
+ public:
+  explicit input(std::shared_ptr<queue<T>> shared) : shared{std::move(shared)}
+  {
+  }
+  // after move only operator= and ~in are allowed to be called
+  input(input&&) = default;
+  input& operator=(input&&) = default;
+  input(const input&) = delete;
+  input& operator=(const input&) = delete;
+
+  template <typename... Args> bool emplace(Args... args)
+  {
+    if (did_close) { return false; }
+    if (auto handle = shared->input_lock()) {
+      handle->data().emplace_back(std::forward<Args>(args)...);
+      return true;
+    } else {
+      close();
+      return false;
+    }
+  }
+
+  template <typename... Args> bool try_emplace(Args... args)
+  {
+    if (did_close) { return false; }
+    auto result = shared->try_input_lock();
+    if (std::holds_alternative<failed_to_acquire_lock>(result)) {
+      return false;
+    } else if (std::holds_alternative<channel_closed>(result)) {
+      close();
+      return false;
+    } else {
+      std::get<typename queue<T>::handle>(result).data().emplace_back(
+          std::forward<Args>(args)...);
+      return true;
+    }
+  }
+
+  void close()
+  {
+    if (!did_close) {
+      shared->close_in();
+      did_close = true;
+    }
+  }
+
+  bool closed() const { return did_close; }
+
+  ~input()
+  {
+    if (shared) { close(); }
+  }
+};
+
+template <typename T> class output {
+  std::shared_ptr<queue<T>> shared;
+  std::deque<T> cache;
+  bool did_close{false};
+
+ public:
+  explicit output(std::shared_ptr<queue<T>> shared) : shared{std::move(shared)}
+  {
+  }
+  // after move only operator= and ~out are allowed to be called
+  output(output&&) = default;
+  output& operator=(output&&) = default;
+  output(const output&) = delete;
+  output& operator=(const output&) = delete;
+
+  std::optional<T> get()
+  {
+    if (did_close) { return std::nullopt; }
+    update_cache();
+
+    if (cache.size() > 0) {
+      std::optional result = std::make_optional<T>(std::move(cache.front()));
+      cache.pop_front();
+      return result;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  std::optional<T> try_get()
+  {
+    if (did_close) { return std::nullopt; }
+    try_update_cache();
+
+    if (cache.size() > 0) {
+      std::optional result = std::make_optional<T>(std::move(cache.front()));
+      cache.pop_front();
+      return result;
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  void close()
+  {
+    if (!did_close) {
+      shared->close_out();
+      did_close = true;
+    }
+  }
+
+  bool closed() const { return did_close; }
+
+  ~output()
+  {
+    if (shared) { close(); }
+  }
+
+ private:
+  void update_cache()
+  {
+    if (cache.empty()) {
+      if (auto handle = shared->output_lock()) {
+        std::swap(handle->data(), cache);
+      } else {
+        // this can only happen if the channel was closed.
+        close();
+      }
+    }
+  }
+
+  void try_update_cache()
+  {
+    if (cache.empty()) {
+      auto result = shared->try_output_lock();
+      if (std::holds_alternative<failed_to_acquire_lock>(result)) {
+        // intentionally left empty
+      } else if (std::holds_alternative<channel_closed>(result)) {
+        close();
+      } else {
+        std::swap(std::get<typename queue<T>::handle>(result).data(), cache);
+      }
+    }
+  }
+};
+
+template <typename T>
+std::pair<input<T>, output<T>> CreateBufferedChannel(std::size_t capacity)
+{
+  auto shared = std::make_shared<queue<T>>(capacity);
+  auto in = input(shared);
+  auto out = output(shared);
+  return {std::move(in), std::move(out)};
+}
+}  // namespace channel
+
+#endif  // BAREOS_LIB_CHANNEL_H_

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -68,6 +68,15 @@ template <typename T> class synchronized {
   {
   }
 
+  ~synchronized()
+  {
+    /* obviously nobody should hold the lock while this object is getting
+     * destroyed, but we still need to ensure that the thread that
+     * is destroying this object has a synchronized view of the contained data
+     * so that data's destructor can run with no race conditions. */
+    std::unique_lock _{mut};
+  }
+
   unique_locked<T> lock() { return {mut, data}; }
 
   std::optional<unique_locked<T>> try_lock()

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -1,0 +1,84 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#ifndef BAREOS_LIB_THREAD_UTIL_H_
+#define BAREOS_LIB_THREAD_UTIL_H_
+
+#include <mutex>
+#include <optional>
+#include <condition_variable>
+
+template <typename T> class locked {
+ public:
+  locked(std::mutex& mut, T& data) : lock{mut}, data(data) {}
+
+  locked(std::unique_lock<std::mutex> lock, T& data)
+      : lock{std::move(lock)}, data(data)
+  {
+  }
+
+  const T& get() const { return data; }
+  T& get() { return data; }
+
+  T& get() { return data; }
+  T& operator*() { return data; }
+  T* operator->() { return &data; }
+
+  const T& get() const { return data; }
+  const T& operator*() const { return data; }
+  const T* operator->() const { return &data; }
+
+  template <typename Pred> void wait(std::condition_variable& cv, Pred&& p)
+  {
+    cv.wait(lock, p);
+  }
+
+ private:
+  std::unique_lock<std::mutex> lock;
+  T& data;
+};
+
+template <typename T> class synchronized {
+ public:
+  template <typename... Args>
+  synchronized(Args... args) : data{std::forward<Args>(args)...}
+  {
+  }
+
+  locked<T> lock() { return locked{mut, data}; }
+
+  std::optional<locked<T>> try_lock()
+  {
+    std::unique_lock l(mut, std::try_to_lock);
+    if (l.owns_lock()) {
+      return locked{std::move(l), data};
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  locked<const T> lock() const { return locked{mut, data}; }
+
+ private:
+  mutable std::mutex mut{};
+  T data;
+};
+
+#endif  // BAREOS_LIB_THREAD_UTIL_H_

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -439,3 +439,7 @@ bareos_add_test(
 bareos_add_test(timer_thread LINK_LIBRARIES bareos GTest::gtest_main)
 
 bareos_add_test(version_strings LINK_LIBRARIES bareos GTest::gtest_main)
+
+bareos_add_test(
+  channel LINK_LIBRARIES bareos Threads::Threads GTest::gtest_main
+)

--- a/core/src/tests/channel.cc
+++ b/core/src/tests/channel.cc
@@ -1,0 +1,190 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#  include "gtest/gtest.h"
+#  include "gmock/gmock.h"
+#else
+#  include "gtest/gtest.h"
+#  include "gmock/gmock.h"
+#  include "include/bareos.h"
+#endif
+
+#include <vector>
+#include <thread>
+#include <random>
+
+#define private public
+#include "lib/channel.h"
+#undef private
+
+
+template <typename T>
+static void SendDataBlocking(const std::vector<T>& to_send,
+                             channel::input<T> in)
+{
+  for (auto& elem : to_send) {
+    ASSERT_TRUE(in.emplace(elem)) << "channel closed unexpectedly";
+  }
+}
+
+template <typename T>
+static void ReceiveDataBlocking(std::vector<T>& to_receive,
+                                channel::output<T> out)
+{
+  for (std::optional elem = out.get(); elem.has_value(); elem = out.get()) {
+    to_receive.push_back(elem.value());
+  }
+}
+
+template <typename T>
+static void SendDataNonBlocking(const std::vector<T>& to_send,
+                                channel::input<T> in)
+{
+  for (auto elem : to_send) {
+    while (!in.try_emplace(elem)) {
+      ASSERT_FALSE(in.closed()) << "channel closed unexpectedly";
+    }
+  }
+}
+
+template <typename T>
+static void ReceiveDataNonBlocking(std::vector<T>& to_receive,
+                                   channel::output<T> out)
+{
+  while (!out.closed()) {
+    std::optional elem = out.try_get();
+    if (elem.has_value()) { to_receive.push_back(*elem); }
+  }
+}
+
+std::vector<int> RandomData(std::size_t size)
+{
+  std::vector<int> vec;
+  std::minstd_rand rd(size);
+  std::uniform_int_distribution dist;
+
+  vec.reserve(size);
+
+  for (std::size_t i = 0; i < size; ++i) { vec.push_back(dist(rd)); }
+
+  return vec;
+}
+
+TEST(random, ConsistentRandData)
+{
+  ASSERT_EQ(RandomData(500), RandomData(500));
+}
+
+TEST(channel, BlockingConsistency)
+{
+  std::size_t size = 100'000;
+  std::vector<int> input = RandomData(size);
+  std::vector<int> output;
+  auto [in, out] = channel::CreateBufferedChannel<int>(40);
+  std::thread sender{&SendDataBlocking<int>, std::cref(input), std::move(in)};
+  std::thread receiver{&ReceiveDataBlocking<int>, std::ref(output),
+                       std::move(out)};
+
+  sender.join();
+  receiver.join();
+
+  ASSERT_EQ(input.size(), output.size());
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    EXPECT_EQ(input[i], output[i]) << "input and output differ at index " << i;
+  }
+}
+
+TEST(channel, NonBlockingConsistency)
+{
+  std::size_t size = 100'000;
+  std::vector<int> input = RandomData(size);
+  std::vector<int> output;
+  auto [in, out] = channel::CreateBufferedChannel<int>(40);
+  std::thread sender{&SendDataNonBlocking<int>, std::cref(input),
+                     std::move(in)};
+  std::thread receiver{&ReceiveDataNonBlocking<int>, std::ref(output),
+                       std::move(out)};
+
+  sender.join();
+  receiver.join();
+
+  ASSERT_EQ(input.size(), output.size());
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    EXPECT_EQ(input[i], output[i]) << "input and output differ at index " << i;
+  }
+}
+
+TEST(channel, ConsistentState)
+{
+  auto [in, out] = channel::CreateBufferedChannel<int>(2);
+  ASSERT_FALSE(in.closed());
+  ASSERT_FALSE(out.closed());
+  ASSERT_TRUE(in.emplace(1));
+  ASSERT_TRUE(in.emplace(2));
+  ASSERT_FALSE(in.closed());
+  ASSERT_FALSE(out.closed());
+  in.close();
+  EXPECT_TRUE(in.closed());
+  ASSERT_FALSE(out.closed());
+  EXPECT_TRUE(out.get().has_value());
+  ASSERT_FALSE(out.closed());
+  EXPECT_TRUE(out.get().has_value());
+  EXPECT_FALSE(out.get().has_value());
+  EXPECT_TRUE(out.closed());
+
+  EXPECT_FALSE(in.emplace(3));
+}
+
+TEST(channel, NoFalsePutsOrGets)
+{
+  std::size_t capacity = 20;
+  auto [in, out] = channel::CreateBufferedChannel<int>(capacity);
+
+  std::vector<int> data_in;
+
+  for (std::size_t i = 0; i < capacity * 2; ++i) { data_in.push_back(i); }
+
+  std::size_t num_writes = 0;
+  for (int i : data_in) {
+    if (in.try_emplace(i)) { num_writes += 1; }
+  }
+
+  EXPECT_EQ(num_writes, capacity);
+
+  // we need to close in or otherwise out will always think
+  // that data is still coming, causing the loop below to
+  // spin endlessly
+  in.close();
+
+  std::vector<int> data_out;
+  while (!out.closed()) {
+    std::optional i = out.try_get();
+    if (i.has_value()) { data_out.push_back(*i); }
+  }
+
+  EXPECT_EQ(num_writes, data_out.size());
+
+  for (std::size_t i = 0; i < num_writes; ++i) {
+    EXPECT_EQ(data_in[i], data_out[i]);
+  }
+}


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Adds utilities and data structures that can be used safely in multi-threaded code.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
