### PR TITLE
stored: fix support for non-tape block-addressed devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - dird: `list jobs`: add `level` keyword and accept a list of job levels [PR #1548]
 - Allow to use the third-party libraries of the OS instead of the bundled ones [PR #1441]
 - packaging: debian fix dependencies [PR #1573]
+- stored: fix support for non-tape block-addressed devices [PR #1554]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -270,6 +271,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1548]: https://github.com/bareos/bareos/pull/1548
 [PR #1549]: https://github.com/bareos/bareos/pull/1549
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
+[PR #1554]: https://github.com/bareos/bareos/pull/1554
 [PR #1556]: https://github.com/bareos/bareos/pull/1556
 [PR #1563]: https://github.com/bareos/bareos/pull/1563
 [PR #1565]: https://github.com/bareos/bareos/pull/1565

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -68,8 +68,6 @@
 #define NPRTB(x) (x) ? (x) : ""
 
 #if defined(HAVE_WIN32)
-// Reduce compiler warnings from Windows vss code
-#  define uuid(x)
 
 void InitWinAPIWrapper();
 

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -29,8 +29,6 @@
 #include "include/bareos.h"
 #include "lib/edit.h"
 #include <math.h>
-
-#define DEFAULT_FORMAT_LENGTH 27
 
 // We assume ASCII input and don't worry about overflow
 uint64_t str_to_uint64(const char* str)
@@ -77,7 +75,7 @@ int64_t str_to_int64(const char* str)
 
 /*
  * Edit an integer number with commas, the supplied buffer must be at least
- * DEFAULT_FORMAT_LENGTH bytes long. The incoming number is always widened to 64
+ * min_buffer_size bytes long. The incoming number is always widened to 64
  * bits.
  */
 char* edit_uint64_with_commas(uint64_t val, char* buf)
@@ -90,7 +88,7 @@ char* edit_uint64_with_commas(uint64_t val, char* buf)
 /*
  * Edit an integer into "human-readable" format with four or fewer significant
  * digits followed by a suffix that indicates the scale factor. The buf array
- * inherits a DEFAULT_FORMAT_LENGTH byte minimum length requirement from
+ * inherits a min_buffer_size byte minimum length requirement from
  * edit_unit64_with_commas(), although the output string is limited to eight
  * characters.
  */
@@ -114,14 +112,14 @@ char* edit_uint64_with_suffix(uint64_t val, char* buf)
   }
 
   if (commas >= suffixes) { commas = suffixes - 1; }
-  Bsnprintf(buf, DEFAULT_FORMAT_LENGTH, "%s %s", mbuf, suffix[commas]);
+  Bsnprintf(buf, edit::min_buffer_size, "%s %s", mbuf, suffix[commas]);
 
   return buf;
 }
 
 /*
  * Edit an integer number, the supplied buffer must be at least
- * DEFAULT_FORMAT_LENGTH bytes long. The incoming number is always widened to 64
+ * min_buffer_size bytes long. The incoming number is always widened to 64
  * bits. Replacement for sprintf(buf, "%" llu, val)
  */
 char* edit_uint64(uint64_t val, char* buf)
@@ -138,44 +136,48 @@ char* edit_uint64(uint64_t val, char* buf)
       val /= 10;
     }
   }
-  bstrncpy(buf, &mbuf[i + 1], DEFAULT_FORMAT_LENGTH);
+  bstrncpy(buf, &mbuf[i + 1], edit::min_buffer_size);
 
   return buf;
 }
 
 /*
  * Edit an integer number, the supplied buffer must be at least
- * DEFAULT_FORMAT_LENGTH bytes long. The incoming number is always widened to 64
+ * min_buffer_size bytes long. The incoming number is always widened to 64
  * bits. Replacement for sprintf(buf, "%" llu, val)
  */
 char* edit_int64(int64_t val, char* buf)
 {
+  if (val == 0) {
+    bstrncpy(buf, "0", edit::min_buffer_size);
+    return buf;
+  } else if (val == std::numeric_limits<int64_t>::min()) {
+    bstrncpy(buf, "-9223372036854775808", edit::min_buffer_size);
+    return buf;
+  }
+
   char mbuf[50];
   bool negative = false;
   mbuf[sizeof(mbuf) - 1] = 0;
   int i = sizeof(mbuf) - 2; /* Edit backward */
 
-  if (val == 0) {
-    mbuf[i--] = '0';
-  } else {
-    if (val < 0) {
-      negative = true;
-      val = -val;
-    }
-    while (val != 0) {
-      mbuf[i--] = "0123456789"[val % 10];
-      val /= 10;
-    }
+  if (val < 0) {
+    negative = true;
+    val = -val;
+  }
+  while (val != 0) {
+    mbuf[i--] = "0123456789"[val % 10];
+    val /= 10;
   }
   if (negative) { mbuf[i--] = '-'; }
-  bstrncpy(buf, &mbuf[i + 1], DEFAULT_FORMAT_LENGTH);
+  bstrncpy(buf, &mbuf[i + 1], edit::min_buffer_size);
 
   return buf;
 }
 
 /*
  * Edit an integer number with commas, the supplied buffer must be at least
- * DEFAULT_FORMAT_LENGTH bytes long. The incoming number is always widened to 64
+ * min_buffer_size bytes long. The incoming number is always widened to 64
  * bits.
  */
 char* edit_int64_with_commas(int64_t val, char* buf)

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,18 +23,31 @@
 
 #include <vector>
 
+namespace edit {
+/* The biggest 64 bit number -- 2^64-1 -- has 20 digits.
+ * As such one needs 27 = 20 + 6 + 1 chracters to safely format 64 bit numbers
+ * with commata every 3 digits and a nul terminator.
+ * 64 bit signed integers have at most 19 digits so this also works for them. */
+inline constexpr int32_t min_buffer_size{27};
+};  // namespace edit
+
 uint64_t str_to_uint64(const char* str);
 #define str_to_uint16(str) ((uint16_t)str_to_uint64(str))
 #define str_to_uint32(str) ((uint32_t)str_to_uint64(str))
 int64_t str_to_int64(const char* str);
 #define str_to_int16(str) ((int16_t)str_to_int64(str))
 #define str_to_int32(str) ((int32_t)str_to_int64(str))
+
+/* the buffer passed to the following edit_* functions
+ * should be able to hold at least min_buffer_size characters */
+
 char* edit_uint64_with_commas(uint64_t val, char* buf);
 char* edit_uint64_with_suffix(uint64_t val, char* buf);
-char* add_commas(char* val, char* buf);
 char* edit_uint64(uint64_t val, char* buf);
 char* edit_int64(int64_t val, char* buf);
 char* edit_int64_with_commas(int64_t val, char* buf);
+
+char* add_commas(char* val, char* buf);
 bool DurationToUtime(char* str, utime_t* value);
 bool size_to_uint64(char* str, uint64_t* value);
 bool speed_to_uint64(char* str, uint64_t* value);
@@ -43,7 +56,7 @@ char* edit_pthread(pthread_t val, char* buf, int buf_len);
 bool Is_a_number(const char* num);
 bool Is_a_number_list(const char* n);
 bool IsAnInteger(const char* n);
-bool IsNameValid(const char* name, std::string &msg);
+bool IsNameValid(const char* name, std::string& msg);
 bool IsNameValid(const char* name);
 bool IsAclEntryValid(const char* acl, std::vector<char>& msg);
 bool IsAclEntryValid(const char* acl);

--- a/core/src/lib/network_order.h
+++ b/core/src/lib/network_order.h
@@ -1,0 +1,107 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation, which is
+   listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_NETWORK_ORDER_H_
+#define BAREOS_LIB_NETWORK_ORDER_H_
+
+#include <cstdint>
+#include <cstring>
+#include <type_traits>
+
+#include "config.h"
+
+namespace network_order {
+
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+constexpr T byteswap(T i)
+{
+  using U = std::make_unsigned_t<T>;
+  static_assert(sizeof(U) == sizeof(T));
+
+  U u;
+  std::memcpy(&u, &i, sizeof(U));
+  if constexpr (sizeof(T) == 1) {
+    u = u;
+  } else if constexpr (sizeof(T) == 2) {
+    u = ((u & 0x00ff) << 8) | ((u & 0xff00) >> 8);
+  } else if constexpr (sizeof(T) == 4) {
+    u = ((u & 0x000000ff) << 24) | ((u & 0x0000ff00) << 8)
+        | ((u & 0x00ff0000) >> 8) | ((u & 0xff000000) >> 24);
+  } else if constexpr (sizeof(T) == 8) {
+    u = ((u & 0x00000000000000ff) << 56) | ((u & 0x000000000000ff00) << 40)
+        | ((u & 0x0000000000ff0000) << 24) | ((u & 0x00000000ff000000) << 8)
+        | ((u & 0x000000ff00000000) >> 8) | ((u & 0x0000ff0000000000) >> 24)
+        | ((u & 0x00ff000000000000) >> 40) | ((u & 0xff00000000000000) >> 56);
+  } else {
+    static_assert(false, "Unsupported integer-width");
+  }
+
+  std::memcpy(&i, &u, sizeof(T));
+  return i;
+}
+
+namespace {
+#if defined(HAVE_BIG_ENDIAN)
+inline constexpr bool needs_flip = false;
+#else
+inline constexpr bool needs_flip = true;
+#endif
+};  // namespace
+
+template <typename T, typename = std::enable_if_t<std::is_integral_v<T>>>
+struct network {
+  [[implicit]] constexpr network(T value) noexcept
+  {
+    // since we have user provided constructors, we are not a pod type
+    // but we should ensure that we meet the other criteria
+    static_assert(sizeof(*this) == sizeof(T));
+    static_assert(alignof(*this) == alignof(T));
+    store(value);
+  }
+
+  constexpr network() noexcept : network{T{}} {}
+
+  constexpr inline T load() const noexcept
+  {
+    if constexpr (needs_flip) {
+      return byteswap(storage);
+    } else {
+      return storage;
+    }
+  }
+
+  constexpr inline void store(T value) noexcept
+  {
+    if constexpr (needs_flip) {
+      storage = byteswap(value);
+    } else {
+      storage = value;
+    }
+  }
+
+  constexpr operator T() const noexcept { return load(); }
+
+ private:
+  T storage;
+};
+
+} /* namespace network_order */
+#endif  // BAREOS_LIB_NETWORK_ORDER_H_

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -1128,7 +1128,7 @@ reread:
   dev->block_num++;
 
   // Update dcr values
-  if (dev->IsTape()) {
+  if (dev->GetSeekMode() == SeekMode::FILE_BLOCK) {
     dcr->EndBlock = dev->EndBlock;
     dcr->EndFile = dev->EndFile;
   } else {

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -145,12 +145,16 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
   if (!VolumeName.empty()) {
     bstrncpy(VolName, VolumeName.c_str(), sizeof(VolName));
     if (VolumeName.size() >= MAX_NAME_LENGTH) {
-      Jmsg0(jcr, M_ERROR, 0,
+      /* We do not handle this case gracefully, so its best to just
+       * abort the job here. */
+      Jmsg0(jcr, M_FATAL, 0,
             _("Volume name or names is too long. Please use a .bsr file.\n"));
+      return false;
     }
   } else {
     VolName[0] = 0;
   }
+
   if (!jcr->sd_impl->read_session.bsr && VolName[0] == 0) {
     if (!bstrncmp(dev_name, "/dev/", 5)) {
       /* Try stripping file part */

--- a/core/src/stored/device.cc
+++ b/core/src/stored/device.cc
@@ -201,7 +201,7 @@ void SetStartVolPosition(DeviceControlRecord* dcr)
 {
   Device* dev = dcr->dev;
   /* Set new start position */
-  if (dev->IsTape()) {
+  if (dev->GetSeekMode() == SeekMode::FILE_BLOCK) {
     dcr->StartBlock = dev->block_num;
     dcr->StartFile = dev->file;
   } else {

--- a/core/src/stored/record.cc
+++ b/core/src/stored/record.cc
@@ -601,13 +601,8 @@ static inline ssize_t WriteHeaderToBlock(DeviceBlock* block,
 
   SerBegin(block->bufp, WRITE_RECHDR_LENGTH);
 
-  if (BLOCK_VER == 1) {
-    ser_uint32(rec->VolSessionId);
-    ser_uint32(rec->VolSessionTime);
-  } else {
-    block->VolSessionId = rec->VolSessionId;
-    block->VolSessionTime = rec->VolSessionTime;
-  }
+  block->VolSessionId = rec->VolSessionId;
+  block->VolSessionTime = rec->VolSessionTime;
 
   ser_int32(rec->FileIndex);
   ser_int32(Stream);

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -761,7 +761,12 @@ static time_t CvtFtimeToUtime(const FILETIME& time)
   mstime -= WIN32_FILETIME_ADJUST;
   mstime /= WIN32_FILETIME_SCALE; /* convert to seconds. */
 
-  return (time_t)(mstime & 0xffffffff);
+  if constexpr (sizeof(time_t) < sizeof(mstime)) {
+    // take care of 32bit time_ts (i.e. on 32bit windows)
+    return static_cast<time_t>(mstime & 0xffff'ffff);
+  } else {
+    return static_cast<time_t>(mstime);
+  }
 }
 
 static time_t CvtFtimeToUtime(const LARGE_INTEGER& time)
@@ -774,7 +779,12 @@ static time_t CvtFtimeToUtime(const LARGE_INTEGER& time)
   mstime -= WIN32_FILETIME_ADJUST;
   mstime /= WIN32_FILETIME_SCALE; /* convert to seconds. */
 
-  return (time_t)(mstime & 0xffffffff);
+  if constexpr (sizeof(time_t) < sizeof(mstime)) {
+    // take care of 32bit time_ts (i.e. on 32bit windows)
+    return static_cast<time_t>(mstime & 0xffff'ffff);
+  } else {
+    return static_cast<time_t>(mstime);
+  }
 }
 
 bool CreateJunction(const char* szJunction, const char* szPath)

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -1166,7 +1166,17 @@ static int GetWindowsFileInfo(const char* filename,
                                            sizeof(basic_info))) {
           pftLastAccessTime = (FILETIME*)&basic_info.LastAccessTime;
           pftLastWriteTime = (FILETIME*)&basic_info.LastWriteTime;
-          pftChangeTime = (FILETIME*)&basic_info.ChangeTime;
+          // changetime is not updated when a file is copied to a new location
+          // only creation time is updated (dont ask me how you update
+          // the creation time without updating the meta data)
+          // as such we need to take the maximum here!
+          if (CompareFileTime((FILETIME*)&basic_info.ChangeTime,
+                              (FILETIME*)&basic_info.CreationTime)
+              < 0) {
+            pftChangeTime = (FILETIME*)&basic_info.CreationTime;
+          } else {
+            pftChangeTime = (FILETIME*)&basic_info.ChangeTime;
+          }
           use_fallback_data = false;
         }
       }
@@ -1181,11 +1191,23 @@ static int GetWindowsFileInfo(const char* filename,
       if (p_FindFirstFileW) { /* use unicode */
         pftLastAccessTime = &info_w.ftLastAccessTime;
         pftLastWriteTime = &info_w.ftLastWriteTime;
-        pftChangeTime = &info_w.ftLastWriteTime;
+        // if change time is not available we fallback to
+        // using lastwritetime instead
+        if (CompareFileTime(&info_w.ftLastWriteTime, &info_w.ftCreationTime)
+            < 0) {
+          pftChangeTime = &info_w.ftCreationTime;
+        } else {
+          pftChangeTime = &info_w.ftLastWriteTime;
+        }
       } else {
         pftLastAccessTime = &info_a.ftLastAccessTime;
         pftLastWriteTime = &info_a.ftLastWriteTime;
-        pftChangeTime = &info_a.ftLastWriteTime;
+        if (CompareFileTime(&info_a.ftLastWriteTime, &info_a.ftCreationTime)
+            < 0) {
+          pftChangeTime = &info_a.ftCreationTime;
+        } else {
+          pftChangeTime = &info_a.ftLastWriteTime;
+        }
       }
     }
 
@@ -1380,7 +1402,18 @@ int fstat(intptr_t fd, struct stat* sb)
                                        sizeof(basic_info))) {
       sb->st_atime = CvtFtimeToUtime(basic_info.LastAccessTime);
       sb->st_mtime = CvtFtimeToUtime(basic_info.LastWriteTime);
-      sb->st_ctime = CvtFtimeToUtime(basic_info.ChangeTime);
+
+      // changetime is not updated when a file is copied to a new location
+      // only creation time is updated (dont ask me how you update
+      // the creation time without updating the meta data)
+      // as such we need to take the maximum here!
+      if (CompareFileTime((FILETIME*)&basic_info.ChangeTime,
+                          (FILETIME*)&basic_info.CreationTime)
+          < 0) {
+        sb->st_ctime = CvtFtimeToUtime(basic_info.CreationTime);
+      } else {
+        sb->st_ctime = CvtFtimeToUtime(basic_info.ChangeTime);
+      }
       use_fallback_data = false;
     }
   }
@@ -1389,7 +1422,12 @@ int fstat(intptr_t fd, struct stat* sb)
   if (use_fallback_data) {
     sb->st_atime = CvtFtimeToUtime(info.ftLastAccessTime);
     sb->st_mtime = CvtFtimeToUtime(info.ftLastWriteTime);
-    sb->st_ctime = CvtFtimeToUtime(info.ftLastWriteTime);
+    // if changetime is not available we fallback to LastWriteTime
+    if (CompareFileTime(&info.ftLastWriteTime, &info.ftCreationTime) < 0) {
+      sb->st_ctime = CvtFtimeToUtime(info.ftCreationTime);
+    } else {
+      sb->st_ctime = CvtFtimeToUtime(info.ftLastWriteTime);
+    }
   }
 
   return 0;

--- a/core/src/win32/filed/vss_generic.cc
+++ b/core/src/win32/filed/vss_generic.cc
@@ -78,10 +78,6 @@ using namespace std;
 class IXMLDOMDocument;
 #  endif
 
-// Reduce compiler warnings from Windows vss code
-#  undef uuid
-#  define uuid(x)
-
 #  define VSSClientGeneric VSSClientVista
 #  include "Win2003/vss.h"
 #  include "Win2003/vswriter.h"


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Currently bareos does some things differently if the target device is a tape.  But in some of those cases it should consider all block based devices instead.

This PR also reverses the changes to ctime on windows, since after the change bareos did not pick up copied files correctly.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR