### PR TITLE
Fix bug for PydanticSchemaGenerationError in rest_api

### DIFF
--- a/restapi/requirements.txt
+++ b/restapi/requirements.txt
@@ -1,10 +1,10 @@
-fastapi
-packaging
-passlib
-pydantic
+fastapi~=0.103
+packaging~=23.1
+passlib~=1.7
+pydantic>=1.10.12, <2.0
 python-bareos
-python-jose
+python-jose~=3.3
 # python-multipart: used by fastapi
-python-multipart
-pyyaml
-uvicorn
+python-multipart~=0.0.6
+PyYAML~=6.0
+uvicorn~=0.23


### PR DESCRIPTION
This patch locks down the pip package version to prevent the backward compatibility problem from pydantic 2.x.

Since pydantic 2.x has been released, users will see the following error without this patch:

pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for <class 'bareos_restapi.models.bareosACL'>. Set `arbitrary_types_allowed=True` in the model_config to ignore this error or implement `__get_pydantic_core_schema__` on your type to fully support it.

All the versions are from `pip freeze` from my Docker.

### Thank you for contributing to the Bareos Project!

**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [X] Is the PR title usable as CHANGELOG entry?
- [X] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted
- [N/A] Check backport line
- [N/A] Required backport PRs have been created

##### Source code quality
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR

##### Tests
Tested in my Docker only