### PR TITLE
dird: show current and allowed console connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: adapt matrix and pkglist for changes to CI [PR #1497]
 - bsmtp: make mailhost and port message info a debug message [PR #1509]
 - dird: cats: abort purge when there are no eligible jobids [PR #1513]
+- dird: show current and allowed console connections [PR #1517]
 
 ## [22.1.0] - 2023-06-13
 
@@ -553,4 +554,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1497]: https://github.com/bareos/bareos/pull/1497
 [PR #1509]: https://github.com/bareos/bareos/pull/1509
 [PR #1513]: https://github.com/bareos/bareos/pull/1513
+[PR #1517]: https://github.com/bareos/bareos/pull/1517
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -37,6 +37,7 @@ set(DIRD_OBJECTS_SRCS
     catreq.cc
     check_catalog.cc
     consolidate.cc
+    console_connection_lease.cc
     dbcheck_utils.cc
     dird_globals.cc
     dir_plugins.cc

--- a/core/src/dird/authenticate_console.cc
+++ b/core/src/dird/authenticate_console.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/authenticate_console.cc
+++ b/core/src/dird/authenticate_console.cc
@@ -36,6 +36,7 @@
 #include "lib/parse_conf.h"
 #include "lib/util.h"
 #include "include/version_numbers.h"
+#include "console_connection_lease.h"
 
 namespace directordaemon {
 
@@ -353,18 +354,6 @@ static void LogErrorMessage(std::string console_name, UaContext* ua)
         ua->UA_sock->port());
 }
 
-static uint32_t CurrentNumberOfConsoleConnections()
-{
-  JobControlRecord* jcr;
-  uint32_t cnt = 0;
-
-  foreach_jcr (jcr) {
-    if (jcr->is_JobType(JT_CONSOLE)) { cnt++; }
-  }
-  endeach_jcr(jcr);
-  return cnt;
-}
-
 static bool GetConsoleNameAndVersion(BareosSocket* ua_sock,
                                      std::string& name_out,
                                      BareosVersionNumber& version_out)
@@ -405,15 +394,7 @@ static ConsoleAuthenticator* CreateConsoleAuthenticator(UaContext* ua)
 
 bool AuthenticateConsole(UaContext* ua)
 {
-  uint32_t ConsoleConnections = CurrentNumberOfConsoleConnections();
-  if (ConsoleConnections >= me->MaxConsoleConnections) {
-    Emsg0(M_ERROR, 0,
-          _("Number of console connections exceeded "
-            "Maximum :%u, Current: %u\n"),
-          me->MaxConsoleConnections, ConsoleConnections);
-    return false;
-  }
-
+  auto num_leases = ConsoleConnectionLease::get_num_leases();
   std::unique_ptr<ConsoleAuthenticator> console_authenticator(
       CreateConsoleAuthenticator(ua));
   if (!console_authenticator) { return false; }
@@ -424,7 +405,21 @@ bool AuthenticateConsole(UaContext* ua)
       LogErrorMessage(console_authenticator->console_name_, ua);
       return false;
     }
+    if (num_leases > me->MaxConsoleConnections) {
+      Emsg0(M_INFO, 0,
+            _("Number of console connections exceeded\n"
+              "Maximum: %u, Current: %zu\n"),
+            me->MaxConsoleConnections, num_leases);
+    }
   } else {
+    if (num_leases > me->MaxConsoleConnections) {
+      Emsg0(M_ERROR, 0,
+            _("Number of console connections exceeded "
+              "Maximum :%u, Current: %zu\n"),
+            me->MaxConsoleConnections, num_leases);
+      return false;
+    }
+
     console_authenticator->AuthenticateNamedConsole();
     if (!console_authenticator->auth_success_) {
       LogErrorMessage(console_authenticator->console_name_, ua);

--- a/core/src/dird/authenticate_console.cc
+++ b/core/src/dird/authenticate_console.cc
@@ -353,17 +353,16 @@ static void LogErrorMessage(std::string console_name, UaContext* ua)
         ua->UA_sock->port());
 }
 
-static bool NumberOfConsoleConnectionsExceeded()
+static uint32_t CurrentNumberOfConsoleConnections()
 {
   JobControlRecord* jcr;
-  unsigned int cnt = 0;
+  uint32_t cnt = 0;
 
   foreach_jcr (jcr) {
     if (jcr->is_JobType(JT_CONSOLE)) { cnt++; }
   }
   endeach_jcr(jcr);
-
-  return (cnt >= me->MaxConsoleConnections) ? true : false;
+  return cnt;
 }
 
 static bool GetConsoleNameAndVersion(BareosSocket* ua_sock,
@@ -406,10 +405,12 @@ static ConsoleAuthenticator* CreateConsoleAuthenticator(UaContext* ua)
 
 bool AuthenticateConsole(UaContext* ua)
 {
-  if (NumberOfConsoleConnectionsExceeded()) {
+  uint32_t ConsoleConnections = CurrentNumberOfConsoleConnections();
+  if (ConsoleConnections >= me->MaxConsoleConnections) {
     Emsg0(M_ERROR, 0,
           _("Number of console connections exceeded "
-            "MaximumConsoleConnections\n"));
+            "Maximum :%u, Current: %u\n"),
+          me->MaxConsoleConnections, ConsoleConnections);
     return false;
   }
 

--- a/core/src/dird/console_connection_lease.cc
+++ b/core/src/dird/console_connection_lease.cc
@@ -1,0 +1,23 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#include "console_connection_lease.h"
+
+std::atomic<std::size_t> ConsoleConnectionLease::num_leases{0};

--- a/core/src/dird/console_connection_lease.h
+++ b/core/src/dird/console_connection_lease.h
@@ -1,0 +1,35 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_DIRD_CONSOLE_CONNECTION_LEASE_H_
+#define BAREOS_DIRD_CONSOLE_CONNECTION_LEASE_H_
+
+#include <atomic>
+
+class ConsoleConnectionLease {
+  static std::atomic<std::size_t> num_leases;
+
+ public:
+  ConsoleConnectionLease() { num_leases++; }
+  ~ConsoleConnectionLease() { num_leases--; }
+  static std::size_t get_num_leases() { return num_leases; }
+};
+#endif  // BAREOS_DIRD_CONSOLE_CONNECTION_LEASE_H_

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,7 +43,7 @@
 #include "lib/parse_conf.h"
 #include "lib/thread_specific_data.h"
 #include "dird/jcr_util.h"
-
+#include "console_connection_lease.h"
 
 namespace directordaemon {
 
@@ -90,6 +90,7 @@ void* HandleUserAgentClientRequest(BareosSocket* user_agent_socket)
   ua->UA_sock = user_agent_socket;
   SetJcrInThreadSpecificData(nullptr);
 
+  ConsoleConnectionLease lease;  // obtain lease to count connections
   bool success = AuthenticateConsole(ua);
 
   if (!success) { ua->quit = true; }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

**Backport of PR #1487 to bareos-22** (remove this line if this is no backport; for backport use cherry-pick -x)

When the allowed number of console connectinos was exceeded, before only the fact that it is exceeded was logged without numbers.

Now both the allowed maximum and the current value are printed.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
