### PR TITLE
bsmtp: make mailhost and port message info a debug message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - vss: remove dependency on live system during backup [PR #1452]
 - build: adapt matrix and pkglist for changes to CI [PR #1490]
 - cats: postgresql introduce pl/sql lstat_decode() function [PR #1466]
+- bsmtp: make mailhost and port message info a debug message [PR #1507]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -200,4 +201,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1490]: https://github.com/bareos/bareos/pull/1490
 [PR #1493]: https://github.com/bareos/bareos/pull/1493
 [PR #1502]: https://github.com/bareos/bareos/pull/1502
+[PR #1507]: https://github.com/bareos/bareos/pull/1507
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -276,6 +276,7 @@ int main(int argc, char* argv[])
 
   int mailport = default_port;
   std::string mailhost = default_mailhost;
+  std::string host_and_port_source = "Mailhost and mailport set to default";
 
   char* env_variable_smtpserver;
   if ((env_variable_smtpserver = getenv("SMTPSERVER")) != nullptr) {
@@ -283,24 +284,21 @@ int main(int argc, char* argv[])
         = ParseHostAndPort(std::string(env_variable_smtpserver));
     mailhost = host_and_port.first;
     mailport = host_and_port.second;
-    Pmsg2(0,
-          "Taking host and mailport from the SMTPSERVER environment variable: "
-          "host=%s ; port=%d\n",
-          mailhost.c_str(), mailport);
+    host_and_port_source
+        = "Mailhost and port extracted from SMTPSERVER environment variable";
   }
 
   bsmtp_app
       .add_option(
           "-h,--mailhost",
-          [&mailport, &mailhost](std::vector<std::string> val) {
+          [&mailport, &mailhost,
+           &host_and_port_source](std::vector<std::string> val) {
             std::pair<std::string, int> host_and_port
                 = ParseHostAndPort(val[0]);
             mailhost = host_and_port.first;
             mailport = host_and_port.second;
-            Pmsg2(0,
-                  "Mailhost argument detected: Taking host and mailport from "
-                  "cli : host=%s ; port=%d\n",
-                  mailhost.c_str(), mailport);
+            host_and_port_source
+                = "Mailhost and port extracted from CLI arguments";
             return true;
           },
           "Use mailhost:port as the SMTP server.")
@@ -323,6 +321,9 @@ int main(int argc, char* argv[])
       ->required();
 
   CLI11_PARSE(bsmtp_app, argc, argv);
+
+  Dmsg3(20, "%s: mailhost=%s ; mailport=%d\n", host_and_port_source.c_str(),
+        mailhost.c_str(), mailport);
 
 
 #if defined(HAVE_WIN32)


### PR DESCRIPTION
#### Description

When extracting the mailhost and port, `bsmtp` would show an info message that later would be interpreted as an error. This PR transforms it into a debug message.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [X] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
