### PR TITLE
build: adapt to FreeBSD 13.2

### DIFF
--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -72,7 +72,6 @@ CPPFLAGS+=      -I${LOCALBASE}/include
 
 LIB_DEPENDS+=	liblzo2.so:archivers/lzo2 \
 		          libjansson.so:devel/jansson
-LIB_DEPENDS+= libpython3.7m.so:lang/python37
 
 # optional overrides, used by build system.
 .-include "BareosCommonMakefile-overrides.mk"

--- a/core/src/dird/vbackup.cc
+++ b/core/src/dird/vbackup.cc
@@ -77,7 +77,7 @@ class JobConsistencyChecker {
   std::vector<std::string> JobList;
   std::vector<std::string> JobsWithPurgedFiles;
 
-  bool operator()(int num_fields, char** row)
+  bool operator()([[maybe_unused]] int num_fields, char** row)
   {
     assert(num_fields == 5);
     JobList.push_back(row[col_JobId]);

--- a/core/src/fastlz/CMakeLists.txt
+++ b/core/src/fastlz/CMakeLists.txt
@@ -34,3 +34,5 @@ set_target_properties(
   bareosfastlz PROPERTIES VERSION "${BAREOS_NUMERIC_VERSION}"
                           SOVERSION "${BAREOS_VERSION_MAJOR}"
 )
+
+bareos_disable_warnings(TARGET bareosfastlz WARNINGS -Wunused-parameter C_ONLY)

--- a/core/src/lmdb/CMakeLists.txt
+++ b/core/src/lmdb/CMakeLists.txt
@@ -25,7 +25,7 @@ if(HAVE_FREEBSD_OS)
 endif()
 
 add_library(bareoslmdb SHARED mdb.c midl.c)
-bareos_disable_warnings(TARGET bareoslmdb WARNINGS -Wunused-parameter -Wimplicit-fallthrough -Wstringop-overflow C_ONLY)
+bareos_disable_warnings(TARGET bareoslmdb WARNINGS -Wunused-parameter -Wimplicit-fallthrough -Wstringop-overflow -Wunused-but-set-variable C_ONLY)
 if(HAVE_WIN32)
   bareos_disable_warnings(TARGET bareoslmdb WARNINGS -Wreturn-local-addr C_ONLY)
 endif()


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR contains changes for FreeBSD 13.2, fixes compile warnings/errors and removes the fixed dependeny on python 3.7-

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
