### PR TITLE
build: remove jansson dependency from MacOS

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -55,9 +55,6 @@ jobs:
         fi
       env:
         WANT_TREE: "${{ inputs.treeid }}"
-    - name: Install dependencies
-      run: |
-        brew install jansson
     - name: Inject version parameters
       run: |
         echo -e "set(VERSION_STRING \"$VERSION\")\nset(VERSION_TIMESTAMP \"$TIMESTAMP\")" >core/cmake/BareosVersion.cmake
@@ -67,12 +64,13 @@ jobs:
         TIMESTAMP: "${{ inputs.timestamp }}"
     - name: Build package
       run: |
-        cmake -S . -B cmake-build -Dclient-only=yes
+        cmake -S . -B cmake-build -DENABLE_JANSSON=OFF -Dclient-only=yes
         cmake --build cmake-build -- package
         ls -la cmake-build/*.pkg
         mkdir -p "${{ env.artifact_dir }}/BUILD_RESULTS/MacOS"
         mv cmake-build/*.pkg "${{ env.artifact_dir }}/BUILD_RESULTS/MacOS"
         cp core/src/include/config.h "${{ env.artifact_dir }}"
+        find cmake-build/core/src -type f -perm +0111 -exec otool -L {} ";" > "${{ env.artifact_dir }}/libdepends.txt"
       env:
         CFLAGS: -I/usr/local/include
         CXXFLAGS: -I/usr/local/include


### PR DESCRIPTION
Previously, Bareos was built for MacOS with Jansson support. As we did not ship the Jansson library, this lead to mostly unusable binaries. This change disables Jansson when building for MacOS and also creates a list of dependencies of all the binaries so we can review them after the build.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

