### PR TITLE
BareosFdPluginPostgres.py: use environment variables for db connection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -195,6 +195,7 @@ Tim Oberfoell
 Tobias Ehrig
 Tobias Groß
 Tobias Plum
+Tobias Ravenstein
 Tomas Cameron
 Tomas Habarta
 Torsten Ueberschar

--- a/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
+++ b/core/src/plugins/filed/python/postgres/BareosFdPluginPostgres.py
@@ -176,11 +176,11 @@ class BareosFdPluginPostgres(BareosFdPluginLocalFilesBaseclass):  # noqa
         try:
             if self.options["dbHost"].startswith("/"):
                 self.dbCon = pg8000.Connection(
-                    self.dbuser, database=self.dbname, unix_sock=self.dbHost
+                    self.dbuser, database=self.dbname, unix_sock=self.dbHost, password=self.dbpassword
                 )
             else:
                 self.dbCon = pg8000.Connection(
-                    self.dbuser, database=self.dbname, host=self.dbHost
+                    self.dbuser, database=self.dbname, host=self.dbHost, port=self.dbport, password=self.dbpassword
                 )
 
             if "role" in self.options:


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Use self.dbpassword and self.dbport fetched from environment variables to connect to database.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Check backport line
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
