### PR TITLE
backport fixes fastlz: remove unaligned memory accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bsmtp: make mailhost and port message info a debug message [PR #1509]
 - dird: cats: abort purge when there are no eligible jobids [PR #1513]
 - dird: show current and allowed console connections [PR #1517]
+- backport fixes fastlz: remove unaligned memory accesses [PR #1519]
 
 ### Fixed
 - stored: fix incoherent meta data when concurrently writing to the same volume [PR #1514]
@@ -559,4 +560,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1513]: https://github.com/bareos/bareos/pull/1513
 [PR #1514]: https://github.com/bareos/bareos/pull/1514
 [PR #1517]: https://github.com/bareos/bareos/pull/1517
+[PR #1519]: https://github.com/bareos/bareos/pull/1519
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/fastlz/src/lz4.c
+++ b/core/src/fastlz/src/lz4.c
@@ -44,51 +44,6 @@
 #define HEAPMODE 0
 
 /*
- * CPU_HAS_EFFICIENT_UNALIGNED_MEMORY_ACCESS :
- * By default, the source code expects the compiler to correctly optimize
- * 4-bytes and 8-bytes read on architectures able to handle it efficiently.
- * This is not always the case. In some circumstances (ARM notably),
- * the compiler will issue cautious code even when target is able to correctly handle unaligned memory accesses.
- *
- * You can force the compiler to use unaligned memory access by uncommenting the line below.
- * One of the below scenarios will happen :
- * 1 - Your target CPU correctly handle unaligned access, and was not well optimized by compiler (good case).
- *     You will witness large performance improvements (+50% and up).
- *     Keep the line uncommented and send a word to upstream (https://groups.google.com/forum/#!forum/lz4c)
- *     The goal is to automatically detect such situations by adding your target CPU within an exception list.
- * 2 - Your target CPU correctly handle unaligned access, and was already already optimized by compiler
- *     No change will be experienced.
- * 3 - Your target CPU inefficiently handle unaligned access.
- *     You will experience a performance loss. Comment back the line.
- * 4 - Your target CPU does not handle unaligned access.
- *     Program will crash.
- * If uncommenting results in better performance (case 1)
- * please report your configuration to upstream (https://groups.google.com/forum/#!forum/lz4c)
- * This way, an automatic detection macro can be added to match your case within later versions of the library.
- */
-/* #define CPU_HAS_EFFICIENT_UNALIGNED_MEMORY_ACCESS 1 */
-
-
-/**************************************
-   CPU Feature Detection
-**************************************/
-/*
- * Automated efficient unaligned memory access detection
- * Based on known hardware architectures
- * This list will be updated thanks to feedbacks
- */
-#if defined(CPU_HAS_EFFICIENT_UNALIGNED_MEMORY_ACCESS) \
-    || defined(__ARM_FEATURE_UNALIGNED) \
-    || defined(__i386__) || defined(__x86_64__) \
-    || defined(_M_IX86) || defined(_M_X64) \
-    || defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_8__) \
-    || (defined(_M_ARM) && (_M_ARM >= 7))
-#  define LZ4_UNALIGNED_ACCESS 1
-#else
-#  define LZ4_UNALIGNED_ACCESS 0
-#endif
-
-/*
  * LZ4_FORCE_SW_BITCOUNT
  * Define this parameter if your target system or compiler does not support hardware bit count
  */
@@ -186,65 +141,37 @@ static unsigned LZ4_isLittleEndian(void)
 
 static U16 LZ4_readLE16(const void* memPtr)
 {
-    if ((LZ4_UNALIGNED_ACCESS) && (LZ4_isLittleEndian()))
-        return *(U16*)memPtr;
-    else
-    {
-        const BYTE* p = (const BYTE*)memPtr;
-        return (U16)((U16)p[0] + (p[1]<<8));
-    }
+    const BYTE* p = (const BYTE*)memPtr;
+    return (U16)((U16)p[0] + (p[1]<<8));
 }
 
 static void LZ4_writeLE16(void* memPtr, U16 value)
 {
-    if ((LZ4_UNALIGNED_ACCESS) && (LZ4_isLittleEndian()))
-    {
-        *(U16*)memPtr = value;
-        return;
-    }
-    else
-    {
-        BYTE* p = (BYTE*)memPtr;
-        p[0] = (BYTE) value;
-        p[1] = (BYTE)(value>>8);
-    }
+    BYTE* p = (BYTE*)memPtr;
+    p[0] = (BYTE) value;
+    p[1] = (BYTE)(value>>8);
 }
 
 
 static U16 LZ4_read16(const void* memPtr)
 {
-    if (LZ4_UNALIGNED_ACCESS)
-        return *(U16*)memPtr;
-    else
-    {
-        U16 val16;
-        memcpy(&val16, memPtr, 2);
-        return val16;
-    }
+    U16 val16;
+    memcpy(&val16, memPtr, 2);
+    return val16;
 }
 
 static U32 LZ4_read32(const void* memPtr)
 {
-    if (LZ4_UNALIGNED_ACCESS)
-        return *(U32*)memPtr;
-    else
-    {
-        U32 val32;
-        memcpy(&val32, memPtr, 4);
-        return val32;
-    }
+    U32 val32;
+    memcpy(&val32, memPtr, 4);
+    return val32;
 }
 
 static U64 LZ4_read64(const void* memPtr)
 {
-    if (LZ4_UNALIGNED_ACCESS)
-        return *(U64*)memPtr;
-    else
-    {
-        U64 val64;
-        memcpy(&val64, memPtr, 8);
-        return val64;
-    }
+    U64 val64;
+    memcpy(&val64, memPtr, 8);
+    return val64;
 }
 
 static size_t LZ4_read_ARCH(const void* p)
@@ -255,30 +182,13 @@ static size_t LZ4_read_ARCH(const void* p)
         return (size_t)LZ4_read32(p);
 }
 
-
 static void LZ4_copy4(void* dstPtr, const void* srcPtr)
 {
-    if (LZ4_UNALIGNED_ACCESS)
-    {
-        *(U32*)dstPtr = *(U32*)srcPtr;
-        return;
-    }
     memcpy(dstPtr, srcPtr, 4);
 }
 
 static void LZ4_copy8(void* dstPtr, const void* srcPtr)
 {
-#if GCC_VERSION!=409  /* disabled on GCC 4.9, as it generates invalid opcode (crash) */
-    if (LZ4_UNALIGNED_ACCESS)
-    {
-        if (LZ4_64bits())
-            *(U64*)dstPtr = *(U64*)srcPtr;
-        else
-            ((U32*)dstPtr)[0] = ((U32*)srcPtr)[0],
-            ((U32*)dstPtr)[1] = ((U32*)srcPtr)[1];
-        return;
-    }
-#endif
     memcpy(dstPtr, srcPtr, 8);
 }
 

--- a/core/src/lib/compression.cc
+++ b/core/src/lib/compression.cc
@@ -836,6 +836,7 @@ void CleanupCompression(JobControlRecord* jcr)
 #endif
 
   if (jcr->compress.workset.pZFAST) {
+    fastlzlibCompressEnd((zfast_stream*)jcr->compress.workset.pZFAST);
     free(jcr->compress.workset.pZFAST);
     jcr->compress.workset.pZFAST = NULL;
   }

--- a/core/src/lib/compression.cc
+++ b/core/src/lib/compression.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -126,8 +126,7 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
     case COMPRESS_GZIP: {
       z_stream* pZlibStream;
 
-      /**
-       * Use compressBound() to get an idea what zlib thinks
+      /* Use compressBound() to get an idea what zlib thinks
        * what the upper limit is of what it needs to compress
        * a buffer of x bytes. To that we add 18 bytes and the size
        * of an compression header.
@@ -138,8 +137,7 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
        *
        * The zlib compression workset is initialized here to minimize
        * the "per file" load. The jcr member is only set, if the init
-       * was successful.
-       */
+       * was successful. */
       wanted_compress_buf_size
           = compressBound(jcr->buf_size) + 18 + (int)sizeof(comp_stream_header);
       if (wanted_compress_buf_size > *compress_buf_size) {
@@ -170,15 +168,13 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
     case COMPRESS_LZO1X: {
       lzo_voidp pLzoMem;
 
-      /**
-       * For LZO1X compression the recommended value is:
+      /* For LZO1X compression the recommended value is:
        *    output_block_size = input_block_size + (input_block_size / 16) + 64
        * + 3 + sizeof(comp_stream_header)
        *
        * The LZO compression workset is initialized here to minimize
        * the "per file" load. The jcr member is only set, if the init
-       * was successful.
-       */
+       * was successful. */
       wanted_compress_buf_size = jcr->buf_size + (jcr->buf_size / 16) + 64 + 3
                                  + (int)sizeof(comp_stream_header);
       if (wanted_compress_buf_size > *compress_buf_size) {
@@ -218,15 +214,13 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
         level = Z_BEST_SPEED;
       }
 
-      /*
-       * For FASTLZ compression the recommended value is:
+      /* For FASTLZ compression the recommended value is:
        *    output_block_size = input_block_size + (input_block_size / 10 + 16 *
        * 2) + sizeof(comp_stream_header)
        *
        * The FASTLZ compression workset is initialized here to minimize
        * the "per file" load. The jcr member is only set, if the init
-       * was successful.
-       */
+       * was successful. */
       wanted_compress_buf_size = jcr->buf_size + (jcr->buf_size / 10 + 16 * 2)
                                  + (int)sizeof(comp_stream_header);
       if (wanted_compress_buf_size > *compress_buf_size) {
@@ -458,11 +452,9 @@ static bool decompress_with_zlib(JobControlRecord* jcr,
   char* wbuf;
   int status, real_compress_len;
 
-  /*
-   * NOTE! We only use uLong and Byte because they are
+  /* NOTE! We only use uLong and Byte because they are
    * needed by the zlib routines, they should not otherwise
-   * be used in Bareos.
-   */
+   * be used in Bareos. */
   if (sparse && want_data_stream) {
     wbuf = jcr->compress.inflate_buffer + OFFSET_FADDR_SIZE;
     compress_len = jcr->compress.inflate_buffer_size - OFFSET_FADDR_SIZE;
@@ -509,10 +501,8 @@ static bool decompress_with_zlib(JobControlRecord* jcr,
     return false;
   }
 
-  /*
-   * We return a decompressed data stream with the fileoffset encoded when this
-   * was a sparse stream.
-   */
+  /* We return a decompressed data stream with the fileoffset encoded when this
+   * was a sparse stream. */
   if (sparse && want_data_stream) {
     memcpy(jcr->compress.inflate_buffer, *data, OFFSET_FADDR_SIZE);
   }
@@ -579,10 +569,8 @@ static bool decompress_with_lzo(JobControlRecord* jcr,
     return false;
   }
 
-  /*
-   * We return a decompressed data stream with the fileoffset encoded when this
-   * was a sparse stream.
-   */
+  /* We return a decompressed data stream with the fileoffset encoded when this
+   * was a sparse stream. */
   if (sparse && want_data_stream) {
     memcpy(jcr->compress.inflate_buffer, *data, OFFSET_FADDR_SIZE);
   }
@@ -617,11 +605,9 @@ static bool decompress_with_fastlz(JobControlRecord* jcr,
       break;
   }
 
-  /*
-   * NOTE! We only use uInt and Bytef because they are
+  /* NOTE! We only use uInt and Bytef because they are
    * needed by the fastlz routines, they should not otherwise
-   * be used in Bareos.
-   */
+   * be used in Bareos. */
   memset(&stream, 0, sizeof(stream));
   stream.next_in = (Bytef*)*data + sizeof(comp_stream_header);
   stream.avail_in = (uInt)*length - sizeof(comp_stream_header);
@@ -671,10 +657,8 @@ static bool decompress_with_fastlz(JobControlRecord* jcr,
     break;
   }
 
-  /*
-   * We return a decompressed data stream with the fileoffset encoded when this
-   * was a sparse stream.
-   */
+  /* We return a decompressed data stream with the fileoffset encoded when this
+   * was a sparse stream. */
   if (sparse && want_data_stream) {
     memcpy(jcr->compress.inflate_buffer, *data, OFFSET_FADDR_SIZE);
   }
@@ -742,10 +726,8 @@ bool DecompressData(JobControlRecord* jcr,
         return false;
       }
 
-      /*
-       * Based on the compression used perform the actual decompression of the
-       * data.
-       */
+      /* Based on the compression used perform the actual decompression of the
+       * data. */
       switch (comp_magic) {
 #ifdef HAVE_LIBZ
         case COMPRESS_GZIP:

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -11,5 +11,4 @@ Device {
   Auto Inflate = both
   Auto Deflate = both
   Auto Deflate Algorithm = gzip
-
 }

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage2.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/device/FileStorage2.conf
@@ -10,6 +10,5 @@ Device {
   Description = "File device. A connecting Director must have the same Name and MediaType."
   Auto Inflate = both
   Auto Deflate = both
-  Auto Deflate Algorithm = gzip
-
+  Auto Deflate Algorithm = lz4
 }

--- a/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
+++ b/systemtests/tests/parallel-jobs/testrunner-parallel-jobs
@@ -18,6 +18,7 @@ export TestName
 start_test
 
 backupjob="slow-backup-big-volume"
+startlog="$tmp/start.out"
 parallelbackuplog="$tmp/backup-parallel-jobs.out"
 parallelrestorelog="$tmp/restore-parallel-jobs.out"
 
@@ -25,15 +26,13 @@ rm -f $parallelbackuplog
 rm -f $parallelrestorelog
 
 cat <<END_OF_DATA >"$tmp/bconcmds"
-@$out /dev/null
+@$out $startlog
+status director
+status client
+status storage=File
+list jobs
 messages
 @$out $parallelbackuplog
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
-run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
 run job=${backupjob} level=Full yes
@@ -61,12 +60,6 @@ restore jobid=${backup_jobids[2]} where=$tmp/restore3 all done yes
 restore jobid=${backup_jobids[3]} where=$tmp/restore4 all done yes
 restore jobid=${backup_jobids[4]} where=$tmp/restore5 all done yes
 restore jobid=${backup_jobids[5]} where=$tmp/restore6 all done yes
-restore jobid=${backup_jobids[6]} where=$tmp/restore7 all done yes
-restore jobid=${backup_jobids[7]} where=$tmp/restore8 all done yes
-restore jobid=${backup_jobids[8]} where=$tmp/restore9 all done yes
-restore jobid=${backup_jobids[9]} where=$tmp/restore10 all done yes
-restore jobid=${backup_jobids[10]} where=$tmp/restore11 all done yes
-restore jobid=${backup_jobids[11]} where=$tmp/restore12 all done yes
 wait
 messages
 quit


### PR DESCRIPTION
** Backport of PR #1508 to bareos-22** 

While we develop new feature and default in #1508 we detect trouble in lz4 lib.


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [-] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
