### PR TITLE
daemons: set CLI11 error exit code to `41` and bareos config parsing error exit code to `42`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - devtools: Update python dependencies [PR #1531]
 - webui: upgrade bootstrap to version 3.4.1 [PR #1550]
 - bareos-check-sources: ignore bootstrap*.css [PR #1556]
+- daemons: set CLI11 error exit code to `41` and bareos config parsing error exit code to `42` [PR #1515]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -237,6 +238,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1508]: https://github.com/bareos/bareos/pull/1508
 [PR #1511]: https://github.com/bareos/bareos/pull/1511
 [PR #1512]: https://github.com/bareos/bareos/pull/1512
+[PR #1515]: https://github.com/bareos/bareos/pull/1515
 [PR #1516]: https://github.com/bareos/bareos/pull/1516
 [PR #1520]: https://github.com/bareos/bareos/pull/1520
 [PR #1521]: https://github.com/bareos/bareos/pull/1521

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-dir
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the the maximum number of open file descriptors
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "console/console_conf.h"
 #include "console/console_globals.h"
 #include "console/auth_pam.h"
@@ -939,7 +940,7 @@ int main(int argc, char* argv[])
     my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
@@ -947,8 +948,8 @@ int main(int argc, char* argv[])
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);
-    TerminateConsole(0);
-    exit(0);
+    TerminateConsole(BEXIT_SUCCESS);
+    exit(BEXIT_SUCCESS);
   }
 
   if (InitCrypto() != 0) {
@@ -969,8 +970,8 @@ int main(int argc, char* argv[])
   }
 
   if (test_config) {
-    TerminateConsole(0);
-    exit(0);
+    TerminateConsole(BEXIT_SUCCESS);
+    exit(BEXIT_SUCCESS);
   }
 
   (void)WSA_Init(); /* Initialize Windows sockets */
@@ -1097,8 +1098,8 @@ int main(int argc, char* argv[])
 
   if (history_file.size()) { ConsoleUpdateHistory(history_file.c_str()); }
 
-  TerminateConsole(0);
-  return 0;
+  TerminateConsole(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 static void TerminateConsole(int sig)

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -917,7 +917,7 @@ int main(int argc, char* argv[])
 
   AddDeprecatedExportOptionsHelp(console_app);
 
-  CLI11_PARSE(console_app, argc, argv);
+  ParseBareosApp(console_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateConsole); }
 

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -936,14 +936,17 @@ int main(int argc, char* argv[])
   if (export_config_schema) {
     PoolMem buffer;
 
-    my_config = InitConsConfig(configfile, M_ERROR_TERM);
+    my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
     exit(0);
   }
 
-  my_config = InitConsConfig(configfile, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -1107,7 +1107,7 @@ static void TerminateConsole(int sig)
   static bool already_here = false;
 
   if (already_here) { /* avoid recursive temination problems */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   already_here = true;
   StopWatchdog();
@@ -1118,7 +1118,7 @@ static void TerminateConsole(int sig)
   ConTerm();
   WSACleanup(); /* Cleanup Windows sockets */
 
-  if (sig != 0) { exit(1); }
+  if (sig != 0) { exit(BEXIT_FAILURE); }
   return;
 }
 

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -943,10 +943,7 @@ int main(int argc, char* argv[])
   }
 
   my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -863,10 +863,7 @@ int main(int argc, char* argv[])
     int found = 0;
 
     my_config = InitDirConfig(configfile.c_str(), M_CONFIG_ERROR);
-    if (!my_config->ParseConfig()) {
-      std::cerr << "Configuration parsing error" << std::endl;
-      exit(configerror_exit_code);
-    }
+    my_config->ParseConfigOrExit();
 
     foreach_res (catalog, R_CATALOG) {
       if (!catalogname.empty()

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -862,8 +862,11 @@ int main(int argc, char* argv[])
     CatalogResource* catalog = nullptr;
     int found = 0;
 
-    my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
-    my_config->ParseConfig();
+    my_config = InitDirConfig(configfile.c_str(), M_CONFIG_ERROR);
+    if (!my_config->ParseConfig()) {
+      std::cerr << "Configuration parsing error" << std::endl;
+      exit(configerror_exit_code);
+    }
 
     foreach_res (catalog, R_CATALOG) {
       if (!catalogname.empty()

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -230,7 +230,7 @@ static void eliminate_duplicate_paths()
       = "SELECT Path, count(Path) as Count FROM Path "
         "GROUP BY Path HAVING count(Path) > 1";
 
-  if (!MakeNameList(db, query, &name_list)) { exit(1); }
+  if (!MakeNameList(db, query, &name_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d duplicate Path records.\n"), name_list.num_ids);
   fflush(stdout);
   if (name_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -246,7 +246,7 @@ static void eliminate_duplicate_paths()
       Bsnprintf(buf, sizeof(buf), "SELECT PathId FROM Path WHERE Path='%s'",
                 esc_name);
       if (verbose > 1) { printf("%s\n", buf); }
-      if (!MakeIdList(db, buf, &id_list)) { exit(1); }
+      if (!MakeIdList(db, buf, &id_list)) { exit(BEXIT_FAILURE); }
       if (verbose) {
         printf(_("Found %d for: %s\n"), id_list.num_ids, name_list.name[i]);
       }
@@ -279,7 +279,7 @@ static void eliminate_orphaned_jobmedia_records()
 
   printf(_("Checking for orphaned JobMedia entries.\n"));
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned JobMedia records.\n"), id_list.num_ids);
@@ -305,7 +305,7 @@ static void eliminate_orphaned_jobmedia_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query, &id_list)) { exit(1); }
+    if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   }
   fflush(stdout);
 }
@@ -320,7 +320,7 @@ static void eliminate_orphaned_file_records()
   printf(_("Checking for orphaned File entries. This may take some time!\n"));
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned File records.\n"), id_list.num_ids);
@@ -343,7 +343,7 @@ static void eliminate_orphaned_file_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query, &id_list)) { exit(1); }
+    if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   }
   fflush(stdout);
 }
@@ -361,7 +361,7 @@ static void eliminate_orphaned_path_records()
   printf(_("Checking for orphaned Path entries. This may take some time!\n"));
   if (verbose > 1) { printf("%s\n", query.c_str()); }
   fflush(stdout);
-  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned Path records.\n"), id_list.num_ids);
@@ -383,7 +383,7 @@ static void eliminate_orphaned_path_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+    if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   }
 }
 
@@ -398,7 +398,7 @@ static void eliminate_orphaned_fileset_records()
         "WHERE Job.FileSetId IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned FileSet records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -439,7 +439,7 @@ static void eliminate_orphaned_client_records()
         "WHERE Job.ClientId IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned Client records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -479,7 +479,7 @@ static void eliminate_orphaned_job_records()
         "WHERE Client.Name IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned Job records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -552,7 +552,7 @@ static void eliminate_admin_records()
         "WHERE Job.Type='D'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d Admin Job records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -585,7 +585,7 @@ static void eliminate_restore_records()
         "WHERE Job.Type='R'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d Restore Job records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -619,7 +619,7 @@ static void repair_bad_filenames()
         "WHERE Name LIKE '%/'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d bad Filename records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (i = 0; i < id_list.num_ids; i++) {
@@ -676,7 +676,7 @@ static void repair_bad_paths()
   db->FillQuery(query, BareosDb::SQL_QUERY::get_bad_paths_0);
   if (verbose > 1) { printf("%s\n", query.c_str()); }
   fflush(stdout);
-  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d bad Path records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -890,7 +890,7 @@ int main(int argc, char* argv[])
                 "[%s]\n"),
               configfile.c_str());
       }
-      exit(1);
+      exit(BEXIT_FAILURE);
     } else {
       {
         ResLocker _{my_config};
@@ -899,7 +899,7 @@ int main(int argc, char* argv[])
       }
       if (!me) {
         Pmsg0(0, _("Error no Director resource defined.\n"));
-        exit(1);
+        exit(BEXIT_FAILURE);
       }
 
       SetWorkingDirectory(me->working_directory);

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -24,6 +24,7 @@
 // Program to check a BAREOS database for consistency and to make repairs
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "cats/cats.h"
 #include "lib/runscript.h"
 #include "lib/cli.h"
@@ -906,7 +907,7 @@ int main(int argc, char* argv[])
       // Print catalog information and exit (-B)
       if (print_catalog) {
         PrintCatalogDetails(catalog);
-        exit(0);
+        exit(BEXIT_SUCCESS);
       }
 
       db_name = catalog->db_name;
@@ -946,5 +947,5 @@ int main(int argc, char* argv[])
   CloseMsg(nullptr);
   TermMsg();
 
-  return 0;
+  return BEXIT_SUCCESS;
 }

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -854,7 +854,7 @@ int main(int argc, char* argv[])
   manual_args->add_option("port", dbport, "Database port")
       ->check(CLI::PositiveNumber);
 
-  CLI11_PARSE(dbcheck_app, argc, argv);
+  ParseBareosApp(dbcheck_app, argc, argv);
 
   const char* db_driver = "postgresql";
 

--- a/core/src/dird/dbcheck_utils.cc
+++ b/core/src/dird/dbcheck_utils.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/dbcheck_utils.cc
+++ b/core/src/dird/dbcheck_utils.cc
@@ -20,6 +20,7 @@
 */
 
 #include "dbcheck_utils.h"
+#include "include/exit_codes.h"
 
 using namespace directordaemon;
 
@@ -166,7 +167,9 @@ std::vector<int> get_deletable_storageids(
   query += ")";
 
   ID_LIST orphaned_storage_ids_list{};
-  if (!MakeIdList(db, query.c_str(), &orphaned_storage_ids_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &orphaned_storage_ids_list)) {
+    exit(BEXIT_FAILURE);
+  }
 
   std::vector<int> storage_ids_to_delete;
   NameList volume_names = {};
@@ -178,7 +181,9 @@ std::vector<int> get_deletable_storageids(
         = "SELECT volumename FROM media WHERE storageid="
           + std::to_string(orphaned_storage_ids_list.Id[orphaned_storage_id]);
 
-    if (!MakeNameList(db, media_query.c_str(), &volume_names)) { exit(1); }
+    if (!MakeNameList(db, media_query.c_str(), &volume_names)) {
+      exit(BEXIT_FAILURE);
+    }
 
     if (volume_names.num_ids > 0) {
       for (int volumename = 0; volumename < volume_names.num_ids;
@@ -197,7 +202,9 @@ std::vector<int> get_deletable_storageids(
         = "SELECT name FROM device WHERE storageid="
           + std::to_string(orphaned_storage_ids_list.Id[orphaned_storage_id]);
 
-    if (!MakeNameList(db, device_query.c_str(), &device_names)) { exit(1); }
+    if (!MakeNameList(db, device_query.c_str(), &device_names)) {
+      exit(BEXIT_FAILURE);
+    }
 
     if (device_names.num_ids > 0) {
       for (int devicename = 0; devicename < device_names.num_ids;
@@ -240,7 +247,7 @@ std::vector<std::string> get_orphaned_storages_names(BareosDb* db)
 
   NameList database_storage_names_list{};
   if (!MakeNameList(db, query.c_str(), &database_storage_names_list)) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   std::vector<std::string> orphaned_storage_names_list;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -390,7 +390,7 @@ static
 
   if (is_reloading) {  /* avoid recursive termination problems */
     Bmicrosleep(2, 0); /* yield */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   is_reloading = true;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -262,10 +262,7 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     int rc = 0;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -226,7 +226,7 @@ int main(int argc, char* argv[])
 
   AddDeprecatedExportOptionsHelp(dir_app);
 
-  CLI11_PARSE(dir_app, argc, argv);
+  ParseBareosApp(dir_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateDird); }
 

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "cats/sql.h"
 #include "cats/sql_pooling.h"
 #include "dird.h"
@@ -258,8 +259,8 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   my_config->ParseConfigOrExit();
@@ -272,7 +273,7 @@ int main(int argc, char* argv[])
       rc = 1;
     }
     TerminateDird(rc);
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   if (!CheckResources()) {
@@ -280,8 +281,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (my_config->HasWarnings()) {
@@ -301,8 +302,8 @@ int main(int argc, char* argv[])
     Jmsg((JobControlRecord*)nullptr, M_ERROR_TERM, 0,
          _("Cryptography library initialization failed.\n"));
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (!test_config) {
@@ -323,8 +324,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (test_config) { TerminateDird(0); }
@@ -334,8 +335,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   MyNameIs(0, nullptr, me->resource_name_); /* set user defined name */
@@ -370,8 +371,8 @@ int main(int argc, char* argv[])
 
   Scheduler::GetMainScheduler().Run();
 
-  TerminateDird(0);
-  return 0;
+  TerminateDird(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 /**

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -251,7 +251,7 @@ int main(int argc, char* argv[])
             "but program was not started with required root privileges.\n"));
   }
 
-  my_config = InitDirConfig(configfile, M_ERROR_TERM);
+  my_config = InitDirConfig(configfile, M_CONFIG_ERROR);
   if (export_config_schema) {
     PoolMem buffer;
 
@@ -262,7 +262,10 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  my_config->ParseConfig();
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     int rc = 0;

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -191,10 +191,7 @@ int main(int argc, char* argv[])
   }
 
   my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -190,8 +190,11 @@ int main(int argc, char* argv[])
     exit(0);
   }
 
-  my_config = InitFdConfig(configfile, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
@@ -202,7 +205,7 @@ int main(int argc, char* argv[])
   if (!CheckResources()) {
     Emsg1(M_ERROR, 0, _("Please correct configuration file: %s\n"),
           my_config->get_base_config_path().c_str());
-    TerminateFiled(1);
+    TerminateFiled(configerror_exit_code);
   }
 
   if (my_config->HasWarnings()) {

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -145,7 +145,7 @@ int main(int argc, char* argv[])
 
   AddDeprecatedExportOptionsHelp(fd_app);
 
-  CLI11_PARSE(fd_app, argc, argv);
+  ParseBareosApp(fd_app, argc, argv);
 
   if (user.empty() && keep_readall_caps) {
     Emsg0(M_ERROR_TERM, 0, _("-k option has no meaning without -u option.\n"));

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
@@ -197,7 +197,7 @@ int main(int argc, char* argv[])
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
 
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   if (!CheckResources()) {
@@ -248,9 +248,8 @@ int main(int argc, char* argv[])
   // start socket server to listen for new connections.
   StartSocketServer(me->FDaddrs);
 
-  TerminateFiled(0);
-
-  exit(0);
+  TerminateFiled(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 namespace filedaemon {

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -259,8 +259,8 @@ void TerminateFiled(int sig)
   static bool already_here = false;
 
   if (already_here) {
-    Bmicrosleep(2, 0); /* yield */
-    exit(1);           /* prevent loops */
+    Bmicrosleep(2, 0);   /* yield */
+    exit(BEXIT_FAILURE); /* prevent loops */
   }
   already_here = true;
   debug_level = 0; /* turn off debug */

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -28,6 +28,7 @@
 
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "filed/dir_cmd.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
@@ -202,7 +203,7 @@ int main(int argc, char* argv[])
   if (!CheckResources()) {
     Emsg1(M_ERROR, 0, _("Please correct configuration file: %s\n"),
           my_config->get_base_config_path().c_str());
-    TerminateFiled(configerror_exit_code);
+    TerminateFiled(BEXIT_CONFIG_ERROR);
   }
 
   if (my_config->HasWarnings()) {

--- a/core/src/include/exit_codes.h
+++ b/core/src/include/exit_codes.h
@@ -1,0 +1,33 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#ifndef BAREOS_INCLUDE_EXIT_CODES_H_
+#define BAREOS_INCLUDE_EXIT_CODES_H_
+
+enum BareosExitCodes : int
+{
+  BEXIT_SUCCESS = 0,
+  BEXIT_FAILURE = 1,
+  BEXIT_CLI_PARSING_ERROR = 41,
+  BEXIT_CONFIG_ERROR = 42,
+};
+
+#endif  // BAREOS_INCLUDE_EXIT_CODES_H_

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -203,3 +203,17 @@ void AddUserAndGroupOptions(CLI::App& app,
                  "Run as given group (requires starting as root)")
       ->type_name("<group>");
 }
+
+void ParseBareosApp(CLI::App& app, int argc, char** argv)
+{
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError& e) {
+    int cli11_exit = app.exit(e);
+    if (cli11_exit == static_cast<int>(CLI::ExitCodes::Success)) {
+      exit(EXIT_SUCCESS);
+    } else {
+      exit(kBareosCLI11ExitCode);
+    }
+  }
+}

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -25,6 +25,8 @@
 #include "lib/version.h"
 #include "lib/message.h"
 #include "lib/edit.h"
+#include "include/exit_codes.h"
+
 #include <regex>
 
 class BareosCliFormatter : public CLI::Formatter {
@@ -211,9 +213,9 @@ void ParseBareosApp(CLI::App& app, int argc, char** argv)
   } catch (const CLI::ParseError& e) {
     int cli11_exit = app.exit(e);
     if (cli11_exit == static_cast<int>(CLI::ExitCodes::Success)) {
-      exit(EXIT_SUCCESS);
+      exit(BEXIT_SUCCESS);
     } else {
-      exit(kBareosCLI11ExitCode);
+      exit(BEXIT_CLI_PARSING_ERROR);
     }
   }
 }

--- a/core/src/lib/cli.h
+++ b/core/src/lib/cli.h
@@ -25,6 +25,9 @@
 #include "CLI/Config.hpp"
 #include "CLI/Formatter.hpp"
 
+const short kBareosCLI11ExitCode = 41;
+
+void ParseBareosApp(CLI::App& app, int argc, char** argv);
 void InitCLIApp(CLI::App& app, std::string description, int fsfyear = 0);
 void AddDebugOptions(CLI::App& app);
 void AddVerboseOption(CLI::App& app);

--- a/core/src/lib/cli.h
+++ b/core/src/lib/cli.h
@@ -25,8 +25,6 @@
 #include "CLI/Config.hpp"
 #include "CLI/Formatter.hpp"
 
-const short kBareosCLI11ExitCode = 41;
-
 void ParseBareosApp(CLI::App& app, int argc, char** argv);
 void InitCLIApp(CLI::App& app, std::string description, int fsfyear = 0);
 void AddDebugOptions(CLI::App& app);

--- a/core/src/lib/daemon.cc
+++ b/core/src/lib/daemon.cc
@@ -36,6 +36,7 @@
 
 #include "include/fcntl_def.h"
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/berrno.h"
 #include "lib/daemon.h"
 
@@ -85,7 +86,7 @@ void daemon_start(const char* progname,
       break;
     }
     default:
-      exit(0);
+      exit(BEXIT_SUCCESS);
   }
 
   Dmsg0(900, "Exit daemon_start\n");

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -38,6 +38,7 @@
 #include "include/fcntl_def.h"
 #include "include/bareos.h"
 #include "include/jcr.h"
+#include "include/exit_codes.h"
 #include "lib/berrno.h"
 #include "lib/bsock.h"
 #include "lib/util.h"
@@ -1198,7 +1199,7 @@ void e_msg(const char* file,
   } else if (type == M_ERROR_TERM) {
     exit(1);
   } else if (type == M_CONFIG_ERROR) {
-    exit(configerror_exit_code);
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 
@@ -1325,7 +1326,7 @@ void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
   } else if (type == M_ERROR_TERM) {
     exit(1);
   } else if (type == M_CONFIG_ERROR) {
-    exit(configerror_exit_code);
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -1197,7 +1197,7 @@ void e_msg(const char* file,
   if (type == M_ABORT) {
     abort();
   } else if (type == M_ERROR_TERM) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   } else if (type == M_CONFIG_ERROR) {
     exit(BEXIT_CONFIG_ERROR);
   }
@@ -1324,7 +1324,7 @@ void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
     syslog(LOG_DAEMON | LOG_ERR, "BAREOS aborting to obtain traceback.\n");
     abort();
   } else if (type == M_ERROR_TERM) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   } else if (type == M_CONFIG_ERROR) {
     exit(BEXIT_CONFIG_ERROR);
   }

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -45,6 +45,8 @@ class JobControlRecord;
 typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*,
                                                           const char*);
 
+const short configerror_exit_code = 42;
+
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 bool GetTrace(void);

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -45,8 +45,6 @@ class JobControlRecord;
 typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*,
                                                           const char*);
 
-const short configerror_exit_code = 42;
-
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 bool GetTrace(void);

--- a/core/src/lib/message_severity.h
+++ b/core/src/lib/message_severity.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message_severity.h
+++ b/core/src/lib/message_severity.h
@@ -90,7 +90,8 @@ enum
   M_SECURITY,
   M_ALERT,
   M_VOLMGMT,
-  M_AUDIT
+  M_AUDIT,
+  M_CONFIG_ERROR,
 };
 
 #define M_MAX M_AUDIT /* keep this updated ! */

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -67,7 +67,6 @@
 #include "lib/berrno.h"
 #include "lib/util.h"
 
-
 #if defined(HAVE_WIN32)
 #  include "shlobj.h"
 #else
@@ -151,6 +150,13 @@ std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
     }
   }
   return qualified_name;
+}
+void ConfigurationParser::ParseConfigOrExit()
+{
+  if (!ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 }
 
 bool ConfigurationParser::ParseConfig()

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -55,6 +55,7 @@
 
 #include "include/bareos.h"
 #include "include/jcr.h"
+#include "include/exit_codes.h"
 #include "lib/address_conf.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
@@ -154,8 +155,8 @@ std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
 void ConfigurationParser::ParseConfigOrExit()
 {
   if (!ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
+    fprintf(stderr, "Configuration parsing error\n");
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -169,7 +169,7 @@ bool ConfigurationParser::ParseConfig()
   parser_first_run_ = false;
 
   if (!FindConfigPath(config_path)) {
-    Jmsg0(nullptr, M_ERROR_TERM, 0, _("Failed to find config filename.\n"));
+    Jmsg0(nullptr, M_CONFIG_ERROR, 0, _("Failed to find config filename.\n"));
   }
   used_config_path_ = config_path.c_str();
   Dmsg1(100, "config file = %s\n", used_config_path_.c_str());

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -249,6 +249,7 @@ class ConfigurationParser {
   ~ConfigurationParser();
 
   bool IsUsingConfigIncludeDir() const { return use_config_include_dir_; }
+  void ParseConfigOrExit();
   bool ParseConfig();
   bool ParseConfigFile(const char* config_file_name,
                        void* caller_ctx,

--- a/core/src/lib/signal.cc
+++ b/core/src/lib/signal.cc
@@ -37,6 +37,7 @@
 #  include <sys/wait.h>
 #  include <unistd.h>
 #  include "include/bareos.h"
+#  include "include/exit_codes.h"
 #  include "lib/watchdog.h"
 #  include "lib/berrno.h"
 #  include "lib/bsignal.h"
@@ -115,7 +116,7 @@ extern "C" void SignalHandler(int sig)
   int chld_status = -1;
 
   // If we come back more than once, get out fast!
-  if (already_dead) { exit(1); }
+  if (already_dead) { exit(BEXIT_FAILURE); }
   Dmsg2(900, "sig=%d %s\n", sig, sig_names[sig]);
 
   // Ignore certain signals -- SIGUSR2 used to interrupt threads

--- a/core/src/qt-tray-monitor/tray-monitor.cc
+++ b/core/src/qt-tray-monitor/tray-monitor.cc
@@ -173,8 +173,8 @@ int main(int argc, char* argv[])
   }
 
   // read the config file
-  my_config = InitTmonConfig(cl.configfile_, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitTmonConfig(cl.configfile_, M_CONFIG_ERROR);
+  my_config->ParseConfigOrExit();
 
   if (cl.export_config_) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/qt-tray-monitor/tray-monitor.cc
+++ b/core/src/qt-tray-monitor/tray-monitor.cc
@@ -39,6 +39,7 @@
 #include "lib/parse_conf.h"
 #include "lib/cli.h"
 #include "lib/crypto.h"
+#include "include/exit_codes.h"
 
 ConfigurationParser* my_config = nullptr;
 
@@ -169,7 +170,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
     fflush(stdout);
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   // read the config file

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
@@ -266,7 +267,7 @@ int main(int argc, char* argv[])
   delete out_dev;
 
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -195,12 +195,12 @@ int main(int argc, char* argv[])
   DeviceControlRecord* in_dcr = new DeviceControlRecord;
   in_jcr = SetupJcr("bcopy", input_archive.data(), bsr, director, in_dcr,
                     inputVolumes, true); /* read device */
-  if (!in_jcr) { exit(1); }
+  if (!in_jcr) { exit(BEXIT_FAILURE); }
 
   in_jcr->sd_impl->ignore_label_errors = ignore_label_errors;
 
   in_dev = in_jcr->sd_impl->dcr->dev;
-  if (!in_dev) { exit(1); }
+  if (!in_dev) { exit(BEXIT_FAILURE); }
 
   // Let SD plugins setup the record translation
   if (GeneratePluginEvent(in_jcr, bSdEventSetupRecordTranslation, in_dcr)
@@ -216,10 +216,10 @@ int main(int argc, char* argv[])
   DeviceControlRecord* out_dcr = new DeviceControlRecord;
   out_jcr = SetupJcr("bcopy", output_archive.data(), bsr, director, out_dcr,
                      outputVolumes, false); /* write device */
-  if (!out_jcr) { exit(1); }
+  if (!out_jcr) { exit(BEXIT_FAILURE); }
 
   out_dev = out_jcr->sd_impl->dcr->dev;
-  if (!out_dev) { exit(1); }
+  if (!out_dev) { exit(BEXIT_FAILURE); }
 
   // Let SD plugins setup the record translation
   if (GeneratePluginEvent(out_jcr, bSdEventSetupRecordTranslation, out_dcr)
@@ -235,12 +235,12 @@ int main(int argc, char* argv[])
   if (!out_dev->open(out_jcr->sd_impl->dcr, DeviceMode::OPEN_READ_WRITE)) {
     Emsg1(M_FATAL, 0, _("dev open failed: %s\n"), out_dev->errmsg);
     out_dev->Unlock();
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   out_dev->Unlock();
   if (!AcquireDeviceForAppend(out_jcr->sd_impl->dcr)) {
     FreeJcr(in_jcr);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   out_block = out_jcr->sd_impl->dcr->block;
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -161,7 +161,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bcopy_app, argc, argv);
+  ParseBareosApp(bcopy_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -167,8 +167,8 @@ int main(int argc, char* argv[])
 
   working_directory = work_dir.c_str();
 
-  my_config = InitSdConfig(configfile.c_str(), M_ERROR_TERM);
-  ParseSdConfig(configfile.c_str(), M_ERROR_TERM);
+  my_config = InitSdConfig(configfile.c_str(), M_CONFIG_ERROR);
+  ParseSdConfig(configfile.c_str(), M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -220,8 +220,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bextract_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   static DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -218,7 +218,7 @@ int main(int argc, char* argv[])
       ->type_name(" ");
 
 
-  CLI11_PARSE(bextract_app, argc, argv);
+  ParseBareosApp(bextract_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -155,7 +155,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open exclude file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -178,7 +178,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open include file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -398,9 +398,9 @@ static void DoExtract(char* devname,
   dcr = new DeviceControlRecord;
   jcr = SetupJcr("bextract", devname, bsr, director, dcr, VolumeName,
                  true); /* read device */
-  if (!jcr) { exit(1); }
+  if (!jcr) { exit(BEXIT_FAILURE); }
   dev = jcr->sd_impl->read_dcr->dev;
-  if (!dev) { exit(1); }
+  if (!dev) { exit(BEXIT_FAILURE); }
   dcr = jcr->sd_impl->read_dcr;
 
   // Let SD plugins setup the record translation

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -28,6 +28,7 @@
 
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/filetypes.h"
 #include "include/streams.h"
 #include "stored/stored.h"
@@ -261,7 +262,7 @@ int main(int argc, char* argv[])
   }
   TermIncludeExcludeFiles(ff);
   TermFindFiles(ff);
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 // Cleanup of delayed restore stack with streams for later processing.

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -138,7 +138,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open exclude file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open include file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -241,7 +241,7 @@ int main(int argc, char* argv[])
     dcr = new DeviceControlRecord;
     jcr = SetupJcr("bls", device.data(), bsr, director, dcr, VolumeNames,
                    true); /* read device */
-    if (!jcr) { exit(1); }
+    if (!jcr) { exit(BEXIT_FAILURE); }
 
 
     // Let SD plugins setup the record translation
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
 
     jcr->sd_impl->ignore_label_errors = ignore_label_errors;
     dev = jcr->sd_impl->dcr->dev;
-    if (!dev) { exit(1); }
+    if (!dev) { exit(BEXIT_FAILURE); }
     dcr = jcr->sd_impl->dcr;
     rec = new_record();
     attr = new_attr(jcr);

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -28,6 +28,7 @@
 
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/streams.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
@@ -276,7 +277,7 @@ int main(int argc, char* argv[])
   if (bsr) { libbareos::FreeBsr(bsr); }
   TermIncludeExcludeFiles(ff);
   TermFindFiles(ff);
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 static void do_close(JobControlRecord* jcr)

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -208,7 +208,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bls_app, argc, argv);
+  ParseBareosApp(bls_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -210,8 +210,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bls_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (!DirectorName.empty()) {
     foreach_res (director, R_DIRECTOR) {

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -240,8 +240,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bscan_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bscan_app, argc, argv);
+  ParseBareosApp(bscan_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -29,6 +29,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/filetypes.h"
 #include "include/streams.h"
 #include "stored/stored.h"
@@ -343,7 +344,7 @@ int main(int argc, char* argv[])
   FreeJcr(bjcr);
   UnloadSdPlugins();
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 /**

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -290,7 +290,7 @@ int main(int argc, char* argv[])
   DeviceControlRecord* dcr = new DeviceControlRecord;
   bjcr = SetupJcr("bscan", device_name.data(), bsr, director, dcr, volumes,
                   true);
-  if (!bjcr) { exit(1); }
+  if (!bjcr) { exit(BEXIT_FAILURE); }
   dev = bjcr->sd_impl->read_dcr->dev;
 
   // Let SD plugins setup the record translation

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -290,7 +290,7 @@ int main(int margc, char* margv[])
   btape_app.add_option_group("Interactive commands",
                              Generate_interactive_commands_help());
 
-  CLI11_PARSE(btape_app, margc, margv)
+  ParseBareosApp(btape_app, margc, margv);
 
   printf(_("Tape block granularity is %d bytes.\n"), TAPE_BSIZE);
 

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -36,6 +36,7 @@
 
 #include "include/fcntl_def.h"
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/streams.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
@@ -213,7 +214,7 @@ int main(int margc, char* margv[])
   if (i != 1 || x32 != y32) {
     Pmsg3(-1, _("32 bit printf/scanf problem. i=%d x32=%u y32=%u\n"), i, x32,
           y32);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   uint64_t x64 = 123456789;
@@ -226,7 +227,7 @@ int main(int margc, char* margv[])
   if (i != 1 || x64 != y64) {
     Pmsg3(-1, _("64 bit printf/scanf problem. i=%d x64=%llu y64=%llu\n"), i,
           x64, y64);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   working_directory = "/tmp";
@@ -325,14 +326,14 @@ int main(int margc, char* margv[])
   dcr = new BTAPE_DCR;
   jcr = SetupJcr("btape", archive_name.data(), bsr, director, dcr, "",
                  false); /* write device */
-  if (!jcr) { exit(1); }
+  if (!jcr) { exit(BEXIT_FAILURE); }
 
   dev = jcr->sd_impl->dcr->dev;
-  if (!dev) { exit(1); }
+  if (!dev) { exit(BEXIT_FAILURE); }
 
   if (!dev->IsTape()) {
     Pmsg0(000, _("btape only works with tape storage.\n"));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   // Let SD plugins setup the record translation
@@ -340,7 +341,7 @@ int main(int margc, char* margv[])
     Jmsg(jcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
   }
 
-  if (!open_the_device()) { exit(1); }
+  if (!open_the_device()) { exit(BEXIT_FAILURE); }
 
   Dmsg0(200, "Do tape commands\n");
   do_tape_cmds();

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -301,8 +301,8 @@ int main(int margc, char* margv[])
 
   daemon_start_time = time(nullptr);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -216,15 +216,15 @@ int main(int argc, char* argv[])
   if (export_config_schema) {
     PoolMem buffer;
 
-    my_config = InitSdConfig(configfile, M_ERROR_TERM);
+    my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
     return 0;
   }
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (forge_on) {
     my_config->AddWarning(

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -589,7 +589,7 @@ static
 
   if (in_here) {       /* prevent loops */
     Bmicrosleep(2, 0); /* yield */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   in_here = true;
   debug_level = 0; /* turn off any debug */

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -32,6 +32,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "lib/crypto_cache.h"
 #include "stored/acquire.h"
@@ -220,7 +221,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
@@ -235,7 +236,7 @@ int main(int argc, char* argv[])
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
 
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   if (!CheckResources()) {
@@ -312,9 +313,9 @@ int main(int argc, char* argv[])
   StartSocketServer(me->SDaddrs);
 
   /* to keep compiler quiet */
-  TerminateStored(0);
+  TerminateStored(BEXIT_SUCCESS);
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 /* Check Configuration file for necessary info */

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -187,7 +187,7 @@ int main(int argc, char* argv[])
 
   AddDeprecatedExportOptionsHelp(sd_app);
 
-  CLI11_PARSE(sd_app, argc, argv);
+  ParseBareosApp(sd_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateStored); }
 

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -34,6 +34,7 @@
 #  include "gtest/gtest.h"
 #  include "include/bareos.h"
 #endif
+#include "include/exit_codes.h"
 #include "lib/dlist.h"
 
 #include <memory>
@@ -281,7 +282,7 @@ TEST(dlist, BinaryInsert)
   foreach_dlist (jcr, jcr_chain) {
     if (!jcr_chain->binary_search(jcr, MyCompare)) {
       printf("Dlist binary_search item not found = %s\n", jcr->buf);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
   }
   foreach_dlist (jcr, jcr_chain) {

--- a/core/src/tests/sd_backend_tests.h
+++ b/core/src/tests/sd_backend_tests.h
@@ -42,8 +42,8 @@ void sd::SetUp()
   /* configfile is a global char* from stored_globals.h */
   configfile
       = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/" CONFIG_SUBDIR "/");
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
   /*
    * we do not run CheckResources() here, so take care the test configration
    * is not broken. Also autochangers will not work.

--- a/core/src/tests/sd_backend_tests.h
+++ b/core/src/tests/sd_backend_tests.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,10 +44,8 @@ void sd::SetUp()
       = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/" CONFIG_SUBDIR "/");
   my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
   ParseSdConfig(configfile, M_CONFIG_ERROR);
-  /*
-   * we do not run CheckResources() here, so take care the test configration
-   * is not broken. Also autochangers will not work.
-   */
+  /* we do not run CheckResources() here, so take care the test configration
+   * is not broken. Also autochangers will not work. */
 }
 void sd::TearDown()
 {

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -72,8 +72,8 @@ void ReservationTest::SetUp()
 
   /* configfile is a global char* from stored_globals.h */
   configfile = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/sd_reservation/");
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
   /* we do not run CheckResources() here, so take care the test configration
    * is not broken. Also autochangers will not work. */
 

--- a/core/src/tests/test_config_parser_sd.cc
+++ b/core/src/tests/test_config_parser_sd.cc
@@ -38,8 +38,8 @@ TEST(ConfigParser_SD, test_stored_config)
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
-  my_config = InitSdConfig(path_to_config_file.c_str(), M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(path_to_config_file.c_str(), M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   my_config->DumpResources(PrintMessage, NULL);
 

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -104,5 +104,5 @@ int main(int argc, char** argv)
     fclose(fd);
     regfree(&preg);
   }
-  exit(0);
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -26,6 +26,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/cli.h"
 
 #ifndef HAVE_REGEX_H
@@ -86,7 +87,7 @@ int main(int argc, char** argv)
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     lineno = 0;
     while (fgets(data, sizeof(data) - 1, fd)) {

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -34,7 +34,7 @@
 #  include <regex.h>
 #endif
 
-int main(int argc, char* const* argv)
+int main(int argc, char** argv)
 {
   setlocale(LC_ALL, "");
   tzset();
@@ -60,7 +60,7 @@ int main(int argc, char* const* argv)
       "-n,--not-match", [&match_only](bool) { match_only = false; },
       "Print line that do not match.");
 
-  CLI11_PARSE(bregex_app, argc, argv);
+  ParseBareosApp(bregex_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -320,7 +320,7 @@ int main(int argc, char* argv[])
   bsmtp_app.add_option("recipients", recipients, "List of recipients.")
       ->required();
 
-  CLI11_PARSE(bsmtp_app, argc, argv);
+  ParseBareosApp(bsmtp_app, argc, argv);
 
   Dmsg3(20, "%s: mailhost=%s ; mailport=%d\n", host_and_port_source.c_str(),
         mailhost.c_str(), mailport);

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -61,6 +61,7 @@
 #include <pwd.h>
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/jcr.h"
 #include "lib/cli.h"
 #include "lib/bstringlist.h"
@@ -619,5 +620,5 @@ lookup_host:
   chat(my_hostname, mailhost, "QUIT\r\n");
 
   //  Go away gracefully ...
-  exit(0);
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -125,7 +125,7 @@ static void GetResponse(const std::string& mailhost)
     Dmsg2(10, "%s --> %s\n", mailhost.c_str(), buf);
     if (!isdigit((int)buf[0]) || buf[0] > '3') {
       Pmsg2(0, _("Fatal malformed reply from %s: %s\n"), mailhost.c_str(), buf);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     if (buf[3] != '-') { break; }
   }
@@ -339,7 +339,7 @@ int main(int argc, char* argv[])
   char my_hostname[MAXSTRING];
   if (gethostname(my_hostname, sizeof(my_hostname) - 1) < 0) {
     Pmsg1(0, _("Fatal gethostname error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
 #ifdef HAVE_GETADDRINFO
@@ -357,7 +357,7 @@ int main(int argc, char* argv[])
   if ((res = getaddrinfo(my_hostname, NULL, &hints, &ai)) != 0) {
     Pmsg2(0, _("Fatal getaddrinfo for myself failed \"%s\": ERR=%s\n"),
           my_hostname, gai_strerror(res));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   strncpy(my_hostname, ai->ai_canonname, sizeof(my_hostname) - 1);
   my_hostname[sizeof(my_hostname) - 1] = '\0';
@@ -369,7 +369,7 @@ int main(int argc, char* argv[])
   if ((hp = gethostbyname(my_hostname)) == NULL) {
     Pmsg2(0, _("Fatal gethostbyname for myself failed \"%s\": ERR=%s\n"),
           my_hostname, strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   strncpy(my_hostname, hp->h_name, sizeof(my_hostname) - 1);
   my_hostname[sizeof(my_hostname) - 1] = '\0';
@@ -433,7 +433,7 @@ lookup_host:
       mailhost = "localhost";
       goto lookup_host;
     }
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
 #  if defined(HAVE_WIN32)
@@ -456,7 +456,7 @@ lookup_host:
 
   if (!rp) {
     Pmsg1(0, _("Failed to connect to mailhost %s\n"), mailhost.c_str());
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   freeaddrinfo(ai);
@@ -469,13 +469,13 @@ lookup_host:
       mailhost = "localhost";
       goto lookup_host;
     }
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   if (hp->h_addrtype != AF_INET) {
     Pmsg1(0, _("Fatal error: Unknown address family for smtp host: %d\n"),
           hp->h_addrtype);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   memset((char*)&sin, 0, sizeof(sin));
   memcpy((char*)&sin.sin_addr, hp->h_addr, hp->h_length);
@@ -484,18 +484,18 @@ lookup_host:
 #  if defined(HAVE_WIN32)
   if ((s = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, 0)) < 0) {
     Pmsg1(0, _("Fatal socket error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #  else
   if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
     Pmsg1(0, _("Fatal socket error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #  endif
   if (connect(s, (struct sockaddr*)&sin, sizeof(sin)) < 0) {
     Pmsg2(0, _("Fatal connect error to %s: ERR=%s\n"), mailhost.c_str(),
           strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   Dmsg0(20, "Connected\n");
 #endif
@@ -504,31 +504,31 @@ lookup_host:
   int fdSocket = _open_osfhandle(s, _O_RDWR | _O_BINARY);
   if (fdSocket == -1) {
     Pmsg1(0, _("Fatal _open_osfhandle error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   int fdSocket2 = dup(fdSocket);
 
   if ((sfp = fdopen(fdSocket, "wb")) == NULL) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((rfp = fdopen(fdSocket2, "rb")) == NULL) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #else
   if ((r = dup(s)) < 0) {
     Pmsg1(0, _("Fatal dup error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((sfp = fdopen(s, "w")) == 0) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((rfp = fdopen(r, "r")) == 0) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #endif
 

--- a/core/src/tools/btestls.cc
+++ b/core/src/tools/btestls.cc
@@ -80,7 +80,7 @@ static void usage()
             "Truncation is only in catalog.\n"
             "\n"));
 
-  exit(1);
+  exit(BEXIT_FAILURE);
 }
 
 
@@ -155,7 +155,7 @@ int main(int argc, char* const* argv)
     fd = fopen(inc, "rb");
     if (!fd) {
       printf(_("Could not open include file: %s\n"), inc);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     while (fgets(name, sizeof(name) - 1, fd)) {
       StripTrailingJunk(name);
@@ -168,7 +168,7 @@ int main(int argc, char* const* argv)
     fd = fopen(exc, "rb");
     if (!fd) {
       printf(_("Could not open exclude file: %s\n"), exc);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     while (fgets(name, sizeof(name) - 1, fd)) {
       StripTrailingJunk(name);

--- a/core/src/tools/btestls.cc
+++ b/core/src/tools/btestls.cc
@@ -29,6 +29,7 @@
 
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/filetypes.h"
 #include "include/jcr.h"
 #include "findlib/find.h"
@@ -187,7 +188,7 @@ int main(int argc, char* const* argv)
   FreeJcr(jcr);
   RecentJobResultsList::Cleanup();
   CleanupJcrChain();
-  exit(0);
+  exit(BEXIT_SUCCESS);
 }
 
 static int CountFiles(JobControlRecord*, FindFilesPacket*, bool)

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -79,7 +79,7 @@ int main(int argc, char** argv)
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     lineno = 0;
     while (fgets(data, sizeof(data) - 1, fd)) {

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -29,7 +29,7 @@
 #include "lib/cli.h"
 #include "lib/fnmatch.h"
 
-int main(int argc, char* const* argv)
+int main(int argc, char** argv)
 {
   setlocale(LC_ALL, "");
   tzset();
@@ -60,7 +60,7 @@ int main(int argc, char* const* argv)
       "-n,--not-match", [&match_only](bool) { match_only = false; },
       "Print line that do not match.");
 
-  CLI11_PARSE(bwild_app, argc, argv);
+  ParseBareosApp(bwild_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -26,6 +26,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/cli.h"
 #include "lib/fnmatch.h"
 
@@ -74,7 +75,7 @@ int main(int argc, char** argv)
     printf("Enter a wild-card: ");
     if (fgets(pat, sizeof(pat) - 1, stdin) == NULL) { break; }
     StripTrailingNewline(pat);
-    if (pat[0] == 0) { exit(0); }
+    if (pat[0] == 0) { exit(BEXIT_SUCCESS); }
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
@@ -95,5 +96,6 @@ int main(int argc, char** argv)
     }
     fclose(fd);
   }
-  exit(0);
+
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/fstype.cc
+++ b/core/src/tools/fstype.cc
@@ -27,11 +27,12 @@
 
 #include <unistd.h>
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "findlib/find.h"
 #include "lib/mntent_cache.h"
 #include "findlib/fstype.h"
 
-static void usage()
+static void usage(int exit_status)
 {
   fprintf(stderr,
           _("\n"
@@ -44,7 +45,7 @@ static void usage()
             "       -?     print this message.\n"
             "\n"));
 
-  exit(1);
+  exit(exit_status);
 }
 
 
@@ -52,7 +53,7 @@ int main(int argc, char* const* argv)
 {
   char fs[1000];
   int verbose = 0;
-  int status = 0;
+  int exit_status = BEXIT_SUCCESS;
   int ch, i;
 
   setlocale(LC_ALL, "");
@@ -66,14 +67,16 @@ int main(int argc, char* const* argv)
         verbose = 1;
         break;
       case '?':
+        usage(BEXIT_SUCCESS);
+        break;
       default:
-        usage();
+        usage(BEXIT_FAILURE);
     }
   }
   argc -= optind;
   argv += optind;
 
-  if (argc < 1) { usage(); }
+  if (argc < 1) { usage(BEXIT_FAILURE); }
 
   OSDependentInit();
 
@@ -86,11 +89,11 @@ int main(int argc, char* const* argv)
       }
     } else {
       fprintf(stderr, _("%s: unknown\n"), *argv);
-      status = 1;
+      exit_status = BEXIT_FAILURE;
     }
   }
 
   FlushMntentCache();
 
-  exit(status);
+  exit(exit_status);
 }

--- a/core/src/tools/gentestdata.cc
+++ b/core/src/tools/gentestdata.cc
@@ -18,9 +18,7 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
-#include "CLI/App.hpp"
-#include "CLI/Formatter.hpp"
-#include "CLI/Config.hpp"
+#include "lib/cli.h"
 #include <random>
 #include <cstring>
 

--- a/core/src/tools/testfind.cc
+++ b/core/src/tools/testfind.cc
@@ -78,7 +78,7 @@ int main(int argc, char** argv)
     foreach_res (var, R_FILESET) {
       std::cerr << "  " << var->resource_name_ << std::endl;
     }
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   ProcessFileset(dir_fileset, configfile.c_str());

--- a/core/src/tools/testfind.cc
+++ b/core/src/tools/testfind.cc
@@ -34,7 +34,7 @@
 
 using namespace directordaemon;
 
-int main(int argc, char* const* argv)
+int main(int argc, char** argv)
 {
   OSDependentInit();
 
@@ -59,7 +59,7 @@ int main(int argc, char* const* argv)
   testfind_app.add_option("-f,--fileset", filesetname,
                           "Specify which FileSet to use.");
 
-  CLI11_PARSE(testfind_app, argc, argv);
+  ParseBareosApp(testfind_app, argc, argv);
 
   directordaemon::my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
 

--- a/core/src/tools/testfind.cc
+++ b/core/src/tools/testfind.cc
@@ -61,16 +61,9 @@ int main(int argc, char** argv)
 
   ParseBareosApp(testfind_app, argc, argv);
 
-  directordaemon::my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
+  directordaemon::my_config = InitDirConfig(configfile.c_str(), M_CONFIG_ERROR);
 
-  if (!directordaemon::my_config) {
-    std::cerr << "Error parsing configuration!\n";
-    exit(2);
-  }
-  if (!directordaemon::my_config->ParseConfig()) {
-    std::cerr << "Error parsing configuration!\n";
-    exit(3);
-  }
+  my_config->ParseConfigOrExit();
 
   FilesetResource* dir_fileset = (FilesetResource*)my_config->GetResWithName(
       R_FILESET, filesetname.c_str());

--- a/core/src/tools/testfind.cc
+++ b/core/src/tools/testfind.cc
@@ -26,7 +26,7 @@
  */
 
 #include "include/bareos.h"
-
+#include "include/exit_codes.h"
 #include "dird/dird_globals.h"
 #include "lib/parse_conf.h"
 #include "lib/cli.h"
@@ -90,5 +90,5 @@ int main(int argc, char** argv)
 
   TermMsg();
 
-  exit(0);
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/testfind_fd.cc
+++ b/core/src/tools/testfind_fd.cc
@@ -37,8 +37,8 @@ using namespace filedaemon;
 void ProcessFileset(directordaemon::FilesetResource* director_fileset,
                     const char* configfile)
 {
-  my_config = InitFdConfig(configfile, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
+  my_config->ParseConfigOrExit();
 
   me = static_cast<ClientResource*>(my_config->GetNextRes(R_CLIENT, nullptr));
 

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-director
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-filedaemon
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the maximum number of open file descriptors```
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-storage
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-sd.service


### PR DESCRIPTION
#### Description

When CLI11 exists on error, it produces a lot of different exit codes that are not always useful to us. Also configuration errors do not have a specific exit code.
This PR makes sure CLI11 error exit codes are overridden so that the daemons exit with a  `41` code no matter what the type of error is, as they are all command line parsing errors anyway. On top of that configuration, parsing errors will report a `42` code on exit.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
