### PR TITLE
postgresql plugin: read config parameters from cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - cats: fix for integer overflow issue when using `offset` in `llist` [PR #1547]
 - VMware Plugin: Fix backup and recreating VMs with PCI passthrough for GPU [PR #1565]
 - catreq.cc: suppress missing batch con warning [PR #1578]
+- postgresql plugin: read config parameters from cluster [PR #1599]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -308,4 +309,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1582]: https://github.com/bareos/bareos/pull/1582
 [PR #1583]: https://github.com/bareos/bareos/pull/1583
 [PR #1588]: https://github.com/bareos/bareos/pull/1588
+[PR #1599]: https://github.com/bareos/bareos/pull/1599
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
+++ b/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
@@ -236,7 +236,9 @@ class BareosFdPluginPostgreSQL(BareosFdPluginBaseclass):  # noqa
         if start_dir == "/" or not start_dir.strip():
             raise ValueError("start_dir can not be '/' or empty")
         if not os.path.isdir(start_dir.strip()):
-            raise ValueError("start_dir needs to be a real directory, symlinks are not supported.")
+            raise ValueError(
+                "start_dir needs to be a real directory, symlinks are not supported."
+            )
         if not start_dir.endswith("/"):
             start_dir += "/"
         self.paths_to_backup.append(start_dir)

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
@@ -361,7 +361,7 @@ Initiate the Recovery Process
 '''''''''''''''''''''''''''''
 
 Make sure that the user :strong:`postgres` is allowed to rename the recovery marker file
-(:file:`recovery.signal` or :file:`recovery.conf`), as the file need to be renamed during the
+(:file:`recovery.signal` or :file:`recovery.conf`), as the file needs to be renamed during the
 recovery process. Should be the case if restored by the plugin.
 You might have to adapt your SELINUX configuration for this.
 
@@ -387,7 +387,7 @@ Troubleshooting the PostgreSQL Plugin
 If things don't work as expected, make sure that
 
 - the |fd| (FD) works in general, so that you can make simple file backups and restores
-- the Bareos FD Python plugins work in general, try one of the shipped simple sample plugins
+- the Bareos FD Python plugins works in general, try one of the shipped simple sample plugins
 - check your |postgresql| data directory for files `backup_label` `recovery.signal` `tablespace_map`.
   If they exists, the cluster has been restored, but has not been restarted yet.
 - make sure your `dbuser` can connect to the database `dbname` and is allowed to issue

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
@@ -41,7 +41,7 @@ This is just a short outline of the tasks performed by the plugin.
 #. |postgresql| will write `Write-Ahead-Logfiles` (WAL) into the WAL Archive directory. These
    transaction logs contain transactions done while the file backup proceeded
 #. Backup fresh created WAL files
-#. Add files required for a restore (`backup_label`, `recovery.signal`/`recovery.conf` (for version <= 12)
+#. Add files required for a restore `backup_label`, `recovery.signal`/`recovery.conf` (for version <= 12)
    and `tablespace_map` (if tablespaces are in use) as virtual files to the backup.
 
 .. uml::
@@ -130,7 +130,7 @@ The restore basically works like this:
 
   group Database restore by PostgreSQL
     admin -> psql: start postgresql
-    psql -> psql: read backup_lablel, recovery.signal, tablespace.map
+    psql -> psql: read backup_label, recovery.signal, tablespace.map
     psql -> psql: recover database to the end of the WAL log
     psql -> psql: startup normal database operation
   end
@@ -143,8 +143,8 @@ The restore basically works like this:
 
 .. warning::
 
-   In order to make coherent backups, it is imperative that :strong:`the same postgresql major version`
-   is used for :strong:`full and incremental` Backups depending on each other.
+   In order to make coherent backups, it is imperative that :strong:`the same |postgresql| major version`
+   is used for :strong:`full and incremental` backups depending on each other.
 
 
 Prerequisites for the PostgreSQL Plugin
@@ -227,7 +227,7 @@ Now include the plugin as command-plugin in the fileset resource and define a jo
            }
            Plugin = "python"
                     ":module_name=bareos-fd-postgresql"
-                    ":postgresql_data_dir=/var/lib/pgsql/data"
+                    ":db_host=/run/postgresql/"
                     ":wal_archive_dir=/var/lib/pgsql/wal_archive/"
        }
    }
@@ -236,8 +236,6 @@ Now include the plugin as command-plugin in the fileset resource and define a jo
 
 You can append options to the plugin call as key=value pairs, separated by ``:``. The following options are available:
 
-postgresql_data_dir
-   the Postgres data directory. Default: :file:`/var/lib/pgsql/data`
 
 wal_archive_dir
    directory where |postgresql| archives the WAL files as defined in your :file:`postgresql.conf`
@@ -245,6 +243,7 @@ wal_archive_dir
 
 db_user
    with this user the plugin will try to connect to the database.
+   this role should be granted to access all `pg_settings` and backup functions in the cluster.
    Default: `root`
 
 db_password
@@ -256,15 +255,18 @@ db_name
    Default: `postgres`
 
 db_host
-   useful, if socket is not in default location. Specify socket-directory with a leading / here
-   Default: `None`
+   used to specify the host or the socket-directory when starting with a leading /
+
+   usually you will set it to `/run/postgresql`
+
+   Default: `localhost`
 
 db_port
    useful, if cluster is not listening default port.
    Default: `5432`
 
 ignore_subdirs
-   a list of comma separated directories below the `postgres_data_dir`, that will not be backed up.
+   a list of comma separated directories below the `data_directory`, you want to exclude.
    Default: `pgsql_tmp`
 
    .. note::
@@ -314,7 +316,7 @@ Restore with the PostgreSQL Plugin
 With the usual Bareos restore mechanism a file-hierarchy will be created on the restore client
 under the default restore location according to the options set:
 
--   :file:`<restore prefix>/<postgresql_data_dir>/`
+-   :file:`<restore prefix>/<cluster_data_directory>/`
 -   :file:`<restore prefix>/<wal_archive_dir>/`
 
 This example describes how to restore to the latest possible consistent point in time. You can
@@ -359,7 +361,7 @@ Initiate the Recovery Process
 '''''''''''''''''''''''''''''
 
 Make sure that the user :strong:`postgres` is allowed to rename the recovery marker file
-(:file:`recovery.signal` or :file:`recovery.conf`), as the file will be renamed during the
+(:file:`recovery.signal` or :file:`recovery.conf`), as the file need to be renamed during the
 recovery process. Should be the case if restored by the plugin.
 You might have to adapt your SELINUX configuration for this.
 
@@ -369,7 +371,14 @@ Starting the |postgresql| server shall now initiate the recovery process.
 
    When restoring a cluster which uses :strong:`tablespaces`, the table space location
    (directory) needs to be empty before the restore. Also ensure that the restored links
-   in `data/pg_tblspc` point to the restored tablespace data.
+   in `data/pg_tblspc` point to the restored tablespace data, by default the symlinks will point
+   to the original location.
+
+
+.. warning::
+
+   We highly advise after a cluster restore, to cleanup older wals than the new history, and
+   trigger as soon as possible a new full backup.
 
 
 Troubleshooting the PostgreSQL Plugin
@@ -378,8 +387,7 @@ Troubleshooting the PostgreSQL Plugin
 If things don't work as expected, make sure that
 
 - the |fd| (FD) works in general, so that you can make simple file backups and restores
-- the Bareos FD Python plugins work in general, try one of
-  the shipped simple sample plugins
+- the Bareos FD Python plugins work in general, try one of the shipped simple sample plugins
 - check your |postgresql| data directory for files `backup_label` `recovery.signal` `tablespace_map`.
   If they exists, the cluster has been restored, but has not been restarted yet.
 - make sure your `dbuser` can connect to the database `dbname` and is allowed to issue
@@ -388,6 +396,20 @@ If things don't work as expected, make sure that
   .. code-block:: sql
 
      SELECT current_setting('server_version_num');
+     SELECT current_setting('archive_mode');
+     SELECT current_setting('archive_command');
+     SELECT current_setting('data_directory');
+     SELECT current_setting('log_directory');
+     SELECT current_setting('config_file');
+     SELECT current_setting('hba_file');
+     SELECT current_setting('identity_file');
+     SELECT current_setting('ssl_ca_file');
+     SELECT current_setting('ssl_cert_file');
+     SELECT current_setting('ssl_crl_file');
+     SELECT current_setting('ssl_key_file');
+     SELECT current_setting('ssl_dh_params_file');
+     SELECT current_setting('ssl_crl_dir');
+
      -- Version >= 15
      SELECT pg_backup_start();
      SELECT pg_backup_stop();

--- a/systemtests/tests/py3plug-fd-postgresql/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgresql/database/setup_local_db.sh.in
@@ -39,8 +39,9 @@ local_db_stop_server() {
 
 local_db_prepare_files() {
   echo "Prepare files"
-  rm --recursive --force tmp data log wal_archive table_space index_space
+  rm --recursive --force tmp data log wal_archive table_space index_space wal_archive_symlink
   mkdir tmp data log wal_archive table_space index_space
+  ln -s wal_archive wal_archive_symlink
   if [ $UID -eq 0 ]; then
     chown postgres  tmp data log wal_archive table_space index_space
     LANG= su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl  --pgdata=data --log=log/postgres.log initdb"
@@ -76,7 +77,7 @@ local_db_start_server() {
 
 local_db_create_superuser_role() {
   if [ $UID -eq 0 ]; then
-    su postgres -c "${POSTGRES_BIN_PATH}/psql -h \"$1\" -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'" 
+    su postgres -c "${POSTGRES_BIN_PATH}/psql -h \"$1\" -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'"
   else
     # create role and db root for podman test.
     ${POSTGRES_BIN_PATH}/psql -h "$1" -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'
@@ -89,9 +90,9 @@ setup_local_db() {
   if ! local_db_start_server "$1"; then return 1; fi
   local_db_create_superuser_role "$1"
   if [ $UID -eq 0 ]; then
-    echo stop server with "su postgres -c '${POSTGRES_BIN_PATH}/pg_ctl  --pgdata=data stop'"
+    echo stop server with "su postgres -c '${POSTGRES_BIN_PATH}/pg_ctl --pgdata=data stop'"
   else
-    echo stop server with "${POSTGRES_BIN_PATH}/pg_ctl  --pgdata=data stop"
+    echo stop server with "${POSTGRES_BIN_PATH}/pg_ctl --pgdata=data stop"
   fi
   return 0
 }

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
@@ -9,7 +9,6 @@ FileSet {
              ":module_path=@current_test_directory@/python-modules"
              ":module_name=bareos-fd-postgresql"
              ":db_host=@dbHost@"
-             ":postgresql_data_dir=@current_test_directory@/database/data/"
              ":wal_archive_dir=@current_test_directory@/database/wal_archive/"
              ":start_fast=True"
   }

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestDebian.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestDebian.conf.in
@@ -1,6 +1,6 @@
 FileSet {
-  Name = "PluginTestNoRole"
-  Description = "Test the Plugin functionality with a Python Plugin."
+  Name = "PluginTestDebian"
+  Description = "Test the Python Plugin functionality on Debian "
   Include {
     Options {
       signature = XXH128
@@ -8,9 +8,9 @@ FileSet {
     Plugin = "@python_module_name@"
              ":module_path=@current_test_directory@/python-modules"
              ":module_name=bareos-fd-postgresql"
-             ":db_host=@dbHost@"
-             ":db_user=db_backup"
-             ":wal_archive_dir=@current_test_directory@/database/wal_archive/"
+             ":db_host=/run/postgresql/"
+             ":db_port=5433"
+             ":wal_archive_dir=/var/tmp/postgresql/wal_archives"
              ":start_fast=True"
   }
 }

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestRole.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestRole.conf.in
@@ -11,8 +11,7 @@ FileSet {
              ":db_host=@dbHost@"
              ":db_user=db_backup"
              ":role=backup_group"
-             ":postgresql_data_dir=@current_test_directory@/database/data/"
              ":wal_archive_dir=@current_test_directory@/database/wal_archive/"
-             ":start_fast_start=True"
+             ":start_fast=True"
   }
 }

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestTablespace.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestTablespace.conf.in
@@ -9,7 +9,6 @@ FileSet {
              ":module_path=@current_test_directory@/python-modules"
              ":module_name=bareos-fd-postgresql"
              ":db_host=@dbHost@"
-             ":postgresql_data_dir=@current_test_directory@/database/data/"
              ":wal_archive_dir=@current_test_directory@/database/wal_archive/"
              ":start_fast=True"
   }

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestWalSymlink.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/PluginTestWalSymlink.conf.in
@@ -1,6 +1,6 @@
 FileSet {
-  Name = "PluginTestNoRole"
-  Description = "Test the Plugin functionality with a Python Plugin."
+  Name = "PluginTestWalSymlink"
+  Description = "Test the Plugin functionality wal_archive_dir pointing to a symlink"
   Include {
     Options {
       signature = XXH128
@@ -9,8 +9,7 @@ FileSet {
              ":module_path=@current_test_directory@/python-modules"
              ":module_name=bareos-fd-postgresql"
              ":db_host=@dbHost@"
-             ":db_user=db_backup"
-             ":wal_archive_dir=@current_test_directory@/database/wal_archive/"
+             ":wal_archive_dir=@current_test_directory@/database/wal_archive_symlink"
              ":start_fast=True"
   }
 }

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-debian
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-debian
@@ -1,0 +1,234 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+# This systemtest tests the plugin functionality
+# of the Bareos FD by using the supplied module
+# bareos-fd-postgresql with debian native pg_cluster tools
+#
+# The module will backup a debian PostgreSQL cluster.
+# Full, Incremental after changes, Incremental after no changes
+# Stop the PostgreSQL, destroy the data directory
+# Restore the server data directory and wal archives
+# Restart and check the PostgreSQL cluster.
+#
+# It can be used for any PostgreSQL version >= 10.
+
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName="backup-bareos-fd"
+#shellcheck source=../environment.in
+. ./environment
+. /etc/os-release
+if ([ -z "${ID}" ] || [ "${ID}" != "debian" ] && [ "${ID}" != "ubuntu" ]);then
+ echo "${TestName} test skipped: not debian/ubuntu"
+ exit 77;
+fi
+
+PGVER=$(psql -V | awk '{gsub(".[0-9]$","",$3);print $3}')
+if [ ${PGVER} -lt 10 ]; then
+# skip test
+ echo "${TestName} test skipped: not compatible with PG <= 10"
+ exit 77;
+fi
+if [ $(pg_lsclusters ${PGVER} regress | grep "regress" -c) -eq 1 ];then
+    pg_dropcluster ${PGVER} regress --stop
+    rm -rf /var/tmp/postgresql/wal_archives
+fi
+
+pg_createcluster ${PGVER} regress
+mkdir -p /var/tmp/postgresql/wal_archives
+chown postgres:postgres /var/tmp/postgresql/wal_archives
+# Adjust configuration
+{
+  echo "wal_level = archive"
+  echo "archive_mode = on"
+  echo "archive_command = 'cp %p /var/tmp/postgresql/wal_archives/%f'"
+  echo "max_wal_senders = 10"
+  echo "log_connections = on"
+  echo "log_disconnections = on"
+  echo "log_min_messages = info"
+  echo "log_min_error_statement = info"
+  echo "log_error_verbosity = verbose"
+  echo "log_statement = 'all'"
+  echo "log_temp_files = 0"
+} >> /etc/postgresql/${PGVER}/regress/conf.d/regress.conf
+pg_ctlcluster ${PGVER} regress start
+
+# setup local database server
+DBNAME="backuptest"
+TESTPGHOST="/var/run/postgresql/"
+TESTPGPORT=5433
+PSQL="psql --host ${TESTPGHOST} --port ${TESTPGPORT} "
+
+if [ $UID -eq 0 ]; then
+   su postgres -c "psql -h \"${TESTPGHOST}\" -p ${TESTPGPORT} -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'"
+else
+  # create role and db root for podman test.
+  psql -h "${TESTPGHOST}" -p ${TESTPGPORT} -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'
+fi
+
+# Create Test DB with table and 1 statement
+${PSQL} postgres -c "create database ${DBNAME}"
+${PSQL} ${DBNAME} -c "
+create table t(id serial primary key, text varchar(20), created_on timestamp);
+insert into t (text, created_on) values ('test for FULL backup', current_timestamp);
+select * from t;
+"
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/dlog1.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestDebian yes
+wait
+setdebug level=0 client=bareos-fd
+status director
+status client
+status storage=File
+wait
+messages
+END_OF_DATA
+
+# Create activity on the cluster during the backup
+${PSQL} ${DBNAME} -f "database/make_cluster_activity.sql" --output ${tmp}/cluster_activity.log &
+
+echo "First full backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/dlog1.out" "Full Backup not found!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+# Now add data to the database and run an incremental job
+${PSQL} ${DBNAME} -c "insert into t (text, created_on) values ('test for INCR backup', current_timestamp)"
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/dlog2.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestDebian Level=Incremental yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+
+echo "First incremental backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/dlog2.out" "First Incremental Backup not found!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+# run another Incr without db changes - should result in empty backup job (only restore object)
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/dlog3.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestDebian Level=Incremental yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+echo "Second incremental backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/dlog3.out" "2nd Incremental Backup not found!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+# Now stop database and try a restore
+echo "destroy pg_cluster"
+pg_dropcluster ${PGVER} regress --stop
+rm -rf /var/tmp/postgresql/wal_archives/*
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/dlog4.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+restore client=bareos-fd fileset=PluginTestDebian where=/ select all done yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+echo "Restore stage"
+run_bconsole
+
+expect_grep "Restore OK" "${tmp}/dlog4.out" "Restore Backup not ok!"
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+check_for_zombie_jobs storage=File
+
+sleep 1
+
+check_two_logs "${tmp}/dlog1.out" "${tmp}/dlog4.out"
+
+# use either recovery.conf or recovery.signal
+# Those files should exist after restore, the plugin create them
+# postgres 11 and lower
+if (( ${PGVER} < 12 )); then
+  echo "PG_VERSION is ${PGVER} so lower than 12, using recovery.conf"
+  recovery_file="/var/lib/postgresql/${PGVER}/regress/recovery.conf"
+else
+  # postgres 12+
+  echo "PG_VERSION is ${PGVER} so 12+, using postgresql.conf and recovery.signal"
+  recovery_file="/var/lib/postgresql/${PGVER}/regress/recovery.signal"
+fi
+if [ ! -f "${recovery_file}" ];then
+ echo "${TestName} ${recovery_file} is missing from restore"
+ exit 1;
+fi
+restore_command="restore_command = 'cp /var/tmp/postgresql/wal_archives/%f %p'"
+if (( ${PGVER} < 12 )); then
+  echo "${restore_command}" >> "${recovery_file}"
+else
+  echo "${restore_command}" >> "/etc/postgresql/${PGVER}/regress/conf.d/restore.conf"
+fi
+
+pg_lsclusters ${PGVER} regress
+
+echo ""
+echo "Restart restored pg_cluster"
+
+if ! pg_ctlcluster ${PGVER} regress start;then
+  echo "cluster restart failed after restore"
+   estat=1
+fi
+
+i=0
+until ${PSQL} ${DBNAME} -c "select * from t" | grep "for INCR"  > ${tmp}/sql.log  ; do
+  echo "waiting for query to succeed"
+  sleep 1
+  i=$((i+1))
+  if [ $i -gt 10 ]; then echo "timeout waiting for query after recovery"; exit 1; fi
+done
+if (grep -q "for INCR" ${tmp}/sql.log)
+then
+   estat=0
+else
+   echo "Error: Database rows not found"
+   estat=1
+fi
+
+if [ $(pg_lsclusters ${PGVER} regress | grep "regress" -c) -eq 1 ];then
+    echo "cluster recovery completed"
+    pg_dropcluster ${PGVER} regress --stop
+    rm -rf /var/tmp/postgresql/wal_archives
+fi
+
+
+end_test

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-roles
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-roles
@@ -71,7 +71,7 @@ messages
 END_OF_DATA
 run_bconsole
 
-expect_grep "permission denied for function pg_" "${tmp}/rlog1.out" "No Role 'Backup Error' not found in job log"
+expect_grep "used role missed privileges to read configuration data_directory value" "${tmp}/rlog1.out" "No Role 'Backup Error' not found in job log"
 if [ ${estat} -ne 0 ]; then
     exit ${estat}
 fi
@@ -79,6 +79,7 @@ fi
 # Affect db_backup role to backup_group
 ${PSQL} -d postgres -c "grant backup_group to db_backup;"
 
+echo "run new full with granted role"
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out /dev/null
 messages

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-walsymlink
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-walsymlink
@@ -1,0 +1,215 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+# This systemtest tests the plugin functionality
+# of the Bareos FD by using the supplied module
+# bareos-fd-postgresql
+#
+# The module will backup a PostgreSQL cluster.
+# Full, Incremental after changes, Incremental after no changes
+# Stop the PostgreSQL, destroy the data directory
+# Restore the server data directory and wal archives
+# Restart and check the PostgreSQL cluster.
+#
+# It can be used for any PostgreSQL version >= 10.
+
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName="backup-bareos-fd"
+#shellcheck source=../environment.in
+. ./environment
+. ./database/setup_local_db.sh
+
+# setup local database server
+DBNAME="backuptest"
+TESTPGHOST="${dbHost}"
+PSQL="${POSTGRES_BIN_PATH}/psql --host ${TESTPGHOST}"
+
+[ -d "${TESTPGHOST}" ] && rm -R  "${TESTPGHOST}"
+mkdir -p "${TESTPGHOST}"
+[ $EUID -eq 0 ] && chown postgres "${TESTPGHOST}"
+
+pushd database > /dev/null
+setup_local_db "${TESTPGHOST}"
+# PG_VERSION will be pick from backuped PG data dir
+PG_VERSION="$(cut -d '.' -f1 data/PG_VERSION)"
+if [ ${PG_VERSION} -lt 10 ]; then
+# skip test
+ echo "${TestName} test skipped: not compatible with PG <= 10"
+ exit 77;
+fi
+
+# Create Test DB with table and 1 statement
+${PSQL} postgres -c "create database ${DBNAME}"
+${PSQL} ${DBNAME} -c "
+create table t(id serial primary key, text varchar(20), created_on timestamp);
+insert into t (text, created_on) values ('test for FULL backup', current_timestamp);
+select * from t;
+"
+popd > /dev/null
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/slog1.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestWalSymlink yes
+wait
+setdebug level=0 client=bareos-fd
+status director
+status client
+status storage=File
+wait
+messages
+END_OF_DATA
+
+# Create activity on the cluster during the backup
+${PSQL} ${DBNAME} -f "database/make_cluster_activity.sql" --output ${tmp}/cluster_activity.log &
+
+echo "First full backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/slog1.out" "Full Backup not found!"
+expect_grep "Warning: python3-fd-mod: symlink detected in wal_archive_dir option" "${tmp}/slog1.out" "Symlink warning missing!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+# Now add data to the database and run an incremental job
+${PSQL} ${DBNAME} -c "insert into t (text, created_on) values ('test for INCR backup', current_timestamp)"
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/slog2.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestWalSymlink Level=Incremental yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+
+echo "First incremental backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/slog2.out" "First Incremental Backup not found!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+# run another Incr without db changes - should result in empty backup job (only restore object)
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out $tmp/slog3.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} fileset=PluginTestWalSymlink Level=Incremental yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+echo "Second incremental backup stage"
+run_bconsole
+expect_grep "Backup OK" "${tmp}/slog3.out" "2nd Incremental Backup not found!"
+
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+# Now stop database and try a restore
+pushd database/ > /dev/null
+echo "destroy pg_cluster"
+local_db_stop_server "$TESTPGHOST"
+# Save previous log
+[ -d "data/log" ] && cp -a data/log/* log/
+rm -Rf data
+rm -Rf wal_archive
+rm -f wal_archive_symlink
+echo "------------ stopped"
+popd > /dev/null
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/slog4.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+restore client=bareos-fd fileset=PluginTestWalSymlink where=/ select all done yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+echo "Restore stage"
+run_bconsole
+
+expect_grep "Restore OK" "${tmp}/slog4.out" "Restore Backup not ok!"
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+check_for_zombie_jobs storage=File
+
+sleep 1
+
+pushd database > /dev/null
+#sometimes the pid file remains
+rm -f data/postmaster.pid ||:
+# reset log file
+rm -f data/log/* ||:
+rm -f data/pg_wall/* ||:
+
+
+# use either recovery.conf or recovery.signal
+# Those files should exist after restore, the plugin create them
+# postgres 11 and lower
+if (( ${PG_VERSION} < 12 )); then
+  echo "PG_VERSION is ${PG_VERSION} so lower than 12, using recovery.conf"
+  recovery_file="${current_test_directory}/database/data/recovery.conf"
+else
+  # postgres 12+
+  echo "PG_VERSION is ${PG_VERSION} so 12+, using postgresql.conf and recovery.signal"
+  recovery_file="${current_test_directory}/database/data/recovery.signal"
+fi
+restore_command="restore_command = 'cp ${current_test_directory}/database/wal_archive/%f %p'"
+if [ ! -f "${recovery_file}" ];then
+ echo "${TestName} ${recovery_file} is missing from restore"
+ exit 1;
+fi
+if (( ${PG_VERSION} < 12 )); then
+  echo "${restore_command}" >> "${recovery_file}"
+else
+  echo "${restore_command}" >> "${current_test_directory}/database/data/postgresql.conf"
+fi
+
+
+echo "Restart restored pg_cluster"
+local_db_start_server "${TESTPGHOST}"
+popd > /dev/null
+
+i=0
+until ${PSQL} ${DBNAME} -c "select * from t" | grep "for INCR"  > ${tmp}/sql.log  ; do
+  echo "waiting for query to succeed"
+  sleep 1
+  i=$((i+1))
+  if [ $i -gt 10 ]; then echo "timeout waiting for query after recovery"; exit 1; fi
+done
+
+pushd database/ > /dev/null
+local_db_stop_server "${TESTPGHOST}"
+popd > /dev/null
+
+check_two_logs "${tmp}/slog1.out" "${tmp}/slog4.out"
+if (grep -q "for INCR" ${tmp}/sql.log)
+then
+   estat=0
+else
+   echo "Error: Database rows not found"
+   estat=1
+fi
+
+end_test


### PR DESCRIPTION
With the previous version of the code, the plugin during restore could overwrite real data if the given `data_dir` was a symlink.
This new version connects to the cluster and asks directly its configuration parameters.

- remove no more used parameter `postgresql_data_dir`
- `wal_archive_dir` parameter is checked if it is a symlink, if the case the real location is retrieved and used instead of the symlink, a warning is added to the joblog (testrunner-walsymlink)
- backup external configuration: The plugin now tries its best to backup the directory content where postgresql.conf resides. This is important especially on on Debian-based OS, as there the configuration is unfortunately **not** stored in the data directory but in `/etc/postgesql/<version>/<instance>/` when using the pg_cluster tools.
- add a systemtest to test debian/ubuntu specific location and tools.
- private function will use python raise and they are called inside try: except: block in main function for a better error handling and stopping failed jobs as early as possible.
- documentation got small changes (removal of parameters) and added warnings (do a full after restore)


Fix Issue [#1563](https://bugs.bareos.org/view.php?id=1563)
OP#5610

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
