### PR TITLE
dird: `list jobs`: add `level` keyword and accept a list of job levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - build: introduce fedora38 [PR #1563]
 - python: adapt for new Python module versions [PR #1546]
 - tools: fix tools not starting up on windows  [PR #1549]
+- dird: `list jobs`: add `level` keyword and accept a list of job levels [PR #1548]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -260,6 +261,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1542]: https://github.com/bareos/bareos/pull/1542
 [PR #1543]: https://github.com/bareos/bareos/pull/1543
 [PR #1546]: https://github.com/bareos/bareos/pull/1546
+[PR #1548]: https://github.com/bareos/bareos/pull/1548
 [PR #1549]: https://github.com/bareos/bareos/pull/1549
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
 [PR #1556]: https://github.com/bareos/bareos/pull/1556

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -780,7 +780,7 @@ class BareosDb : public BareosDbQueryEnum {
                       const char* range,
                       const char* clientname,
                       std::vector<char> jobstatusarray,
-                      int joblevel,
+                      std::vector<char> joblevels,
                       std::vector<char> jobtypes,
                       const char* volumename,
                       const char* poolname,

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -504,7 +504,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
                               const char* range,
                               const char* clientname,
                               std::vector<char> jobstatuslist,
-                              int joblevel,
+                              std::vector<char> joblevels,
                               std::vector<char> jobtypes,
                               const char* volumename,
                               const char* poolname,
@@ -542,8 +542,9 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
     PmStrcat(selection, temp.c_str());
   }
 
-  if (joblevel) {
-    temp.bsprintf("AND Job.Level = '%c' ", joblevel);
+  if (!joblevels.empty()) {
+    std::string levels = CreateDelimitedStringForSqlQueries(joblevels, ',');
+    temp.bsprintf("AND Job.Level in (%s) ", levels.c_str());
     PmStrcat(selection, temp.c_str());
   }
 

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -667,8 +667,8 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
   }
 
   // joblevel=X
-  int joblevel = 0;
-  if (!GetUserJobLevelSelection(ua, &joblevel)) {
+  std::vector<char> joblevel_list;
+  if (!GetUserJobLevelSelection(ua, joblevel_list)) {
     ua->ErrorMsg(_("invalid joblevel parameter\n"));
     return false;
   }
@@ -739,7 +739,7 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     SetQueryRange(query_range, ua, &jr);
 
     ua->db->ListJobRecords(ua->jcr, &jr, query_range.c_str(), clientname,
-                           jobstatuslist, joblevel, jobtypes, volumename,
+                           jobstatuslist, joblevel_list, jobtypes, volumename,
                            poolname, schedtime, optionslist.last,
                            optionslist.count, ua->send, llist);
   } else if (Bstrcasecmp(ua->argk[1], NT_("jobtotals"))) {
@@ -787,10 +787,10 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
 
         SetQueryRange(query_range, ua, &jr);
 
-        ua->db->ListJobRecords(ua->jcr, &jr, query_range.c_str(), clientname,
-                               jobstatuslist, joblevel, jobtypes, volumename,
-                               poolname, schedtime, optionslist.last,
-                               optionslist.count, ua->send, llist);
+        ua->db->ListJobRecords(
+            ua->jcr, &jr, query_range.c_str(), clientname, jobstatuslist,
+            joblevel_list, jobtypes, volumename, poolname, schedtime,
+            optionslist.last, optionslist.count, ua->send, llist);
       }
     }
   } else if (Bstrcasecmp(ua->argk[1], NT_("basefiles"))) {

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -971,9 +971,8 @@ PoolResource* get_pool_resource(UaContext* ua)
 // List all jobs and ask user to select one
 int SelectJobDbr(UaContext* ua, JobDbRecord* jr)
 {
-  ua->db->ListJobRecords(ua->jcr, jr, "", NULL, std::vector<char>{}, 0,
-                         std::vector<char>{}, NULL, NULL, 0, 0, 0, ua->send,
-                         HORZ_LIST);
+  ua->db->ListJobRecords(ua->jcr, jr, "", NULL, {}, {}, {}, nullptr, nullptr, 0,
+                         0, 0, ua->send, HORZ_LIST);
   if (!GetPint(ua, _("Enter the JobId to select: "))) { return 0; }
 
   jr->JobId = ua->int64_val;
@@ -1961,18 +1960,22 @@ bool GetUserJobStatusSelection(UaContext* ua, std::vector<char>& jobstatuslist)
   return true;
 }
 
-bool GetUserJobLevelSelection(UaContext* ua, int* joblevel)
+bool GetUserJobLevelSelection(UaContext* ua, std::vector<char>& joblevel_list)
 {
   int i;
 
   if (((i = FindArgWithValue(ua, NT_("joblevel"))) >= 0)
       || ((i = FindArgWithValue(ua, NT_("level"))) >= 0)) {
-    if (strlen(ua->argv[i]) == 1 && ua->argv[i][0] >= 'A'
-        && ua->argv[i][0] <= 'z') {
-      *joblevel = ua->argv[i][0];
-    } else {
-      /* invalid joblevel */
-      return false;
+    std::vector<std::string> joblevelinput_list
+        = split_string(ua->argv[i], ',');
+
+    for (const auto& level : joblevelinput_list) {
+      if (level.size() == 1 && level[0] >= 'A' && level[0] <= 'z') {
+        joblevel_list.push_back(level[0]);
+      } else {
+        /* invalid joblevel */
+        return false;
+      }
     }
   }
   return true;

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1965,7 +1965,8 @@ bool GetUserJobLevelSelection(UaContext* ua, int* joblevel)
 {
   int i;
 
-  if ((i = FindArgWithValue(ua, NT_("joblevel"))) >= 0) {
+  if (((i = FindArgWithValue(ua, NT_("joblevel"))) >= 0)
+      || ((i = FindArgWithValue(ua, NT_("level"))) >= 0)) {
     if (strlen(ua->argv[i]) == 1 && ua->argv[i][0] >= 'A'
         && ua->argv[i][0] <= 'z') {
       *joblevel = ua->argv[i][0];

--- a/core/src/dird/ua_select.h
+++ b/core/src/dird/ua_select.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -93,7 +93,7 @@ bool GetUserJobTypeListSelection(UaContext* ua,
                                  std::vector<char>& passed_jobtypes,
                                  bool ask_user);
 bool GetUserJobStatusSelection(UaContext* ua, std::vector<char>& jobstatus);
-bool GetUserJobLevelSelection(UaContext* ua, int* joblevel);
+bool GetUserJobLevelSelection(UaContext* ua, std::vector<char>& joblevel_list);
 
 int FindArgKeyword(UaContext* ua, const char** list);
 int FindArg(UaContext* ua, const char* keyword);


### PR DESCRIPTION
#### Description

This PR add the `level` keyword that works as an alias to `joblevel`, and also enables the `list jobs` command to parse a list of job levels (i.e. `list jobs level=F,I,D`)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
