### PR TITLE
catreq.cc: suppress missing batch con warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - filed: fix possible data-loss when excluding hardlinks [PR #1506]
 - cats: fix for integer overflow issue when using `offset` in `llist` [PR #1547]
 - VMware Plugin: Fix backup and recreating VMs with PCI passthrough for GPU [PR #1565]
+- catreq.cc: suppress missing batch con warning [PR #1578]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -290,6 +291,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1565]: https://github.com/bareos/bareos/pull/1565
 [PR #1573]: https://github.com/bareos/bareos/pull/1573
 [PR #1577]: https://github.com/bareos/bareos/pull/1577
+[PR #1578]: https://github.com/bareos/bareos/pull/1578
 [PR #1582]: https://github.com/bareos/bareos/pull/1582
 [PR #1583]: https://github.com/bareos/bareos/pull/1583
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -367,6 +367,10 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
              jcr->db_batch->strerror());
         bs->fsend(_("1992 Update File table error\n"));
       }
+    } else {
+      Dmsg0(400,
+            "No batch database connection exists, no files have been added to "
+            "the batch (yet).\n");
     }
   } else if (sscanf(bs->msg, Update_jobrecord, &Job, &update_jobfiles,
                     &update_jobbytes)

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -367,9 +367,6 @@ void CatalogRequest(JobControlRecord* jcr, BareosSocket* bs)
              jcr->db_batch->strerror());
         bs->fsend(_("1992 Update File table error\n"));
       }
-    } else {
-      Jmsg(jcr, M_WARNING, 0,
-           _("Batch database connection not found. Cannot update file list\n"));
     }
   } else if (sscanf(bs->msg, Update_jobrecord, &Job, &update_jobfiles,
                     &update_jobbytes)


### PR DESCRIPTION
When the Update_filelist command is received, the code issued a warning though this is not required.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

