### PR TITLE
VMware Plugin: Fix backup and recreating VMs with PCI passthrough for GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - VMware Plugin: Fix transformer issues [PR #1532]
 - filed: fix possible data-loss when excluding hardlinks [PR #1506]
 - cats: fix for integer overflow issue when using `offset` in `llist` [PR #1547]
+- VMware Plugin: Fix backup and recreating VMs with PCI passthrough for GPU [PR #1565]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -268,4 +269,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1550]: https://github.com/bareos/bareos/pull/1550
 [PR #1556]: https://github.com/bareos/bareos/pull/1556
 [PR #1563]: https://github.com/bareos/bareos/pull/1563
+[PR #1565]: https://github.com/bareos/bareos/pull/1565
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
+++ b/core/src/plugins/filed/python/vmware/BareosFdPluginVMware.py
@@ -1177,7 +1177,7 @@ class BareosVADPWrapper(object):
             if self.enable_cbt:
                 bareosfd.JobMessage(
                     bareosfd.M_INFO,
-                    "Error vm %s is not cbt enabled, enabling it now.\n"
+                    "Error vm %s is not CBT enabled, enabling it now.\n"
                     % (StringCodec.encode(self.vm.name)),
                 )
                 if self.vm.snapshot is not None:
@@ -1196,7 +1196,7 @@ class BareosVADPWrapper(object):
             else:
                 bareosfd.JobMessage(
                     bareosfd.M_FATAL,
-                    "Error vm %s is not cbt enabled\n"
+                    "Error vm %s is not CBT enabled\n"
                     % (StringCodec.encode(self.vm.name)),
                 )
                 return bareosfd.bRC_Error

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -295,6 +295,9 @@ Backup
 
 Before running the first backup, CBT (Changed Block Tracking) must be enabled for the VMs to be backed up.
 
+Since :sinceVersion:`22.1.1: VMware Plugin: enable_cbt` the plugin will try to
+enable CBT automatically when the plugin option **enable_cbt=yes** is set (see below).
+
 As of https://kb.vmware.com/s/article/2075984 manually enabling CBT is currently not working properly. The API however works properly. To enable CBT use the Script :command:`vmware_cbt_tool.py`, it is packaged in the bareos-vmware-plugin package:
 
 .. code-block:: shell-session
@@ -612,6 +615,9 @@ snapshot_retry_wait (optional)
 
 poweron_timeout (optional)
    Timeout in seconds to wait for a VM to be powered on after restore, default 15s. When a VM is powered on after restore (see also the option *restore_powerstate* above), the plugin will check if it succeeded by checking the power state. If it is not powered on within this timeout, the restore job will issue a warning message.
+
+enable_cbt (optional)
+   When using ``enable_cbt=yes`` the plugin will enable CBT (changed block tracking) if possible and it is not yet enabled. It is required that no snapshot exists when enabling CBT, otherwise the plugin will emit an error message. By default this option is not set and ``vmware_cbt_tool.py`` must be used to enable CBT (see above). Since :sinceVersion:`22.1.1: VMware Plugin`
 
 uuid (deprecated)
    The uuid option could be used instead of *dc*, *folder* and *vmname* to uniquely address a VM for backup. As the plugin since :sinceVersion:`22.0.0: VMware Plugin` is able recreate VMs in a different datacenter, folder or datastore, this option has become useless. When using uuid, restoring is only possible to the same still existing VM. It is recommended to change the configuration, as the uuid option will be dropped in the next version.


### PR DESCRIPTION
The Bareos VMware plugin can now backup an recreate VMs which have a virtual PCI passthrough for GPU configured.
Additionally, the plugin can now try to enable CBT by setting the new plugin option enable_cbt=yes. 

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
