### PR TITLE
vadp-dumper: fix multithreaded backup/restore issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - build: introduce Fedora 39 [PR #1614]
 - libcloud: modularize systemtest [PR #1609]
 - filedaemon: remove ovirt plugin [PR #1617]
+- vadp-dumper: fix multithreaded backup/restore issues [PR #1593]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -29,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1587]: https://github.com/bareos/bareos/pull/1587
 [PR #1589]: https://github.com/bareos/bareos/pull/1589
 [PR #1592]: https://github.com/bareos/bareos/pull/1592
+[PR #1593]: https://github.com/bareos/bareos/pull/1593
 [PR #1605]: https://github.com/bareos/bareos/pull/1605
 [PR #1606]: https://github.com/bareos/bareos/pull/1606
 [PR #1607]: https://github.com/bareos/bareos/pull/1607

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -33,12 +33,30 @@ else()
 endif()
 
 set(KTLS_DEFINITIONS)
+set(DISABLE_KTLS OFF)
 find_package(OpenSSL)
 if((OPENSSL_VERSION VERSION_LESS "3.0.0") OR (LINUX_KERNEL_VERSION VERSION_LESS
                                               "5.3")
 )
-  set(KTLS_DEFINITIONS DISABLE_KTLS)
+  set(DISABLE_KTLS ON)
 else()
+
+  check_cxx_source_compiles(
+    "
+#include <openssl/ssl.h>
+int main(void)
+{
+#ifndef OPENSSL_NO_KTLS
+#error ktls is enabled
+#endif
+return 0;
+}
+"
+    KTLS_DISABLED
+  )
+  if(KTLS_DISABLED)
+    set(DISABLE_KTLS ON)
+  endif()
   if(LINUX_KERNEL_VERSION VERSION_LESS "5.16")
     list(APPEND KTLS_DEFINITIONS DISABLE_KTLS_12_RECV)
   endif()
@@ -215,18 +233,21 @@ if(NOT client-only)
     ADDITIONAL_SOURCES ${SSL_UNIT_TEST_FILES}
     LINK_LIBRARIES testing_common ${LINK_LIBRARIES}
   )
-  bareos_add_test(
-    ktls
-    ADDITIONAL_SOURCES ${SSL_UNIT_TEST_FILES}
-    LINK_LIBRARIES testing_common ${LINK_LIBRARIES}
-    COMPILE_DEFINITIONS ${KTLS_DEFINITIONS}
-  )
-  set_tests_properties(gtest:ktls.v12_send PROPERTIES LABELS broken)
-  set_tests_properties(gtest:ktls.v12_recv PROPERTIES LABELS broken)
-  set_tests_properties(gtest:ktls.v12_256_send PROPERTIES LABELS broken)
-  set_tests_properties(gtest:ktls.v13_send PROPERTIES LABELS broken)
-  set_tests_properties(gtest:ktls.v13_recv PROPERTIES LABELS broken)
-  set_tests_properties(gtest:ktls.v13_256_send PROPERTIES LABELS broken)
+
+  if(NOT DISABLE_KTLS)
+    bareos_add_test(
+      ktls
+      ADDITIONAL_SOURCES ${SSL_UNIT_TEST_FILES}
+      LINK_LIBRARIES testing_common ${LINK_LIBRARIES}
+      COMPILE_DEFINITIONS ${KTLS_DEFINITIONS}
+    )
+    set_tests_properties(gtest:ktls.v12_send PROPERTIES LABELS broken)
+    set_tests_properties(gtest:ktls.v12_recv PROPERTIES LABELS broken)
+    set_tests_properties(gtest:ktls.v12_256_send PROPERTIES LABELS broken)
+    set_tests_properties(gtest:ktls.v13_send PROPERTIES LABELS broken)
+    set_tests_properties(gtest:ktls.v13_recv PROPERTIES LABELS broken)
+    set_tests_properties(gtest:ktls.v13_256_send PROPERTIES LABELS broken)
+  endif()
 
   bareos_add_test(
     catalog

--- a/core/src/tests/ktls.cc
+++ b/core/src/tests/ktls.cc
@@ -156,7 +156,7 @@ static void EnsureKtlsRecv(BareosSocket* sock)
 
 TEST(ktls, v12_send)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_12_SEND)
+#if defined(DISABLE_KTLS_12_SEND)
   GTEST_SKIP();
 #endif
   InitOpenSsl();
@@ -167,7 +167,7 @@ TEST(ktls, v12_send)
 
 TEST(ktls, v12_recv)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_12_RECV)
+#if defined(DISABLE_KTLS_12_RECV)
   GTEST_SKIP();
 #endif
   InitOpenSsl();
@@ -178,7 +178,7 @@ TEST(ktls, v12_recv)
 
 TEST(ktls, v13_send)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_13_SEND)
+#if defined(DISABLE_KTLS_13_SEND)
   GTEST_SKIP();
 #endif
   InitOpenSsl();
@@ -189,7 +189,7 @@ TEST(ktls, v13_send)
 
 TEST(ktls, v13_recv)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_13_RECV)
+#if defined(DISABLE_KTLS_13_RECV)
   GTEST_SKIP();
 #endif
   InitOpenSsl();
@@ -200,7 +200,7 @@ TEST(ktls, v13_recv)
 
 TEST(ktls, v12_256_send)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_12_256_SEND)
+#if defined(DISABLE_KTLS_12_256_SEND)
   GTEST_SKIP();
 #endif
   InitOpenSsl();
@@ -211,7 +211,7 @@ TEST(ktls, v12_256_send)
 
 TEST(ktls, v13_256_send)
 {
-#if defined(DISABLE_KTLS) || defined(DISABLE_KTLS_13_256_SEND)
+#if defined(DISABLE_KTLS_13_256_SEND)
   GTEST_SKIP();
 #endif
   InitOpenSsl();

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -969,7 +969,7 @@ static inline bool read_meta_data_key(char* key)
   rmde.start_magic = BAREOSMAGIC;
   rmde.end_magic = BAREOSMAGIC;
   rmde.meta_key_length = strlen(key) + 1;
-  rmde.meta_data_length = requiredLen + 1;
+  rmde.meta_data_length = requiredLen;
 
   if (robust_writer(STDOUT_FILENO, &rmde, rmde_size) != rmde_size) {
     fprintf(stderr,

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -131,7 +131,7 @@ struct runtime_disk_info_encoding {
   uint32_t padding[16];
   uint32_t end_magic;
 };
-inline constexpr int rdie_size = sizeof(struct runtime_disk_info_encoding);
+inline constexpr int rdie_size = sizeof(runtime_disk_info_encoding);
 
 /*
  * Disk Meta data structure,
@@ -144,7 +144,7 @@ struct runtime_meta_data_encoding {
   uint32_t meta_data_length;
   uint32_t end_magic;
 };
-inline constexpr int rmde_size = sizeof(struct runtime_meta_data_encoding);
+inline constexpr int rmde_size = sizeof(runtime_meta_data_encoding);
 
 /*
  * Changed Block Tracking structure.
@@ -157,7 +157,7 @@ struct runtime_cbt_encoding {
   uint64_t offset_length;
   uint32_t end_magic;
 };
-inline constexpr int rce_size = sizeof(struct runtime_cbt_encoding);
+inline constexpr int rce_size = sizeof(runtime_cbt_encoding);
 
 static bool cleanup_on_start = false;
 static bool cleanup_on_disconnect = false;
@@ -187,7 +187,7 @@ static int exit_code = 1;
 
 // Encode the VDDK VixDiskLibInfo into an internal representation.
 static inline void fill_runtime_disk_info_encoding(
-    struct runtime_disk_info_encoding* rdie)
+    runtime_disk_info_encoding* rdie)
 {
   memset(rdie, 0, rdie_size);
 
@@ -224,7 +224,7 @@ static inline void fill_runtime_disk_info_encoding(
  * mode.
  */
 static inline void dump_runtime_disk_info_encoding(
-    struct runtime_disk_info_encoding* rdie)
+    runtime_disk_info_encoding* rdie)
 {
   fprintf(stderr, "Protocol version = %u\n", rdie->protocol_version);
   fprintf(stderr, "Absolute disk length = %lu\n", rdie->absolute_disk_length);
@@ -242,7 +242,7 @@ static inline void dump_runtime_disk_info_encoding(
  * VDMK settings.
  */
 static inline char validate_runtime_disk_info_encoding(
-    struct runtime_disk_info_encoding* rdie)
+    runtime_disk_info_encoding* rdie)
 {
   if (info->biosGeo.cylinders > 0
       && info->biosGeo.cylinders < rdie->bios_cylinders) {
@@ -832,7 +832,7 @@ static inline bool save_disk_info(const char* key,
                                   uint64_t* absolute_disk_length)
 {
   bool retval = false;
-  struct runtime_disk_info_encoding rdie;
+  runtime_disk_info_encoding rdie;
   json_t* object;
 
   fill_runtime_disk_info_encoding(&rdie);
@@ -877,7 +877,7 @@ bail_out:
 // Decode the disk info of the disk restored from the backup input stream.
 static inline bool process_disk_info(bool validate_only, json_t* value)
 {
-  struct runtime_disk_info_encoding rdie;
+  runtime_disk_info_encoding rdie;
 
   memset(&rdie, 0, rdie_size);
   if (robust_reader(STDIN_FILENO, (char*)&rdie, rdie_size) != rdie_size) {
@@ -943,7 +943,7 @@ static inline bool read_meta_data_key(char* key)
   VixError err;
   size_t requiredLen;
   char* buffer = NULL;
-  struct runtime_meta_data_encoding rmde;
+  runtime_meta_data_encoding rmde;
 
   if (verbose) { fprintf(stderr, "Processing metadata key %s\n", key); }
 
@@ -1026,7 +1026,7 @@ static inline bool save_meta_data()
   size_t requiredLen;
   char* bp;
   char* buffer = NULL;
-  struct runtime_meta_data_encoding rmde;
+  runtime_meta_data_encoding rmde;
 
   /* See if we are actually saving all meta data or should only write the META
    * data end marker. */
@@ -1090,7 +1090,7 @@ bail_out:
  */
 static inline bool process_meta_data(bool validate_only)
 {
-  struct runtime_meta_data_encoding rmde;
+  runtime_meta_data_encoding rmde;
   char* key = NULL;
   char* buffer = NULL;
 
@@ -1181,7 +1181,7 @@ static bool process_single_cbt(std::vector<uint8>& buffer,
                                uint64 start_offset,
                                uint64 offset_length)
 {
-  struct runtime_cbt_encoding rce;
+  runtime_cbt_encoding rce;
   rce.start_magic = BAREOSMAGIC;
   rce.end_magic = BAREOSMAGIC;
   rce.start_offset = start_offset;
@@ -1448,7 +1448,7 @@ static inline bool process_restore_stream(bool validate_only, json_t* value)
   size_t cnt;
   uint64_t current_offset, max_offset;
   uint64_t sector_offset, sectors_to_read;
-  struct runtime_cbt_encoding rce;
+  runtime_cbt_encoding rce;
 
   std::vector<uint8> buffer;
   if (!multi_threaded) {

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -780,10 +780,10 @@ static size_t write_to_vmdk(size_t sector_offset, size_t nbyte, void* buf)
 // Read data from a stream using the robust reader function.
 static size_t read_from_stream(size_t, size_t nbyte, void* buf)
 {
-  return robust_reader(STDOUT_FILENO, buf, nbyte);
+  return robust_reader(STDIN_FILENO, buf, nbyte);
 }
 
-// Write data from a stream using the robust reader function.
+// Write data from a stream using the robust writer function.
 static size_t write_to_stream(size_t sector_offset, size_t nbyte, void* buf)
 {
   // Should we clone to rawdevice ?

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1265,7 +1265,12 @@ static inline bool process_cbt(const char* key, json_t* cbt)
       offset_length -= sectors_to_read * DEFAULT_SECTOR_SIZE;
     }
 
-    if (multi_threaded) { flush_copy_thread(); }
+    if (multi_threaded) {
+      /* we need to wait until the thread has finished writing
+       * all data that we have given him to write -- otherwise both this thread
+       * and the copy thread would write to stdout at the same time! */
+      flush_copy_thread();
+    }
 
     if (verbose) { fflush(stderr); }
   }

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
    Copyright (C) 2015-2015 Planets Communications B.V.
 
    This program is Free Software; you can redistribute it and/or
@@ -1008,10 +1008,8 @@ static inline bool save_meta_data()
   char* buffer = NULL;
   struct runtime_meta_data_encoding rmde;
 
-  /*
-   * See if we are actually saving all meta data or should only write the META
-   * data end marker.
-   */
+  /* See if we are actually saving all meta data or should only write the META
+   * data end marker. */
   if (save_metadata) {
     err = VixDiskLib_GetMetadataKeys(read_diskHandle, NULL, 0, &requiredLen);
     if (err != VIX_OK && err != VIX_E_BUFFER_TOOSMALL) { return false; }
@@ -1043,10 +1041,8 @@ static inline bool save_meta_data()
     }
   }
 
-  /*
-   * Write an META data end marker.
-   * e.g. metadata header with key and data length == 0
-   */
+  /* Write an META data end marker.
+   * e.g. metadata header with key and data length == 0 */
   rmde.start_magic = BAREOSMAGIC;
   rmde.end_magic = BAREOSMAGIC;
   rmde.meta_key_length = 0;
@@ -1190,10 +1186,8 @@ static inline bool process_cbt(const char* key, json_t* cbt)
     goto bail_out;
   }
 
-  /*
-   * Iterate over each element of the JSON array and get the "start" and
-   * "length" member.
-   */
+  /* Iterate over each element of the JSON array and get the "start" and
+   * "length" member. */
   rce.start_magic = BAREOSMAGIC;
   rce.end_magic = BAREOSMAGIC;
   json_array_foreach(object, index, array_element)
@@ -1232,19 +1226,15 @@ static inline bool process_cbt(const char* key, json_t* cbt)
       }
     }
 
-    /*
-     * Calculate the start offset and read as many sectors as defined by the
-     * length element of the JSON structure.
-     */
+    /* Calculate the start offset and read as many sectors as defined by the
+     * length element of the JSON structure. */
     current_offset = absolute_start_offset + start_offset;
     max_offset = current_offset + offset_length;
     sector_offset = current_offset / DEFAULT_SECTOR_SIZE;
     while (current_offset < max_offset) {
-      /*
-       * The number of sectors to read is the minimum of either the total number
+      /* The number of sectors to read is the minimum of either the total number
        * of sectors still available in this CBT range or the upper setting
-       * specified in the sectors_per_call variable.
-       */
+       * specified in the sectors_per_call variable. */
       sectors_to_read
           = MIN(sectors_per_call, (offset_length / DEFAULT_SECTOR_SIZE));
 
@@ -1363,11 +1353,9 @@ static inline bool process_restore_stream(bool validate_only, json_t* value)
     max_offset = current_offset + rce.offset_length;
     sector_offset = current_offset / DEFAULT_SECTOR_SIZE;
     while (current_offset < max_offset) {
-      /*
-       * The number of sectors to read is the minimum of either the total number
+      /* The number of sectors to read is the minimum of either the total number
        * of sectors still available in this CBT range or the upper setting
-       * specified in the sectors_per_call variable.
-       */
+       * specified in the sectors_per_call variable. */
       sectors_to_read
           = MIN(sectors_per_call, (rce.offset_length / DEFAULT_SECTOR_SIZE));
 
@@ -1483,10 +1471,8 @@ static inline bool dump_vmdk_stream(const char* json_work_file)
     exit(1);
   }
 
-  /*
-   * See if we are requested to clone the content to a new VMDK.
-   * save_disk_info() initializes absolute_disk_length.
-   */
+  /* See if we are requested to clone the content to a new VMDK.
+   * save_disk_info() initializes absolute_disk_length. */
   if (vmdk_disk_name) {
     if (create_disk) {
       do_vixdisklib_create(NULL, vmdk_disk_name, value, absolute_disk_length);
@@ -1587,10 +1573,8 @@ int main(int argc, char** argv)
     switch (ch) {
       case 'C':
         create_disk = true;
-        /*
-         * If we create the disk we should not check for the size as that won't
-         * match.
-         */
+        /* If we create the disk we should not check for the size as that won't
+         * match. */
         check_size = false;
         break;
       case 'c':

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -50,6 +50,7 @@
 
 #include <vixDiskLib.h>
 
+/* This is the minimum version we require, i.e. vSphere 6.5 or later */
 #define VIXDISKLIB_VERSION_MAJOR 6
 #define VIXDISKLIB_VERSION_MINOR 5
 
@@ -127,7 +128,7 @@ struct runtime_disk_info_encoding {
   uint32_t padding[16];
   uint32_t end_magic;
 };
-const int rdie_size = sizeof(struct runtime_disk_info_encoding);
+inline constexpr int rdie_size = sizeof(struct runtime_disk_info_encoding);
 
 /*
  * Disk Meta data structure,
@@ -140,7 +141,7 @@ struct runtime_meta_data_encoding {
   uint32_t meta_data_length;
   uint32_t end_magic;
 };
-const int rmde_size = sizeof(struct runtime_meta_data_encoding);
+inline constexpr int rmde_size = sizeof(struct runtime_meta_data_encoding);
 
 /*
  * Changed Block Tracking structure.
@@ -153,7 +154,7 @@ struct runtime_cbt_encoding {
   uint64_t offset_length;
   uint32_t end_magic;
 };
-const int rce_size = sizeof(struct runtime_cbt_encoding);
+inline constexpr int rce_size = sizeof(struct runtime_cbt_encoding);
 
 static bool cleanup_on_start = false;
 static bool cleanup_on_disconnect = false;

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -667,6 +667,7 @@ static inline void do_vixdisklib_open(const char* key,
               info->logicalSectorSize);
       fprintf(stderr, "DiskInfo physicalSectorSize: %u\n",
               info->physicalSectorSize);
+      fprintf(stderr, "DiskInfo capacity: %lu\n", info->capacity);
     }
 #endif
   }

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1417,7 +1417,10 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
     }
   }
 
-  fprintf(stderr, "Changed len: %lu, Saved len: %lu\n", changed_len, saved_len);
+  if (verbose) {
+    fprintf(stderr, "Changed len: %lu, Saved len: %lu\n", changed_len,
+            saved_len);
+  }
 
 
   retval = true;

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1397,8 +1397,8 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
       // But since we cannot currently take advantage of that information
       // -- we do restores first -> last instead of last -> first and we
       //    do not do consolidations for plugins --
-      // we just ignore them.  See process_empty_block on how one could
-      // add that information to the stream.
+      // we just ignore them.  If needed in the future, we can mark "empty"
+      // by e.g. changing the BAREOS_MAGIC to a different one.
       if (boffset < start_offset + offset_length
           && boffset + blength > start_offset) {
         uint64 offset = std::max(boffset, start_offset);

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1860,9 +1860,21 @@ int main(int argc, char** argv)
       case 'S':
         cleanup_on_start = true;
         break;
-      case 's':
-        sectors_per_call = atoi(optarg);
-        break;
+      case 's': {
+        auto new_sectors_per_call = atoi(optarg);
+
+        if (new_sectors_per_call <= 0) {
+          fprintf(stderr,
+                  "We cannot back up data while not being able to request data "
+                  "from vmware; sectors_per_call has to be a number > 0 "
+                  "(got '%s')!\n",
+                  optarg);
+          exit(1);
+        }
+
+        sectors_per_call = new_sectors_per_call;
+
+      } break;
       case 't':
         disktype = strdup(optarg);
         if (!disktype) {

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -631,7 +631,6 @@ static inline void do_vixdisklib_open(const char* key,
                                       bool getdiskinfo,
                                       VixDiskLibHandle* diskHandle)
 {
-  int succeeded = 0;
   VixError err;
   const char* disk_path;
   uint32_t flags;
@@ -644,7 +643,7 @@ static inline void do_vixdisklib_open(const char* key,
     if (!object) {
       fprintf(stderr, "Failed to find %s in JSON definition of object %s\n",
               DISK_PARAMS_DISK_PATH_KEY, key);
-      goto bail_out;
+      exit(1);
     }
 
     disk_path = json_string_value(object);
@@ -663,7 +662,7 @@ static inline void do_vixdisklib_open(const char* key,
     fprintf(stderr, "Failed to open %s : %s [%lu]\n", disk_path, error_txt,
             err);
     VixDiskLib_FreeErrorText(error_txt);
-    goto bail_out;
+    exit(1);
   }
 
   if (getdiskinfo) {
@@ -676,7 +675,7 @@ static inline void do_vixdisklib_open(const char* key,
       fprintf(stderr, "Failed to get Logical Disk Info for %s, %s [%lu]\n",
               disk_path, error_txt, err);
       VixDiskLib_FreeErrorText(error_txt);
-      goto bail_out;
+      exit(1);
     }
 #ifdef VIXDISKLIBCREATEPARAMS_HAS_PHYSICALSECTORSIZE
     if (verbose) {
@@ -693,11 +692,6 @@ static inline void do_vixdisklib_open(const char* key,
     fprintf(stderr, "Selected transport method: %s\n",
             VixDiskLib_GetTransportMode(*diskHandle));
   }
-
-  succeeded = 1;
-
-bail_out:
-  if (!succeeded) { exit(1); }
 }
 
 // Create a VMDK using VDDK.

--- a/core/src/vmware/vadp_dumper/cbuf.cc
+++ b/core/src/vmware/vadp_dumper/cbuf.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/vmware/vadp_dumper/cbuf.cc
+++ b/core/src/vmware/vadp_dumper/cbuf.cc
@@ -45,6 +45,7 @@ int circbuf::init()
   m_next_out = 0;
   m_size = 0;
   m_capacity = QSIZE;
+  m_flush = false;
 
   return 0;
 }

--- a/core/src/vmware/vadp_dumper/cbuf.cc
+++ b/core/src/vmware/vadp_dumper/cbuf.cc
@@ -77,7 +77,7 @@ int circbuf::enqueue(void* data)
   return 0;
 }
 
-// Dequeue an item from the circular buffer.
+// Look at the next item in the circular buffer.
 void* circbuf::peek()
 {
   void* data;
@@ -102,6 +102,7 @@ void* circbuf::peek()
   return data;
 }
 
+// Dequeue an item from the circular buffer.
 void circbuf::dequeue()
 {
   pthread_mutex_lock(&m_lock);

--- a/core/src/vmware/vadp_dumper/cbuf.h
+++ b/core/src/vmware/vadp_dumper/cbuf.h
@@ -44,7 +44,8 @@ class circbuf {
   int init();
   void destroy();
   int enqueue(void* data);
-  void* dequeue();
+  void* peek();
+  void dequeue();
   int next_slot();
   int flush();
   bool full() { return m_size == m_capacity; };

--- a/core/src/vmware/vadp_dumper/cbuf.h
+++ b/core/src/vmware/vadp_dumper/cbuf.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -69,8 +69,7 @@ static void* copy_thread(void* data)
       context->do_end = false;
     }
 
-    pthread_cond_signal(&context->flush);
-
+    assert(0 == pthread_cond_signal(&context->flush));
     pthread_mutex_unlock(&context->lock);
   }
 
@@ -170,7 +169,7 @@ void flush_copy_thread()
 {
   CP_THREAD_CTX* context = cp_thread;
 
-  if (pthread_mutex_lock(&context->lock) != 0) { return; }
+  assert(pthread_mutex_lock(&context->lock) == 0);
 
   /* In essence the flush should work in one shot but be a bit more
    * conservative. */
@@ -179,7 +178,7 @@ void flush_copy_thread()
     context->cb->flush();
 
     // Wait for the copy thread to say it flushed the data out.
-    pthread_cond_wait(&context->flush, &context->lock);
+    assert(pthread_cond_wait(&context->flush, &context->lock) == 0);
   }
 
   context->flushed = false;

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -173,9 +173,12 @@ void flush_copy_thread()
 
   /* In essence the flush should work in one shot but be a bit more
    * conservative. */
+  // make sure the other thread noticed
+  context->flushed = false;
+  context->cb->flush();
+
   while (!context->flushed) {
     // Tell the copy thread to flush out all data.
-    context->cb->flush();
 
     // Wait for the copy thread to say it flushed the data out.
     assert(pthread_cond_wait(&context->flush, &context->lock) == 0);

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -56,10 +56,8 @@ static void* copy_thread(void* data)
   while (1) {
     size_t cnt;
 
-    /*
-     * Wait for the moment we are supposed to start.
-     * We are signalled by the restore thread.
-     */
+    /* Wait for the moment we are supposed to start.
+     * We are signalled by the restore thread. */
     pthread_cond_wait(&context->start, &context->lock);
     context->started = true;
 
@@ -153,11 +151,9 @@ bool send_to_copy_thread(size_t sector_offset, size_t nbyte)
   circbuf* cb = cp_thread->cb;
   CP_THREAD_SAVE_DATA* save_data;
 
-  /*
-   * Find out which next slot will be used on the Circular Buffer.
+  /* Find out which next slot will be used on the Circular Buffer.
    * The method will block when the circular buffer is full until a slot is
-   * available.
-   */
+   * available. */
   slotnr = cb->next_slot();
   save_data = &cp_thread->save_data[slotnr];
 
@@ -195,10 +191,8 @@ void flush_copy_thread()
 
   if (pthread_mutex_lock(&context->lock) != 0) { return; }
 
-  /*
-   * In essence the flush should work in one shot but be a bit more
-   * conservative.
-   */
+  /* In essence the flush should work in one shot but be a bit more
+   * conservative. */
   while (!context->flushed) {
     // Tell the copy thread to flush out all data.
     context->cb->flush();

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -143,8 +143,6 @@ bool send_to_copy_thread(size_t sector_offset, size_t nbyte)
   // If this is the first time we use this slot we need to allocate some memory.
   if (save_data->capacity < nbyte) {
     if (save_data->data) {
-      fprintf(stderr, "Making slot %d bigger (%zu -> %zu)\n", slotnr,
-              save_data->capacity, nbyte);
       save_data->data = realloc(save_data->data, nbyte + 1);
     } else {
       save_data->data = malloc(nbyte + 1);

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -173,7 +173,8 @@ void flush_copy_thread()
 
   /* In essence the flush should work in one shot but be a bit more
    * conservative. */
-  // make sure the other thread noticed
+  // make sure the other thread has noticed by checking that
+  // this was set to true _after_ we flushed the buffer.
   context->flushed = false;
   context->cb->flush();
 

--- a/core/src/vmware/vadp_dumper/copy_thread.h
+++ b/core/src/vmware/vadp_dumper/copy_thread.h
@@ -30,6 +30,7 @@
 typedef size_t(IO_FUNCTION)(size_t sector_offset, size_t nbyte, void* buf);
 
 struct CP_THREAD_SAVE_DATA {
+  size_t capacity;      /* capacity */
   size_t sector_offset; /* Sector offset where to write data */
   size_t data_len;      /* Length of Data */
   void* data;           /* Data */

--- a/core/src/vmware/vadp_dumper/copy_thread.h
+++ b/core/src/vmware/vadp_dumper/copy_thread.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/vmware/vadp_dumper/copy_thread.h
+++ b/core/src/vmware/vadp_dumper/copy_thread.h
@@ -41,12 +41,11 @@ struct CP_THREAD_CTX {
   CP_THREAD_SAVE_DATA*
       save_data; /* To save data (cached structure build during restore) */
   circbuf* cb;   /* Circular buffer for passing work to copy thread */
-  bool started;  /* Copy thread consuming data */
   bool flushed;  /* Copy thread flushed data */
-  pthread_t thread_id;  /* Id of copy thread */
-  pthread_mutex_t lock; /* Lock the structure */
-  pthread_cond_t start; /* Start consuming data from the Circular buffer */
-  pthread_cond_t flush; /* Flush data from the Circular buffer */
+  bool do_end;   /* If set, write thread will stop. */
+  pthread_t thread_id;          /* Id of copy thread */
+  pthread_mutex_t lock;         /* Lock the structure */
+  pthread_cond_t flush;         /* Flush data from the Circular buffer */
   IO_FUNCTION* input_function;  /* IO function that performs the output I/O */
   IO_FUNCTION* output_function; /* IO function that performs the output I/O */
 };


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr fixes some bugs of the vadp_dumper, mostly related to its multithreaded mode.  For example:
* fixed multithreaded writing trying to read from stdout instead of stdin
* fixed runtime value of sectors_per_call not being taken into account when allocating buffers
* fixed multiple data races related to memory reuse when using multithreaded mode

Additionally this PR adds support for the QueryAllocatedBlocks function in the following way:
Previously we backed up every block that was reported by vmware to have changed since some point
in time (or at all in case of full backups).  This list can contain blocks that were once changed but are now
not needed anymore which we previously backed up needlessly.  As such we now ask vmware to also give us a list
of all allocated (i.e. needed) blocks and backup only sectors that are both part of a allocated block and part of a
changed block.


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

