### PR TITLE
github actions: PyPi: install setuptools

### DIFF
--- a/.github/workflows/publish-python-packages-to-pypi.yml
+++ b/.github/workflows/publish-python-packages-to-pypi.yml
@@ -31,9 +31,9 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: "Python: install wheel"
+    - name: "Python: install dependencies"
       run: |
-        pip install --user wheel
+        pip install --user wheel setuptools
 
     - name: "python-bareos: build package"
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - github actions: update/fix publish to PyPI workflows [PR #1586]
+- github actions: PyPi: install setuptools [PR #1591]
 
 ## [21.1.8] - 2023-10-23
 
@@ -698,4 +699,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1569]: https://github.com/bareos/bareos/pull/1569
 [PR #1575]: https://github.com/bareos/bareos/pull/1575
 [PR #1586]: https://github.com/bareos/bareos/pull/1586
+[PR #1591]: https://github.com/bareos/bareos/pull/1591
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
With Python >= 3.12 the setuptools isn't available by default but have to be installed manually.

(cherry picked from commit 258f6be461d3955a2861b6fb7e9f2e3c05cee382)

### Thank you for contributing to the Bareos Project!

**Backport of PR #1589 to bareos-21**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR