### PR TITLE
bsmtp: make mailhost and port message info a debug message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - packaging: cleanup SUSE webui dependencies [PR #1494]
 - VMware Plugin: improve snapshot cleanup [PR #1492]
 - build: adapt matrix and pkglist for changes to CI [PR #1497]
+- bsmtp: make mailhost and port message info a debug message [PR #1509]
 
 ## [22.1.0] - 2023-06-13
 
@@ -549,4 +550,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1492]: https://github.com/bareos/bareos/pull/1492
 [PR #1494]: https://github.com/bareos/bareos/pull/1494
 [PR #1497]: https://github.com/bareos/bareos/pull/1497
+[PR #1509]: https://github.com/bareos/bareos/pull/1509
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
**Backport of PR #1507 to bareos-22**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

