### PR TITLE
build: switch from FreeBSD 13.1 to 13.2

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -90,7 +90,7 @@ OS:
       TYPE: freebsd
       ARCH:
         - amd64
-    "13.1":
+    "13.2":
       TYPE: freebsd
       ARCH:
         - amd64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - improve default configuration [PR #1508]
 - stored: add AccessMode SD->Device directive to reserve devices exclusively for reading or writing [PR #1464]
 - plugins: switch python-ldap plugin to  python3 [PR #1522]
+- build: switch from FreeBSD 13.1 to 13.2 [PR #1524]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -226,4 +227,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1511]: https://github.com/bareos/bareos/pull/1511
 [PR #1512]: https://github.com/bareos/bareos/pull/1512
 [PR #1522]: https://github.com/bareos/bareos/pull/1522
+[PR #1524]: https://github.com/bareos/bareos/pull/1524
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/tests/bconsole-basic/testrunner-autocompletion
+++ b/systemtests/tests/bconsole-basic/testrunner-autocompletion
@@ -15,9 +15,9 @@ export TestName
 . "${rscripts}"/functions
 
 case "$(uname)" in
-  FreeBSD)
-    script_opts=("$tmp/log3.out" bin/bconsole)
-    ;;
+#  FreeBSD)
+#    script_opts=("$tmp/log3.out" bin/bconsole)
+#    ;;
   Linux)
     script_opts=(--return --command bin/bconsole "$tmp/log3.out")
     ;;


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

As FreeBSD 13.1 is EOL since 31 Jul 2023, this PR switches to build for 13.2.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
