### PR TITLE
bareos-check-sources: ignore bootstrap*.css

### DIFF
--- a/.bareos-check-sources-ignore
+++ b/.bareos-check-sources-ignore
@@ -20,6 +20,7 @@ webui/public/js/apexcharts.js
 webui/public/js/partials/*.min.*
 webui/public/js/bootstrap-select.js.map
 webui/public/css/*.min.*
+webui/public/css/bootstrap*.css
 webui/public/css/bootstrap*.css.map
 systemtests/tests/bareos-basic/expected/status-subscriptions.txt
 systemtests/tests/bareos-basic/expected/status-subscriptions-detail.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - config: deprecate `LabelType` and `CheckLabels` [PR #1521]
 - devtools: Update python dependencies [PR #1531]
 - webui: upgrade bootstrap to version 3.4.1 [PR #1550]
+- bareos-check-sources: ignore bootstrap*.css [PR #1556]
 
 ### Removed
 - remove no longer used pkglists [PR #1335]
@@ -242,4 +243,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1524]: https://github.com/bareos/bareos/pull/1524
 [PR #1531]: https://github.com/bareos/bareos/pull/1531
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
+[PR #1556]: https://github.com/bareos/bareos/pull/1556
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
The bareos-webui uses bootstrap
and therefore we include bootstrap files in our repo. bareos-check-sources should not modify these files and therefore we exclude them.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

