### PR TITLE
dird: cats: abort purge when there are no eligible jobids

### DIFF
--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -202,6 +202,11 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 
 void BareosDb::PurgeFiles(const char* jobids)
 {
+  if (strcmp(jobids, "") == 0) {
+    Dmsg0(100, "No jobids to use for purging files\n");
+    return;
+  }
+
   PoolMem query(PM_MESSAGE);
 
   Mmsg(query, "DELETE FROM File WHERE JobId IN (%s)", jobids);

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -218,6 +218,11 @@ void BareosDb::PurgeJobs(const char* jobids)
 {
   PoolMem query(PM_MESSAGE);
 
+  if (strcmp(jobids, "") == 0) {
+    Dmsg0(100, "No jobids to purge\n");
+    return;
+  }
+
   /* Delete (or purge) records associated with the job */
   PurgeFiles(jobids);
 

--- a/core/src/dird/ua_prune.cc
+++ b/core/src/dird/ua_prune.cc
@@ -768,8 +768,6 @@ bool PruneJobs(UaContext* ua, ClientResource* client, PoolResource* pool)
     ua->InfoMsg(
         _("Pruned %d %s for client %s from catalog.\n"), prune_list.size(),
         prune_list.size() == 1 ? _("Job") : _("Jobs"), client->resource_name_);
-  } else if (ua->verbose) {
-    ua->InfoMsg(_("No Jobs found to prune.\n"));
   }
 
   DropTempTables(ua);

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -428,6 +428,11 @@ void PurgeJobListFromCatalog(UaContext* ua, std::vector<JobId_t>& deletion_list)
 
   std::string jobids_to_delete_string
       = PrepareJobidsTobedeleted(ua, deletion_list);
+  if (deletion_list.empty()) {
+    ua->SendMsg(_("No jobids found to be purged\n"), deletion_list.size(),
+                jobids_to_delete_string.c_str());
+    return;
+  }
   ua->SendMsg(_("Purging the following %d JobIds: %s\n"), deletion_list.size(),
               jobids_to_delete_string.c_str());
   PurgeJobsFromCatalog(ua, jobids_to_delete_string.c_str());


### PR DESCRIPTION
#### Description

When pruning/purging jobs or files, Bareos does not check whether the list of jobids it provides to the SQL queries is empty or not, which makes the queries fail and Postgres emitting errors in the logs

This PR adds checks for empty jobids lists when purging and pruning.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
