### PR TITLE
ua_restore: change restore argument handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - plugins: switch python-ldap plugin to  python3 [PR #1522]
 - build: switch from FreeBSD 13.1 to 13.2 [PR #1524]
 - stored: automatically increment tape block size in case the buffer is too small [PR #1496]
+- ua_restore: change restore argument handling [PR #1516]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -228,6 +229,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1508]: https://github.com/bareos/bareos/pull/1508
 [PR #1511]: https://github.com/bareos/bareos/pull/1511
 [PR #1512]: https://github.com/bareos/bareos/pull/1512
+[PR #1516]: https://github.com/bareos/bareos/pull/1516
 [PR #1522]: https://github.com/bareos/bareos/pull/1522
 [PR #1524]: https://github.com/bareos/bareos/pull/1524
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -841,7 +841,7 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
   } else {
     ua->InfoMsg(_("You have selected the following JobId: %s\n"), rx->JobIds);
   }
-  return true;
+  return 1;
 }
 
 // Get date from user

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -84,6 +84,7 @@ static bool InsertDirIntoFindexList(UaContext* ua,
                                     char* date);
 static void InsertOneFileOrDir(UaContext* ua,
                                RestoreContext* rx,
+                               char* p,
                                char* date,
                                bool dir);
 static bool GetClientName(UaContext* ua, RestoreContext* rx);
@@ -591,15 +592,9 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
     if (!have_date) { bstrutime(date, sizeof(date), now); }
     if (!GetClientName(ua, rx)) { return 0; }
 
-    for (auto* file : files) {
-      PmStrcpy(ua->cmd, file);
-      InsertOneFileOrDir(ua, rx, date, false);
-    }
+    for (auto& file : files) { InsertOneFileOrDir(ua, rx, file, date, false); }
 
-    for (auto* dir : dirs) {
-      PmStrcpy(ua->cmd, dir);
-      InsertOneFileOrDir(ua, rx, date, true);
-    }
+    for (auto& dir : dirs) { InsertOneFileOrDir(ua, rx, dir, date, true); }
 
     return 2;
   }
@@ -703,7 +698,7 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
           if (!GetCmd(ua, _("Enter full filename: "))) { return 0; }
           len = strlen(ua->cmd);
           if (len == 0) { break; }
-          InsertOneFileOrDir(ua, rx, date, false);
+          InsertOneFileOrDir(ua, rx, ua->cmd, date, false);
         }
         return 2;
       case 7: /* enter files backed up before specified time */
@@ -719,7 +714,7 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
           if (!GetCmd(ua, _("Enter full filename: "))) { return 0; }
           len = strlen(ua->cmd);
           if (len == 0) { break; }
-          InsertOneFileOrDir(ua, rx, date, false);
+          InsertOneFileOrDir(ua, rx, ua->cmd, date, false);
         }
         return 2;
 
@@ -765,7 +760,7 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
           if (ua->cmd[0] != '<' && !IsPathSeparator(ua->cmd[len - 1])) {
             strcat(ua->cmd, "/");
           }
-          InsertOneFileOrDir(ua, rx, date, true);
+          InsertOneFileOrDir(ua, rx, ua->cmd, date, true);
         }
         return 2;
 
@@ -912,12 +907,12 @@ std::string CompensateShortDate(const char* cmd)
 // Insert a single file, or read a list of files from a file
 static void InsertOneFileOrDir(UaContext* ua,
                                RestoreContext* rx,
+                               char* p,
                                char* date,
                                bool dir)
 {
   FILE* ffd;
   char file[5000];
-  char* p = ua->cmd;
   int line = 0;
 
   switch (*p) {
@@ -950,9 +945,9 @@ static void InsertOneFileOrDir(UaContext* ua,
       break;
     default:
       if (dir) {
-        InsertDirIntoFindexList(ua, rx, ua->cmd, date);
+        InsertDirIntoFindexList(ua, rx, p, date);
       } else {
-        InsertFileIntoFindexList(ua, rx, ua->cmd, date);
+        InsertFileIntoFindexList(ua, rx, p, date);
       }
       break;
   }

--- a/core/src/dird/ua_restore.cc
+++ b/core/src/dird/ua_restore.cc
@@ -534,6 +534,7 @@ static int UserSelectJobidsOrFiles(UaContext* ua, RestoreContext* rx)
         if (!HasValue(ua, i)) { return 0; }
         if (*rx->JobIds != 0) { PmStrcat(rx->JobIds, ","); }
         PmStrcat(rx->JobIds, ua->argv[i]);
+        bstrncpy(rx->last_jobid, ua->argv[i], sizeof(rx->last_jobid));
         done = true;
         break;
       case 1: /* current */

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -422,13 +422,24 @@ static void DoExtract(char* devname,
   attr = new_attr(jcr);
 
   jcr->buf_size = DEFAULT_NETWORK_BUFFER_SIZE;
-  /* SetupDecompressionBuffers(jcr, &decompress_buf_size); */
 
-  /* if (decompress_buf_size > 0) { */
-  /*   jcr->compress = CompressionContext{}; */
-  /*   jcr->compress.inflate_buffer = GetMemory(decompress_buf_size); */
-  /*   jcr->compress.inflate_buffer_size = decompress_buf_size; */
-  /* } */
+  uint32_t decompress_buf_size;
+
+  SetupDecompressionBuffers(jcr, &decompress_buf_size);
+  if (decompress_buf_size > 0) {
+    // See if we need to create a new compression buffer or make sure the
+    // existing is big enough.
+    if (!jcr->compress.inflate_buffer) {
+      jcr->compress.inflate_buffer = GetMemory(decompress_buf_size);
+      jcr->compress.inflate_buffer_size = decompress_buf_size;
+    } else {
+      if (decompress_buf_size > jcr->compress.inflate_buffer_size) {
+        jcr->compress.inflate_buffer = ReallocPoolMemory(
+            jcr->compress.inflate_buffer, decompress_buf_size);
+        jcr->compress.inflate_buffer_size = decompress_buf_size;
+      }
+    }
+  }
 
   acl_data.last_fname = GetPoolMemory(PM_FNAME);
   xattr_data.last_fname = GetPoolMemory(PM_FNAME);

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -782,8 +782,8 @@ check_restore_diff()
 
    restorepath="$restoredirectory/${dest}"
 
-   if "$rscripts/diff.pl" -s "${dest}" -d "${restorepath}"; then
-       result=$?
+   if ! "$rscripts/diff.pl" -d "${restorepath}" -s "${dest}"; then
+       dstat=1
    fi
 
    # gnu diff is required

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = xxh128
+      HardLinks = Yes
       fstype = ext2
       fstype = ext3
       fstype = ext4

--- a/systemtests/tests/block-size/etc/bareos/bareos-dir.d/fileset/FS_TESTJOB.conf.in
+++ b/systemtests/tests/block-size/etc/bareos/bareos-dir.d/fileset/FS_TESTJOB.conf.in
@@ -3,7 +3,8 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
-      xattrsupport = no           # Prevent problems on FreeBSD
+      XattrSupport = No           # Prevent problems on FreeBSD
+      HardLinks = Yes
     }
     File = "<@tmpdir@/file-list"
   }

--- a/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      Compression = LZ4
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -5,6 +5,7 @@ FileSet {
     Options {
       Signature = XXH128
       Compression = LZ4
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
       fstype = ext2
       fstype = ext3
       fstype = ext4
@@ -15,6 +16,5 @@ FileSet {
       fstype = btrfs
     }
     File=<@tmpdir@/file-list
-
   }
 }

--- a/systemtests/tests/client-initiated/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/client-initiated/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/droplet-s3/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/droplet-s3/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/gfapi-fd/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/gfapi-fd/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -4,7 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
-      HardLinks = yes
+      HardLinks = Yes
     }
     File = "@working_dir@/@db_name@.sql" # database dump
     File = "@confdir@"                   # configuration

--- a/systemtests/tests/gfapi-fd/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/gfapi-fd/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,7 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
-      Hardlinks = yes
+      HardLinks = Yes
     }
     Plugin = "gfapi:volume=gluster\\://@gfapi_fd_host@/@gfapi_fd_testvolume@:"`
   }

--- a/systemtests/tests/glusterfs-backend/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -4,7 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
-      HardLinks = yes
+      HardLinks = Yes
     }
     File = "@working_dir@/@db_name@.sql" # database dump
     File = "@confdir@"                   # configuration

--- a/systemtests/tests/glusterfs-backend/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,7 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
-      Hardlinks = yes
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/multiplied-device/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/multiplied-device/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/notls/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/notls/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
       fstype = ext2
       fstype = ext3
       fstype = ext4

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -10,4 +10,5 @@ Device {
   Description = "File device. A connecting Director must have the same Name and MediaType."
 
   Maximum Block Size = 64k
+  Maximum Concurrent Jobs = 12
 }

--- a/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
+++ b/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
@@ -34,12 +34,6 @@ run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
 wait
 messages
 quit
@@ -61,12 +55,6 @@ restore jobid=${backup_jobids[2]} where=$tmp/restore3 all done yes
 restore jobid=${backup_jobids[3]} where=$tmp/restore4 all done yes
 restore jobid=${backup_jobids[4]} where=$tmp/restore5 all done yes
 restore jobid=${backup_jobids[5]} where=$tmp/restore6 all done yes
-restore jobid=${backup_jobids[6]} where=$tmp/restore7 all done yes
-restore jobid=${backup_jobids[7]} where=$tmp/restore8 all done yes
-restore jobid=${backup_jobids[8]} where=$tmp/restore9 all done yes
-restore jobid=${backup_jobids[9]} where=$tmp/restore10 all done yes
-restore jobid=${backup_jobids[10]} where=$tmp/restore11 all done yes
-restore jobid=${backup_jobids[11]} where=$tmp/restore12 all done yes
 wait
 messages
 quit

--- a/systemtests/tests/passive/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/passive/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/restore/CMakeLists.txt
+++ b/systemtests/tests/restore/CMakeLists.txt
@@ -60,6 +60,11 @@ set_tests_properties(
              "system:restore:backup-job-fixture;system:restore-fixture"
 )
 set_tests_properties(
+  system:restore:multi
+  PROPERTIES FIXTURES_REQUIRED
+             "system:restore:backup-job-fixture;system:restore-fixture"
+)
+set_tests_properties(
   system:restore:restore-old-archive
   PROPERTIES FIXTURES_REQUIRED
              "system:restore:backup-job-fixture;system:restore-fixture"

--- a/systemtests/tests/restore/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/restore/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = xxh128
+      HardLinks = Yes
       fstype = ext2
       fstype = ext3
       fstype = ext4

--- a/systemtests/tests/restore/testrunner-check-hints
+++ b/systemtests/tests/restore/testrunner-check-hints
@@ -3,7 +3,7 @@ set -e
 set -o pipefail
 set -u
 #
-# Check wether hints are issued when trying to restore
+# Check whether hints are issued when trying to restore
 # backups, but none of the right type exist.
 # (i.e. an archive exists, but a non-archive is wanted.)
 #

--- a/systemtests/tests/restore/testrunner-multi
+++ b/systemtests/tests/restore/testrunner-multi
@@ -1,0 +1,94 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+#
+# Check whether multiple file=/dir= are handled
+# correctly during restore.
+#
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+#shellcheck source=functions
+. functions
+
+start_test
+
+long_dir_name="This-Is-A-Very-Long-Directory-Name-1111111111-2222222222-3333333333-44444444444-55555555555-66666666666-77777777777-8888888888-9999999999-0000000000"
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $log_home/setup.out
+setdebug level=100 storage=File
+status director
+status client
+status storage=File
+wait
+messages
+@$out $log_home/jobs.out
+list jobs
+@$out $log_home/multi-file.out
+restore client=bareos-fd fileset=SelfTest where=$tmp/multi-file/1 file=$tmp/data/weird-files/2 file=$tmp/data/weird-files/1 yes
+restore client=bareos-fd fileset=SelfTest where=$tmp/multi-file/2 file=$tmp/data/weird-files/1 yes
+restore client=bareos-fd fileset=SelfTest where=$tmp/multi-file/2 file=$tmp/data/weird-files/2 yes
+wait
+messages
+@$out $log_home/multi-dir.out
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/multi-dir/1 directory=$tmp/data/weird-files/ directory=$tmp/data/build/src/tests/ yes
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/multi-dir/2 directory=$tmp/data/build/src/tests/ yes
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/multi-dir/2 directory=$tmp/data/weird-files/ yes
+wait
+messages
+@$out $log_home/file-and-dir.out
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/files-and-dir/1 directory=$tmp/data/build/src/tests/ file=$tmp/data/weird-files/2 file=$tmp/data/weird-files/1 yes
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/files-and-dir/2 directory=$tmp/data/build/src/tests/ yes
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/files-and-dir/2 file=$tmp/data/weird-files/2 yes
+restore jobid=1 client=bareos-fd fileset=SelfTest where=$tmp/files-and-dir/2 file=$tmp/data/weird-files/1 yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+check_for_zombie_jobs storage=File
+
+check_preconditions
+
+
+check_log "$log_home/multi-file.out"
+check_log "$log_home/multi-dir.out"
+check_log "$log_home/file-and-dir.out"
+
+expect_not_grep "No database record found for:" \
+		"$log_home/multi-file.out" \
+		"Something was not restored in test 1"
+expect_not_grep "No database record found for:" \
+		"$log_home/multi-dir.out" \
+		"Something was not restored in test 2"
+expect_not_grep "No database record found for:" \
+		"$log_home/file-and-dir.out" \
+		"Something was not restored in test 3"
+
+if ! "$rscripts/diff.pl" -d "$tmp/multi-file/1" -s "$tmp/multi-file/2"; then
+    echo "Error: multi-file"
+    estat=1
+fi
+
+if ! "$rscripts/diff.pl" -d "$tmp/multi-dir/1" -s "$tmp/multi-dir/2"; then
+    echo "Error: multi-dir"
+    estat=1
+fi
+
+if ! "$rscripts/diff.pl" -d "$tmp/files-and-dir/1" -s "$tmp/files-and-dir/2"; then
+    echo "Error: files-and-dir"
+    estat=1
+fi
+
+end_test

--- a/systemtests/tests/scheduler/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/scheduler/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/sparse-file/etc/bareos/bareos-dir.d/fileset/FS_TESTJOB.conf.in
+++ b/systemtests/tests/sparse-file/etc/bareos/bareos-dir.d/fileset/FS_TESTJOB.conf.in
@@ -3,6 +3,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
       Sparse=yes
     }
     File = "<@tmpdir@/file-list"

--- a/systemtests/tests/spool/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/spool/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/tlsrestricted/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/tlsrestricted/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/virtualfull-basic/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/virtualfull-basic/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -4,6 +4,7 @@ FileSet {
   Include {
     Options {
       Signature = XXH128
+      HardLinks = Yes
     }
    #File = "@sbindir@"
     File=<@tmpdir@/file-list


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

restore does not parse its arguments correctly.  It only considers a single file=/directory= keyword and only considers jobid=/current/before= if they are specified before their respective command.

This PR changes the argument parsing such that first all keywords are looked at and then the found commands are executed.

It also contains a fix for bextract not setting up decompression buffers when compression is on but autoxflate is not.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
