### PR TITLE
stored: fix incoherent meta data when concurrently writing to the same volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: cats: abort purge when there are no eligible jobids [PR #1513]
 - dird: show current and allowed console connections [PR #1517]
 
+### Fixed
+- stored: fix incoherent meta data when concurrently writing to the same volume [PR #1514]
+
 ## [22.1.0] - 2023-06-13
 
 ### Changed
@@ -554,5 +557,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1497]: https://github.com/bareos/bareos/pull/1497
 [PR #1509]: https://github.com/bareos/bareos/pull/1509
 [PR #1513]: https://github.com/bareos/bareos/pull/1513
+[PR #1514]: https://github.com/bareos/bareos/pull/1514
 [PR #1517]: https://github.com/bareos/bareos/pull/1517
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -626,6 +626,7 @@ class BareosDb : public BareosDbQueryEnum {
   bool CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr);
   bool CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr);
   bool CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pool_dbr);
+  int DeleteNullJobmediaRecords(JobControlRecord* jcr, std::uint32_t jobid);
   bool CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jr);
   bool CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr);
   bool CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr);

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -215,9 +215,7 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   }
 
   Mmsg(cmd, "DELETE FROM Media WHERE MediaId=%d", mr->MediaId);
-  SqlQuery(cmd);
-
-  return true;
+  return DELETE_DB(jcr, cmd) != -1;
 }
 
 /**

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -125,6 +125,26 @@ static int DeleteHandler(void* ctx, int, char** row)
   return 0;
 }
 
+/**
+ * Delete all NullJobMedia records for this job
+ * Returns: -1 on failure
+ *          n>=0 on success,
+ *               where n is the number of rows affected
+ */
+int BareosDb::DeleteNullJobmediaRecords(JobControlRecord* jcr,
+                                        std::uint32_t jobid)
+{
+  DbLocker _{this};
+
+  Mmsg(cmd,
+       "DELETE FROM jobmedia WHERE jobid=%u AND firstindex=0 AND lastindex=0",
+       jobid);
+  Dmsg1(200, "DeleteNullJobmediaRecords: %s\n", cmd);
+
+  int numrows = DELETE_DB(jcr, cmd);
+
+  return numrows;
+}
 
 /**
  * This routine will purge (delete) all records

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -70,6 +70,8 @@ static char Update_filelist[] = "Catreq Job=%127s UpdateFileList\n";
 
 static char Update_jobrecord[]
     = "Catreq Job=%127s UpdateJobRecord JobFiles=%lu JobBytes=%llu\n";
+static char Delete_nulljobmediarecord[]
+    = "CatReq Job=%127s DeleteNullJobmediaRecords jobid=%u\n";
 
 // Responses sent to Storage daemon
 static char OK_media[]
@@ -80,6 +82,7 @@ static char OK_media[]
       " VolWriteTime=%s EndFile=%u EndBlock=%u LabelType=%d"
       " MediaId=%s EncryptionKey=%s MinBlocksize=%d MaxBlocksize=%d\n";
 static char OK_create[] = "1000 OK CreateJobMedia\n";
+static char OK_delete[] = "1000 OK DeleteNullJobmediaRecords\n";
 
 static int SendVolumeInfoToStorageDaemon(JobControlRecord* jcr,
                                          BareosSocket* sd,
@@ -118,6 +121,7 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
   uint64_t MediaId;
   utime_t VolFirstWritten;
   utime_t VolLastWritten;
+  std::uint32_t jobid;
 
   // Request to find next appendable Volume for this Job
   Dmsg1(100, "catreq %s", bs->msg);
@@ -375,6 +379,14 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
       Jmsg(jcr, M_FATAL, 0, _("Catalog error updating Job record. %s\n"),
            jcr->db->strerror());
       bs->fsend(_("1992 Update job record error\n"));
+    }
+  } else if (sscanf(bs->msg, Delete_nulljobmediarecord, &Job, &jobid) == 2) {
+    int numrows = jcr->db->DeleteNullJobmediaRecords(jcr, jobid);
+    Dmsg1(400, "Deleted %d rows.\n", numrows);
+    if (numrows == -1) {
+      bs->fsend(_("1992 DeleteNullJobMediaRecords error\n"));
+    } else {
+      bs->fsend(OK_delete);
     }
   } else {
     omsg = GetMemory(bs->message_length + 1);

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -558,7 +558,12 @@ bool ReleaseDevice(DeviceControlRecord* dcr)
      * already been done, which means we skip them here. */
     dev->num_writers--;
     Dmsg1(100, "There are %d writers in ReleaseDevice\n", dev->num_writers);
-    if (dev->IsLabeled()) {
+    if (dcr->VolFirstIndex) {
+      // Send a new jobmedia record if we have written to a volume
+      // take note that the volume we wrote to is not necessarily the volume
+      // that is currently inside the device.
+      dcr->DirCreateJobmediaRecord(false);
+    } else if (dev->IsLabeled()) {
       Dmsg2(200, "dir_create_jobmedia. Release vol=%s dev=%s\n",
             dev->getVolCatName(), dev->print_name());
       if (!dev->AtWeot() && !dcr->DirCreateJobmediaRecord(false)) {

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -563,7 +563,8 @@ bool ReleaseDevice(DeviceControlRecord* dcr)
       // take note that the volume we wrote to is not necessarily the volume
       // that is currently inside the device.
       dcr->DirCreateJobmediaRecord(false);
-    } else if (dev->IsLabeled()) {
+    }
+    if (dev->IsLabeled()) {
       Dmsg2(200, "dir_create_jobmedia. Release vol=%s dev=%s\n",
             dev->getVolCatName(), dev->print_name());
       if (!dev->AtWeot() && !dcr->DirCreateJobmediaRecord(false)) {

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -109,23 +109,7 @@ static bool SaveFullyProcessedFilesAttributes(
   return false;
 }
 
-bool DeleteNullJobmediaRecords(JobControlRecord* jcr)
-{
-  Dmsg0(100, "Deleting null jobmedia records\n");
-  BareosSocket* dir = jcr->dir_bsock;
-  const char* delete_null_records
-      = "CatReq Job=%s DeleteNullJobmediaRecords jobid=%u";
-  dir->fsend(delete_null_records, jcr->Job, jcr->JobId);
-  if (dir->recv() <= 0) {
-    Dmsg0(100, "DeleteNullJobmediaRecords error BnetRecv\n");
-    Mmsg(jcr->errmsg,
-         _("Network error on BnetRecv in DeleteNullJobmediaRecords.\n"));
-    return false;
-  }
-  Dmsg1(100, ">dird %s", dir->msg);
-  if (strncmp(dir->msg, "1000", 4) == 0) { return true; }
-  return false;
-}
+bool DeleteNullJobmediaRecords(JobControlRecord* jcr);
 
 // Append Data sent from File daemon
 bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -26,6 +26,7 @@
  */
 
 #include "stored/append.h"
+#include "stored/askdir.h"
 #include "stored/stored.h"
 #include "stored/acquire.h"
 #include "stored/checkpoint_handler.h"
@@ -108,8 +109,6 @@ static bool SaveFullyProcessedFilesAttributes(
   }
   return false;
 }
-
-bool DeleteNullJobmediaRecords(JobControlRecord* jcr);
 
 // Append Data sent from File daemon
 bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -403,6 +403,8 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   if (!ok && !jcr->is_JobStatus(JS_Incomplete)) {
     DiscardDataSpool(jcr->sd_impl->dcr);
   } else {
+    // if we had any job media updates hanging, do them now
+    jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
     // Note: if commit is OK, the device will remain blocked
     CommitDataSpool(jcr->sd_impl->dcr);
   }

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -403,8 +403,6 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   if (!ok && !jcr->is_JobStatus(JS_Incomplete)) {
     DiscardDataSpool(jcr->sd_impl->dcr);
   } else {
-    // if we had any job media updates hanging, do them now
-    jcr->sd_impl->dcr->DirCreateJobmediaRecord(false);
     // Note: if commit is OK, the device will remain blocked
     CommitDataSpool(jcr->sd_impl->dcr);
   }

--- a/core/src/stored/askdir.cc
+++ b/core/src/stored/askdir.cc
@@ -28,6 +28,8 @@
  */
 
 #include "include/bareos.h"
+#include "stored/askdir.h"
+
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 

--- a/core/src/stored/askdir.cc
+++ b/core/src/stored/askdir.cc
@@ -640,6 +640,24 @@ bool DeviceControlRecord::DirAskSysopToMountVolume(int /*mode*/)
   return true;
 }
 
+bool DeleteNullJobmediaRecords(JobControlRecord* jcr)
+{
+  Dmsg0(100, "Deleting null jobmedia records\n");
+  BareosSocket* dir = jcr->dir_bsock;
+  const char* delete_null_records
+      = "CatReq Job=%s DeleteNullJobmediaRecords jobid=%u";
+  dir->fsend(delete_null_records, jcr->Job, jcr->JobId);
+  if (dir->recv() <= 0) {
+    Dmsg0(100, "DeleteNullJobmediaRecords error BnetRecv\n");
+    Mmsg(jcr->errmsg,
+         _("Network error on BnetRecv in DeleteNullJobmediaRecords.\n"));
+    return false;
+  }
+  Dmsg1(100, ">dird %s", dir->msg);
+  if (strncmp(dir->msg, "1000", 4) == 0) { return true; }
+  return false;
+}
+
 bool DeviceControlRecord::DirGetVolumeInfo(enum get_vol_info_rw)
 {
   Dmsg0(100, "Fake DirGetVolumeInfo\n");
@@ -652,5 +670,4 @@ DeviceControlRecord* DeviceControlRecord::get_new_spooling_dcr()
 {
   return new StorageDaemonDeviceControlRecord;
 }
-
 } /* namespace storagedaemon */

--- a/core/src/stored/askdir.h
+++ b/core/src/stored/askdir.h
@@ -1,0 +1,32 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#ifndef BAREOS_STORED_ASKDIR_H_
+#define BAREOS_STORED_ASKDIR_H_
+
+#include "lib/jcr.h"
+
+namespace storagedaemon {
+// deletes all null jobmedia records from the current job (jcr->job)
+// a null jobmedia record is a record with firstindex = 0 and lastindex = 0
+bool DeleteNullJobmediaRecords(JobControlRecord* jcr);
+}  // namespace storagedaemon
+
+#endif  // BAREOS_STORED_ASKDIR_H_

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -789,6 +789,19 @@ bool DeviceControlRecord::WriteBlockToDev()
     return false;
   }
 
+  // if this is the first write to this volume (from this job) create a null
+  // jobmedia entry to prevent the volume from getting recycled.
+  dcr->VolMediaId = dev->VolCatInfo.VolMediaId;
+  if (dcr->VolFirstIndex == 0 && block->FirstIndex > 0) {
+    dcr->WroteVol = true;
+    ASSERT(dcr->DirCreateJobmediaRecord(true));
+    dcr->VolFirstIndex = block->FirstIndex;
+    uint64_t addr = dev->file_addr;
+    dcr->StartBlock = (uint32_t)addr;
+    dcr->StartFile = (uint32_t)(addr >> 32);
+  }
+  if (block->LastIndex > 0) { dcr->VolLastIndex = block->LastIndex; }
+
   // We successfully wrote the block, now do housekeeping
   Dmsg2(1300, "VolCatBytes=%d newVolCatBytes=%d\n",
         (int)dev->VolCatInfo.VolCatBytes,
@@ -813,11 +826,6 @@ bool DeviceControlRecord::WriteBlockToDev()
     dev->block_num = dcr->EndBlock;
     dev->file = dcr->EndFile;
   }
-  dcr->VolMediaId = dev->VolCatInfo.VolMediaId;
-  if (dcr->VolFirstIndex == 0 && block->FirstIndex > 0) {
-    dcr->VolFirstIndex = block->FirstIndex;
-  }
-  if (block->LastIndex > 0) { dcr->VolLastIndex = block->LastIndex; }
   dcr->WroteVol = true;
   dev->file_addr += wlen; /* update file address */
   dev->file_size += wlen;

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -630,13 +630,6 @@ bool WriteSessionLabel(DeviceControlRecord* dcr, int label)
       SetStartVolPosition(dcr);
       break;
     case EOS_LABEL:
-      if (dev->IsTape()) {
-        dcr->EndBlock = dev->EndBlock;
-        dcr->EndFile = dev->EndFile;
-      } else {
-        dcr->EndBlock = (uint32_t)dev->file_addr;
-        dcr->EndFile = (uint32_t)(dev->file_addr >> 32);
-      }
       break;
     default:
       Jmsg1(jcr, M_ABORT, 0, _("Bad Volume session label = %d\n"), label);

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -627,7 +627,7 @@ bool WriteSessionLabel(DeviceControlRecord* dcr, int label)
   Dmsg1(130, "session_label record=%x\n", rec);
   switch (label) {
     case SOS_LABEL:
-      SetStartVolPosition(dcr);
+      //      SetStartVolPosition(dcr);
       break;
     case EOS_LABEL:
       break;
@@ -1115,7 +1115,7 @@ bool DeviceControlRecord::RewriteVolumeLabel(bool recycle)
     dev->VolCatInfo.VolCatRecycles = 0;
     dev->VolCatInfo.VolCatWrites = 1;
     dev->VolCatInfo.VolCatReads = 1;
-    dcr->DirCreateJobmediaRecord(true);
+    // dcr->DirCreateJobmediaRecord(true);
   }
   Dmsg1(150, "dir_update_vol_info. Set Append vol=%s\n", dcr->VolumeName);
   dev->VolCatInfo.VolFirstWritten = time(NULL);

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -1115,6 +1115,7 @@ bool DeviceControlRecord::RewriteVolumeLabel(bool recycle)
     dev->VolCatInfo.VolCatRecycles = 0;
     dev->VolCatInfo.VolCatWrites = 1;
     dev->VolCatInfo.VolCatReads = 1;
+    dcr->DirCreateJobmediaRecord(true);
   }
   Dmsg1(150, "dir_update_vol_info. Set Append vol=%s\n", dcr->VolumeName);
   dev->VolCatInfo.VolFirstWritten = time(NULL);

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -625,15 +625,8 @@ bool WriteSessionLabel(DeviceControlRecord* dcr, int label)
 
   rec = new_record();
   Dmsg1(130, "session_label record=%x\n", rec);
-  switch (label) {
-    case SOS_LABEL:
-      //      SetStartVolPosition(dcr);
-      break;
-    case EOS_LABEL:
-      break;
-    default:
-      Jmsg1(jcr, M_ABORT, 0, _("Bad Volume session label = %d\n"), label);
-      break;
+  if (label != SOS_LABEL && label != EOS_LABEL) {
+    Jmsg1(jcr, M_ABORT, 0, _("Bad Volume session label = %d\n"), label);
   }
   CreateSessionLabel(dcr, rec, label);
   rec->FileIndex = label;
@@ -1115,7 +1108,6 @@ bool DeviceControlRecord::RewriteVolumeLabel(bool recycle)
     dev->VolCatInfo.VolCatRecycles = 0;
     dev->VolCatInfo.VolCatWrites = 1;
     dev->VolCatInfo.VolCatReads = 1;
-    // dcr->DirCreateJobmediaRecord(true);
   }
   Dmsg1(150, "dir_update_vol_info. Set Append vol=%s\n", dcr->VolumeName);
   dev->VolCatInfo.VolFirstWritten = time(NULL);

--- a/systemtests/scripts/diff.pl.in
+++ b/systemtests/scripts/diff.pl.in
@@ -85,7 +85,7 @@ foreach my $f (keys %src_attr)
 {
     if (!defined $dst_attr{$f}) {
         $ret++;
-        print "diff.pl ERROR: Can't find $f in dst\n";
+        print "diff.pl ERROR: Can't find $f in (dst) $dst\n";
 
     } else {
         compare($src_attr{$f}, $dst_attr{$f});
@@ -97,7 +97,7 @@ foreach my $f (keys %src_attr)
 foreach my $f (keys %dst_attr)
 {
     $ret++;
-    print "diff.pl ERROR: Can't find $f in src\n";
+    print "diff.pl ERROR: Can't find $f in (src) $src\n";
 }
 
 if ($ret) {

--- a/systemtests/tests/block-size/testrunner
+++ b/systemtests/tests/block-size/testrunner
@@ -45,8 +45,6 @@ setup_data
 VolumeName=TestVolume001
 # VolumePath=storage/${VolumeName}
 DEFAULT_BLOCK_SIZE=64512
-LABEL_BLOCK_SIZE=${DEFAULT_BLOCK_SIZE}
-
 
 bls_blocks()
 {
@@ -55,22 +53,11 @@ bls_blocks()
   ${BAREOS_BLS_BINARY} -c ${configs} ${DEVICE} -V"${VOLUME}" -k -d 250
 }
 
-get_block_and_data_size()
-{
-    # block 1 and 2 are label blocks.
-    # blocks >= 3 are data blocks.
-    # Parameter 3 is the block of interest. Default is block 1.
-    DEVICE="$1"
-    VOLUME="${2:-*}"
-    LINE=${3:-1}
-    bls_blocks "$DEVICE" "$VOLUME" | sed -r -n -e "s/^bls .* Exit read_block (read_len=[0-9]+) (block_len=[0-9]*)/\1 \2/p" | sed "${LINE}q;d"
-}
-
 get_block_size()
 {
     # block 1 and 2 are label blocks.
     # blocks >= 3 are data blocks.
-    # Parameter 3 is the block of interest. Default is block 1.
+    # Parameter 2 is the block of interest. Default is block 1.
     DATA="$1"
     LINE=${2:-1}
     echo "$DATA" | sed -r -n -e "s/^bls .* Exit read_block read_len=([0-9]+) block_len=[0-9]*/\1/p" | sed "${LINE}q;d"
@@ -80,7 +67,7 @@ get_data_size()
 {
     # block 1 and 2 are label blocks.
     # blocks >= 3 are data blocks.
-    # Parameter 3 is the block of interest. Default is block 1.
+    # Parameter 2 is the block of interest. Default is block 1.
     DATA="$1"
     LINE=${2:-1}
     echo "$DATA" | sed -r -n -e "s/^bls .* Exit read_block read_len=[0-9]+ block_len=([0-9]*)/\1/p" | sed "${LINE}q;d"

--- a/systemtests/tests/block-size/testrunner
+++ b/systemtests/tests/block-size/testrunner
@@ -71,10 +71,9 @@ get_block_size()
     # block 1 and 2 are label blocks.
     # blocks >= 3 are data blocks.
     # Parameter 3 is the block of interest. Default is block 1.
-    DEVICE="$1"
-    VOLUME="${2:-*}"
-    LINE=${3:-1}
-    bls_blocks "$DEVICE" "$VOLUME" | sed -r -n -e "s/^bls .* Exit read_block read_len=([0-9]+) block_len=[0-9]*/\1/p" | sed "${LINE}q;d"
+    DATA="$1"
+    LINE=${2:-1}
+    echo "$DATA" | sed -r -n -e "s/^bls .* Exit read_block read_len=([0-9]+) block_len=[0-9]*/\1/p" | sed "${LINE}q;d"
 }
 
 get_data_size()
@@ -82,10 +81,9 @@ get_data_size()
     # block 1 and 2 are label blocks.
     # blocks >= 3 are data blocks.
     # Parameter 3 is the block of interest. Default is block 1.
-    DEVICE="$1"
-    VOLUME="${2:-*}"
-    LINE=${3:-1}
-    bls_blocks "$DEVICE" "$VOLUME" | sed -r -n -e "s/^bls .* Exit read_block read_len=[0-9]+ block_len=([0-9]*)/\1/p" | sed "${LINE}q;d"
+    DATA="$1"
+    LINE=${2:-1}
+    echo "$DATA" | sed -r -n -e "s/^bls .* Exit read_block read_len=[0-9]+ block_len=([0-9]*)/\1/p" | sed "${LINE}q;d"
 }
 
 
@@ -148,27 +146,35 @@ if [ ! -d ${BackupDirectory} ]; then
     set_error "Directory ${BackupDirectory} does not exists any more."
 fi
 
-blocksize_label=$(get_block_size File1 ${VolumeName} 1)
+file_out=$(bls_blocks File1 ${VolumeName})
+blocksize_label=$(get_block_size "${file_out}" 1)
 print_debug "File Label block size: $blocksize_label"
-if [ $blocksize_label != $DEFAULT_BLOCK_SIZE ]; then
+if [ "$blocksize_label" != $DEFAULT_BLOCK_SIZE ]; then
     set_error "Wrong label block size: expected: $DEFAULT_BLOCK_SIZE, got: $blocksize_label"
 fi
 
-blocksize_data=$(get_block_size File1 ${VolumeName} 3)
+blocksize_data=$(get_block_size "${file_out}" 3)
 print_debug "File Data block size (block 3): $blocksize_data"
-if [ $blocksize_data != $DEFAULT_BLOCK_SIZE ]; then
+if [ "$blocksize_data" != $DEFAULT_BLOCK_SIZE ]; then
     set_error "Wrong data block size (block 3): expected: $DEFAULT_BLOCK_SIZE, got: $blocksize_data"
 fi
 
-blocksize_label=$(get_block_size tapedrive0-0 "*" 1)
+tape_out=$(bls_blocks tapedrive0-0 "*")
+blocksize_label=$(get_block_size "${tape_out}" 1)
+if [[ -z "$blocksize_data" ]]; then
+    set_error "Could not read the label blocksize"
+fi
 print_debug "Tape Label block size: $blocksize_label"
-if [ $blocksize_label != $DEFAULT_BLOCK_SIZE ]; then
+if [ "$blocksize_label" != $DEFAULT_BLOCK_SIZE ]; then
     set_error "Wrong label block size: expected: $DEFAULT_BLOCK_SIZE, got: $blocksize_label"
 fi
 
-blocksize_data=$(get_block_size tapedrive0-0 "*" 3)
+blocksize_data=$(get_block_size "${tape_out}" 3)
+if [[ -z "$blocksize_data" ]]; then
+    set_error "Could not read the data blocksize"
+fi
 print_debug "Tape Data block size (block 3): $blocksize_data"
-if [ $blocksize_data -le $DEFAULT_BLOCK_SIZE ]; then
+if [ "$blocksize_data" -lt $DEFAULT_BLOCK_SIZE ]; then
     set_error "Wrong data block size (block 3): expected: $DEFAULT_BLOCK_SIZE, got: $blocksize_data"
 fi
 

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -4,7 +4,7 @@ Pool {
   Recycle = yes                       # Bareos can automatically recycle Volumes
   AutoPrune = yes                     # Prune expired volumes
   Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
-  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volume Bytes = 70K          # Limit Volume size to something reasonable
   Maximum Volumes = 100               # Limit number of Volumes in Pool
   Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
 }

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -8,4 +8,7 @@ Device {
   RemovableMedia = no;
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
+
+  Maximum Block Size = 64k
+  Maximum Concurrent Jobs = 12
 }

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage2.conf
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage2.conf
@@ -9,4 +9,6 @@ Device {
   AlwaysOpen = no;
   Description = "File device. A connecting Director must have the same Name and MediaType."
   Maximum Concurrent Jobs = 1
+
+  Maximum Block Size = 64k
 }

--- a/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
+++ b/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
@@ -34,6 +34,12 @@ run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
+run job=${backupjob} level=Full yes
 wait
 messages
 quit
@@ -43,12 +49,9 @@ run_bconsole
 
 backup_jobids=($(grep 'Job queued.' $parallelbackuplog | sed -n -e 's/^.*JobId=//p'))
 
-rm -rf $tmp/restore1
-rm -rf $tmp/restore2
-rm -rf $tmp/restore3
-rm -rf $tmp/restore4
-rm -rf $tmp/restore5
-rm -rf $tmp/restore6
+num_jobs=${#backup_jobids[@]}
+
+find "$tmp" -type d -name "restore*" -exec rm -rf {} +
 
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out $parallelrestorelog
@@ -58,6 +61,12 @@ restore jobid=${backup_jobids[2]} where=$tmp/restore3 all done yes
 restore jobid=${backup_jobids[3]} where=$tmp/restore4 all done yes
 restore jobid=${backup_jobids[4]} where=$tmp/restore5 all done yes
 restore jobid=${backup_jobids[5]} where=$tmp/restore6 all done yes
+restore jobid=${backup_jobids[6]} where=$tmp/restore7 all done yes
+restore jobid=${backup_jobids[7]} where=$tmp/restore8 all done yes
+restore jobid=${backup_jobids[8]} where=$tmp/restore9 all done yes
+restore jobid=${backup_jobids[9]} where=$tmp/restore10 all done yes
+restore jobid=${backup_jobids[10]} where=$tmp/restore11 all done yes
+restore jobid=${backup_jobids[11]} where=$tmp/restore12 all done yes
 wait
 messages
 quit
@@ -65,17 +74,17 @@ END_OF_DATA
 
 run_bconsole
 
-if [[ $(grep -c "Termination:.*Backup OK" "$parallelbackuplog") -ne "6" ]]; then
+if [[ $(grep -c "Termination:.*Backup OK" "$parallelbackuplog") -ne "$num_jobs" ]]; then
     echo "Not all backups jobs finished successfully."
     estat=1
 fi
 
-if [[ $(grep -c "Termination:.*Restore OK" "$parallelrestorelog") -ne "6" ]]; then
+if [[ $(grep -c "Termination:.*Restore OK" "$parallelrestorelog") -ne "$num_jobs" ]]; then
     echo "Not all restore jobs finished successfully."
     estat=2
 fi
 
-for i in {1..6}; do
+for i in $(seq 1 "$num_jobs"); do
     restoredir="$tmp/restore$i"
     check_restore_diff "${BackupDirectory}" "$restoredir"
 done


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Backport of PR #1495 to bareos-22

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
