### PR TITLE
tools: fix tools not starting up on windows 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - require TLS by default [PR #1529]
 - build: introduce fedora38 [PR #1563]
 - python: adapt for new Python module versions [PR #1546]
+- tools: fix tools not starting up on windows  [PR #1549]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -259,6 +260,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1542]: https://github.com/bareos/bareos/pull/1542
 [PR #1543]: https://github.com/bareos/bareos/pull/1543
 [PR #1546]: https://github.com/bareos/bareos/pull/1546
+[PR #1549]: https://github.com/bareos/bareos/pull/1549
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
 [PR #1556]: https://github.com/bareos/bareos/pull/1556
 [PR #1563]: https://github.com/bareos/bareos/pull/1563

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -165,7 +165,7 @@ int main(int argc, char* argv[])
   AddDebugOptions(dir_app);
 
   bool foreground = false;
-  CLI::Option* foreground_option
+  [[maybe_unused]] CLI::Option* foreground_option
       = dir_app.add_flag("-f,--foreground", foreground, "Run in foreground.");
 
   std::string user;
@@ -175,20 +175,16 @@ int main(int argc, char* argv[])
   dir_app.add_flag("-m,--print-kaboom", prt_kaboom,
                    "Print kaboom output (for debugging).");
 
-  auto testconfig_option = dir_app.add_flag(
+  [[maybe_unused]] auto testconfig_option = dir_app.add_flag(
       "-t,--test-config", test_config, "Test - read configuration and exit.");
 
-#if !defined(HAVE_WIN32)
+#ifndef HAVE_WIN32
   dir_app
       .add_option("-p,--pid-file", pidfile_path,
                   "Full path to pidfile (default: none).")
       ->excludes(foreground_option)
       ->excludes(testconfig_option)
       ->type_name("<file>");
-#else
-  // to silence unused variable error on windows
-  (void)testconfig_option;
-  (void)foreground_option;
 #endif
 
   bool no_signals = false;

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -95,7 +95,7 @@ int main(int argc, char* argv[])
   AddDebugOptions(fd_app);
 
   bool foreground = false;
-  CLI::Option* foreground_option = fd_app.add_flag(
+  [[maybe_unused]] CLI::Option* foreground_option = fd_app.add_flag(
       "-f,--foreground", foreground, "Run in foreground (for debugging).");
 
   std::string user;
@@ -111,20 +111,15 @@ int main(int argc, char* argv[])
                   "Print kaboom output (for debugging)");
 
   bool test_config = false;
-  auto testconfig_option = fd_app.add_flag(
+  [[maybe_unused]] auto testconfig_option = fd_app.add_flag(
       "-t,--test-config", test_config, "Test - read configuration and exit.");
-
-#if !defined(HAVE_WIN32)
+#ifndef HAVE_WIN32
   fd_app
       .add_option("-p,--pid-file", pidfile_path,
                   "Full path to pidfile (default: none)")
       ->excludes(foreground_option)
       ->excludes(testconfig_option)
       ->type_name("<file>");
-#else
-  // to silence unused variable error on windows
-  (void)testconfig_option;
-  (void)foreground_option;
 #endif
 
   fd_app.add_flag("-r,--restore-only", restore_only_mode, "Restore only mode.");

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -28,6 +28,7 @@ set(BAREOS_SRCS
     alist.cc
     attr.cc
     attribs.cc
+    bareos_universal_initialiser.cc
     backtrace.cc
     base64.cc
     berrno.cc

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -365,7 +365,7 @@ bool CheckIfFamilyEnabled(IpFamily family)
   do {
     ++tries;
     if ((fd = socket(GetFamily(family).value(), SOCK_STREAM, 0)) < 0) {
-      Bmicrosleep(15, 0);
+      Bmicrosleep(1, 0);
     }
   } while (fd < 0 && tries < 3);
 

--- a/core/src/lib/bareos_universal_initialiser.cc
+++ b/core/src/lib/bareos_universal_initialiser.cc
@@ -1,0 +1,52 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#include "bareos_universal_initialiser.h"
+
+#include <stdio.h>
+#if defined(HAVE_WIN32)
+#  include <winsock2.h>
+#  include <windows.h>
+#endif
+
+BareosUniversalInitialiser universal_initialiser();
+
+BareosUniversalInitialiser::BareosUniversalInitialiser()
+{
+#if HAVE_WIN32
+  WORD wVersionRequested = MAKEWORD(1, 1);
+  WSADATA wsaData;
+
+  int err = WSAStartup(wVersionRequested, &wsaData);
+
+  if (err != 0) {
+    printf("Can not start Windows Sockets\n");
+    errno = ENOSYS;
+  }
+#endif
+}
+
+BareosUniversalInitialiser::~BareosUniversalInitialiser()
+{
+#if HAVE_WIN32
+  WSACleanup();
+#endif
+}

--- a/core/src/lib/bareos_universal_initialiser.h
+++ b/core/src/lib/bareos_universal_initialiser.h
@@ -1,0 +1,36 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_BAREOS_UNIVERSAL_INITIALISER_H_
+#define BAREOS_LIB_BAREOS_UNIVERSAL_INITIALISER_H_
+
+#include "include/config.h"
+
+class BareosUniversalInitialiser {
+ public:
+  BareosUniversalInitialiser();
+  ~BareosUniversalInitialiser();
+};
+
+BareosUniversalInitialiser universal_initialiser();
+
+
+#endif  // BAREOS_LIB_BAREOS_UNIVERSAL_INITIALISER_H_

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -52,6 +52,7 @@
 #include "include/jcr.h"
 #include "lib/parse_conf.h"
 #include "lib/compression.h"
+#include "lib/bareos_universal_initialiser.h"
 
 namespace storagedaemon {
 extern bool ParseSdConfig(const char* configfile, int exit_code);
@@ -83,7 +84,6 @@ static BootStrapRecord* bsr = nullptr;
 int main(int argc, char* argv[])
 {
   DirectorResource* director = nullptr;
-
   setlocale(LC_ALL, "");
   tzset();
   bindtextdomain("bareos", LOCALEDIR);

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -139,7 +139,7 @@ int main(int argc, char* argv[])
   AddDebugOptions(sd_app);
 
   bool foreground = false;
-  CLI::Option* foreground_option = sd_app.add_flag(
+  [[maybe_unused]] CLI::Option* foreground_option = sd_app.add_flag(
       "-f,--foreground", foreground, "Run in foreground (for debugging).");
 
   std::string user{};
@@ -153,20 +153,16 @@ int main(int argc, char* argv[])
   sd_app.add_flag("-i,--ignore-io-errors", forge_on, "Ignore IO errors.");
 
   bool test_config = false;
-  auto testconfig_option = sd_app.add_flag(
+  [[maybe_unused]] auto testconfig_option = sd_app.add_flag(
       "-t,--test-config", test_config, "Test - read configuration and exit.");
 
-#if !defined(HAVE_WIN32)
+#ifndef HAVE_WIN32
   sd_app
       .add_option("-p,--pid-file", pidfile_path,
                   "Full path to pidfile (default: none)")
       ->excludes(foreground_option)
       ->excludes(testconfig_option)
       ->type_name("<file>");
-#else
-  // to silence unused variable error on windows
-  (void)testconfig_option;
-  (void)foreground_option;
 #endif
 
   bool no_signals = false;


### PR DESCRIPTION
#### Description

On windows, tools that require configuration parsing are not able to startup, with socket errors showing up. This is because using sockets on windows requires some special initialization that tools do not have (but main daemons do).

This was introduced when we added checks for `IPv4` and `IPv6` family availability. The check is done during the config parsing part, which tools use, but on windows, they do not have the socket initialization necessary to do it, so they fail.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
