### PR TITLE
jcr: remove `last rate` and `last bytes`

### DIFF
--- a/core/src/dird/dir_plugins.cc
+++ b/core/src/dird/dir_plugins.cc
@@ -690,11 +690,6 @@ static bRC bareosGetValue(PluginContext* ctx, brDirVariable var, void* value)
         Dmsg1(debuglevel, "dir-plugin: return bDirVarSDJobStatus=%c\n",
               jcr->dir_impl->SDJobStatus.load());
         break;
-      case bDirVarLastRate:
-        *((int*)value) = jcr->LastRate;
-        Dmsg1(debuglevel, "dir-plugin: return bDirVarLastRate=%d\n",
-              jcr->LastRate);
-        break;
       case bDirVarJobBytes:
         *((uint64_t*)value) = jcr->JobBytes;
         Dmsg1(debuglevel, "dir-plugin: return bDirVarJobBytes=%u\n",

--- a/core/src/dird/dir_plugins.h
+++ b/core/src/dird/dir_plugins.h
@@ -80,9 +80,8 @@ typedef enum
   bDirVarFDJobStatus = 22,
   bDirVarSDJobStatus = 23,
   bDirVarPluginDir = 24,
-  bDirVarLastRate = 25,
-  bDirVarJobBytes = 26,
-  bDirVarReadBytes = 27
+  bDirVarJobBytes = 25,
+  bDirVarReadBytes = 26,
 } brDirVariable;
 
 // Bareos Variable Ids (Write)

--- a/core/src/include/jcr.h
+++ b/core/src/include/jcr.h
@@ -138,7 +138,6 @@ class JobControlRecord {
   void MyThreadSendSignal(int sig);              /**< in lib/jcr.c */
   void SetKillable(bool killable);               /**< in lib/jcr.c */
   bool IsKillable() const { return my_thread_killable_; }
-  void UpdateJobStats();
 
   dlink<JobControlRecord> link;                     /**< JobControlRecord chain link */
   pthread_t my_thread_id{};       /**< Id of thread controlling jcr */
@@ -160,10 +159,7 @@ class JobControlRecord {
   uint32_t JobFiles{};          /**< Number of files written, this job */
   uint32_t JobErrors{};         /**< Number of non-fatal errors this job */
   uint32_t JobWarnings{};       /**< Number of warning messages */
-  uint32_t AverageRate{};       /**< Last average bytes/sec */
-  uint32_t LastRate{};            /**< Last sample bytes/sec */
   uint64_t JobBytes{};          /**< Number of bytes processed this job */
-  uint64_t LastJobBytes{};      /**< Last sample number bytes */
   uint64_t ReadBytes{};         /**< Bytes read -- before compression */
   FileId_t FileId{};            /**< Last FileId used */
   int32_t JobPriority{};        /**< Job priority */
@@ -171,7 +167,6 @@ class JobControlRecord {
   time_t initial_sched_time{};  /**< Original sched time before any reschedules are done */
   time_t start_time{};          /**< When job actually started */
   time_t run_time{};            /**< Used for computing speed */
-  time_t last_time{};           /**< Last sample time */
   time_t end_time{};            /**< Job end time */
   time_t wait_time_sum{};       /**< Cumulative wait time since job start */
   time_t wait_time{};           /**< Timestamp when job have started to wait */

--- a/core/src/lib/jcr.cc
+++ b/core/src/lib/jcr.cc
@@ -841,23 +841,6 @@ void JcrWalkEnd(JobControlRecord* jcr)
   }
 }
 
-
-void JobControlRecord::UpdateJobStats()
-{
-  time_t now = time(nullptr);
-  int sec;
-
-  if (last_time == 0) { last_time = run_time; }
-  sec = now - last_time;
-  if (sec <= 0) { sec = 1; }
-  LastRate = (JobBytes - LastJobBytes) / sec;
-  time_t totalruntime = now - run_time;
-  if (totalruntime <= 0) { totalruntime = 1; }
-  AverageRate = JobBytes / totalruntime;
-  LastJobBytes = JobBytes;
-  last_time = now;
-}
-
 // Return number of Jobs
 int JobCount()
 {

--- a/core/src/plugins/dird/python/module/bareosdir.cc
+++ b/core/src/plugins/dird/python/module/bareosdir.cc
@@ -223,7 +223,6 @@ static PyObject* PyBareosGetValue(PyObject*, PyObject* args)
     case bDirVarSDErrors:
     case bDirVarJobFiles:
     case bDirVarSDJobFiles:
-    case bDirVarLastRate:
     case bDirVarJobBytes:
     case bDirVarReadBytes: {
       uint64_t value = 0;

--- a/core/src/plugins/dird/python/module/bareosdir.h
+++ b/core/src/plugins/dird/python/module/bareosdir.h
@@ -140,9 +140,8 @@ MOD_INIT(bareosdir)
   ConstSet_StrLong(pDictbDirVariable, bDirVarFDJobStatus, 22);
   ConstSet_StrLong(pDictbDirVariable, bDirVarSDJobStatus, 23);
   ConstSet_StrLong(pDictbDirVariable, bDirVarPluginDir, 24);
-  ConstSet_StrLong(pDictbDirVariable, bDirVarLastRate, 25);
-  ConstSet_StrLong(pDictbDirVariable, bDirVarJobBytes, 26);
-  ConstSet_StrLong(pDictbDirVariable, bDirVarReadBytes, 27);
+  ConstSet_StrLong(pDictbDirVariable, bDirVarJobBytes, 25);
+  ConstSet_StrLong(pDictbDirVariable, bDirVarReadBytes, 26);
   if (PyModule_AddObject(m, bDirVariable, pDictbDirVariable)) {
     return MOD_ERROR_VAL;
   }


### PR DESCRIPTION
#### Description

`last rate` and `last bytes` are calculated since the last time we run the `status` command. They give the rate and bytes that happened in between `status` command calls, which is not generally very useful information.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
