### PR TITLE
cats: fix for integer overflow issue when using `offset` in `llist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: fix expected file count error during bsr build  [PR #1511]
 - VMware Plugin: Fix transformer issues [PR #1532]
 - filed: fix possible data-loss when excluding hardlinks [PR #1506]
+- cats: fix for integer overflow issue when using `offset` in `llist` [PR #1547]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -261,6 +262,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1542]: https://github.com/bareos/bareos/pull/1542
 [PR #1543]: https://github.com/bareos/bareos/pull/1543
 [PR #1546]: https://github.com/bareos/bareos/pull/1546
+[PR #1547]: https://github.com/bareos/bareos/pull/1547
 [PR #1548]: https://github.com/bareos/bareos/pull/1548
 [PR #1549]: https://github.com/bareos/bareos/pull/1549
 [PR #1550]: https://github.com/bareos/bareos/pull/1550

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -142,8 +142,8 @@ struct JobDbRecord {
   char cRealEndTime[MAX_TIME_LENGTH]{0};
 
   // Extra stuff not in DB
-  int limit = 0;  /**< limit records to display */
-  int offset = 0; /**< offset records to display */
+  uint64_t limit = 0;  /**< limit records to display */
+  uint64_t offset = 0; /**< offset records to display */
   faddr_t rec_addr = 0;
   uint32_t FileIndex = 0; /**< added during Verify */
 };

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -462,14 +462,24 @@ static void SetQueryRange(std::string& query_range,
   // Apply any limit
   int i = FindArgWithValue(ua, NT_("limit"));
   if (i >= 0) {
-    jr->limit = std::stoull(ua->argv[i]);
+    try {
+      jr->limit = std::stoull(ua->argv[i]);
+    } catch (...) {
+      Dmsg1(50, "Could not convert %s to limit value.\n", ua->argv[i]);
+      jr->limit = 0;
+    }
     ua->send->AddLimitFilterTuple(jr->limit);
     query_range.append(" LIMIT " + std::to_string(jr->limit));
 
     // offset is only valid, if limit is given
     i = FindArgWithValue(ua, NT_("offset"));
     if (i >= 0) {
-      jr->offset = std::stoull(ua->argv[i]);
+      try {
+        jr->offset = std::stoull(ua->argv[i]);
+      } catch (...) {
+        Dmsg1(50, "Could not convert %s to offset value.\n", ua->argv[i]);
+        jr->offset = 0;
+      }
       ua->send->AddOffsetFilterTuple(jr->offset);
       query_range.append(" OFFSET " + std::to_string(jr->offset));
     }

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -61,8 +61,8 @@ static bool ParseListBackupsCmd(UaContext* ua,
                                 e_list_type llist);
 
 // Some defaults.
-#define DEFAULT_LOG_LINES 5
-#define DEFAULT_NR_DAYS 50
+const int kDefaultLogLines = 5;
+const int kDefaultNumberOfDays = 50;
 
 // Turn auto display of console messages on/off
 bool AutodisplayCmd(UaContext* ua, const char*)
@@ -447,40 +447,31 @@ static inline void SetHiddenColumn(UaContext* ua, int column)
   ua->send->AddHiddenColumn(column);
 }
 
-static void SetQueryRange(PoolMem& query_range, UaContext* ua, JobDbRecord* jr)
+static void SetQueryRange(std::string& query_range,
+                          UaContext* ua,
+                          JobDbRecord* jr)
 {
-  int i;
-
-  /* Ensure query range is an empty string instead of NULL
-   * to avoid any issues. */
-  if (query_range.c_str() == NULL) { PmStrcpy(query_range, ""); }
-
   /* See if this is a second call to SetQueryRange() if so and any acl
    * filters have been set we setup a new query_range filter including a
    * limit filter. */
-  if (query_range.strlen()) {
+  if (!query_range.empty()) {
     if (!ua->send->has_acl_filters()) { return; }
-    PmStrcpy(query_range, "");
+    query_range.clear();
   }
 
   // Apply any limit
-  i = FindArgWithValue(ua, NT_("limit"));
+  int i = FindArgWithValue(ua, NT_("limit"));
   if (i >= 0) {
-    PoolMem temp(PM_MESSAGE);
-
     jr->limit = atoi(ua->argv[i]);
     ua->send->AddLimitFilterTuple(jr->limit);
-
-    temp.bsprintf(" LIMIT %d", jr->limit);
-    PmStrcat(query_range, temp.c_str());
+    query_range.append(" LIMIT " + std::to_string(jr->limit));
 
     // offset is only valid, if limit is given
     i = FindArgWithValue(ua, NT_("offset"));
     if (i >= 0) {
       jr->offset = atoi(ua->argv[i]);
       ua->send->AddOffsetFilterTuple(jr->offset);
-      temp.bsprintf(" OFFSET %d", atoi(ua->argv[i]));
-      PmStrcat(query_range, temp.c_str());
+      query_range.append(" OFFSET " + std::to_string(jr->offset));
     }
   }
 }
@@ -507,9 +498,7 @@ static bool ListMedia(UaContext* ua,
                       ListCmdOptions optionslist)
 {
   JobDbRecord jr;
-  PoolMem query_range;
-
-  PmStrcpy(query_range, "");
+  std::string query_range;
   SetQueryRange(query_range, ua, &jr);
 
   // List MEDIA or VOLUMES
@@ -641,11 +630,9 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     schedtime = now - secs_in_hour * hours; /* Hours in the past */
   }
 
-  PoolMem query_range(PM_MESSAGE);
+  std::string query_range;
   JobDbRecord jr;
-  PmStrcpy(query_range, "");
   SetQueryRange(query_range, ua, &jr);
-
 
   char* clientname = nullptr;
   argument = FindArgWithValue(ua, NT_("client"));
@@ -872,8 +859,8 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
      * default is DEFAULT_LOG_LINES entries */
     reverse = FindArg(ua, NT_("reverse")) >= 0;
 
-    if (strlen(query_range.c_str()) == 0) {
-      Mmsg(query_range, " LIMIT %d", DEFAULT_LOG_LINES);
+    if (query_range.empty()) {
+      query_range = " LIMIT " + std::to_string(kDefaultLogLines);
     }
 
     if (ua->api != API_MODE_JSON) {
@@ -970,9 +957,9 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     argument = FindArgWithValue(ua, NT_("days"));
     if (argument >= 0) {
       days = atoi(ua->argv[argument]);
-      if ((days < 0) || (days > DEFAULT_NR_DAYS)) {
+      if ((days < 0) || (days > kDefaultNumberOfDays)) {
         ua->WarningMsg(_("Ignoring invalid value for days. Max is %d.\n"),
-                       DEFAULT_NR_DAYS);
+                       kDefaultNumberOfDays);
         days = 1;
       }
     }

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -1437,8 +1437,8 @@ void DoMessages(UaContext* ua, const char*)
     DoTruncate = true;
   }
   if (DoTruncate) { (void)!ftruncate(fileno(con_fd), 0L); }
-  console_msg_pending = FALSE;
-  ua->user_notified_msg_pending = FALSE;
+  console_msg_pending = false;
+  ua->user_notified_msg_pending = false;
   pthread_cleanup_pop(0);
   Vw(con_lock);
 }

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -462,14 +462,14 @@ static void SetQueryRange(std::string& query_range,
   // Apply any limit
   int i = FindArgWithValue(ua, NT_("limit"));
   if (i >= 0) {
-    jr->limit = atoi(ua->argv[i]);
+    jr->limit = std::stoull(ua->argv[i]);
     ua->send->AddLimitFilterTuple(jr->limit);
     query_range.append(" LIMIT " + std::to_string(jr->limit));
 
     // offset is only valid, if limit is given
     i = FindArgWithValue(ua, NT_("offset"));
     if (i >= 0) {
-      jr->offset = atoi(ua->argv[i]);
+      jr->offset = std::stoull(ua->argv[i]);
       ua->send->AddOffsetFilterTuple(jr->offset);
       query_range.append(" OFFSET " + std::to_string(jr->offset));
     }

--- a/core/src/findlib/bfile.cc
+++ b/core/src/findlib/bfile.cc
@@ -348,7 +348,7 @@ bool processWin32BackupAPIBlock(BareosFilePacket* bfd,
   /* set "NextHeader" relative to the beginning of the next block */
   plugin_private_context->liNextHeader -= dwSize;
 
-  return TRUE;
+  return true;
 }
 
 /* ===============================================================

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -35,11 +35,6 @@
 
 /* Bareos common configuration defines */
 
-#undef TRUE
-#undef FALSE
-#define TRUE 1
-#define FALSE 0
-
 #ifdef HAVE_TLS
 #  define have_tls 1
 #else

--- a/core/src/lib/btimers.cc
+++ b/core/src/lib/btimers.cc
@@ -237,7 +237,7 @@ static btimer_t* btimer_start_common()
     return NULL;
   }
   wid->wd->data = wid;
-  wid->killed = FALSE;
+  wid->killed = false;
 
   return wid;
 }

--- a/core/src/lib/btimers.cc
+++ b/core/src/lib/btimers.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2017-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -61,7 +61,7 @@ char my_name[128] = {0};              /* daemon name is stored here */
 char host_name[256] = {0};            /* host machine name */
 char* exepath = (char*)NULL;
 char* exename = (char*)NULL;
-int console_msg_pending = false;
+bool console_msg_pending = false;
 char con_fname[500]; /* Console filename */
 FILE* con_fd = NULL; /* Console file descriptor */
 brwlock_t con_lock;  /* Console lock structure */

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -65,7 +65,7 @@ extern char my_name[];
 extern const char* working_directory;
 extern utime_t daemon_start_time;
 
-extern int console_msg_pending;
+extern bool console_msg_pending;
 extern FILE* con_fd;       /* Console file descriptor */
 extern brwlock_t con_lock; /* Console lock structure */
 

--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -135,11 +135,9 @@ void OutputFormatter::ObjectStart(const char* name,
           json_array_append_new(json_object_current, json_object_new);
           result_stack_json->push(json_object_new);
         } else {
-          /*
-           * nameless objects only are indented to be added to arrays.
+          /* nameless objects only are indented to be added to arrays.
            * We do a workaround here, but this will only keep the last added
-           * entry (others will be overwritten).
-           */
+           * entry (others will be overwritten). */
           Dmsg0(800,
                 "Warning: requested to add a nameless object to another "
                 "object. This does not match.\n");
@@ -517,24 +515,18 @@ void OutputFormatter::rewrap(PoolMem& string, int wrap)
   int charsinline = 0;
   PoolMem rewrap_string(PM_MESSAGE);
 
-  /*
-   * wrap < 0: no modification
+  /* wrap < 0: no modification
    * wrap = 0: single line
-   * wrap > 0: wrap line after x characters (if api==0)
-   */
+   * wrap > 0: wrap line after x characters (if api==0) */
   if (wrap < 0) { return; }
 
-  /*
-   * Allocate a wrap buffer that is big enough to hold the original string and
+  /* Allocate a wrap buffer that is big enough to hold the original string and
    * the wrap chars. Using strlen * 2 means, we could add a wrap character after
-   * each character, which should be enough.
-   */
+   * each character, which should be enough. */
   rewrap_string.check_size(string.strlen() * 2);
 
-  /*
-   * Walk the input buffer and copy the data to the wrap buffer
-   * inserting line breaks as needed.
-   */
+  /* Walk the input buffer and copy the data to the wrap buffer
+   * inserting line breaks as needed. */
   q = rewrap_string.c_str();
   p = string.c_str();
   while (*p) {
@@ -686,10 +678,8 @@ bool OutputFormatter::FilterData(void* data)
   of_filter_tuple* tuple = nullptr;
   int acl_filter_show = 0, acl_filter_unknown = 0;
 
-  /*
-   * See if a filtering function is registered.
-   * See if there are any filters.
-   */
+  /* See if a filtering function is registered.
+   * See if there are any filters. */
   if (filter_func && filters && !filters->empty()) {
     foreach_alist (tuple, filters) {
       state = filter_func(filter_ctx, data, tuple);
@@ -709,12 +699,10 @@ bool OutputFormatter::FilterData(void* data)
     }
   }
 
-  /*
-   * If we have multiple ACL filters and none gave an
+  /* If we have multiple ACL filters and none gave an
    * explicit show state we suppress the entry just to
    * be sure we do not show to much information if we
-   * are not sure if we should show the item.
-   */
+   * are not sure if we should show the item. */
   if (acl_filter_unknown > 0 && acl_filter_show == 0) {
     Dmsg2(200,
           "tri-state filtering acl_filter_unknown %d, acl_filter_show %d\n",
@@ -765,10 +753,8 @@ bool OutputFormatter::ProcessTextBuffer()
   if (string_length > 0) {
     retval = send_func(send_ctx, "%s", result_message_plain->c_str());
     if (!retval) {
-      /*
-       * If send failed, include short messages in error messages.
-       * As messages can get quite long, don't show long messages.
-       */
+      /* If send failed, include short messages in error messages.
+       * As messages can get quite long, don't show long messages. */
       ErrorMsg.bsprintf("Failed to send message (length=%lld). ",
                         string_length);
       if (string_length < max_message_length_shown_in_error) {
@@ -791,18 +777,14 @@ void OutputFormatter::message([[maybe_unused]] const char* type,
   switch (api) {
 #if HAVE_JANSSON
     case API_MODE_JSON:
-      /*
-       * currently, only error message influence the JSON result.
-       * Other messages are not visible.
-       */
+      /* currently, only error message influence the JSON result.
+       * Other messages are not visible. */
       JsonAddMessage(type, message);
       break;
 #endif
     default:
-      /*
-       * Send message immediately.
-       * Type is not relevant here (handled before).
-       */
+      /* Send message immediately.
+       * Type is not relevant here (handled before). */
       send_func(send_ctx, "%s", message.c_str());
       break;
   }
@@ -859,11 +841,9 @@ bool OutputFormatter::JsonArrayItemAdd(json_t* value)
   if (json_is_array(json_array_current)) {
     json_array_append_new(json_array_current, value);
   } else {
-    /*
-     * nameless objects only are indented to be added to arrays.
+    /* nameless objects only are indented to be added to arrays.
      * We do a workaround here, but this will only keep the last added
-     * entry (others will be overwritten).
-     */
+     * entry (others will be overwritten). */
     Dmsg0(800,
           "Warning: requested to add a nameless object to another "
           "object. This does not match.\n");
@@ -890,10 +870,8 @@ bool OutputFormatter::JsonKeyValueAddBool(const char* key, bool value)
 #  if JANSSON_VERSION_HEX >= 0x020400
   json_object_set_new(json_obj, lkey.c_str(), json_boolean(value));
 #  else
-  /*
-   * The function json_boolean(bool) requires jansson >= 2.4,
-   * which is not available on all platform, so assign the value manually.
-   */
+  /* The function json_boolean(bool) requires jansson >= 2.4,
+   * which is not available on all platform, so assign the value manually. */
   if (value) {
     json_bool = json_true();
   } else {
@@ -980,10 +958,8 @@ void OutputFormatter::JsonFinalizeResult(bool result)
   PoolMem ErrorMsg;
   char* string;
 
-  /*
-   * We mimic json-rpc result and error messages,
-   * To make it easier to implement real json-rpc later on.
-   */
+  /* We mimic json-rpc result and error messages,
+   * To make it easier to implement real json-rpc later on. */
   json_object_set_new(msg_obj, "jsonrpc", json_string("2.0"));
   json_object_set_new(msg_obj, "id", json_null());
 
@@ -1034,10 +1010,8 @@ void OutputFormatter::JsonFinalizeResult(bool result)
     Dmsg1(800, "message length (json): %lld\n", string_length);
     // send json string, on failure, send json error message
     if (!send_func(send_ctx, "%s", string)) {
-      /*
-       * If send failed, include short messages in error messages.
-       * As messages can get quite long, don't show long messages.
-       */
+      /* If send failed, include short messages in error messages.
+       * As messages can get quite long, don't show long messages. */
       ErrorMsg.bsprintf("Failed to send json message (length=%lld). ",
                         string_length);
       if (string_length < max_message_length_shown_in_error) {

--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -603,7 +603,7 @@ void OutputFormatter::CreateNewResFilter(of_filter_type type,
   filters->append(tuple);
 }
 
-void OutputFormatter::AddLimitFilterTuple(int limit)
+void OutputFormatter::AddLimitFilterTuple(uint64_t limit)
 {
   of_filter_tuple* tuple;
 
@@ -616,7 +616,7 @@ void OutputFormatter::AddLimitFilterTuple(int limit)
   filters->append(tuple);
 }
 
-void OutputFormatter::AddOffsetFilterTuple(int offset)
+void OutputFormatter::AddOffsetFilterTuple(uint64_t offset)
 {
   of_filter_tuple* tuple;
 

--- a/core/src/lib/output_formatter.h
+++ b/core/src/lib/output_formatter.h
@@ -52,6 +52,7 @@ typedef struct json_t json_t;
 
 #include "lib/alist.h"
 #include "lib/api_mode.h"
+#include <stdint.h>
 
 class PoolMem;
 
@@ -75,11 +76,11 @@ typedef enum of_filter_type
 } of_filter_type;
 
 typedef struct of_limit_filter_tuple {
-  int limit = 0; /* Filter output to a maximum of limit entries */
+  uint64_t limit = 0; /* Filter output to a maximum of limit entries */
 } of_limit_filter_tuple;
 
 typedef struct of_offset_filter_tuple {
-  int offset = 0;
+  uint64_t offset = 0;
 } of_offset_filter_tuple;
 
 typedef struct of_acl_filter_tuple {
@@ -237,8 +238,8 @@ class OutputFormatter {
   void SendBuffer();
 
   // Filtering.
-  void AddLimitFilterTuple(int limit);
-  void AddOffsetFilterTuple(int offset);
+  void AddLimitFilterTuple(uint64_t limit);
+  void AddOffsetFilterTuple(uint64_t offset);
   void AddAclFilterTuple(int column, int acltype);
   void AddResFilterTuple(int column, int restype);
   void AddEnabledFilterTuple(int column, int restype);

--- a/core/src/lib/output_formatter.h
+++ b/core/src/lib/output_formatter.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -141,13 +141,11 @@ class OutputFormatter {
   void CreateNewResFilter(of_filter_type type, int column, int restype);
   bool ProcessTextBuffer();
 
-  /*
-   * reformat string.
+  /* reformat string.
    * remove newlines and replace tabs with a single space.
    * wrap < 0: no modification
    * wrap = 0: reformat to single line
-   * wrap > 0: if api==0: wrap after x characters, else no modifications
-   */
+   * wrap > 0: if api==0: wrap after x characters, else no modifications */
   void rewrap(PoolMem& string, int wrap);
 
 #if HAVE_JANSSON
@@ -167,10 +165,8 @@ class OutputFormatter {
   void SetMode(int mode) { api = mode; }
   int GetMode() { return api; }
 
-  /*
-   * Allow to set compact output mode. Only used for json api mode.
-   * There it can reduce the size of message by 1/3.
-   */
+  /* Allow to set compact output mode. Only used for json api mode.
+   * There it can reduce the size of message by 1/3. */
   void SetCompact(bool value) { compact = value; }
   bool GetCompact() { return compact; }
 
@@ -190,12 +186,10 @@ class OutputFormatter {
                    bool case_sensitiv_name = false);
   void ObjectEnd(const char* name = NULL, const char* fmt = NULL);
 
-  /*
-   * boolean and integer can not be used to distinguish overloading functions,
+  /* boolean and integer can not be used to distinguish overloading functions,
    * therefore the bool function have the postfix _bool.
    * The boolean value is given a string ("true" or "false") to the value_fmt
-   * string. The format string must therefore match "%s".
-   */
+   * string. The format string must therefore match "%s". */
   void ObjectKeyValueBool(const char* key, bool value);
   void ObjectKeyValueBool(const char* key, bool value, const char* value_fmt);
   void ObjectKeyValueBool(const char* key,
@@ -227,14 +221,12 @@ class OutputFormatter {
                       const char* value_fmt,
                       int wrap = -1);
 
-  /*
-   * some programs (BAT in api mode 1) parses data message by message,
+  /* some programs (BAT in api mode 1) parses data message by message,
    * instead of using a separator.
    * An example for this is BAT with the ".defaults job" command in API mode 1.
    * In this cases, the SendBuffer function must be called at between two
    * messages. In API mode 2 this function has no effect. This function should
-   * only be used, when there is a specific need for it.
-   */
+   * only be used, when there is a specific need for it. */
   void SendBuffer();
 
   // Filtering.

--- a/systemtests/tests/python-bareos/test_list_command.py
+++ b/systemtests/tests/python-bareos/test_list_command.py
@@ -233,6 +233,11 @@ class PythonBareosListCommandTest(bareos_unittest.Base):
             "",
         )
 
+        result = director.call(
+            "llist jobs limit=99999999999999999999999999999999999999 offset=99999999999999999999999999999999999999999999999"
+        )
+        self.assertEqual(len(result["jobs"]), 0)
+
         # list jobs jobstatus=X
         result = director.call("list jobs jobstatus=T")
         self.assertTrue(result["jobs"])


### PR DESCRIPTION
### Description

This PR is a bug fix for the [mantis bug 1027](https://bugs.bareos.org/view.php?id=1027)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
