### PR TITLE
plugins: fix cancel handling crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - dird: fix `purge oldest volume` [PR #1628]
 - Fix continuation on colons in plugin baseclass [PR #1637]
+- plugins: fix cancel handling crash [PR #1595]
 
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
 [PR #1587]: https://github.com/bareos/bareos/pull/1587
 [PR #1589]: https://github.com/bareos/bareos/pull/1589
 [PR #1592]: https://github.com/bareos/bareos/pull/1592
 [PR #1593]: https://github.com/bareos/bareos/pull/1593
+[PR #1595]: https://github.com/bareos/bareos/pull/1595
 [PR #1598]: https://github.com/bareos/bareos/pull/1598
 [PR #1605]: https://github.com/bareos/bareos/pull/1605
 [PR #1606]: https://github.com/bareos/bareos/pull/1606

--- a/core/scripts/btraceback.in
+++ b/core/scripts/btraceback.in
@@ -22,19 +22,21 @@ MDB="@MDB@"
 # Try to generate a core dump for postmortem analyzing.
 #
 POSTMORTEM="NONE"
-if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
-   POSTMORTEM="${WD}/${PNAME}.core"
-   ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
-   POSTMORTEM="${POSTMORTEM}.$2"
-   echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
-else
-   which gcore > /dev/null 2>&1 && GCORE="`which gcore`" || GCORE=''
-   if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
-      POSTMORTEM="${WD}/${PNAME}.core"
-      ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
-      POSTMORTEM="${POSTMORTEM}.$2"
-      echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
-   fi
+if [ -n "${DUMPCORE+x}" ]; then
+    if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
+        POSTMORTEM="${WD}/${PNAME}.core"
+        ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
+        POSTMORTEM="${POSTMORTEM}.$2"
+        echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
+    else
+        which gcore > /dev/null 2>&1 && GCORE="`which gcore`" || GCORE=''
+        if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
+            POSTMORTEM="${WD}/${PNAME}.core"
+            ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
+            POSTMORTEM="${POSTMORTEM}.$2"
+            echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
+        fi
+    fi
 fi
 
 #

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -375,7 +375,12 @@ bool CheckIfFamilyEnabled(IpFamily family)
           FamilyName(family), be.bstrerror());
     return false;
   }
-  close(fd);
+
+#ifdef HAVE_WIN32
+  ::closesocket(fd);
+#else
+  ::close(fd);
+#endif
   return true;
 }
 

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -574,6 +574,15 @@ static inline bool PyIoPacketToNative(PyIoPacket* pIoPkt, io_pkt* io)
 
       if (!(buf = PyByteArray_AsString(pIoPkt->buf))) { return false; }
       memcpy(io->buf, buf, io->status);
+    } else if (PyBytes_Check(pIoPkt->buf)) {
+      char* buf;
+
+      if (PyBytes_Size(pIoPkt->buf) > io->count || io->status > io->count) {
+        return false;
+      }
+
+      if (!(buf = PyBytes_AsString(pIoPkt->buf))) { return false; }
+      memcpy(io->buf, buf, io->status);
     }
   }
 

--- a/core/src/plugins/filed/python/plugin_private_context.h
+++ b/core/src/plugins/filed/python/plugin_private_context.h
@@ -35,8 +35,9 @@ struct plugin_private_context {
   char* link;                       // Target symlink points to
   char* object_name;                // Restore Object Name
   char* object;                     // Restore Object Content
-  PyInterpreterState* interp;
-  PyObject* pModule;                // Python Module entry point
+  PyInterpreterState*
+      interp;         // Python interpreter for this instance of the plugin
+  PyObject* pModule;  // Python Module entry point
   PyObject* pyModuleFunctionsDict;  // Python Dictionary
 };
 

--- a/core/src/plugins/filed/python/plugin_private_context.h
+++ b/core/src/plugins/filed/python/plugin_private_context.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,9 +35,8 @@ struct plugin_private_context {
   char* link;                       // Target symlink points to
   char* object_name;                // Restore Object Name
   char* object;                     // Restore Object Content
-  PyThreadState*
-      interpreter;    // Python interpreter for this instance of the plugin
-  PyObject* pModule;  // Python Module entry point
+  PyInterpreterState* interp;
+  PyObject* pModule;                // Python Module entry point
   PyObject* pyModuleFunctionsDict;  // Python Dictionary
 };
 

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -296,6 +296,8 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
+  Bareosfd_set_plugin_context(plugin_ctx);
+
   /* First handle some events internally before calling python if it
    * want to do some special handling on the event triggered. */
   switch (event->eventType) {

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -146,9 +146,7 @@ static inline unsigned long PyVersion()
 }
 
 
-#ifdef __cplusplus
 extern "C" {
-#endif
 
 // Plugin called here when it is first loaded
 bRC loadPlugin(PluginApiDefinition* lbareos_plugin_interface_version,
@@ -211,9 +209,7 @@ bRC unloadPlugin()
   return bRC_OK;
 }
 
-#ifdef __cplusplus
-}
-#endif
+}  //  extern "C"
 
 /**
  * Called here to make a new instance of the plugin -- i.e. when

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -207,8 +207,37 @@ bRC unloadPlugin()
  * plugin instance must be thread safe and keep its own
  * local data.
  */
+thread_local PyThreadState* global_interpreter = nullptr;
+
+// return if global_interpreter needs to be freed on release
+static bool AcquireLock(PyInterpreterState* interp)
+{
+  bool needs_free = false;
+  if (!global_interpreter) {
+    global_interpreter = PyThreadState_New(interp);
+    needs_free = true;
+  }
+  ASSERT(global_interpreter->interp == interp);
+  PyEval_RestoreThread(global_interpreter);
+
+  return needs_free;
+}
+
+static void ReleaseLock(bool needs_free)
+{
+  ASSERT(global_interpreter);
+  if (needs_free) {
+    PyThreadState_Clear(global_interpreter);
+    PyThreadState_DeleteCurrent();
+    global_interpreter = nullptr;
+  } else {
+    PyEval_ReleaseThread(global_interpreter);
+  }
+}
+
 static bRC newPlugin(PluginContext* plugin_ctx)
 {
+  ASSERT(global_interpreter == nullptr);
   struct plugin_private_context* plugin_priv_ctx
       = (struct plugin_private_context*)malloc(
           sizeof(struct plugin_private_context));
@@ -223,8 +252,9 @@ static bRC newPlugin(PluginContext* plugin_ctx)
 
   /* For each plugin instance we instantiate a new Python interpreter. */
   PyEval_AcquireThread(mainThreadState);
-  plugin_priv_ctx->interpreter = Py_NewInterpreter();
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  global_interpreter = Py_NewInterpreter();
+  plugin_priv_ctx->interp = global_interpreter->interp;
+  PyEval_ReleaseThread(global_interpreter);
 
   /* Always register some events the python plugin itself can register
      any other events it is interested in. */
@@ -242,6 +272,7 @@ static bRC newPlugin(PluginContext* plugin_ctx)
  */
 static bRC freePlugin(PluginContext* plugin_ctx)
 {
+  ASSERT(global_interpreter);
   struct plugin_private_context* plugin_priv_ctx
       = (struct plugin_private_context*)plugin_ctx->plugin_private_context;
 
@@ -264,12 +295,12 @@ static bRC freePlugin(PluginContext* plugin_ctx)
   if (plugin_priv_ctx->object) { free(plugin_priv_ctx->object); }
 
   // Stop any sub interpreter started per plugin instance.
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
+  PyEval_AcquireThread(global_interpreter);
 
 
   if (plugin_priv_ctx->pModule) { Py_DECREF(plugin_priv_ctx->pModule); }
 
-  Py_EndInterpreter(plugin_priv_ctx->interpreter);
+  Py_EndInterpreter(global_interpreter);
 #if PY_VERSION_HEX < VERSION_HEX(3, 2, 0)
   PyEval_ReleaseLock();
 #else
@@ -355,7 +386,7 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
    * we only do a dispatch to the python entry point when that internal
    * processing was successful (e.g. retval == bRC_OK). */
   if (!event_dispatched || retval == bRC_OK) {
-    PyEval_AcquireThread(plugin_priv_ctx->interpreter);
+    auto l = AcquireLock(plugin_priv_ctx->interp);
 
     /* Now dispatch the event to Python.
      * First the calls that need special handling. */
@@ -422,7 +453,7 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
         break;
     }
 
-    PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+    ReleaseLock(l);
   }
 
 bail_out:
@@ -444,12 +475,14 @@ static bRC startBackupFile(PluginContext* plugin_ctx, save_pkt* sp)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyStartBackupFile(plugin_ctx, sp);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyStartBackupFile(plugin_ctx, sp);
+    ReleaseLock(l);
+  }
+
   Dmsg(plugin_ctx, debuglevel, LOGPREFIX "StartBackupFile returned: %d\n",
        retval);
-
   if (retval != bRC_OK) { goto bail_out; }
 
   /* For Incremental and Differential backups use checkChanges method to
@@ -493,9 +526,11 @@ static bRC endBackupFile(PluginContext* plugin_ctx)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyEndBackupFile(plugin_ctx);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyEndBackupFile(plugin_ctx);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -516,9 +551,11 @@ static bRC pluginIO(PluginContext* plugin_ctx, io_pkt* io)
 
   if (!plugin_priv_ctx->python_loaded) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyPluginIO(plugin_ctx, io);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyPluginIO(plugin_ctx, io);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -533,9 +570,11 @@ static bRC startRestoreFile(PluginContext* plugin_ctx, const char* cmd)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyStartRestoreFile(plugin_ctx, cmd);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyStartRestoreFile(plugin_ctx, cmd);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -550,9 +589,11 @@ static bRC endRestoreFile(PluginContext* plugin_ctx)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyEndRestoreFile(plugin_ctx);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyEndRestoreFile(plugin_ctx);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -573,9 +614,11 @@ static bRC createFile(PluginContext* plugin_ctx, restore_pkt* rp)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyCreateFile(plugin_ctx, rp);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyCreateFile(plugin_ctx, rp);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -593,9 +636,11 @@ static bRC setFileAttributes(PluginContext* plugin_ctx, restore_pkt* rp)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PySetFileAttributes(plugin_ctx, rp);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PySetFileAttributes(plugin_ctx, rp);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -612,9 +657,11 @@ static bRC checkFile(PluginContext* plugin_ctx, char* fname)
 
   if (!plugin_priv_ctx->python_loaded) { return bRC_OK; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyCheckFile(plugin_ctx, fname);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyCheckFile(plugin_ctx, fname);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -630,9 +677,11 @@ static bRC getAcl(PluginContext* plugin_ctx, acl_pkt* ap)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyGetAcl(plugin_ctx, ap);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyGetAcl(plugin_ctx, ap);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -648,9 +697,11 @@ static bRC setAcl(PluginContext* plugin_ctx, acl_pkt* ap)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PySetAcl(plugin_ctx, ap);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PySetAcl(plugin_ctx, ap);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -666,9 +717,11 @@ static bRC getXattr(PluginContext* plugin_ctx, xattr_pkt* xp)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyGetXattr(plugin_ctx, xp);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyGetXattr(plugin_ctx, xp);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -684,9 +737,11 @@ static bRC setXattr(PluginContext* plugin_ctx, xattr_pkt* xp)
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PySetXattr(plugin_ctx, xp);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PySetXattr(plugin_ctx, xp);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -885,9 +940,11 @@ static bRC getPluginValue(PluginContext* bareos_plugin_ctx,
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
-  retval = Bareosfd_PyGetPluginValue(bareos_plugin_ctx, var, value);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  {
+    auto l = AcquireLock(plugin_priv_ctx->interp);
+    retval = Bareosfd_PyGetPluginValue(bareos_plugin_ctx, var, value);
+    ReleaseLock(l);
+  }
 
 bail_out:
   return retval;
@@ -904,9 +961,9 @@ static bRC setPluginValue(PluginContext* bareos_plugin_ctx,
 
   if (!plugin_priv_ctx) { return bRC_Error; }
 
-  PyEval_AcquireThread(plugin_priv_ctx->interpreter);
+  auto l = AcquireLock(plugin_priv_ctx->interp);
   retval = Bareosfd_PySetPluginValue(bareos_plugin_ctx, var, value);
-  PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
+  ReleaseLock(l);
 
   return retval;
 }

--- a/core/src/plugins/stored/python/python-sd.cc
+++ b/core/src/plugins/stored/python/python-sd.cc
@@ -301,6 +301,8 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
+  Bareossd_set_plugin_context(plugin_ctx);
+
   /* First handle some events internally before calling python if it
    * want to do some special handling on the event triggered. */
   switch (event->eventType) {

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/CancelFileset.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/CancelFileset.conf.in
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "CancelFileset"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "@python_module_name@:module_path=@python_plugin_module_src_test_dir@:module_name=cancel-check-module"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/CancelNoWaitFileset.conf
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/CancelNoWaitFileset.conf
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "CancelNoWaitFileset"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "python3:module_path=/home/ssura/Projekte/bareos/build/systemtests/tests/py3plug-fd-basic/python-modules:module_name=cancel-check-module:should_wait=No"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/job/cancel-check.conf
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/job/cancel-check.conf
@@ -1,0 +1,6 @@
+Job {
+  Name = "cancel-check"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  FileSet = "CancelFileset"
+}

--- a/systemtests/tests/py3plug-fd-basic/python-modules/cancel-check-module.py
+++ b/systemtests/tests/py3plug-fd-basic/python-modules/cancel-check-module.py
@@ -63,7 +63,7 @@ class TestPlugin(BareosFdPluginBaseclass):
         JobMessage(M_INFO, "parse_plugin_definition('{}')\n".format(plugindef))
         ret = super().parse_plugin_definition(plugindef)
         self.plugindef = plugindef
-        wait_opt = self.options["should_wait"]
+        wait_opt = self.options.get("should_wait")
         if wait_opt is not None:
             if wait_opt == "Yes":
                 self.should_wait = True

--- a/systemtests/tests/py3plug-fd-basic/python-modules/cancel-check-module.py
+++ b/systemtests/tests/py3plug-fd-basic/python-modules/cancel-check-module.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+# this test module will emit a job message in every single callback there is
+# to make sure emitting a message won't break anything
+
+# import all the wrapper functions in our module scope
+from BareosFdWrapper import *
+
+from bareosfd import (
+    bRC_OK,
+    JobMessage,
+    DebugMessage,
+    M_INFO,
+    M_WARNING,
+    bFileType,
+    StatPacket,
+    FT_REG,
+    GetValue,
+    bVarJobId,
+    bEventCancelCommand,
+    RegisterEvents,
+)
+
+from BareosFdPluginBaseclass import BareosFdPluginBaseclass
+
+import sys
+from stat import S_IFREG, S_IFDIR, S_IRWXU
+from subprocess import Popen, PIPE
+import time
+
+
+@BareosPlugin
+class TestPlugin(BareosFdPluginBaseclass):
+    def __init__(self, plugindef):
+        super().__init__(plugindef)
+        JobMessage(M_INFO, "__init__('{}')\n".format(plugindef))
+
+        RegisterEvents([bEventCancelCommand])
+        self.files_to_backup = ["result"]
+
+    def parse_plugin_definition(self, plugindef):
+        JobMessage(M_INFO, "parse_plugin_definition('{}')\n".format(plugindef))
+        self.plugindef = plugindef
+        return super().parse_plugin_definition(plugindef)
+
+    def handle_plugin_event(self, event):
+        JobMessage(M_INFO, "handle_plugin_event({})\n".format(event))
+        if event == bEventCancelCommand:
+            JobMessage(M_INFO, f"Canceling jobid={GetValue(bVarJobId)}")
+            time.sleep(5)
+            return bRC_OK
+        else:
+            return super().handle_plugin_event(event)
+
+    def start_backup_file(self, savepkt):
+        JobMessage(M_INFO, "start_backup_file()\n")
+        jobid = GetValue(bVarJobId)
+
+        self.p = Popen("bin/bconsole", stdin=PIPE, text=True)
+        self.p.stdin.write(f"cancel jobid={jobid}")
+        self.p.stdin.close()
+
+        statp = StatPacket()
+        statp.st_size = 0
+        statp.st_mode = S_IRWXU | S_IFREG
+        savepkt.statp = statp
+        savepkt.type = FT_REG
+        savepkt.no_read = False
+        savepkt.fname = "result"
+        return bRC_OK
+
+    def plugin_io_read(self, IOP):
+        JobMessage(M_INFO, "plugin_io called plugin_io_read()\n")
+
+        if self.p.poll() == None:
+            JobMessage(M_INFO, "waiting...")
+            IOP.buf = "1".encode()
+            IOP.status = 1
+        else:
+            JobMessage(M_INFO, f"canceled jobid={jobid}\n")
+            self.p = None
+            IOP.buf = bytarray()
+            IOP.status = 0
+
+        IOP.io_errno = 0
+        return bRC_OK

--- a/systemtests/tests/py3plug-fd-basic/testrunner-cancel-check
+++ b/systemtests/tests/py3plug-fd-basic/testrunner-cancel-check
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# This tests checks that the fd correctly handles the case where two different
+# threads access the same plugin context at the same time.  This is done by
+# canceling a job while the job is inside the plugin.
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=cancel-check
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+logf="$tmp/cancel-check.out"
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $logf
+run job=$JobName yes
+wait
+messages
+status client
+END_OF_DATA
+
+run_bconsole
+
+expect_not_grep "Failed to connect to Client" \
+		"$logf" \
+		"The client crashed"
+
+end_test

--- a/systemtests/tests/py3plug-fd-basic/testrunner-cancel-check-no-wait
+++ b/systemtests/tests/py3plug-fd-basic/testrunner-cancel-check-no-wait
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+# This tests checks that the fd correctly handles the case where two different
+# threads access the same plugin context at the same time.  This is done by
+# canceling a job while the job is inside the plugin.
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=cancel-check
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+logf="$tmp/cancel-check-no-wait.out"
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out $logf
+run job=$JobName fileset=CancelNoWaitFileset yes
+wait
+messages
+status client
+END_OF_DATA
+
+run_bconsole
+
+expect_not_grep "Failed to connect to Client" \
+		"$logf" \
+		"The client crashed"
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The plugin context is not explicitly set when handling plugin events.  This is fine for all events except for the cancel event, since the cancel event is issued on seperate threads (and the plugin context is stored in a thread local variable).

This PR fixes the crash by setting the plugin context whenever an event needs to be handled.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [X] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
