### PR TITLE
stored: buffer fd messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - github actions: update/fix publish to PyPI workflows [PR #1572]
 - filed: parallel compression/reading/sending [PR #1533]
 - database: media table: use bigint instead of integer [PR #1579]
+- stored: buffer fd messages [PR #1539]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -281,6 +282,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1531]: https://github.com/bareos/bareos/pull/1531
 [PR #1532]: https://github.com/bareos/bareos/pull/1532
 [PR #1533]: https://github.com/bareos/bareos/pull/1533
+[PR #1539]: https://github.com/bareos/bareos/pull/1539
 [PR #1541]: https://github.com/bareos/bareos/pull/1541
 [PR #1542]: https://github.com/bareos/bareos/pull/1542
 [PR #1543]: https://github.com/bareos/bareos/pull/1543

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -63,6 +63,8 @@
 #  include "vss.h"
 #endif
 
+#include <atomic>
+
 namespace filedaemon {
 
 extern bool backup_only_mode;
@@ -87,7 +89,7 @@ const bool have_xattr = false;
 const bool have_encryption = true;
 
 /* Global variables to handle Client Initiated Connections */
-static bool quit_client_initiate_connection = false;
+static std::atomic<bool> quit_client_initiate_connection = false;
 static alist<pthread_t*>* client_initiated_connection_threads = nullptr;
 
 /* Imported functions */

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -164,7 +164,7 @@ void InitWinAPIWrapper();
 #define AUTH_TIMEOUT 60 * 10
 
 // Default network buffer size
-#define DEFAULT_NETWORK_BUFFER_SIZE (256 * 1024)
+inline constexpr std::size_t DEFAULT_NETWORK_BUFFER_SIZE = 256 * 1024;
 
 // Tape label types -- stored in catalog
 #define B_BAREOS_LABEL 0
@@ -249,12 +249,12 @@ typedef uint16_t slot_flags_t;
 
 #include <limits>
 
-constexpr slot_number_t kInvalidSlotNumber
+inline constexpr slot_number_t kInvalidSlotNumber
     = std::numeric_limits<slot_number_t>::max();
-constexpr slot_number_t kInvalidDriveNumber
+inline constexpr slot_number_t kInvalidDriveNumber
     = std::numeric_limits<drive_number_t>::max();
 
-constexpr int kInvalidFiledescriptor = -1;
+inline constexpr int kInvalidFiledescriptor = -1;
 
 inline bool IsSlotNumberValid(slot_number_t slot)
 {

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -164,7 +164,7 @@ void InitWinAPIWrapper();
 #define AUTH_TIMEOUT 60 * 10
 
 // Default network buffer size
-#define DEFAULT_NETWORK_BUFFER_SIZE (64 * 1024)
+#define DEFAULT_NETWORK_BUFFER_SIZE (256 * 1024)
 
 // Tape label types -- stored in catalog
 #define B_BAREOS_LABEL 0

--- a/core/src/lib/bsock.h
+++ b/core/src/lib/bsock.h
@@ -179,6 +179,9 @@ class BareosSocket {
   virtual void RestoreBlocking(int flags) = 0;
   virtual bool ConnectionReceivedTerminateSignal() = 0;
   // Returns: 1 if data available, 0 if timeout, -1 if error
+  static inline constexpr int DataAvailable = 1;
+  static inline constexpr int Timeout = 0;
+  static inline constexpr int Error = -1;
   virtual int WaitData(int sec, int usec = 0) = 0;
   virtual int WaitDataIntr(int sec, int usec = 0) = 0;
   bool fsend(const char*, ...);

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -190,7 +190,7 @@ class MessageHandler {
     POOLMEM* save = fd->msg;
     bool cont = true;
     for (int res = 0; cont; res = fd->WaitData(0, 100'000)) {
-      if (res == 1) {
+      if (res == fd->DataAvailable) {
         PoolMem msg(PM_MESSAGE);
         fd->msg = msg.addr();
         result_type result;
@@ -220,9 +220,11 @@ class MessageHandler {
                 "Tried to put message into queue; but it did not succeed.\n");
           cont = false;
         }
-      } else if (res == -1) {
+      } else if (res == fd->Error) {
         cont = false;
         error_while_reading = true;
+      } else {
+        ASSERT(res == fd->Timeout);
       }
       if (end.load()) { cont = false; }
     }

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -591,7 +591,10 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
   /* Check if we can still write. This may not be the case
    * if we are at the end of the tape or we got a fatal I/O error. */
   if (ok || dev->CanWrite()) {
-    jcr->JobFiles = file_currently_processed.GetFileIndex();
+    // take into account the fact that GetFileIndex() may return -1
+    // if no file is currently getting processed.
+    // This should only happen if no file was send to begin with!
+    jcr->JobFiles = std::max(file_currently_processed.GetFileIndex(), 0);
     if (!WriteSessionLabel(jcr->sd_impl->dcr, EOS_LABEL)) {
       // Print only if ok and not cancelled to avoid spurious messages
       if (ok && !jcr->IsJobCanceled()) {

--- a/systemtests/tests/restore/testrunner-create-backup
+++ b/systemtests/tests/restore/testrunner-create-backup
@@ -24,7 +24,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $log_home/create-backup.out
-setdebug level=100 storage=File
+setdebug level=100 storage=File trace=1
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr adds an asynchronous message buffer to the sd.  This should reduce the time the file daemon has to wait when sending data to the storage daemon.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
