### PR TITLE
daemons: set CLI11 error exit code to `41` and bareos config parsing error exit code to `42`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: upgrade bootstrap to version 3.4.1 [PR #1551]
 - VMware Plugin: Fix transformer issues [PR #1555]
 - build: introduce fedora38 [PR #1564]
+- daemons: set CLI11 error exit code to `41` and bareos config parsing error exit code to `42` [PR #1557]
 
 ### Fixed
 - stored: fix incoherent meta data when concurrently writing to the same volume [PR #1514]
@@ -572,5 +573,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1534]: https://github.com/bareos/bareos/pull/1534
 [PR #1551]: https://github.com/bareos/bareos/pull/1551
 [PR #1555]: https://github.com/bareos/bareos/pull/1555
+[PR #1557]: https://github.com/bareos/bareos/pull/1557
 [PR #1564]: https://github.com/bareos/bareos/pull/1564
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/systemd/bareos-dir.service.in
+++ b/core/platforms/systemd/bareos-dir.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service mysql.service mariadb.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-dir
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-fd.service.in
+++ b/core/platforms/systemd/bareos-fd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/platforms/systemd/bareos-sd.service.in
+++ b/core/platforms/systemd/bareos-sd.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the the maximum number of open file descriptors
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-fd
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -945,14 +945,17 @@ int main(int argc, char* argv[])
   if (export_config_schema) {
     PoolMem buffer;
 
-    my_config = InitConsConfig(configfile, M_ERROR_TERM);
+    my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
     exit(0);
   }
 
-  my_config = InitConsConfig(configfile, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "console/console_conf.h"
 #include "console/console_globals.h"
 #include "console/auth_pam.h"
@@ -948,7 +949,7 @@ int main(int argc, char* argv[])
     my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
@@ -956,8 +957,8 @@ int main(int argc, char* argv[])
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);
-    TerminateConsole(0);
-    exit(0);
+    TerminateConsole(BEXIT_SUCCESS);
+    exit(BEXIT_SUCCESS);
   }
 
   if (InitCrypto() != 0) {
@@ -980,8 +981,8 @@ int main(int argc, char* argv[])
   }
 
   if (test_config) {
-    TerminateConsole(0);
-    exit(0);
+    TerminateConsole(BEXIT_SUCCESS);
+    exit(BEXIT_SUCCESS);
   }
 
   (void)WSA_Init(); /* Initialize Windows sockets */
@@ -1108,8 +1109,8 @@ int main(int argc, char* argv[])
 
   if (history_file.size()) { ConsoleUpdateHistory(history_file.c_str()); }
 
-  TerminateConsole(0);
-  return 0;
+  TerminateConsole(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 static void TerminateConsole(int sig)

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -952,10 +952,7 @@ int main(int argc, char* argv[])
   }
 
   my_config = InitConsConfig(configfile, M_CONFIG_ERROR);
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -259,10 +259,8 @@ static void ReadAndProcessInput(FILE* input, BareosSocket* UA_sock)
         at_prompt = false;
       }
 
-      /*
-       * Suppress output if running
-       * in background or user hit ctl-c
-       */
+      /* Suppress output if running
+       * in background or user hit ctl-c */
       if (!stop && !usrbrk()) {
         if (UA_sock->msg) { ConsoleOutput(UA_sock->msg); }
       }
@@ -585,10 +583,8 @@ int GetCmd(FILE* input, const char* prompt, BareosSocket* sock, int)
   StripTrailingJunk(line);
   command = line;
 
-  /*
-   * Split "line" into multiple commands separated by the eol character.
-   *   Each part is pointed to by "next" until finally it becomes null.
-   */
+  /* Split "line" into multiple commands separated by the eol character.
+   *   Each part is pointed to by "next" until finally it becomes null. */
   if (eol == '\0') {
     next = NULL;
   } else {
@@ -675,13 +671,9 @@ static bool SelectDirector(const char* director,
 
   LockRes(console::my_config);
   numdir = 0;
-  foreach_res (director_resource_tmp, R_DIRECTOR) {
-    numdir++;
-  }
+  foreach_res (director_resource_tmp, R_DIRECTOR) { numdir++; }
   numcon = 0;
-  foreach_res (console_resource_tmp, R_CONSOLE) {
-    numcon++;
-  }
+  foreach_res (console_resource_tmp, R_CONSOLE) { numcon++; }
   UnlockRes(my_config);
 
   if (numdir == 1) { /* No choose */
@@ -1141,9 +1133,7 @@ static int CheckResources()
   LockRes(my_config);
 
   numdir = 0;
-  foreach_res (director, R_DIRECTOR) {
-    numdir++;
-  }
+  foreach_res (director, R_DIRECTOR) { numdir++; }
 
   if (numdir == 0) {
     const std::string& configfile = my_config->get_base_config_path();

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -926,7 +926,7 @@ int main(int argc, char* argv[])
 
   AddNetworkDebuggingOption(console_app);
 
-  CLI11_PARSE(console_app, argc, argv);
+  ParseBareosApp(console_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateConsole); }
 

--- a/core/src/console/console.cc
+++ b/core/src/console/console.cc
@@ -1118,7 +1118,7 @@ static void TerminateConsole(int sig)
   static bool already_here = false;
 
   if (already_here) { /* avoid recursive temination problems */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   already_here = true;
   StopWatchdog();
@@ -1129,7 +1129,7 @@ static void TerminateConsole(int sig)
   ConTerm();
   WSACleanup(); /* Cleanup Windows sockets */
 
-  if (sig != 0) { exit(1); }
+  if (sig != 0) { exit(BEXIT_FAILURE); }
   return;
 }
 

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -862,7 +862,7 @@ int main(int argc, char* argv[])
   manual_args->add_option("port", dbport, "Database port")
       ->check(CLI::PositiveNumber);
 
-  CLI11_PARSE(dbcheck_app, argc, argv);
+  ParseBareosApp(dbcheck_app, argc, argv);
 
   const char* db_driver = "postgresql";
 #if defined(HAVE_DYNAMIC_CATS_BACKENDS)

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -431,14 +431,12 @@ static void eliminate_orphaned_client_records()
   const char* query;
 
   printf(_("Checking for orphaned Client entries.\n"));
-  /*
-   * In English:
+  /* In English:
    *   Wiffle through Client for every Client
    *   joining with the Job table including every Client even if
    *   there is not a match in Job (left outer join), then
    *   filter out only those where no Job points to a Client
-   *   i.e. Job.Client is NULL
-   */
+   *   i.e. Job.Client is NULL */
   query
       = "SELECT Client.ClientId,Client.Name FROM Client "
         "LEFT OUTER JOIN Job USING(ClientId) "
@@ -473,14 +471,12 @@ static void eliminate_orphaned_job_records()
   const char* query;
 
   printf(_("Checking for orphaned Job entries.\n"));
-  /*
-   * In English:
+  /* In English:
    *   Wiffle through Job for every Job
    *   joining with the Client table including every Job even if
    *   there is not a match in Client (left outer join), then
    *   filter out only those where no Client exists
-   *   i.e. Client.Name is NULL
-   */
+   *   i.e. Client.Name is NULL */
   query
       = "SELECT Job.JobId,Job.Name FROM Job "
         "LEFT OUTER JOIN Client USING(ClientId) "

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -234,7 +234,7 @@ static void eliminate_duplicate_paths()
       = "SELECT Path, count(Path) as Count FROM Path "
         "GROUP BY Path HAVING count(Path) > 1";
 
-  if (!MakeNameList(db, query, &name_list)) { exit(1); }
+  if (!MakeNameList(db, query, &name_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d duplicate Path records.\n"), name_list.num_ids);
   fflush(stdout);
   if (name_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -250,7 +250,7 @@ static void eliminate_duplicate_paths()
       Bsnprintf(buf, sizeof(buf), "SELECT PathId FROM Path WHERE Path='%s'",
                 esc_name);
       if (verbose > 1) { printf("%s\n", buf); }
-      if (!MakeIdList(db, buf, &id_list)) { exit(1); }
+      if (!MakeIdList(db, buf, &id_list)) { exit(BEXIT_FAILURE); }
       if (verbose) {
         printf(_("Found %d for: %s\n"), id_list.num_ids, name_list.name[i]);
       }
@@ -283,7 +283,7 @@ static void eliminate_orphaned_jobmedia_records()
 
   printf(_("Checking for orphaned JobMedia entries.\n"));
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned JobMedia records.\n"), id_list.num_ids);
@@ -309,7 +309,7 @@ static void eliminate_orphaned_jobmedia_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query, &id_list)) { exit(1); }
+    if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   }
   fflush(stdout);
 }
@@ -324,7 +324,7 @@ static void eliminate_orphaned_file_records()
   printf(_("Checking for orphaned File entries. This may take some time!\n"));
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned File records.\n"), id_list.num_ids);
@@ -347,7 +347,7 @@ static void eliminate_orphaned_file_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query, &id_list)) { exit(1); }
+    if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   }
   fflush(stdout);
 }
@@ -365,7 +365,7 @@ static void eliminate_orphaned_path_records()
   printf(_("Checking for orphaned Path entries. This may take some time!\n"));
   if (verbose > 1) { printf("%s\n", query.c_str()); }
   fflush(stdout);
-  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   // Loop doing 300000 at a time
   while (id_list.num_ids != 0) {
     printf(_("Found %d orphaned Path records.\n"), id_list.num_ids);
@@ -387,7 +387,7 @@ static void eliminate_orphaned_path_records()
     } else {
       break; /* get out if not updating db */
     }
-    if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+    if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   }
 }
 
@@ -402,7 +402,7 @@ static void eliminate_orphaned_fileset_records()
         "WHERE Job.FileSetId IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned FileSet records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -445,7 +445,7 @@ static void eliminate_orphaned_client_records()
         "WHERE Job.ClientId IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned Client records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -487,7 +487,7 @@ static void eliminate_orphaned_job_records()
         "WHERE Client.Name IS NULL";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d orphaned Job records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -560,7 +560,7 @@ static void eliminate_admin_records()
         "WHERE Job.Type='D'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d Admin Job records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -593,7 +593,7 @@ static void eliminate_restore_records()
         "WHERE Job.Type='R'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d Restore Job records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (int i = 0; i < id_list.num_ids; i++) {
@@ -627,7 +627,7 @@ static void repair_bad_filenames()
         "WHERE Name LIKE '%/'";
   if (verbose > 1) { printf("%s\n", query); }
   fflush(stdout);
-  if (!MakeIdList(db, query, &id_list)) { exit(1); }
+  if (!MakeIdList(db, query, &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d bad Filename records.\n"), id_list.num_ids);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
     for (i = 0; i < id_list.num_ids; i++) {
@@ -684,7 +684,7 @@ static void repair_bad_paths()
   db->FillQuery(query, BareosDb::SQL_QUERY::get_bad_paths_0);
   if (verbose > 1) { printf("%s\n", query.c_str()); }
   fflush(stdout);
-  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &id_list)) { exit(BEXIT_FAILURE); }
   printf(_("Found %d bad Path records.\n"), id_list.num_ids);
   fflush(stdout);
   if (id_list.num_ids && verbose && yes_no(_("Print them? (yes/no): "))) {
@@ -902,7 +902,7 @@ int main(int argc, char* argv[])
                 "[%s]\n"),
               configfile.c_str());
       }
-      exit(1);
+      exit(BEXIT_FAILURE);
     } else {
       LockRes(my_config);
       me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
@@ -910,7 +910,7 @@ int main(int argc, char* argv[])
       UnlockRes(my_config);
       if (!me) {
         Pmsg0(0, _("Error no Director resource defined.\n"));
-        exit(1);
+        exit(BEXIT_FAILURE);
       }
 
       SetWorkingDirectory(me->working_directory);

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -24,6 +24,7 @@
 // Program to check a BAREOS database for consistency and to make repairs
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "cats/cats.h"
 #include "cats/cats_backends.h"
 #include "lib/runscript.h"
@@ -920,7 +921,7 @@ int main(int argc, char* argv[])
       // Print catalog information and exit (-B)
       if (print_catalog) {
         PrintCatalogDetails(catalog);
-        exit(0);
+        exit(BEXIT_SUCCESS);
       }
 
       db_name = catalog->db_name;
@@ -966,5 +967,5 @@ int main(int argc, char* argv[])
   CloseMsg(nullptr);
   TermMsg();
 
-  return 0;
+  return BEXIT_SUCCESS;
 }

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -874,10 +874,7 @@ int main(int argc, char* argv[])
     int found = 0;
 
     my_config = InitDirConfig(configfile.c_str(), M_CONFIG_ERROR);
-    if (!my_config->ParseConfig()) {
-      std::cerr << "Configuration parsing error" << std::endl;
-      exit(configerror_exit_code);
-    }
+    my_config->ParseConfigOrExit();
 
     LockRes(my_config);
     foreach_res (catalog, R_CATALOG) {

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -873,8 +873,12 @@ int main(int argc, char* argv[])
     CatalogResource* catalog = nullptr;
     int found = 0;
 
-    my_config = InitDirConfig(configfile.c_str(), M_ERROR_TERM);
-    my_config->ParseConfig();
+    my_config = InitDirConfig(configfile.c_str(), M_CONFIG_ERROR);
+    if (!my_config->ParseConfig()) {
+      std::cerr << "Configuration parsing error" << std::endl;
+      exit(configerror_exit_code);
+    }
+
     LockRes(my_config);
     foreach_res (catalog, R_CATALOG) {
       if (!catalogname.empty()

--- a/core/src/dird/dbcheck_utils.cc
+++ b/core/src/dird/dbcheck_utils.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/dird/dbcheck_utils.cc
+++ b/core/src/dird/dbcheck_utils.cc
@@ -20,6 +20,7 @@
 */
 
 #include "dbcheck_utils.h"
+#include "include/exit_codes.h"
 
 using namespace directordaemon;
 
@@ -166,7 +167,9 @@ std::vector<int> get_deletable_storageids(
   query += ")";
 
   ID_LIST orphaned_storage_ids_list{};
-  if (!MakeIdList(db, query.c_str(), &orphaned_storage_ids_list)) { exit(1); }
+  if (!MakeIdList(db, query.c_str(), &orphaned_storage_ids_list)) {
+    exit(BEXIT_FAILURE);
+  }
 
   std::vector<int> storage_ids_to_delete;
   NameList volume_names = {};
@@ -178,7 +181,9 @@ std::vector<int> get_deletable_storageids(
         = "SELECT volumename FROM media WHERE storageid="
           + std::to_string(orphaned_storage_ids_list.Id[orphaned_storage_id]);
 
-    if (!MakeNameList(db, media_query.c_str(), &volume_names)) { exit(1); }
+    if (!MakeNameList(db, media_query.c_str(), &volume_names)) {
+      exit(BEXIT_FAILURE);
+    }
 
     if (volume_names.num_ids > 0) {
       for (int volumename = 0; volumename < volume_names.num_ids;
@@ -197,7 +202,9 @@ std::vector<int> get_deletable_storageids(
         = "SELECT name FROM device WHERE storageid="
           + std::to_string(orphaned_storage_ids_list.Id[orphaned_storage_id]);
 
-    if (!MakeNameList(db, device_query.c_str(), &device_names)) { exit(1); }
+    if (!MakeNameList(db, device_query.c_str(), &device_names)) {
+      exit(BEXIT_FAILURE);
+    }
 
     if (device_names.num_ids > 0) {
       for (int devicename = 0; devicename < device_names.num_ids;
@@ -240,7 +247,7 @@ std::vector<std::string> get_orphaned_storages_names(BareosDb* db)
 
   NameList database_storage_names_list{};
   if (!MakeNameList(db, query.c_str(), &database_storage_names_list)) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   std::vector<std::string> orphaned_storage_names_list;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -265,10 +265,7 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     int rc = 0;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -444,10 +444,8 @@ extern "C" void SighandlerReloadConfig(int, siginfo_t*, void*)
   static bool is_reloading = false;
 
   if (is_reloading) {
-    /*
-     * Note: don't use Jmsg here, as it could produce a race condition
-     * on multiple parallel reloads
-     */
+    /* Note: don't use Jmsg here, as it could produce a race condition
+     * on multiple parallel reloads */
     Qmsg(nullptr, M_ERROR, 0, _("Already reloading. Request ignored.\n"));
     return;
   }
@@ -464,10 +462,8 @@ static bool InitSighandlerSighup()
   sigset_t block_mask;
   struct sigaction action = {};
 
-  /*
-   *  while handling SIGHUP signal,
-   *  ignore further SIGHUP signals.
-   */
+  /*  while handling SIGHUP signal,
+   *  ignore further SIGHUP signals. */
   sigemptyset(&block_mask);
   sigaddset(&block_mask, SIGHUP);
 

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -400,7 +400,7 @@ static
 
   if (is_reloading) {  /* avoid recursive termination problems */
     Bmicrosleep(2, 0); /* yield */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   is_reloading = true;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "cats/cats_backends.h"
 #include "cats/sql.h"
 #include "cats/sql_pooling.h"
@@ -261,8 +262,8 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   my_config->ParseConfigOrExit();
@@ -275,7 +276,7 @@ int main(int argc, char* argv[])
       rc = 1;
     }
     TerminateDird(rc);
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   if (!CheckResources()) {
@@ -283,8 +284,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (my_config->HasWarnings()) {
@@ -304,8 +305,8 @@ int main(int argc, char* argv[])
     Jmsg((JobControlRecord*)nullptr, M_ERROR_TERM, 0,
          _("Cryptography library initialization failed.\n"));
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (!test_config) {
@@ -333,8 +334,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   if (test_config) { TerminateDird(0); }
@@ -344,8 +345,8 @@ int main(int argc, char* argv[])
          _("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
 
-    TerminateDird(0);
-    return 0;
+    TerminateDird(BEXIT_SUCCESS);
+    return BEXIT_SUCCESS;
   }
 
   MyNameIs(0, nullptr, me->resource_name_); /* set user defined name */
@@ -380,8 +381,8 @@ int main(int argc, char* argv[])
 
   Scheduler::GetMainScheduler().Run();
 
-  TerminateDird(0);
-  return 0;
+  TerminateDird(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 /**

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -254,7 +254,7 @@ int main(int argc, char* argv[])
             "but program was not started with required root privileges.\n"));
   }
 
-  my_config = InitDirConfig(configfile, M_ERROR_TERM);
+  my_config = InitDirConfig(configfile, M_CONFIG_ERROR);
   if (export_config_schema) {
     PoolMem buffer;
 
@@ -265,7 +265,10 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-  my_config->ParseConfig();
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     int rc = 0;

--- a/core/src/dird/dird.cc
+++ b/core/src/dird/dird.cc
@@ -229,7 +229,7 @@ int main(int argc, char* argv[])
 
   AddNetworkDebuggingOption(dir_app);
 
-  CLI11_PARSE(dir_app, argc, argv);
+  ParseBareosApp(dir_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateDird); }
 

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -204,7 +204,7 @@ int main(int argc, char* argv[])
   if (!CheckResources()) {
     Emsg1(M_ERROR, 0, _("Please correct configuration file: %s\n"),
           my_config->get_base_config_path().c_str());
-    TerminateFiled(configerror_exit_code);
+    TerminateFiled(BEXIT_CONFIG_ERROR);
   }
 
   if (my_config->HasWarnings()) {

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -421,8 +421,7 @@ static bool CheckResources()
         }
       }
 
-      /*
-       * Crypto recipients. We're always included as a recipient.
+      /* Crypto recipients. We're always included as a recipient.
        * The symmetric session key will be encrypted for each of these readers.
        */
       me->pki_recipients = new alist<X509_KEYPAIR*>(10, not_owned_by_alist);

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -147,7 +147,7 @@ int main(int argc, char* argv[])
 
   AddNetworkDebuggingOption(fd_app);
 
-  CLI11_PARSE(fd_app, argc, argv);
+  ParseBareosApp(fd_app, argc, argv);
 
   if (user.empty() && keep_readall_caps) {
     Emsg0(M_ERROR_TERM, 0, _("-k option has no meaning without -u option.\n"));

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "filed/filed.h"
 #include "filed/filed_globals.h"
 #include "filed/dir_cmd.h"
@@ -189,7 +190,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
@@ -198,7 +199,7 @@ int main(int argc, char* argv[])
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
 
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   if (!CheckResources()) {
@@ -257,9 +258,8 @@ int main(int argc, char* argv[])
   // start socket server to listen for new connections.
   StartSocketServer(me->FDaddrs);
 
-  TerminateFiled(0);
-
-  exit(0);
+  TerminateFiled(BEXIT_SUCCESS);
+  return BEXIT_SUCCESS;
 }
 
 namespace filedaemon {

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -192,8 +192,11 @@ int main(int argc, char* argv[])
     exit(0);
   }
 
-  my_config = InitFdConfig(configfile, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
+  if (!my_config->ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
@@ -204,7 +207,7 @@ int main(int argc, char* argv[])
   if (!CheckResources()) {
     Emsg1(M_ERROR, 0, _("Please correct configuration file: %s\n"),
           my_config->get_base_config_path().c_str());
-    TerminateFiled(1);
+    TerminateFiled(configerror_exit_code);
   }
 
   if (my_config->HasWarnings()) {

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -193,10 +193,7 @@ int main(int argc, char* argv[])
   }
 
   my_config = InitFdConfig(configfile, M_CONFIG_ERROR);
-  if (!my_config->ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
-  }
+  my_config->ParseConfigOrExit();
 
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);

--- a/core/src/filed/filed.cc
+++ b/core/src/filed/filed.cc
@@ -269,8 +269,8 @@ void TerminateFiled(int sig)
   static bool already_here = false;
 
   if (already_here) {
-    Bmicrosleep(2, 0); /* yield */
-    exit(1);           /* prevent loops */
+    Bmicrosleep(2, 0);   /* yield */
+    exit(BEXIT_FAILURE); /* prevent loops */
   }
   already_here = true;
   debug_level = 0; /* turn off debug */

--- a/core/src/include/exit_codes.h
+++ b/core/src/include/exit_codes.h
@@ -1,0 +1,33 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+This program is Free Software; you can redistribute it and/or
+modify it under the terms of version three of the GNU Affero General Public
+License as published by the Free Software Foundation and included
+in the file LICENSE.
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.
+*/
+
+#ifndef BAREOS_INCLUDE_EXIT_CODES_H_
+#define BAREOS_INCLUDE_EXIT_CODES_H_
+
+enum BareosExitCodes : int
+{
+  BEXIT_SUCCESS = 0,
+  BEXIT_FAILURE = 1,
+  BEXIT_CLI_PARSING_ERROR = 41,
+  BEXIT_CONFIG_ERROR = 42,
+};
+
+#endif  // BAREOS_INCLUDE_EXIT_CODES_H_

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -25,6 +25,8 @@
 #include "lib/version.h"
 #include "lib/message.h"
 #include "lib/edit.h"
+#include "include/exit_codes.h"
+
 #include <regex>
 
 class BareosCliFormatter : public CLI::Formatter {
@@ -227,9 +229,9 @@ void ParseBareosApp(CLI::App& app, int argc, char** argv)
   } catch (const CLI::ParseError& e) {
     int cli11_exit = app.exit(e);
     if (cli11_exit == static_cast<int>(CLI::ExitCodes::Success)) {
-      exit(EXIT_SUCCESS);
+      exit(BEXIT_SUCCESS);
     } else {
-      exit(kBareosCLI11ExitCode);
+      exit(BEXIT_CLI_PARSING_ERROR);
     }
   }
 }

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -219,3 +219,17 @@ void AddUserAndGroupOptions(CLI::App& app,
                  "Run as given group (requires starting as root)")
       ->type_name("<group>");
 }
+
+void ParseBareosApp(CLI::App& app, int argc, char** argv)
+{
+  try {
+    app.parse(argc, argv);
+  } catch (const CLI::ParseError& e) {
+    int cli11_exit = app.exit(e);
+    if (cli11_exit == static_cast<int>(CLI::ExitCodes::Success)) {
+      exit(EXIT_SUCCESS);
+    } else {
+      exit(kBareosCLI11ExitCode);
+    }
+  }
+}

--- a/core/src/lib/cli.h
+++ b/core/src/lib/cli.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/cli.h
+++ b/core/src/lib/cli.h
@@ -25,6 +25,9 @@
 #include "CLI/Config.hpp"
 #include "CLI/Formatter.hpp"
 
+const short kBareosCLI11ExitCode = 41;
+
+void ParseBareosApp(CLI::App& app, int argc, char** argv);
 void InitCLIApp(CLI::App& app, std::string description, int fsfyear = 0);
 void AddDebugOptions(CLI::App& app);
 void AddVerboseOption(CLI::App& app);

--- a/core/src/lib/cli.h
+++ b/core/src/lib/cli.h
@@ -25,8 +25,6 @@
 #include "CLI/Config.hpp"
 #include "CLI/Formatter.hpp"
 
-const short kBareosCLI11ExitCode = 41;
-
 void ParseBareosApp(CLI::App& app, int argc, char** argv);
 void InitCLIApp(CLI::App& app, std::string description, int fsfyear = 0);
 void AddDebugOptions(CLI::App& app);

--- a/core/src/lib/daemon.cc
+++ b/core/src/lib/daemon.cc
@@ -32,6 +32,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/berrno.h"
 #include "lib/daemon.h"
 
@@ -85,7 +86,7 @@ void daemon_start(const char* progname,
       break;
     }
     default:
-      exit(0);
+      exit(BEXIT_SUCCESS);
   }
 
   Dmsg0(900, "Exit daemon_start\n");

--- a/core/src/lib/daemon.cc
+++ b/core/src/lib/daemon.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -35,6 +35,7 @@
 
 #include "include/bareos.h"
 #include "include/jcr.h"
+#include "include/exit_codes.h"
 #include "lib/berrno.h"
 #include "lib/bsock.h"
 #include "lib/util.h"
@@ -1215,7 +1216,7 @@ void e_msg(const char* file,
   } else if (type == M_ERROR_TERM) {
     exit(1);
   } else if (type == M_CONFIG_ERROR) {
-    exit(configerror_exit_code);
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 
@@ -1344,7 +1345,7 @@ void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
   } else if (type == M_ERROR_TERM) {
     exit(1);
   } else if (type == M_CONFIG_ERROR) {
-    exit(configerror_exit_code);
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -211,10 +211,8 @@ void InitMsg(JobControlRecord* jcr,
   int i;
 
   if (jcr == NULL && msg == NULL) {
-    /*
-     * Setup a daemon key then set invalid jcr
-     * Maybe we should give the daemon a jcr???
-     */
+    /* Setup a daemon key then set invalid jcr
+     * Maybe we should give the daemon a jcr??? */
     SetJcrInThreadSpecificData(nullptr);
   }
 
@@ -412,11 +410,9 @@ void CloseMsg(JobControlRecord* jcr)
             Pmsg1(000, _("close error: ERR=%s\n"), be.bstrerror());
           }
 
-          /*
-           * Since we are closing all messages, before "recursing"
+          /* Since we are closing all messages, before "recursing"
            * make sure we are not closing the daemon messages, otherwise
-           * kaboom.
-           */
+           * kaboom. */
           if (msgs != daemon_msgs) {
             // Read what mail prog returned -- should be nothing
             while (fgets(line, len, bpipe->rfd)) {
@@ -616,12 +612,10 @@ void DispatchMessage(JobControlRecord* jcr,
 
   Dmsg2(850, "Enter DispatchMessage type=%d msg=%s", type, msg);
 
-  /*
-   * Most messages are prefixed by a date and time. If mtime is
+  /* Most messages are prefixed by a date and time. If mtime is
    * zero, then we use the current time.  If mtime is 1 (special
    * kludge), we do not prefix the date and time. Otherwise,
-   * we assume mtime is a utime_t and use it.
-   */
+   * we assume mtime is a utime_t and use it. */
   if (mtime == 0) { mtime = time(NULL); }
 
   *dt = 0;
@@ -653,10 +647,8 @@ void DispatchMessage(JobControlRecord* jcr,
   if (jcr) {
     // See if we need to suppress the messages.
     if (jcr->suppress_output) {
-      /*
-       * See if this JobControlRecord has a controlling JobControlRecord and if
-       * so redirect this message to the controlling JobControlRecord.
-       */
+      /* See if this JobControlRecord has a controlling JobControlRecord and if
+       * so redirect this message to the controlling JobControlRecord. */
       if (jcr->cjcr) {
         jcr = jcr->cjcr;
       } else {
@@ -689,10 +681,8 @@ void DispatchMessage(JobControlRecord* jcr,
 
   for (MessageDestinationInfo* d : msgs->dest_chain_) {
     if (BitIsSet(type, d->msg_types_)) {
-      /*
-       * See if a specific timestamp format was specified for this log resource.
-       * Otherwise apply the global setting in log_timestamp_format.
-       */
+      /* See if a specific timestamp format was specified for this log resource.
+       * Otherwise apply the global setting in log_timestamp_format. */
       if (dt_conversion) {
         if (!d->timestamp_format_.empty()) {
           bstrftime(dt, sizeof(dt), mtime, d->timestamp_format_.c_str());
@@ -744,10 +734,8 @@ void DispatchMessage(JobControlRecord* jcr,
             break;
           }
 
-          /*
-           * Dispatch based on our internal message type to a matching syslog
-           * one.
-           */
+          /* Dispatch based on our internal message type to a matching syslog
+           * one. */
           SendToSyslog(d->syslog_facility_ | MessageTypeToLogPriority(type),
                        msg);
           break;
@@ -882,10 +870,8 @@ const char* get_basename(const char* pathname)
 // Print or write output to trace file
 static void pt_out(char* buf)
 {
-  /*
-   * Used the "trace on" command in the console to turn on
-   * output to the trace file.  "trace off" will close the file.
-   */
+  /* Used the "trace on" command in the console to turn on
+   * output to the trace file.  "trace off" will close the file. */
   if (trace) {
     if (!trace_fd) {
       PoolMem fn(PM_FNAME);
@@ -1198,10 +1184,8 @@ void e_msg(const char* file,
   // show error message also as debug message (level 10)
   d_msg(file, line, 10, "%s: %s", typestr.c_str(), more.c_str());
 
-  /*
-   * Check if we have a message destination defined.
-   * We always report M_ABORT and M_ERROR_TERM
-   */
+  /* Check if we have a message destination defined.
+   * We always report M_ABORT and M_ERROR_TERM */
   if (!daemon_msgs
       || ((type != M_ABORT && type != M_ERROR_TERM && type != M_CONFIG_ERROR)
           && !BitIsSet(type, daemon_msgs->send_msg_types_))) {
@@ -1231,11 +1215,9 @@ void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
 
   Dmsg1(850, "Enter Jmsg type=%d\n", type);
 
-  /*
-   * Special case for the console, which has a dir_bsock and JobId == 0,
+  /* Special case for the console, which has a dir_bsock and JobId == 0,
    * in that case, we send the message directly back to the
-   * dir_bsock.
-   */
+   * dir_bsock. */
   if (jcr && jcr->JobId == 0 && jcr->dir_bsock) {
     BareosSocket* dir = jcr->dir_bsock;
 

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -1214,7 +1214,7 @@ void e_msg(const char* file,
   if (type == M_ABORT) {
     abort();
   } else if (type == M_ERROR_TERM) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   } else if (type == M_CONFIG_ERROR) {
     exit(BEXIT_CONFIG_ERROR);
   }
@@ -1343,7 +1343,7 @@ void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...)
     syslog(LOG_DAEMON | LOG_ERR, "BAREOS aborting to obtain traceback.\n");
     abort();
   } else if (type == M_ERROR_TERM) {
-    exit(1);
+    exit(BEXIT_FAILURE);
   } else if (type == M_CONFIG_ERROR) {
     exit(BEXIT_CONFIG_ERROR);
   }

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -45,6 +45,8 @@ class JobControlRecord;
 typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*,
                                                           const char*);
 
+const short configerror_exit_code = 42;
+
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 bool GetTrace(void);

--- a/core/src/lib/message.h
+++ b/core/src/lib/message.h
@@ -45,8 +45,6 @@ class JobControlRecord;
 typedef std::optional<std::string> (*job_code_callback_t)(JobControlRecord*,
                                                           const char*);
 
-const short configerror_exit_code = 42;
-
 void Jmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 void Qmsg(JobControlRecord* jcr, int type, utime_t mtime, const char* fmt, ...);
 bool GetTrace(void);

--- a/core/src/lib/message_severity.h
+++ b/core/src/lib/message_severity.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message_severity.h
+++ b/core/src/lib/message_severity.h
@@ -90,7 +90,8 @@ enum
   M_SECURITY,
   M_ALERT,
   M_VOLMGMT,
-  M_AUDIT
+  M_AUDIT,
+  M_CONFIG_ERROR,
 };
 
 #define M_MAX M_AUDIT /* keep this updated ! */

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -168,7 +168,7 @@ bool ConfigurationParser::ParseConfig()
   parser_first_run_ = false;
 
   if (!FindConfigPath(config_path)) {
-    Jmsg0(nullptr, M_ERROR_TERM, 0, _("Failed to find config filename.\n"));
+    Jmsg0(nullptr, M_CONFIG_ERROR, 0, _("Failed to find config filename.\n"));
   }
   used_config_path_ = config_path.c_str();
   Dmsg1(100, "config file = %s\n", used_config_path_.c_str());

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -53,6 +53,7 @@
 
 #include "include/bareos.h"
 #include "include/jcr.h"
+#include "include/exit_codes.h"
 #include "lib/address_conf.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
@@ -154,8 +155,8 @@ std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
 void ConfigurationParser::ParseConfigOrExit()
 {
   if (!ParseConfig()) {
-    std::cerr << "Configuration parsing error" << std::endl;
-    exit(configerror_exit_code);
+    fprintf(stderr, "Configuration parsing error\n");
+    exit(BEXIT_CONFIG_ERROR);
   }
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -151,6 +151,13 @@ std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
   }
   return qualified_name;
 }
+void ConfigurationParser::ParseConfigOrExit()
+{
+  if (!ParseConfig()) {
+    std::cerr << "Configuration parsing error" << std::endl;
+    exit(configerror_exit_code);
+  }
+}
 
 bool ConfigurationParser::ParseConfig()
 {

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -408,11 +408,9 @@ bool ConfigurationParser::GetConfigIncludePath(PoolMem& full_path,
   bool found = false;
 
   if (!config_include_dir_.empty()) {
-    /*
-     * Set full_path to the initial part of the include path,
+    /* Set full_path to the initial part of the include path,
      * so it can be used as result, even on errors.
-     * On success, full_path will be overwritten with the full path.
-     */
+     * On success, full_path will be overwritten with the full path. */
     full_path.strcpy(config_dir);
     PathAppend(full_path, config_include_dir_.c_str());
     if (PathIsDirectory(full_path)) {
@@ -476,11 +474,9 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
       found = true;
     }
   } else if (config_default_filename_.empty()) {
-    /*
-     * Compatibility with older versions.
+    /* Compatibility with older versions.
      * If config_default_filename_ is not set,
-     * cf_ may contain what is expected in config_default_filename_.
-     */
+     * cf_ may contain what is expected in config_default_filename_. */
     found = GetConfigFile(full_path, GetDefaultConfigDir(), cf_.c_str());
     if (!found) {
       Jmsg2(nullptr, M_ERROR, 0,
@@ -523,8 +519,7 @@ bool ConfigurationParser::RemoveResource(int rcode, const char* name)
   int rindex = rcode;
   BareosResource* last;
 
-  /*
-   * Remove resource from list.
+  /* Remove resource from list.
    *
    * Note: this is intended for removing a resource that has just been added,
    * but proven to be incorrect (added by console command "configure add").
@@ -673,11 +668,9 @@ bool ConfigurationParser::GetPathOfNewResource(PoolMem& path,
     return false;
   }
 
-  /*
-   * Store name for temporary file in extramsg.
+  /* Store name for temporary file in extramsg.
    * Can be used, if result is true.
-   * Otherwise it contains an error message.
-   */
+   * Otherwise it contains an error message. */
   extramsg.bsprintf("%s.tmp", path.c_str());
 
   if (!error_if_exists) { return true; }

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -248,6 +248,7 @@ class ConfigurationParser {
   ~ConfigurationParser();
 
   bool IsUsingConfigIncludeDir() const { return use_config_include_dir_; }
+  void ParseConfigOrExit();
   bool ParseConfig();
   bool ParseConfigFile(const char* config_file_name,
                        void* caller_ctx,

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/signal.cc
+++ b/core/src/lib/signal.cc
@@ -34,6 +34,7 @@
 
 #ifndef HAVE_WIN32
 #  include "include/bareos.h"
+#  include "include/exit_codes.h"
 #  include "lib/watchdog.h"
 #  include "lib/berrno.h"
 #  include "lib/bsignal.h"
@@ -112,7 +113,7 @@ extern "C" void SignalHandler(int sig)
   int chld_status = -1;
 
   // If we come back more than once, get out fast!
-  if (already_dead) { exit(1); }
+  if (already_dead) { exit(BEXIT_FAILURE); }
   Dmsg2(900, "sig=%d %s\n", sig, sig_names[sig]);
 
   // Ignore certain signals -- SIGUSR2 used to interrupt threads

--- a/core/src/qt-tray-monitor/tray-monitor.cc
+++ b/core/src/qt-tray-monitor/tray-monitor.cc
@@ -35,6 +35,7 @@
 #include "lib/bsignal.h"
 #include "lib/parse_conf.h"
 #include "lib/cli.h"
+#include "include/exit_codes.h"
 
 ConfigurationParser* my_config = nullptr;
 
@@ -165,7 +166,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
     fflush(stdout);
-    exit(0);
+    exit(BEXIT_SUCCESS);
   }
 
   // read the config file

--- a/core/src/qt-tray-monitor/tray-monitor.cc
+++ b/core/src/qt-tray-monitor/tray-monitor.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/qt-tray-monitor/tray-monitor.cc
+++ b/core/src/qt-tray-monitor/tray-monitor.cc
@@ -169,8 +169,8 @@ int main(int argc, char* argv[])
   }
 
   // read the config file
-  my_config = InitTmonConfig(cl.configfile_, M_ERROR_TERM);
-  my_config->ParseConfig();
+  my_config = InitTmonConfig(cl.configfile_, M_CONFIG_ERROR);
+  my_config->ParseConfigOrExit();
 
   if (cl.export_config_) {
     my_config->DumpResources(PrintMessage, NULL);

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bcopy_app, argc, argv);
+  ParseBareosApp(bcopy_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -194,12 +194,12 @@ int main(int argc, char* argv[])
   DeviceControlRecord* in_dcr = new DeviceControlRecord;
   in_jcr = SetupJcr("bcopy", input_archive.data(), bsr, director, in_dcr,
                     inputVolumes, true); /* read device */
-  if (!in_jcr) { exit(1); }
+  if (!in_jcr) { exit(BEXIT_FAILURE); }
 
   in_jcr->sd_impl->ignore_label_errors = ignore_label_errors;
 
   in_dev = in_jcr->sd_impl->dcr->dev;
-  if (!in_dev) { exit(1); }
+  if (!in_dev) { exit(BEXIT_FAILURE); }
 
   // Let SD plugins setup the record translation
   if (GeneratePluginEvent(in_jcr, bSdEventSetupRecordTranslation, in_dcr)
@@ -215,10 +215,10 @@ int main(int argc, char* argv[])
   DeviceControlRecord* out_dcr = new DeviceControlRecord;
   out_jcr = SetupJcr("bcopy", output_archive.data(), bsr, director, out_dcr,
                      outputVolumes, false); /* write device */
-  if (!out_jcr) { exit(1); }
+  if (!out_jcr) { exit(BEXIT_FAILURE); }
 
   out_dev = out_jcr->sd_impl->dcr->dev;
-  if (!out_dev) { exit(1); }
+  if (!out_dev) { exit(BEXIT_FAILURE); }
 
   // Let SD plugins setup the record translation
   if (GeneratePluginEvent(out_jcr, bSdEventSetupRecordTranslation, out_dcr)
@@ -234,12 +234,12 @@ int main(int argc, char* argv[])
   if (!out_dev->open(out_jcr->sd_impl->dcr, DeviceMode::OPEN_READ_WRITE)) {
     Emsg1(M_FATAL, 0, _("dev open failed: %s\n"), out_dev->errmsg);
     out_dev->Unlock();
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   out_dev->Unlock();
   if (!AcquireDeviceForAppend(out_jcr->sd_impl->dcr)) {
     FreeJcr(in_jcr);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   out_block = out_jcr->sd_impl->dcr->block;
 

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -166,8 +166,8 @@ int main(int argc, char* argv[])
 
   working_directory = work_dir.c_str();
 
-  my_config = InitSdConfig(configfile.c_str(), M_ERROR_TERM);
-  ParseSdConfig(configfile.c_str(), M_ERROR_TERM);
+  my_config = InitSdConfig(configfile.c_str(), M_CONFIG_ERROR);
+  ParseSdConfig(configfile.c_str(), M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
@@ -265,7 +266,7 @@ int main(int argc, char* argv[])
   delete out_dev;
 
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -150,7 +150,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open exclude file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -173,7 +173,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open include file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -393,9 +393,9 @@ static void DoExtract(char* devname,
   dcr = new DeviceControlRecord;
   jcr = SetupJcr("bextract", devname, bsr, director, dcr, VolumeName,
                  true); /* read device */
-  if (!jcr) { exit(1); }
+  if (!jcr) { exit(BEXIT_FAILURE); }
   dev = jcr->sd_impl->read_dcr->dev;
-  if (!dev) { exit(1); }
+  if (!dev) { exit(BEXIT_FAILURE); }
   dcr = jcr->sd_impl->read_dcr;
 
   // Let SD plugins setup the record translation

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -213,7 +213,7 @@ int main(int argc, char* argv[])
       ->type_name(" ");
 
 
-  CLI11_PARSE(bextract_app, argc, argv);
+  ParseBareosApp(bextract_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -215,8 +215,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bextract_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   static DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "lib/crypto_cache.h"
@@ -256,7 +257,7 @@ int main(int argc, char* argv[])
   }
   TermIncludeExcludeFiles(ff);
   TermFindFiles(ff);
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 // Cleanup of delayed restore stack with streams for later processing.

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -207,8 +207,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bls_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (!DirectorName.empty()) {
     foreach_res (director, R_DIRECTOR) {

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -27,6 +27,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "lib/berrno.h"
@@ -273,7 +274,7 @@ int main(int argc, char* argv[])
   if (bsr) { libbareos::FreeBsr(bsr); }
   TermIncludeExcludeFiles(ff);
   TermFindFiles(ff);
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 static void do_close(JobControlRecord* jcr)

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -205,7 +205,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bls_app, argc, argv);
+  ParseBareosApp(bls_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -135,7 +135,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open exclude file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -156,7 +156,7 @@ int main(int argc, char* argv[])
               BErrNo be;
               Pmsg2(0, _("Could not open include file: %s, ERR=%s\n"),
                     val.front().c_str(), be.bstrerror());
-              exit(1);
+              exit(BEXIT_FAILURE);
             }
             while (fgets(line, sizeof(line), fd) != nullptr) {
               StripTrailingJunk(line);
@@ -238,7 +238,7 @@ int main(int argc, char* argv[])
     dcr = new DeviceControlRecord;
     jcr = SetupJcr("bls", device.data(), bsr, director, dcr, VolumeNames,
                    true); /* read device */
-    if (!jcr) { exit(1); }
+    if (!jcr) { exit(BEXIT_FAILURE); }
 
 
     // Let SD plugins setup the record translation
@@ -249,7 +249,7 @@ int main(int argc, char* argv[])
 
     jcr->sd_impl->ignore_label_errors = ignore_label_errors;
     dev = jcr->sd_impl->dcr->dev;
-    if (!dev) { exit(1); }
+    if (!dev) { exit(BEXIT_FAILURE); }
     dcr = jcr->sd_impl->dcr;
     rec = new_record();
     attr = new_attr(jcr);

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -254,8 +254,8 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bscan_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -304,7 +304,7 @@ int main(int argc, char* argv[])
   DeviceControlRecord* dcr = new DeviceControlRecord;
   bjcr = SetupJcr("bscan", device_name.data(), bsr, director, dcr, volumes,
                   true);
-  if (!bjcr) { exit(1); }
+  if (!bjcr) { exit(BEXIT_FAILURE); }
   dev = bjcr->sd_impl->read_dcr->dev;
 
   // Let SD plugins setup the record translation

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
       ->required()
       ->type_name(" ");
 
-  CLI11_PARSE(bscan_app, argc, argv);
+  ParseBareosApp(bscan_app, argc, argv);
 
   my_config = InitSdConfig(configfile, M_ERROR_TERM);
   ParseSdConfig(configfile, M_ERROR_TERM);

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -29,6 +29,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/stored_jcr_impl.h"
@@ -363,7 +364,7 @@ int main(int argc, char* argv[])
   FreeJcr(bjcr);
   UnloadSdPlugins();
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 /**

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -296,8 +296,8 @@ int main(int margc, char* margv[])
 
   daemon_start_time = time(nullptr);
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   DirectorResource* director = nullptr;
   if (!DirectorName.empty()) {

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -209,7 +209,7 @@ int main(int margc, char* margv[])
   if (i != 1 || x32 != y32) {
     Pmsg3(-1, _("32 bit printf/scanf problem. i=%d x32=%u y32=%u\n"), i, x32,
           y32);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   uint64_t x64 = 123456789;
@@ -222,7 +222,7 @@ int main(int margc, char* margv[])
   if (i != 1 || x64 != y64) {
     Pmsg3(-1, _("64 bit printf/scanf problem. i=%d x64=%llu y64=%llu\n"), i,
           x64, y64);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   working_directory = "/tmp";
@@ -321,14 +321,14 @@ int main(int margc, char* margv[])
   dcr = new BTAPE_DCR;
   jcr = SetupJcr("btape", archive_name.data(), bsr, director, dcr, "",
                  false); /* write device */
-  if (!jcr) { exit(1); }
+  if (!jcr) { exit(BEXIT_FAILURE); }
 
   dev = jcr->sd_impl->dcr->dev;
-  if (!dev) { exit(1); }
+  if (!dev) { exit(BEXIT_FAILURE); }
 
   if (!dev->IsTape()) {
     Pmsg0(000, _("btape only works with tape storage.\n"));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   // Let SD plugins setup the record translation
@@ -336,7 +336,7 @@ int main(int margc, char* margv[])
     Jmsg(jcr, M_FATAL, 0, _("bSdEventSetupRecordTranslation call failed!\n"));
   }
 
-  if (!open_the_device()) { exit(1); }
+  if (!open_the_device()) { exit(BEXIT_FAILURE); }
 
   Dmsg0(200, "Do tape commands\n");
   do_tape_cmds();

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -285,7 +285,7 @@ int main(int margc, char* margv[])
   btape_app.add_option_group("Interactive commands",
                              Generate_interactive_commands_help());
 
-  CLI11_PARSE(btape_app, margc, margv)
+  ParseBareosApp(btape_app, margc, margv);
 
   printf(_("Tape block granularity is %d bytes.\n"), TAPE_BSIZE);
 

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -33,6 +33,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "lib/crypto_cache.h"

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -189,7 +189,7 @@ int main(int argc, char* argv[])
 
   AddNetworkDebuggingOption(sd_app);
 
-  CLI11_PARSE(sd_app, argc, argv);
+  ParseBareosApp(sd_app, argc, argv);
 
   if (!no_signals) { InitSignals(TerminateStored); }
 

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -592,7 +592,7 @@ static
 
   if (in_here) {       /* prevent loops */
     Bmicrosleep(2, 0); /* yield */
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   in_here = true;
   debug_level = 0; /* turn off any debug */

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -218,15 +218,15 @@ int main(int argc, char* argv[])
   if (export_config_schema) {
     PoolMem buffer;
 
-    my_config = InitSdConfig(configfile, M_ERROR_TERM);
+    my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
     return 0;
   }
 
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (forge_on) {
     my_config->AddWarning(

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -605,12 +605,10 @@ static
   StopWatchdog();
 
   if (sig == SIGTERM) { /* normal shutdown request? */
-    /*
-     * This is a normal shutdown request. We wiffle through
+    /* This is a normal shutdown request. We wiffle through
      *   all open jobs canceling them and trying to wake
      *   them up so that they will report back the correct
-     *   volume status.
-     */
+     *   volume status. */
     foreach_jcr (jcr) {
       BareosSocket* fd;
       if (jcr->JobId == 0) { continue; /* ignore console */ }

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -32,6 +32,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "stored/stored.h"
 #include "lib/crypto_cache.h"
 #include "stored/acquire.h"
@@ -222,7 +223,7 @@ int main(int argc, char* argv[])
     PrintConfigSchemaJson(buffer);
     printf("%s\n", buffer.c_str());
 
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
@@ -237,7 +238,7 @@ int main(int argc, char* argv[])
   if (export_config) {
     my_config->DumpResources(PrintMessage, nullptr);
 
-    return 0;
+    return BEXIT_SUCCESS;
   }
 
   if (!CheckResources()) {
@@ -314,9 +315,9 @@ int main(int argc, char* argv[])
   StartSocketServer(me->SDaddrs);
 
   /* to keep compiler quiet */
-  TerminateStored(0);
+  TerminateStored(BEXIT_SUCCESS);
 
-  return 0;
+  return BEXIT_SUCCESS;
 }
 
 /* Check Configuration file for necessary info */

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -34,6 +34,7 @@
 #  include "gtest/gtest.h"
 #  include "include/bareos.h"
 #endif
+#include "include/exit_codes.h"
 #include "lib/dlist.h"
 
 #include <memory>
@@ -281,7 +282,7 @@ TEST(dlist, BinaryInsert)
   foreach_dlist (jcr, jcr_chain) {
     if (!jcr_chain->binary_search(jcr, MyCompare)) {
       printf("Dlist binary_search item not found = %s\n", jcr->buf);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
   }
   foreach_dlist (jcr, jcr_chain) {

--- a/core/src/tests/sd_backend_tests.h
+++ b/core/src/tests/sd_backend_tests.h
@@ -42,8 +42,8 @@ void sd::SetUp()
   /* configfile is a global char* from stored_globals.h */
   configfile
       = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/" CONFIG_SUBDIR "/");
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
   /*
    * we do not run CheckResources() here, so take care the test configration
    * is not broken. Also autochangers will not work.

--- a/core/src/tests/sd_backend_tests.h
+++ b/core/src/tests/sd_backend_tests.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,10 +44,8 @@ void sd::SetUp()
       = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/" CONFIG_SUBDIR "/");
   my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
   ParseSdConfig(configfile, M_CONFIG_ERROR);
-  /*
-   * we do not run CheckResources() here, so take care the test configration
-   * is not broken. Also autochangers will not work.
-   */
+  /* we do not run CheckResources() here, so take care the test configration
+   * is not broken. Also autochangers will not work. */
 }
 void sd::TearDown()
 {

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -72,12 +72,10 @@ void ReservationTest::SetUp()
 
   /* configfile is a global char* from stored_globals.h */
   configfile = strdup(RELATIVE_PROJECT_SOURCE_DIR "/configs/sd_reservation/");
-  my_config = InitSdConfig(configfile, M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
-  /*
-   * we do not run CheckResources() here, so take care the test configration
-   * is not broken. Also autochangers will not work.
-   */
+  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
+  /* we do not run CheckResources() here, so take care the test configration
+   * is not broken. Also autochangers will not work. */
 
   InitReservationsLock();
   CreateVolumeLists();

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/test_config_parser_sd.cc
+++ b/core/src/tests/test_config_parser_sd.cc
@@ -38,8 +38,8 @@ TEST(ConfigParser, test_stored_config)
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");
-  my_config = InitSdConfig(path_to_config_file.c_str(), M_ERROR_TERM);
-  ParseSdConfig(configfile, M_ERROR_TERM);
+  my_config = InitSdConfig(path_to_config_file.c_str(), M_CONFIG_ERROR);
+  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   my_config->DumpResources(PrintMessage, NULL);
 

--- a/core/src/tests/test_config_parser_sd.cc
+++ b/core/src/tests/test_config_parser_sd.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -104,5 +104,5 @@ int main(int argc, char** argv)
     fclose(fd);
     regfree(&preg);
   }
-  exit(0);
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -26,6 +26,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/cli.h"
 
 #ifndef HAVE_REGEX_H
@@ -86,7 +87,7 @@ int main(int argc, char** argv)
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     lineno = 0;
     while (fgets(data, sizeof(data) - 1, fd)) {

--- a/core/src/tools/bregex.cc
+++ b/core/src/tools/bregex.cc
@@ -34,7 +34,7 @@
 #  include <regex.h>
 #endif
 
-int main(int argc, char* const* argv)
+int main(int argc, char** argv)
 {
   setlocale(LC_ALL, "");
   tzset();
@@ -60,7 +60,7 @@ int main(int argc, char* const* argv)
       "-n,--not-match", [&match_only](bool) { match_only = false; },
       "Print line that do not match.");
 
-  CLI11_PARSE(bregex_app, argc, argv);
+  ParseBareosApp(bregex_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -317,7 +317,7 @@ int main(int argc, char* argv[])
   bsmtp_app.add_option("recipients", recipients, "List of recipients.")
       ->required();
 
-  CLI11_PARSE(bsmtp_app, argc, argv);
+  ParseBareosApp(bsmtp_app, argc, argv);
 
   Dmsg3(20, "%s: mailhost=%s ; mailport=%d\n", host_and_port_source.c_str(),
         mailhost.c_str(), mailport);

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -58,6 +58,7 @@
         http://archives.neohapsis.com/archives/postfix/2000-05/1520.html
  */
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/jcr.h"
 #include "lib/cli.h"
 #include "lib/bstringlist.h"
@@ -616,5 +617,5 @@ lookup_host:
   chat(my_hostname, mailhost, "QUIT\r\n");
 
   //  Go away gracefully ...
-  exit(0);
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/bsmtp.cc
+++ b/core/src/tools/bsmtp.cc
@@ -122,7 +122,7 @@ static void GetResponse(const std::string& mailhost)
     Dmsg2(10, "%s --> %s\n", mailhost.c_str(), buf);
     if (!isdigit((int)buf[0]) || buf[0] > '3') {
       Pmsg2(0, _("Fatal malformed reply from %s: %s\n"), mailhost.c_str(), buf);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     if (buf[3] != '-') { break; }
   }
@@ -336,7 +336,7 @@ int main(int argc, char* argv[])
   char my_hostname[MAXSTRING];
   if (gethostname(my_hostname, sizeof(my_hostname) - 1) < 0) {
     Pmsg1(0, _("Fatal gethostname error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
 #ifdef HAVE_GETADDRINFO
@@ -354,7 +354,7 @@ int main(int argc, char* argv[])
   if ((res = getaddrinfo(my_hostname, NULL, &hints, &ai)) != 0) {
     Pmsg2(0, _("Fatal getaddrinfo for myself failed \"%s\": ERR=%s\n"),
           my_hostname, gai_strerror(res));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   strncpy(my_hostname, ai->ai_canonname, sizeof(my_hostname) - 1);
   my_hostname[sizeof(my_hostname) - 1] = '\0';
@@ -366,7 +366,7 @@ int main(int argc, char* argv[])
   if ((hp = gethostbyname(my_hostname)) == NULL) {
     Pmsg2(0, _("Fatal gethostbyname for myself failed \"%s\": ERR=%s\n"),
           my_hostname, strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   strncpy(my_hostname, hp->h_name, sizeof(my_hostname) - 1);
   my_hostname[sizeof(my_hostname) - 1] = '\0';
@@ -430,7 +430,7 @@ lookup_host:
       mailhost = "localhost";
       goto lookup_host;
     }
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
 #  if defined(HAVE_WIN32)
@@ -453,7 +453,7 @@ lookup_host:
 
   if (!rp) {
     Pmsg1(0, _("Failed to connect to mailhost %s\n"), mailhost.c_str());
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   freeaddrinfo(ai);
@@ -466,13 +466,13 @@ lookup_host:
       mailhost = "localhost";
       goto lookup_host;
     }
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   if (hp->h_addrtype != AF_INET) {
     Pmsg1(0, _("Fatal error: Unknown address family for smtp host: %d\n"),
           hp->h_addrtype);
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   memset((char*)&sin, 0, sizeof(sin));
   memcpy((char*)&sin.sin_addr, hp->h_addr, hp->h_length);
@@ -481,18 +481,18 @@ lookup_host:
 #  if defined(HAVE_WIN32)
   if ((s = WSASocket(AF_INET, SOCK_STREAM, 0, NULL, 0, 0)) < 0) {
     Pmsg1(0, _("Fatal socket error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #  else
   if ((s = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
     Pmsg1(0, _("Fatal socket error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #  endif
   if (connect(s, (struct sockaddr*)&sin, sizeof(sin)) < 0) {
     Pmsg2(0, _("Fatal connect error to %s: ERR=%s\n"), mailhost.c_str(),
           strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   Dmsg0(20, "Connected\n");
 #endif
@@ -501,31 +501,31 @@ lookup_host:
   int fdSocket = _open_osfhandle(s, _O_RDWR | _O_BINARY);
   if (fdSocket == -1) {
     Pmsg1(0, _("Fatal _open_osfhandle error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 
   int fdSocket2 = dup(fdSocket);
 
   if ((sfp = fdopen(fdSocket, "wb")) == NULL) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((rfp = fdopen(fdSocket2, "rb")) == NULL) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #else
   if ((r = dup(s)) < 0) {
     Pmsg1(0, _("Fatal dup error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((sfp = fdopen(s, "w")) == 0) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
   if ((rfp = fdopen(r, "r")) == 0) {
     Pmsg1(0, _("Fatal fdopen error: ERR=%s\n"), strerror(errno));
-    exit(1);
+    exit(BEXIT_FAILURE);
   }
 #endif
 

--- a/core/src/tools/btestls.cc
+++ b/core/src/tools/btestls.cc
@@ -78,7 +78,7 @@ static void usage()
             "Truncation is only in catalog.\n"
             "\n"));
 
-  exit(1);
+  exit(BEXIT_FAILURE);
 }
 
 
@@ -153,7 +153,7 @@ int main(int argc, char* const* argv)
     fd = fopen(inc, "rb");
     if (!fd) {
       printf(_("Could not open include file: %s\n"), inc);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     while (fgets(name, sizeof(name) - 1, fd)) {
       StripTrailingJunk(name);
@@ -166,7 +166,7 @@ int main(int argc, char* const* argv)
     fd = fopen(exc, "rb");
     if (!fd) {
       printf(_("Could not open exclude file: %s\n"), exc);
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     while (fgets(name, sizeof(name) - 1, fd)) {
       StripTrailingJunk(name);

--- a/core/src/tools/btestls.cc
+++ b/core/src/tools/btestls.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/btestls.cc
+++ b/core/src/tools/btestls.cc
@@ -28,6 +28,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "include/jcr.h"
 #include "findlib/find.h"
 #include "filed/fd_plugins.h"
@@ -185,7 +186,7 @@ int main(int argc, char* const* argv)
   FreeJcr(jcr);
   RecentJobResultsList::Cleanup();
   CleanupJcrChain();
-  exit(0);
+  exit(BEXIT_SUCCESS);
 }
 
 static int CountFiles(JobControlRecord*, FindFilesPacket*, bool)

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -79,7 +79,7 @@ int main(int argc, char** argv)
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
-      exit(1);
+      exit(BEXIT_FAILURE);
     }
     lineno = 0;
     while (fgets(data, sizeof(data) - 1, fd)) {

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -29,7 +29,7 @@
 #include "lib/cli.h"
 #include "lib/fnmatch.h"
 
-int main(int argc, char* const* argv)
+int main(int argc, char** argv)
 {
   setlocale(LC_ALL, "");
   tzset();
@@ -60,7 +60,7 @@ int main(int argc, char* const* argv)
       "-n,--not-match", [&match_only](bool) { match_only = false; },
       "Print line that do not match.");
 
-  CLI11_PARSE(bwild_app, argc, argv);
+  ParseBareosApp(bwild_app, argc, argv);
 
   OSDependentInit();
 

--- a/core/src/tools/bwild.cc
+++ b/core/src/tools/bwild.cc
@@ -26,6 +26,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "lib/cli.h"
 #include "lib/fnmatch.h"
 
@@ -74,7 +75,7 @@ int main(int argc, char** argv)
     printf("Enter a wild-card: ");
     if (fgets(pat, sizeof(pat) - 1, stdin) == NULL) { break; }
     StripTrailingNewline(pat);
-    if (pat[0] == 0) { exit(0); }
+    if (pat[0] == 0) { exit(BEXIT_SUCCESS); }
     fd = fopen(fname.c_str(), "r");
     if (!fd) {
       printf(_("Could not open data file: %s\n"), fname.c_str());
@@ -95,5 +96,6 @@ int main(int argc, char** argv)
     }
     fclose(fd);
   }
-  exit(0);
+
+  return BEXIT_SUCCESS;
 }

--- a/core/src/tools/drivetype.cc
+++ b/core/src/tools/drivetype.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/drivetype.cc
+++ b/core/src/tools/drivetype.cc
@@ -26,10 +26,11 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "findlib/find.h"
 #include "findlib/drivetype.h"
 
-static void usage()
+static void usage(int exit_code)
 {
   fprintf(stderr,
           _("\n"
@@ -44,13 +45,13 @@ static void usage()
             "       -?     print this message.\n"
             "\n"));
 
-  exit(1);
+  exit(exit_code);
 }
 
 int DisplayDrive(char* drive, bool display_local, int verbose)
 {
   char dt[100];
-  int status = 0;
+  int status = BEXIT_SUCCESS;
 
   if (Drivetype(drive, dt, sizeof(dt))) {
     if (display_local) { /* in local mode, display only harddrive */
@@ -62,7 +63,7 @@ int DisplayDrive(char* drive, bool display_local, int verbose)
     }
   } else if (!display_local) { /* local mode is used by FileSet scripts */
     fprintf(stderr, _("%s: unknown\n"), drive);
-    status = 1;
+    status = BEXIT_FAILURE;
   }
   return status;
 }
@@ -70,7 +71,6 @@ int DisplayDrive(char* drive, bool display_local, int verbose)
 int main(int argc, char* const* argv)
 {
   int verbose = 0;
-  int status = 0;
   int ch, i;
   bool display_local = false;
   bool display_all = false;
@@ -94,8 +94,10 @@ int main(int argc, char* const* argv)
         display_all = true;
         break;
       case '?':
+        usage(BEXIT_SUCCESS);
+        break;
       default:
-        usage();
+        usage(BEXIT_FAILURE);
     }
   }
   argc -= optind;
@@ -103,19 +105,20 @@ int main(int argc, char* const* argv)
 
   OSDependentInit();
 
-  if (argc < 1 && display_all) {
+  if (display_all) {
     /* Try all letters */
     for (drive = 'A'; drive <= 'Z'; drive++) {
       Bsnprintf(buf, sizeof(buf), "%c:/", drive);
       DisplayDrive(buf, display_local, verbose);
     }
-    exit(status);
+    exit(BEXIT_SUCCESS);
   }
 
-  if (argc < 1) { usage(); }
+  if (argc < 1) { usage(BEXIT_FAILURE); }
 
+  int exit_status = BEXIT_SUCCESS;
   for (i = 0; i < argc; --argc, ++argv) {
-    status += DisplayDrive(*argv, display_local, verbose);
+    exit_status = DisplayDrive(*argv, display_local, verbose);
   }
-  exit(status);
+  exit(exit_status);
 }

--- a/core/src/tools/fstype.cc
+++ b/core/src/tools/fstype.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2006 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tools/fstype.cc
+++ b/core/src/tools/fstype.cc
@@ -26,11 +26,12 @@
  */
 
 #include "include/bareos.h"
+#include "include/exit_codes.h"
 #include "findlib/find.h"
 #include "lib/mntent_cache.h"
 #include "findlib/fstype.h"
 
-static void usage()
+static void usage(int exit_status)
 {
   fprintf(stderr,
           _("\n"
@@ -43,7 +44,7 @@ static void usage()
             "       -?     print this message.\n"
             "\n"));
 
-  exit(1);
+  exit(exit_status);
 }
 
 
@@ -51,7 +52,7 @@ int main(int argc, char* const* argv)
 {
   char fs[1000];
   int verbose = 0;
-  int status = 0;
+  int exit_status = BEXIT_SUCCESS;
   int ch, i;
 
   setlocale(LC_ALL, "");
@@ -65,14 +66,16 @@ int main(int argc, char* const* argv)
         verbose = 1;
         break;
       case '?':
+        usage(BEXIT_SUCCESS);
+        break;
       default:
-        usage();
+        usage(BEXIT_FAILURE);
     }
   }
   argc -= optind;
   argv += optind;
 
-  if (argc < 1) { usage(); }
+  if (argc < 1) { usage(BEXIT_FAILURE); }
 
   OSDependentInit();
 
@@ -85,11 +88,11 @@ int main(int argc, char* const* argv)
       }
     } else {
       fprintf(stderr, _("%s: unknown\n"), *argv);
-      status = 1;
+      exit_status = BEXIT_FAILURE;
     }
   }
 
   FlushMntentCache();
 
-  exit(status);
+  exit(exit_status);
 }

--- a/debian/bareos-director.service.in
+++ b/debian/bareos-director.service.in
@@ -6,15 +6,14 @@
 Description=Bareos Director Daemon service
 Documentation=man:bareos-dir(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target postgresql.service
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target postgresql.service
 # Dependency about the database
 # We let administrators decide if they need it (if local db instance)
 # Wants=@DEFAULT_DB_TYPE@.service
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -30,8 +29,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-director
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-dir.service

--- a/debian/bareos-filedaemon.service.in
+++ b/debian/bareos-filedaemon.service.in
@@ -6,12 +6,11 @@
 Description=Bareos File Daemon service
 Documentation=man:bareos-fd(8)
 Requires=network.target nss-lookup.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
 
 [Service]
 Type=simple
@@ -26,8 +25,10 @@ LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-filedaemon
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 
 [Install]

--- a/debian/bareos-storage.service.in
+++ b/debian/bareos-storage.service.in
@@ -6,12 +6,11 @@
 Description=Bareos Storage Daemon service
 Documentation=man:bareos-sd(8)
 Requires=network.target nss-lookup.target time-sync.target
-After=network-online.target nss-lookup.target remote-fs.target time-sync.target
+After=network-online.target nss-lookup.target local-fs.target remote-fs.target time-sync.target
 # Check if working dir exist
 ConditionPathExists=@working_dir@
-# Limit the number of restart per day to 10
+# Limit the number of restart per day
 StartLimitIntervalSec=1d
-StartLimitBurst=10
 
 [Service]
 Type=simple
@@ -20,13 +19,15 @@ Group=@sd_group@
 WorkingDirectory=@working_dir@
 ExecStart=@sbindir@/bareos-sd -f
 SuccessExitStatus=0 15
-# Increase the maximum number of open file descriptors```
+# Increase the maximum number of open file descriptors
 LimitNOFILE=8192:524288
 # Restart on failure, wait 30 seconds
 Restart=on-failure
 RestartSec=30
+# Limit the number of restart to 10. to reset counter use systemctl reset-failed bareos-storage
+StartLimitBurst=10
 # Don't restart on wrong exec arguments and configuration errors.
-RestartPreventExitStatus=109 1
+RestartPreventExitStatus=41 42
 
 [Install]
 Alias=bareos-sd.service

--- a/systemtests/tests/bareos-basic/testrunner-bcopy-autoxflate
+++ b/systemtests/tests/bareos-basic/testrunner-bcopy-autoxflate
@@ -2,7 +2,6 @@
 set -e
 set -o pipefail
 set -u
-set -x
 
 # run bls and make sure it works (with autoxflate plugin)
 TestName="$(basename "$(pwd)")"
@@ -26,7 +25,7 @@ if [ $ret -ne 0 ]; then
   exit $ret
 fi
 
-if ! grep -q "bcopy: stored/bcopy.cc:253-0 . Jobs copied. .*records copied." "$tmp/bcopy.out"; then
+if ! grep -q "bcopy: stored/bcopy.cc:.*-0 . Jobs copied. .*records copied." "$tmp/bcopy.out"; then
   echo 'Expected string \"weird-files/dangling-link\" not found in bcopy output'
   stop_bareos
   exit 1


### PR DESCRIPTION
**Backport of PR #1515 to bareos-22**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
