### PR TITLE
VMware Plugin: Fix transformer issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - status storage: fix wrong data displayed about waiting jobs [PR #1476]
 - stored: fix incoherent meta data when concurrently writing to the same volume [PR #1495]
 - dird: fix expected file count error during bsr build  [PR #1511]
+- VMware Plugin: Fix transformer issues [PR #1532]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -241,5 +242,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1522]: https://github.com/bareos/bareos/pull/1522
 [PR #1524]: https://github.com/bareos/bareos/pull/1524
 [PR #1531]: https://github.com/bareos/bareos/pull/1531
+[PR #1532]: https://github.com/bareos/bareos/pull/1532
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -2958,7 +2958,9 @@ class BareosVmConfigInfoToSpec(object):
             "numCoresPerSocket"
         ]
         config_spec.numCPUs = self.config_info["hardware"]["numCPU"]
-        config_spec.pmem = self._transform_pmem()
+        # Since vSphere API 7.0.3.0:
+        if hasattr(config_spec, "pmem"):
+            config_spec.pmem = self._transform_pmem()
         config_spec.pmemFailoverEnabled = self.config_info["pmemFailoverEnabled"]
         config_spec.powerOpInfo = self._transform_defaultPowerOps()
         # Since vSphere API 7.0.1.0:
@@ -2982,9 +2984,12 @@ class BareosVmConfigInfoToSpec(object):
         config_spec.virtualSMCPresent = self.config_info["hardware"][
             "virtualSMCPresent"
         ]
-        config_spec.vmOpNotificationToAppEnabled = self.config_info[
-            "vmOpNotificationToAppEnabled"
-        ]
+        # Since vSphere API 7.0.3.0:
+        if hasattr(config_spec, "vmOpNotificationToAppEnabled"):
+            if "vmOpNotificationToAppEnabled" in self.config_info:
+                config_spec.vmOpNotificationToAppEnabled = self.config_info[
+                    "vmOpNotificationToAppEnabled"
+                ]
 
         return config_spec
 
@@ -3743,7 +3748,10 @@ class BareosVmConfigInfoToSpec(object):
         return managed_by
 
     def _transform_pmem(self):
-        if self.config_info["pmem"] is None:
+        if (
+            self.config_info.get("pmem") is None
+            or self.config_info["pmem"].get("snapshotMode") is None
+        ):
             return None
 
         pmem = vim.vm.VirtualPMem()

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -3339,14 +3339,7 @@ class BareosVmConfigInfoToSpec(object):
             return None
 
         add_device.connectable = self._transform_connectable(device)
-
-        # Looks like negative values must not be used for default devices,
-        # the second VirtualIDEController seems to have key 201, that always seems to be the case.
-        # Same for VirtualCdrom, getting error "The device '1' is referring to a nonexisting controller '-200'."
-        add_device.controllerKey = device["controllerKey"]
-        if device["controllerKey"] not in [200, 201]:
-            add_device.controllerKey = device["controllerKey"] * -1
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
 
         return add_device
 
@@ -3374,13 +3367,7 @@ class BareosVmConfigInfoToSpec(object):
             return None
 
         add_device.connectable = self._transform_connectable(device)
-
-        # Looks like negative values must not be used for default devices,
-        # the VirtualSIOController seems to have key 400, that seems to be always the case.
-        add_device.controllerKey = device["controllerKey"]
-        if device["controllerKey"] not in [400]:
-            add_device.controllerKey = device["controllerKey"] * -1
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
 
         return add_device
 
@@ -3408,13 +3395,7 @@ class BareosVmConfigInfoToSpec(object):
         if device["connectable"]:
             add_device.connectable = self._transform_connectable(device)
 
-        # Looks like negative values must not be used for default devices,
-        # the VirtualPCIController always seems to have key 100.
-        add_device.controllerKey = device["controllerKey"]
-        if device["controllerKey"] != 100:
-            add_device.controllerKey = device["controllerKey"] * -1
-
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
 
         return add_device
 
@@ -3438,13 +3419,7 @@ class BareosVmConfigInfoToSpec(object):
         if device["connectable"]:
             add_device.connectable = self._transform_connectable(device)
 
-        # Looks like negative values must not be used for default devices,
-        # the VirtualPCIController always seems to have key 100.
-        add_device.controllerKey = device["controllerKey"]
-        if device["controllerKey"] != 100:
-            add_device.controllerKey = device["controllerKey"] * -1
-
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
 
         return add_device
 
@@ -3533,8 +3508,7 @@ class BareosVmConfigInfoToSpec(object):
             "reservation"
         ]
 
-        add_device.controllerKey = device["controllerKey"] * -1
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
         add_device.capacityInBytes = device["capacityInBytes"]
 
         return add_device
@@ -3609,12 +3583,7 @@ class BareosVmConfigInfoToSpec(object):
 
         add_device.key = device["key"] * -1
         add_device.connectable = self._transform_connectable(device)
-        # Looks like negative values must not be used for default devices,
-        # the VirtualPCIController always seems to have key 100.
-        add_device.controllerKey = device["controllerKey"]
-        if device["controllerKey"] != 100:
-            add_device.controllerKey = device["controllerKey"] * -1
-        add_device.unitNumber = device["unitNumber"]
+        self._transform_controllerkey_and_unitnumber(add_device, device)
         # Note: MAC address preservation is not safe with addressType "manual", the
         # server does not check for conflicts. The calling code should check for
         # MAC address conflicts before and set addressType to "generated" or "assigned"
@@ -3917,6 +3886,22 @@ class BareosVmConfigInfoToSpec(object):
             spec_vcpu_configs.append(spec_vcpu_config)
 
         return spec_vcpu_configs
+
+    def _transform_controllerkey_and_unitnumber(self, add_device, device):
+        # Looks like negative values must not be used for default devices,
+        # the second VirtualIDEController seems to have key 201, that always seems to be the case.
+        # Same for VirtualCdrom, getting error "The device '1' is referring to a nonexisting controller '-200'."
+        # Looks like negative values must not be used for default devices,
+        # the VirtualSIOController seems to have key 400, that seems to be always the case.
+        # Looks like negative values must not be used for default devices,
+        # the VirtualPCIController always seems to have key 100.
+        default_devices_controller_keys = [100, 200, 201, 400]
+        add_device.controllerKey = device["controllerKey"]
+        if device["controllerKey"] not in default_devices_controller_keys:
+            add_device.controllerKey = device["controllerKey"] * -1
+        add_device.unitNumber = device["unitNumber"]
+
+        return
 
 
 # vim: tabstop=4 shiftwidth=4 softtabstop=4 expandtab

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -127,7 +127,7 @@ class BareosFdPluginVMware(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         self.vadp = BareosVADPWrapper()
         self.vadp.plugin = self
         self.vm_config_info_saved = False
-        self.current_object_index = -1
+        self.current_object_index = int(time.time())
 
     def parse_plugin_definition(self, plugindef):
         """

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -335,7 +335,7 @@ As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently
 
 .. note::
 
-The options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components.
+   The options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components.
 
 With :command:`--listall` all VMs in the given datacenter are reported in a tabular output including instance UUID and containing Folder/vApp name.
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -304,7 +304,8 @@ As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently
    usage: vmware_cbt_tool.py [-h] -s HOST [-o PORT] -u USER [-p PASSWORD] -d
                              DATACENTER [-f FOLDER] [-v VMNAME]
                              [--vm-uuid VM_UUID] [--enablecbt] [--disablecbt]
-                             [--resetcbt] [--info] [--listall]
+                             [--resetcbt] [--info] [--listall] [--sslverify]
+                             [--dumpvmconfig]
 
    Process args for enabling/disabling/resetting CBT
 
@@ -329,9 +330,18 @@ As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently
                            disabled)
      --listall             List all VMs in the given datacenter with UUID and
                            containing folder
+     --sslverify           Force SSL certificate verification
+     --dumpvmconfig        Dump VM config metadata to JSON file
 
-Note: the options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components. With :command:`--listall` all VMs in the given datacenter are reported
-in a tabular output including instance UUID and containing Folder/vApp name.
+Note: the options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components.
+With :command:`--listall` all VMs in the given datacenter are reported in a tabular output including instance UUID and containing Folder/vApp name.
+
+Without the option :command:`--sslverify` also self-signed SSL certificates will
+be accepted, but a warning message will be emitted in this case.
+
+The option :command:`--dumpvmconfig` is helpful to debug issues with the transformation
+of VM config metadata for recreating virtual machines.
+The JSON file will be written to the current working directory when this option is used.
 
 For the above configuration example, the command to enable CBT would be
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -333,7 +333,10 @@ As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently
      --sslverify           Force SSL certificate verification
      --dumpvmconfig        Dump VM config metadata to JSON file
 
-Note: the options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components.
+.. note::
+
+The options :command:`--vm-uuid` and :command:`--listall` have been added in version :sinceVersion:`17.2.8: VMware Plugin: new options in vmware\_cbt\_tool.py`, the tool is also able now to process non-ascii character arguments for the :command:`--folder` and :command:`--vmname` arguments and vApp names can be used like folder name components.
+
 With :command:`--listall` all VMs in the given datacenter are reported in a tabular output including instance UUID and containing Folder/vApp name.
 
 Without the option :command:`--sslverify` also self-signed SSL certificates will


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR fixes multiple issue with the transformation of VM config data for recreation of VMs on restore.

Additionally, the vmware_cbt_tool.py can now dump the virtual machine config metadata to a JSON file, this can be helpful to debug this type of issue.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

