### PR TITLE
Improve python plugin configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - github actions: PyPi: install setuptools [PR #1589]
 - restore: add fileregex parameter [PR #1587]
 - scripts: force cd / for all PostgreSQL scripts [PR #1607]
+- Improve python plugin configuration [PR #1605]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -19,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
 [PR #1587]: https://github.com/bareos/bareos/pull/1587
 [PR #1589]: https://github.com/bareos/bareos/pull/1589
+[PR #1605]: https://github.com/bareos/bareos/pull/1605
 [PR #1606]: https://github.com/bareos/bareos/pull/1606
 [PR #1607]: https://github.com/bareos/bareos/pull/1607
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -773,10 +773,10 @@ endif()
 
 include(BareosConfigureFile)
 
-add_subdirectory(scripts)
-add_subdirectory(manpages)
 add_subdirectory(platforms)
 add_subdirectory(src)
+add_subdirectory(scripts)
+add_subdirectory(manpages)
 
 include(BareosLocalBuildDefinitions OPTIONAL
         RESULT_VARIABLE BareosLocalBuildDefinitionsFile

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon-python-plugins-common
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon-python-plugins-common
@@ -3,3 +3,4 @@ lib/bareos/plugins/bareos-fd-local-fileset.py
 lib/bareos/plugins/BareosFdPluginBaseclass.py
 lib/bareos/plugins/BareosFdPluginLocalFilesBaseclass.py
 lib/bareos/plugins/BareosFdWrapper.py
+lib/bareos/scripts/bareos_encode_string.py

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1454,6 +1454,7 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %{plugin_dir}/BareosFdPluginBaseclass.py*
 %{plugin_dir}/BareosFdPluginLocalFilesBaseclass.py*
 %{plugin_dir}/BareosFdWrapper.py*
+%{script_dir}/bareos_encode_string.py
 
 %files filedaemon-ldap-python-plugin
 %defattr(-, root, root)

--- a/core/scripts/CMakeLists.txt
+++ b/core/scripts/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -46,6 +46,14 @@ install(
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
   DESTINATION "${scriptdir}"
 )
+if(TARGET python3-fd)
+  install(
+    FILES bareos_encode_string.py
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE
+                WORLD_READ WORLD_EXECUTE
+    DESTINATION "${scriptdir}"
+  )
+endif()
 
 if(NOT client-only)
   install(

--- a/core/scripts/bareos_encode_string.py
+++ b/core/scripts/bareos_encode_string.py
@@ -18,7 +18,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-from base64 import a85encode
+from base64 import b85encode
 from sys import argv, stdin, stderr
 
 usage = f"""Usage: {argv[0]} [VALUE]
@@ -27,7 +27,7 @@ If VALUE is omitted, it will be read from stdin."""
 
 
 def encode(val):
-    return a85encode(val.encode("utf-8")).decode("ascii")
+    return b85encode(val.encode("utf-8")).decode("ascii")
 
 
 def main():

--- a/core/scripts/bareos_encode_string.py
+++ b/core/scripts/bareos_encode_string.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+from base64 import a85encode
+from sys import argv, stdin, stderr
+
+usage = f"""Usage: {argv[0]} [VALUE]
+Encode VALUE so it can be used as encoded value in Bareos plugin configuration.
+If VALUE is omitted, it will be read from stdin."""
+
+
+def encode(val):
+    return a85encode(val.encode("utf-8")).decode("ascii")
+
+
+def main():
+    if len(argv) == 1:
+        if stdin.isatty():
+            print("Value to encode: ", file=stderr, end="")
+        val = input()
+    elif len(argv) == 2:
+        val = argv[1]
+    else:
+        print(usage, file=stderr)
+        exit(1)
+
+    print(encode(val))
+    exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -43,6 +43,7 @@
 #include "lib/berrno.h"
 #include "lib/bsock.h"
 #include "lib/plugins.h"
+#include "lib/parse_conf.h"
 
 // Function pointers to be set here (findlib)
 extern int (*plugin_bopen)(BareosFilePacket* bfd,
@@ -2009,6 +2010,9 @@ static bRC bareosGetValue(PluginContext* ctx, bVariable var, void* value)
       break;
     case bVarWorkingDir:
       *(void**)value = me->working_directory;
+      break;
+    case bVarUsedConfig:
+      *(const void**)value = my_config->get_base_config_path().c_str();
       break;
     case bVarExePath:
       *(char**)value = exepath;

--- a/core/src/filed/fd_plugins.h
+++ b/core/src/filed/fd_plugins.h
@@ -211,6 +211,7 @@ typedef enum
   bVarPrevJobName = 18,
   bVarPrefixLinks = 19,
   bVarCheckChanges = 20,
+  bVarUsedConfig = 21,
 } bVariable;
 
 // Events that are passed to plugin

--- a/core/src/include/filetypes.h
+++ b/core/src/include/filetypes.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,6 +28,7 @@
 #ifndef BAREOS_INCLUDE_FILETYPES_H_
 #define BAREOS_INCLUDE_FILETYPES_H_
 
+#include <cstdint>
 
 /**
  *  File type (Bareos defined).
@@ -38,48 +39,55 @@
  *    used for the file type. The upper bits are used to indicate
  *    additional optional fields in the attribute record.
  */
-#define FT_MASK 0xFFFF  /**< Bits used by FT (type) */
-#define FT_LNKSAVED 1   /**< hard link to file already saved */
-#define FT_REGE 2       /**< Regular file but empty */
-#define FT_REG 3        /**< Regular file */
-#define FT_LNK 4        /**< Soft Link */
-#define FT_DIREND 5     /**< Directory at end (saved) */
-#define FT_SPEC 6       /**< Special file -- chr, blk, fifo, sock */
-#define FT_NOACCESS 7   /**< Not able to access */
-#define FT_NOFOLLOW 8   /**< Could not follow link */
-#define FT_NOSTAT 9     /**< Could not stat file */
-#define FT_NOCHG 10     /**< Incremental option, file not changed */
-#define FT_DIRNOCHG 11  /**< Incremental option, directory not changed */
-#define FT_ISARCH 12    /**< Trying to save archive file */
-#define FT_NORECURSE 13 /**< No recursion into directory */
-#define FT_NOFSCHG 14   /**< Different file system, prohibited */
-#define FT_NOOPEN 15    /**< Could not open directory */
-#define FT_RAW 16       /**< Raw block device */
-#define FT_FIFO 17      /**< Raw fifo device */
-/*
- * The DIRBEGIN packet is sent to the FD file processing routine so
- * that it can filter packets, but otherwise, it is not used
- * or saved */
-#define FT_DIRBEGIN 18      /**< Directory at beginning (not saved) */
-#define FT_INVALIDFS 19     /**< File system not allowed for */
-#define FT_INVALIDDT 20     /**< Drive type not allowed for */
-#define FT_REPARSE 21       /**< Win NTFS reparse point */
-#define FT_PLUGIN 22        /**< Plugin generated filename */
-#define FT_DELETED 23       /**< Deleted file entry */
-#define FT_BASE 24          /**< Duplicate base file entry */
-#define FT_RESTORE_FIRST 25 /**< Restore this "object" first */
-#define FT_JUNCTION 26      /**< Win32 Junction point */
-#define FT_PLUGIN_CONFIG 27 /**< Object for Plugin configuration */
-#define FT_PLUGIN_CONFIG_FILLED \
-  28 /**< Object for Plugin configuration filled by Director */
+constexpr int32_t FT_MASK = 0xFFFF; /**< Bits used by FT (type) */
+enum FILETYPES : int32_t
+{
+  FT_LNKSAVED = 1, /**< hard link to file already saved */
+  FT_REGE,         /**< Regular file but empty */
+  FT_REG,          /**< Regular file */
+  FT_LNK,          /**< Soft Link */
+  FT_DIREND,       /**< Directory at end (saved) */
+  FT_SPEC,         /**< Special file -- chr, blk, fifo, sock */
+  FT_NOACCESS,     /**< Not able to access */
+  FT_NOFOLLOW,     /**< Could not follow link */
+  FT_NOSTAT,       /**< Could not stat file */
+  FT_NOCHG,        /**< Incremental option, file not changed */
+  FT_DIRNOCHG,     /**< Incremental option, directory not changed */
+  FT_ISARCH,       /**< Trying to save archive file */
+  FT_NORECURSE,    /**< No recursion into directory */
+  FT_NOFSCHG,      /**< Different file system, prohibited */
+  FT_NOOPEN,       /**< Could not open directory */
+  FT_RAW,          /**< Raw block device */
+  FT_FIFO,         /**< Raw fifo device */
+  /*
+   * The DIRBEGIN packet is sent to the FD file processing routine so
+   * that it can filter packets, but otherwise, it is not used
+   * or saved */
+  FT_DIRBEGIN,             /**< Directory at beginning (not saved) */
+  FT_INVALIDFS,            /**< File system not allowed for */
+  FT_INVALIDDT,            /**< Drive type not allowed for */
+  FT_REPARSE,              /**< Win NTFS reparse point */
+  FT_PLUGIN,               /**< Plugin generated filename */
+  FT_DELETED,              /**< Deleted file entry */
+  FT_BASE,                 /**< Duplicate base file entry */
+  FT_RESTORE_FIRST,        /**< Restore this "object" first */
+  FT_JUNCTION,             /**< Win32 Junction point */
+  FT_PLUGIN_CONFIG,        /**< Object for Plugin configuration */
+  FT_PLUGIN_CONFIG_FILLED, /**< Object for Plugin configuration filled by
+                              Director */
+};
+static_assert(FT_PLUGIN_CONFIG_FILLED == 28);
 
-#define FT_UNSET FT_MASK /**< Initial value when not determined yet  */
+constexpr int32_t FT_UNSET
+    = FT_MASK; /**< Initial value when not determined yet  */
 /* Definitions for upper part of type word (see above). */
-#define AR_DATA_STREAM (1 << 16) /**< Data stream id present */
+constexpr int32_t AR_DATA_STREAM = (1 << 16); /**< Data stream id present */
 
 /* Quick way to know if a Filetype is about a plugin "Object" */
-#define IS_FT_OBJECT(x)                                          \
-  (((x) == FT_RESTORE_FIRST) || ((x) == FT_PLUGIN_CONFIG_FILLED) \
-   || ((x) == FT_PLUGIN_CONFIG))
+inline bool IS_FT_OBJECT(int32_t x)
+{
+  return x == FT_RESTORE_FIRST || x == FT_PLUGIN_CONFIG_FILLED
+         || x == FT_PLUGIN_CONFIG;
+}
 
 #endif  // BAREOS_INCLUDE_FILETYPES_H_

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -1281,6 +1281,7 @@ static PyObject* PyBareosGetValue(PyObject*, PyObject* args)
   switch (var) {
     case bVarFDName:
     case bVarWorkingDir:
+    case bVarUsedConfig:
     case bVarExePath:
     case bVarVersion:
     case bVarDistName: {

--- a/core/src/plugins/filed/python/module/bareosfd.h
+++ b/core/src/plugins/filed/python/module/bareosfd.h
@@ -41,6 +41,8 @@
 
 
 #ifdef BAREOSFD_MODULE
+
+#  include "include/filetypes.h"
 /* This section is used when compiling bareosfd.cc */
 
 namespace filedaemon {
@@ -663,31 +665,33 @@ MOD_INIT(bareosfd)
   DEFINE_bRCs_DICT();
   DEFINE_bJobMessageTypes_DICT();
 
+#define EXPORT_ENUM_VALUE(dict, symbol) ConstSet_StrLong(dict, symbol, symbol)
+
   const char* bVariable = "bVariable";
   PyObject* pDictbVariable = NULL;
   pDictbVariable = PyDict_New();
   if (!pDictbVariable) { return MOD_ERROR_VAL; }
-  ConstSet_StrLong(pDictbVariable, bVarJobId, 1);
-  ConstSet_StrLong(pDictbVariable, bVarFDName, 2);
-  ConstSet_StrLong(pDictbVariable, bVarLevel, 3);
-  ConstSet_StrLong(pDictbVariable, bVarType, 4);
-  ConstSet_StrLong(pDictbVariable, bVarClient, 5);
-  ConstSet_StrLong(pDictbVariable, bVarJobName, 6);
-  ConstSet_StrLong(pDictbVariable, bVarJobStatus, 7);
-  ConstSet_StrLong(pDictbVariable, bVarSinceTime, 8);
-  ConstSet_StrLong(pDictbVariable, bVarAccurate, 9);
-  ConstSet_StrLong(pDictbVariable, bVarFileSeen, 10);
-  ConstSet_StrLong(pDictbVariable, bVarVssClient, 11);
-  ConstSet_StrLong(pDictbVariable, bVarWorkingDir, 12);
-  ConstSet_StrLong(pDictbVariable, bVarWhere, 13);
-  ConstSet_StrLong(pDictbVariable, bVarRegexWhere, 14);
-  ConstSet_StrLong(pDictbVariable, bVarExePath, 15);
-  ConstSet_StrLong(pDictbVariable, bVarVersion, 16);
-  ConstSet_StrLong(pDictbVariable, bVarDistName, 17);
-  ConstSet_StrLong(pDictbVariable, bVarPrevJobName, 18);
-  ConstSet_StrLong(pDictbVariable, bVarPrefixLinks, 19);
-  ConstSet_StrLong(pDictbVariable, bVarCheckChanges, 20);
-  ConstSet_StrLong(pDictbVariable, bVarUsedConfig, 21);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarJobId);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarFDName);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarLevel);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarType);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarClient);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarJobName);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarJobStatus);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarSinceTime);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarAccurate);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarFileSeen);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarVssClient);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarWorkingDir);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarWhere);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarRegexWhere);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarExePath);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarVersion);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarDistName);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarPrevJobName);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarPrefixLinks);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarCheckChanges);
+  EXPORT_ENUM_VALUE(pDictbVariable, bVarUsedConfig);
   if (PyModule_AddObject(m, bVariable, pDictbVariable)) {
     return MOD_ERROR_VAL;
   }
@@ -696,35 +700,35 @@ MOD_INIT(bareosfd)
   const char* bFileType = "bFileType";
   PyObject* pDictbFileType = NULL;
   pDictbFileType = PyDict_New();
-  ConstSet_StrLong(pDictbFileType, FT_LNKSAVED, 1);
-  ConstSet_StrLong(pDictbFileType, FT_REGE, 2);
-  ConstSet_StrLong(pDictbFileType, FT_REG, 3);
-  ConstSet_StrLong(pDictbFileType, FT_LNK, 4);
-  ConstSet_StrLong(pDictbFileType, FT_DIREND, 5);
-  ConstSet_StrLong(pDictbFileType, FT_SPEC, 6);
-  ConstSet_StrLong(pDictbFileType, FT_NOACCESS, 7);
-  ConstSet_StrLong(pDictbFileType, FT_NOFOLLOW, 8);
-  ConstSet_StrLong(pDictbFileType, FT_NOSTAT, 9);
-  ConstSet_StrLong(pDictbFileType, FT_NOCHG, 10);
-  ConstSet_StrLong(pDictbFileType, FT_DIRNOCHG, 11);
-  ConstSet_StrLong(pDictbFileType, FT_ISARCH, 12);
-  ConstSet_StrLong(pDictbFileType, FT_NORECURSE, 13);
-  ConstSet_StrLong(pDictbFileType, FT_NOFSCHG, 14);
-  ConstSet_StrLong(pDictbFileType, FT_NOOPEN, 15);
-  ConstSet_StrLong(pDictbFileType, FT_RAW, 16);
-  ConstSet_StrLong(pDictbFileType, FT_FIFO, 17);
-  ConstSet_StrLong(pDictbFileType, FT_DIRBEGIN, 18);
-  ConstSet_StrLong(pDictbFileType, FT_INVALIDFS, 19);
-  ConstSet_StrLong(pDictbFileType, FT_INVALIDDT, 20);
-  ConstSet_StrLong(pDictbFileType, FT_REPARSE, 21);
-  ConstSet_StrLong(pDictbFileType, FT_PLUGIN, 22);
-  ConstSet_StrLong(pDictbFileType, FT_DELETED, 23);
-  ConstSet_StrLong(pDictbFileType, FT_BASE, 24);
-  ConstSet_StrLong(pDictbFileType, FT_RESTORE_FIRST, 25);
-  ConstSet_StrLong(pDictbFileType, FT_JUNCTION, 26);
-  ConstSet_StrLong(pDictbFileType, FT_PLUGIN_CONFIG, 27);
-  ConstSet_StrLong(pDictbFileType, FT_PLUGIN_CONFIG_FILLED, 28);
   if (!pDictbFileType) { return MOD_ERROR_VAL; }
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_LNKSAVED);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_REGE);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_REG);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_LNK);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_DIREND);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_SPEC);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOACCESS);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOFOLLOW);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOSTAT);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOCHG);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_DIRNOCHG);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_ISARCH);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NORECURSE);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOFSCHG);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_NOOPEN);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_RAW);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_FIFO);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_DIRBEGIN);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_INVALIDFS);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_INVALIDDT);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_REPARSE);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_PLUGIN);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_DELETED);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_BASE);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_RESTORE_FIRST);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_JUNCTION);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_PLUGIN_CONFIG);
+  EXPORT_ENUM_VALUE(pDictbFileType, FT_PLUGIN_CONFIG_FILLED);
   if (PyModule_AddObject(m, bFileType, pDictbFileType)) {
     return MOD_ERROR_VAL;
   }
@@ -733,49 +737,49 @@ MOD_INIT(bareosfd)
   const char* bCFs = "bCFs";
   PyObject* pDictbCFs = NULL;
   pDictbCFs = PyDict_New();
-  ConstSet_StrLong(pDictbCFs, CF_SKIP, 1);
-  ConstSet_StrLong(pDictbCFs, CF_ERROR, 2);
-  ConstSet_StrLong(pDictbCFs, CF_EXTRACT, 3);
-  ConstSet_StrLong(pDictbCFs, CF_CREATED, 4);
-  ConstSet_StrLong(pDictbCFs, CF_CORE, 5);
   if (!pDictbCFs) { return MOD_ERROR_VAL; }
+  EXPORT_ENUM_VALUE(pDictbCFs, CF_SKIP);
+  EXPORT_ENUM_VALUE(pDictbCFs, CF_ERROR);
+  EXPORT_ENUM_VALUE(pDictbCFs, CF_EXTRACT);
+  EXPORT_ENUM_VALUE(pDictbCFs, CF_CREATED);
+  EXPORT_ENUM_VALUE(pDictbCFs, CF_CORE);
   if (PyModule_AddObject(m, bCFs, pDictbCFs)) { return MOD_ERROR_VAL; }
 
   const char* bEventType = "bEventType";
   PyObject* pDictbEventType = NULL;
   pDictbEventType = PyDict_New();
-  ConstSet_StrLong(pDictbEventType, bEventJobStart, 1);
-  ConstSet_StrLong(pDictbEventType, bEventJobEnd, 2);
-  ConstSet_StrLong(pDictbEventType, bEventStartBackupJob, 3);
-  ConstSet_StrLong(pDictbEventType, bEventEndBackupJob, 4);
-  ConstSet_StrLong(pDictbEventType, bEventStartRestoreJob, 5);
-  ConstSet_StrLong(pDictbEventType, bEventEndRestoreJob, 6);
-  ConstSet_StrLong(pDictbEventType, bEventStartVerifyJob, 7);
-  ConstSet_StrLong(pDictbEventType, bEventEndVerifyJob, 8);
-  ConstSet_StrLong(pDictbEventType, bEventBackupCommand, 9);
-  ConstSet_StrLong(pDictbEventType, bEventRestoreCommand, 10);
-  ConstSet_StrLong(pDictbEventType, bEventEstimateCommand, 11);
-  ConstSet_StrLong(pDictbEventType, bEventLevel, 12);
-  ConstSet_StrLong(pDictbEventType, bEventSince, 13);
-  ConstSet_StrLong(pDictbEventType, bEventCancelCommand, 14);
-  ConstSet_StrLong(pDictbEventType, bEventRestoreObject, 15);
-  ConstSet_StrLong(pDictbEventType, bEventEndFileSet, 16);
-  ConstSet_StrLong(pDictbEventType, bEventPluginCommand, 17);
-  ConstSet_StrLong(pDictbEventType, bEventOptionPlugin, 18);
-  ConstSet_StrLong(pDictbEventType, bEventHandleBackupFile, 19);
-  ConstSet_StrLong(pDictbEventType, bEventNewPluginOptions, 20);
-  ConstSet_StrLong(pDictbEventType, bEventVssInitializeForBackup, 21);
-  ConstSet_StrLong(pDictbEventType, bEventVssInitializeForRestore, 22);
-  ConstSet_StrLong(pDictbEventType, bEventVssSetBackupState, 23);
-  ConstSet_StrLong(pDictbEventType, bEventVssPrepareForBackup, 24);
-  ConstSet_StrLong(pDictbEventType, bEventVssBackupAddComponents, 25);
-  ConstSet_StrLong(pDictbEventType, bEventVssPrepareSnapshot, 26);
-  ConstSet_StrLong(pDictbEventType, bEventVssCreateSnapshots, 27);
-  ConstSet_StrLong(pDictbEventType, bEventVssRestoreLoadComponentMetadata, 28);
-  ConstSet_StrLong(pDictbEventType, bEventVssRestoreSetComponentsSelected, 29);
-  ConstSet_StrLong(pDictbEventType, bEventVssCloseRestore, 30);
-  ConstSet_StrLong(pDictbEventType, bEventVssBackupComplete, 31);
   if (!pDictbEventType) { return MOD_ERROR_VAL; }
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventJobStart);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventJobEnd);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventStartBackupJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventEndBackupJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventStartRestoreJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventEndRestoreJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventStartVerifyJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventEndVerifyJob);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventBackupCommand);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventRestoreCommand);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventEstimateCommand);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventLevel);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventSince);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventCancelCommand);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventRestoreObject);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventEndFileSet);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventPluginCommand);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventOptionPlugin);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventHandleBackupFile);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventNewPluginOptions);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssInitializeForBackup);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssInitializeForRestore);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssSetBackupState);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssPrepareForBackup);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssBackupAddComponents);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssPrepareSnapshot);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssCreateSnapshots);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssRestoreLoadComponentMetadata);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssRestoreSetComponentsSelected);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssCloseRestore);
+  EXPORT_ENUM_VALUE(pDictbEventType, bEventVssBackupComplete);
   if (PyModule_AddObject(m, bEventType, pDictbEventType)) {
     return MOD_ERROR_VAL;
   }
@@ -784,21 +788,21 @@ MOD_INIT(bareosfd)
   const char* bIOPS = "bIOPS";
   PyObject* pDictbIOPS = NULL;
   pDictbIOPS = PyDict_New();
-  ConstSet_StrLong(pDictbIOPS, IO_OPEN, 1);
-  ConstSet_StrLong(pDictbIOPS, IO_READ, 2);
-  ConstSet_StrLong(pDictbIOPS, IO_WRITE, 3);
-  ConstSet_StrLong(pDictbIOPS, IO_CLOSE, 4);
-  ConstSet_StrLong(pDictbIOPS, IO_SEEK, 5);
   if (!pDictbIOPS) { return MOD_ERROR_VAL; }
+  EXPORT_ENUM_VALUE(pDictbIOPS, IO_OPEN);
+  EXPORT_ENUM_VALUE(pDictbIOPS, IO_READ);
+  EXPORT_ENUM_VALUE(pDictbIOPS, IO_WRITE);
+  EXPORT_ENUM_VALUE(pDictbIOPS, IO_CLOSE);
+  EXPORT_ENUM_VALUE(pDictbIOPS, IO_SEEK);
   if (PyModule_AddObject(m, bIOPS, pDictbIOPS)) { return MOD_ERROR_VAL; }
 
   const char* bIOPstatus = "bIOPstatus";
   PyObject* pDictbIOPstatus = NULL;
   pDictbIOPstatus = PyDict_New();
+  if (!pDictbIOPstatus) { return MOD_ERROR_VAL; }
   ConstSet_StrLong(pDictbIOPstatus, iostat_error, IoStatus::error);
   ConstSet_StrLong(pDictbIOPstatus, iostat_do_in_plugin, IoStatus::success);
   ConstSet_StrLong(pDictbIOPstatus, iostat_do_in_core, IoStatus::do_io_in_core);
-  if (!pDictbIOPstatus) { return MOD_ERROR_VAL; }
   if (PyModule_AddObject(m, bIOPstatus, pDictbIOPstatus)) { return MOD_ERROR_VAL; }
 
 
@@ -806,6 +810,7 @@ MOD_INIT(bareosfd)
   const char* bLevels = "bLevels";
   PyObject* pDictbLevels = NULL;
   pDictbLevels = PyDict_New();
+  if (!pDictbLevels) { return MOD_ERROR_VAL; }
   ConstSet_StrStr(pDictbLevels, L_FULL, "F");
   ConstSet_StrStr(pDictbLevels, L_INCREMENTAL, "I");
   ConstSet_StrStr(pDictbLevels, L_DIFFERENTIAL, "D");
@@ -818,7 +823,6 @@ MOD_INIT(bareosfd)
   ConstSet_StrStr(pDictbLevels, L_BASE, "B");
   ConstSet_StrStr(pDictbLevels, L_NONE, " ");
   ConstSet_StrStr(pDictbLevels, L_VIRTUAL_FULL, "f");
-  if (!pDictbLevels) { return MOD_ERROR_VAL; }
   if (PyModule_AddObject(m, bLevels, pDictbLevels)) { return MOD_ERROR_VAL; }
 
 

--- a/core/src/plugins/filed/python/module/bareosfd.h
+++ b/core/src/plugins/filed/python/module/bareosfd.h
@@ -687,6 +687,7 @@ MOD_INIT(bareosfd)
   ConstSet_StrLong(pDictbVariable, bVarPrevJobName, 18);
   ConstSet_StrLong(pDictbVariable, bVarPrefixLinks, 19);
   ConstSet_StrLong(pDictbVariable, bVarCheckChanges, 20);
+  ConstSet_StrLong(pDictbVariable, bVarUsedConfig, 21);
   if (PyModule_AddObject(m, bVariable, pDictbVariable)) {
     return MOD_ERROR_VAL;
   }

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2014-2022 Bareos GmbH & Co. KG
+# Copyright (C) 2014-2023 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -32,9 +32,81 @@ import sys
 import time
 
 
+def parse_plugindef_string(plugindef):
+    options = {}
+    parts = plugindef.split(":")
+    while parts:
+        raw_key, _, raw_val = parts.pop(0).partition("=")
+        key = raw_key.strip()
+        val = raw_val.strip()
+        if not key:
+            continue
+        if not val:
+            bareosfd.JobMessage(
+                M_WARNING, "ignoring option '%s' with no value!\n" % (key)
+            )
+            continue
+        # See if the last character is a escape of the value string
+        while val[-1:] == "\\":
+            val = val[:-1] + ":" + plugin_options.pop(0)
+        if key not in options:
+            options[key] = val
+    return options
+
+
+def parse_options_file(path):
+    bareosfd.DebugMessage(100, 'reading options from file "%s"\n' % (path))
+    options = {}
+    with open(path, "r") as fp:
+        lines = fp.readlines()
+        while lines:
+            line = lines.pop(0)
+            raw_key, _, raw_val = line.partition("=")
+            key = raw_key.strip()
+            val = raw_val.strip()
+            if key == "" and val == "":  # empty line
+                continue
+            elif key.startswith(("#", ";", "[")):
+                continue
+            elif not key or not val:
+                bareosfd.JobMessage(
+                    M_FATAL,
+                    "error parsing '%s' (found no key or value)!\n" % (line.strip()),
+                )
+                return {}
+            # check if last character escapes the newline
+            while val[-1:] == "\\":
+                val = val[:-1] + lines.pop(0).strip()
+            if key in options:
+                bareosfd.JobMessage(
+                    M_WARNING,
+                    "duplicate option '%s' overriding previous value!\n" % (key),
+                )
+            options[key] = val
+    return options
+
+
+def get_config_path():
+    """
+    we can only get the effective configuration file from core, so this function
+    tries to convert it to a path that our plugin configuration can be relative to
+    """
+    used_config = bareosfd.GetValue(bareosfd.bVarUsedConfig)
+    if used_config.endswith("/*/*.conf"):
+        path = used_config[:-8]
+    elif os.path.isfile(used_config):
+        path = os.path.dirname(used_config)
+    else:
+        return "/"
+    if os.path.isdir(path):
+        return path
+    else:
+        return "/"
+
+
 class BareosFdPluginBaseclass(object):
 
-    """ Bareos python plugin base class """
+    """Bareos python plugin base class"""
 
     def __init__(self, plugindef, mandatory_options=None):
         bareosfd.DebugMessage(
@@ -65,6 +137,7 @@ class BareosFdPluginBaseclass(object):
         # short Name is everything left of the third point seen from the right
         self.shortName = self.jobName.rsplit(".", 3)[0]
         self.workingdir = bareosfd.GetValue(bVarWorkingDir)
+        self.configdir = get_config_path()
         self.startTime = int(time.time())
         self.FNAME = "undef"
         self.filetype = "undef"
@@ -75,38 +148,76 @@ class BareosFdPluginBaseclass(object):
         self.mandatory_options = mandatory_options
 
     def __str__(self):
-        return "<%s:fdname=%s jobId=%s client=%s since=%d level=%c jobName=%s workingDir=%s>" % (
-            self.__class__,
-            self.fdname,
-            self.jobId,
-            self.client,
-            self.since,
-            self.level,
-            self.jobName,
-            self.workingdir,
+        return (
+            "<%s:fdname=%s jobId=%s client=%s since=%d level=%c jobName=%s workingDir=%s>"
+            % (
+                self.__class__,
+                self.fdname,
+                self.jobId,
+                self.client,
+                self.since,
+                self.level,
+                self.jobName,
+                self.workingdir,
+            )
         )
+
+    def _load_options_from_file(self, option_dict, key):
+        """
+        consume the given key from the option_dict if it exists and return
+        the options that are configured in the file the option pointed to
+        """
+        if key in option_dict:
+            try:
+                self.configdir
+            except AttributeError:
+                self.configdir = get_config_path()
+                JobMessage(
+                    M_WARNING, "Plugin did not call BareosFdPluginBaseclass.__init__()"
+                )
+            path = os.path.join(self.configdir, option_dict[key])
+            try:
+                options = parse_options_file(path)
+            except OSError as e:
+                JobMessage(
+                    M_FATAL,
+                    "While loading options file '%s': %s" % (option_dict[key], e),
+                )
+                raise
+            del option_dict[key]
+            return options
+        else:
+            return {}
+
+    def _add_options(self, options):
+        for k, v in options.items():
+            if k not in self.options:
+                bareosfd.DebugMessage(100, 'key:value = "%s:%s"\n' % (key, value))
+                self.options[k] = v
 
     def parse_plugin_definition(self, plugindef):
         bareosfd.DebugMessage(100, 'plugin def parser called with "%s"\n' % (plugindef))
         # Parse plugin options into a dict
         if not hasattr(self, "options"):
             self.options = dict()
-        plugin_options = plugindef.split(":")
-        while plugin_options:
-            current_option = plugin_options.pop(0)
-            key, sep, val = current_option.partition("=")
-            # See if the last character is a escape of the value string
-            while val[-1:] == "\\":
-                val = val[:-1] + ":" + plugin_options.pop(0)
-            # Replace all '\\'
-            val = val.replace("\\", "")
-            bareosfd.DebugMessage(100, 'key:val = "%s:%s"\n' % (key, val))
-            if val == "":
-                continue
-            else:
-                if key not in self.options:
-                    self.options[key] = val
-        # after we've parsed all arguments, we check the options for mandatory settings
+
+        plugindef_options = parse_plugindef_string(plugindef)
+        try:
+            default_options = self._load_options_from_file(
+                plugindef_options, "defaults_file"
+            )
+            override_options = self._load_options_from_file(
+                plugindef_options, "overrides_file"
+            )
+        except OSError:
+            return False
+
+        effective_options = {}
+        effective_options.update(default_options)
+        effective_options.update(plugindef_options)
+        effective_options.update(override_options)
+
+        self._add_options(effective_options)
         return self.check_options(self.mandatory_options)
 
     def check_options(self, mandatory_options=None):

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
@@ -30,7 +30,7 @@ import os
 import stat
 import sys
 import time
-from base64 import a85decode
+from base64 import b85decode
 
 
 def parse_plugindef_string(plugindef):
@@ -107,7 +107,7 @@ def get_config_path():
 
 def transform_value(value, transform):
     if transform == "enc":
-        return a85decode(value).decode("utf-8")
+        return b85decode(value).decode("utf-8")
     else:
         raise NameError("unknown transformation")
     return value

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -448,8 +448,10 @@ bareos_add_test(test_edit LINK_LIBRARIES bareos GTest::gtest_main)
 
 bareos_add_test(
   test_fd_plugins
-  ADDITIONAL_SOURCES ${PROJECT_SOURCE_DIR}/src/filed/fd_plugins.cc
-                     ${PROJECT_SOURCE_DIR}/src/filed/fileset.cc
+  ADDITIONAL_SOURCES
+    ${PROJECT_SOURCE_DIR}/src/filed/fd_plugins.cc
+    ${PROJECT_SOURCE_DIR}/src/filed/fileset.cc
+    ${PROJECT_SOURCE_DIR}/src/filed/filed_globals.cc
   LINK_LIBRARIES bareos bareosfind GTest::gtest_main
 )
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -221,6 +221,12 @@ if(NOT client-only)
     LINK_LIBRARIES testing_common ${LINK_LIBRARIES}
     COMPILE_DEFINITIONS ${KTLS_DEFINITIONS}
   )
+  set_tests_properties(gtest:ktls.v12_send PROPERTIES LABELS broken)
+  set_tests_properties(gtest:ktls.v12_recv PROPERTIES LABELS broken)
+  set_tests_properties(gtest:ktls.v12_256_send PROPERTIES LABELS broken)
+  set_tests_properties(gtest:ktls.v13_send PROPERTIES LABELS broken)
+  set_tests_properties(gtest:ktls.v13_recv PROPERTIES LABELS broken)
+  set_tests_properties(gtest:ktls.v13_256_send PROPERTIES LABELS broken)
 
   bareos_add_test(
     catalog

--- a/core/src/tests/test_fd_plugins.cc
+++ b/core/src/tests/test_fd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -69,9 +69,6 @@ namespace filedaemon {
 
 int SaveFile(JobControlRecord*, FindFilesPacket*, bool);
 bool SetCmdPlugin(BareosFilePacket*, JobControlRecord*);
-
-/* Exported variables */
-ClientResource* me; /* my resource */
 
 int SaveFile(JobControlRecord*, FindFilesPacket*, bool) { return 0; }
 

--- a/debian/bareos-filedaemon-python-plugins-common.install.in
+++ b/debian/bareos-filedaemon-python-plugins-common.install.in
@@ -2,3 +2,4 @@
 @plugindir@/BareosFdPluginBaseclass.py*
 @plugindir@/BareosFdPluginLocalFilesBaseclass.py*
 @plugindir@/BareosFdWrapper.py*
+@scriptdir@/bareos_encode_string.py

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PythonFdPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PythonFdPlugin.rst.inc
@@ -7,8 +7,11 @@ python-fd Plugin
    single: Plugin; Python; File Daemon
 
 The **python-fd** plugin behaves similar to the :ref:`director-python-plugin`.
-Configuration is done in the :ref:`DirectorResourceFileSet` on the |dir|.
+Configuration is done in the :ref:`DirectorResourceFileSet` on the |dir| and in optional configuration files on the |fd|.
 
+
+Configuration
+^^^^^^^^^^^^^
 To load a Python plugin you need
 
 module_name
@@ -18,12 +21,68 @@ module_path
 
 Plugin specific options can be added as key-value pairs, each pair separated by ’:’ key=value.
 
+Configuration Files
+'''''''''''''''''''
+This plugin can handle additional configuration files for the python-based plugins it wraps.
+
+When supplying one or both of the options `defaults_file` or `overrides_file`, the supplied value will be treated as a path relative to the |fd| configuration.
+When using a single configuration file instead of a configuration directory, it will be relative to that file's parent directory.
+All configuration files will be read on the |fd| that executes the job.
+
+Depending on how the file was loaded, the options will have different precedence.
+When loaded via `defaults_file` the options in the FileSet will override those from the file.
+When loaded via `overrides_file` the options from the file will override those in the FileSet and the ones loaded from a `defaults_file`.
+In other words: a `defaults_file` provides default values that you can override in your FileSet and an `overrides_file` provides mandatory values that always take precedence.
 
 
+The configuration files should contain one key-value pair per line that will be used as if they were added to the :config:option:`dir/Fileset/Include/Plugin` option.
+Empty lines or lines starting with semicolon (``;``), hash (``#``) or left square bracket (``[``) will be ignored.
+Long values can be split across multiple lines by marking the end-of-line with a backslash (``\``).
+Finally, whitespace around keys, values or continuation lines is discarded.
+
+.. code-block:: bareosconfig
+   :caption: plugin_defaults.ini: python-fd example configuration
+
+   # this is a comment
+   ; this is also a comment
+   [sections like this will also be ignored]
+   
+   key=value
+   
+   # no inline comments
+   key=value ; this is not a comment, but part of the value
+   
+   # whitespace around the key will be ignored
+    another_key = another_value
+   
+   # whitespace around continuation lines will be ignored, too.
+   long_value_key = very-long-value-\
+                    split-across-lines
+
+   # trailing whitespace of the continued line will be preserved.
+   multiline_whitespace = value1 \
+                          value2     \
+                          value3
+
+.. note::
+   It is not possible to pass `module_path` or `module_name` using a configuration file.
+   The python plugin will be loaded before the plugin options including the configuration files are handled.
+
+Encoded option values
+'''''''''''''''''''''
+
+In some cases it is desireable to have option values in an encoded format.
+Every option passed to a Python plugin, can be encoded using the supplied script ``bareos_encode_string.py`` from the scripts directory.
+To use such an encoded value, the option-name must be suffixed with ``#enc`` so the plugin knows it needs to decode the value.
+Thus, if you previously configured ``api_key=secret_string`` you could now configure ``api_key#enc=b7f<4WprP2baH8KX8``.
+
+
+Python plugin types
+^^^^^^^^^^^^^^^^^^^
 We basically distinguish between command-plugin and option-plugins.
 
 Command Plugins
-^^^^^^^^^^^^^^^
+'''''''''''''''
 
 Command plugins are used to replace or extend the FileSet definition in the File Section. If you have a command-plugin, you can use it like in this example:
 
@@ -48,7 +107,7 @@ Command plugins are used to replace or extend the FileSet definition in the File
 This example uses the :ref:`MySQL plugin <backup-mysql-python>` to backup MySQL dumps.
 
 Option Plugins
-^^^^^^^^^^^^^^
+''''''''''''''
 
 Option plugins are activated in the Options resource of a FileSet definition.
 

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestBothFiles.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestBothFiles.conf.in
@@ -1,0 +1,18 @@
+FileSet {
+  Name = "PluginConfigTestBothFiles"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "@python_module_name@"
+    ":module_path=@python_plugin_module_src_test_dir@"
+    ":module_name=config-test-module"
+    ":option1=value1"
+    ":option2=value2"
+    ":overrides_file=plugin_overrides.ini"
+    ":option3=value3"
+    ":option4=value4"
+    ":defaults_file=plugin_defaults.ini"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestDefaultsFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestDefaultsFile.conf.in
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "PluginConfigTestDefaultsFile"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "@python_module_name@"
+    ":module_path=@python_plugin_module_src_test_dir@"
+    ":module_name=config-test-module"
+    ":option1=value1"
+    ":option2=value2"
+    ":option3=value3"
+    ":option4=value4"
+    ":defaults_file=plugin_defaults.ini"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
@@ -12,6 +12,6 @@ FileSet {
     ":option2=value2"
     ":option3=value3"
     ":option4=value4"
-    ":password#enc=E+*g/GAhM4"
+    ":password#enc=aA9+EcW-iJ"
   }
 }

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
@@ -12,5 +12,6 @@ FileSet {
     ":option2=value2"
     ":option3=value3"
     ":option4=value4"
+    ":password#enc=E+*g/GAhM4"
   }
 }

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
@@ -1,0 +1,16 @@
+FileSet {
+  Name = "PluginConfigTestNoFile"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "@python_module_name@"
+    ":module_path=@python_plugin_module_src_test_dir@"
+    ":module_name=config-test-module"
+    ":option1 = value1"
+    ":option2=value2"
+    ":option3=value3"
+    ":option4=value4"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestOverridesFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestOverridesFile.conf.in
@@ -1,0 +1,17 @@
+FileSet {
+  Name = "PluginConfigTestOverridesFile"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    Plugin = "@python_module_name@"
+    ":module_path=@python_plugin_module_src_test_dir@"
+    ":module_name=config-test-module"
+    ":option1=value1"
+    ":option2=value2"
+    ":option3=value3"
+    ":option4=value4"
+    ":overrides_file=plugin_overrides.ini"
+  }
+}

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
@@ -14,4 +14,4 @@ whitespace_separated = one \
                        three   \
                        end
 
-password#enc = A7]@]F_l.OE+*g/GAhM4
+password#enc = WMyVyb!>DkaA9+EcW-iJ

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
@@ -1,0 +1,15 @@
+# this is a comment
+
+[this section header will be ignored]
+option3=default-value3
+option4=default-value4
+option5=default-value5
+option6 = default-value6
+
+multiline=multiline-\
+          value
+
+whitespace_separated = one \
+                       two  \
+                       three   \
+                       end

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_defaults.ini
@@ -13,3 +13,5 @@ whitespace_separated = one \
                        two  \
                        three   \
                        end
+
+password#enc = A7]@]F_l.OE+*g/GAhM4

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_overrides.ini
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/plugin_overrides.ini
@@ -1,0 +1,4 @@
+option1=override-value1
+option6=override-value6
+option7=override-value7
+option8=override-value8

--- a/systemtests/tests/py3plug-fd-basic/python-modules/config-test-module.py
+++ b/systemtests/tests/py3plug-fd-basic/python-modules/config-test-module.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# BAREOS - Backup Archiving REcovery Open Sourced
+#
+# Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+#
+# This program is Free Software; you can redistribute it and/or
+# modify it under the terms of version three of the GNU Affero General Public
+# License as published by the Free Software Foundation, which is
+# listed in the file LICENSE.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.
+#
+
+# this test module will emit a job message in every single callback there is
+# to make sure emitting a message won't break anything
+
+# import all the wrapper functions in our module scope
+from BareosFdWrapper import *
+
+from bareosfd import (
+    bRC_OK,
+    bRC_More,
+    JobMessage,
+    DebugMessage,
+    M_INFO,
+    M_WARNING,
+    bFileType,
+    StatPacket,
+    FT_REG,
+)
+
+from BareosFdPluginBaseclass import BareosFdPluginBaseclass
+
+import sys
+from stat import S_IFREG, S_IFDIR, S_IRWXU
+
+
+@BareosPlugin
+class TestConfigPlugin(BareosFdPluginBaseclass):
+    mandatory_options = []
+
+    def __init__(self, plugindef):
+        super().__init__(plugindef)
+
+    def parse_plugin_definition(self, plugindef):
+        JobMessage(M_INFO, "plugindef: {}\n".format(plugindef))
+        res = super().parse_plugin_definition(plugindef)
+        for k, v in self.options.items():
+            JobMessage(M_INFO, "effective configuration: {} = '{}'\n".format(k, v))
+        return res
+
+    def start_backup_file(self, savepkt):
+        statp = StatPacket()
+        statp.st_size = 65 * 1024
+        statp.st_mode = S_IRWXU | S_IFREG
+        savepkt.statp = statp
+        savepkt.type = FT_REG
+        savepkt.no_read = False
+        savepkt.fname = "/file"
+        return bRC_OK
+
+    def plugin_io_read(self, IOP):
+        IOP.buf = bytearray(IOP.count)
+        IOP.io_errno = 0
+        IOP.status = 0
+        return bRC_OK
+
+    def plugin_io_open(self, IOP):
+        return bRC_OK
+
+    def plugin_io_close(self, IOP):
+        return bRC_OK

--- a/systemtests/tests/py3plug-fd-basic/testrunner-config
+++ b/systemtests/tests/py3plug-fd-basic/testrunner-config
@@ -65,6 +65,7 @@ done
 for i in 1 2 3 4; do
   check_option "option$i" "value$i" nofile
 done
+check_option "password" "password" nofile
 
 for i in 1 6 7 8; do
   check_not_option "option$i" "override-value$i" defaults-file
@@ -80,6 +81,7 @@ for i in 1 2 3 4; do
 done
 check_option "multiline" "multiline-value" defaults-file
 check_option "whitespace_separated" "one two  three   end" defaults-file
+check_option "password" "default-password" defaults-file
 
 for i in 3 4 5 6; do
   check_not_option "option$i" "default-value$i" override-file

--- a/systemtests/tests/py3plug-fd-basic/testrunner-config
+++ b/systemtests/tests/py3plug-fd-basic/testrunner-config
@@ -1,0 +1,118 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+
+check_option() {
+  expect_grep \
+    "effective configuration: $1 = '$2'" \
+    "$tmp/config-test-$3.out" \
+    "$3 is missing or has wrong option $1"
+}
+
+check_not_option() {
+  expect_not_grep \
+    "effective configuration: $1 = '$2'" \
+    "$tmp/config-test-$3.out" \
+    "$3 has wrong option $1"
+}
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../../environment.in
+. ./environment
+
+#shellcheck source=../../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+rm -f "$tmp/config-test.out"
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $tmp/config-test-nofile.out
+run job=$JobName fileset=PluginConfigTestNoFile yes
+wait
+messages
+@$out $tmp/config-test-defaults-file.out
+run job=$JobName fileset=PluginConfigTestDefaultsFile yes
+wait
+messages
+@$out $tmp/config-test-override-file.out
+run job=$JobName fileset=PluginConfigTestOverridesFile yes
+wait
+messages
+@$out $tmp/config-test-both-files.out
+run job=$JobName fileset=PluginConfigTestBothFiles yes
+wait
+messages
+END_OF_DATA
+
+run_bconsole
+check_for_zombie_jobs storage=File
+
+for i in 1 6 7 8; do
+  check_not_option "option$i" "override-value$i" nofile
+done
+for i in 3 4 5 6; do
+  check_not_option "option$i" "default-value$i" nofile
+done
+for i in 1 2 3 4; do
+  check_option "option$i" "value$i" nofile
+done
+
+for i in 1 6 7 8; do
+  check_not_option "option$i" "override-value$i" defaults-file
+done
+for i in 3 4; do
+  check_not_option "option$i" "default-value$i" defaults-file
+done
+for i in 5 6; do
+  check_option "option$i" "default-value$i" defaults-file
+done
+for i in 1 2 3 4; do
+  check_option "option$i" "value$i" defaults-file
+done
+check_option "multiline" "multiline-value" defaults-file
+check_option "whitespace_separated" "one two  three   end" defaults-file
+
+for i in 3 4 5 6; do
+  check_not_option "option$i" "default-value$i" override-file
+done
+check_not_option "option1" "value1" override-file
+for i in 2 3 4; do
+  check_option "option$i" "value$i" override-file
+done
+for i in 1 6 7 8; do
+  check_option "option$i" "override-value$i" override-file
+done
+
+check_option "option5" "default-value5" both-files
+for i in 3 4 6; do
+  check_not_option "option$i" "default-value$i" both-files
+done
+check_not_option "option1" "value1" both-files
+for i in 2 3 4; do
+  check_option "option$i" "value$i" both-files
+done
+for i in 1 6 7 8; do
+  check_option "option$i" "override-value$i" both-files
+done
+
+for f in defaults-file override-file both-files; do
+expect_not_grep \
+  "effective configuration: defaults_file" \
+  "$tmp/config-test-$f.out" \
+  "defaults_file option was not consumed"
+expect_not_grep \
+  "effective configuration: overrides_file" \
+  "$tmp/config-test-$f.out" \
+  "overrides_file option was not consumed"
+done
+
+end_test


### PR DESCRIPTION
## add support for configuration files
by setting one or both of the options `defaults_file` or `overrides_file` you can now tell every plugin using the baseclass to read a configuration file.
While `defaults_file` will add the values before the plugin definition (i.e. plugin defintion will override the values from that file), using `overrides_files` will add the values after defaults and plugin definition (i.e. will override defaults and plugin definition).

All paths are also treated relative to the FD's configuration directory to make life easier.

## add support for encoded configuration values
if you need to encode a value to make it unreadable (e.g. an api-key), you can now do that. If you - for example - want to set option `password` to an encoded value, you instead set the option `password#enc` to the encoded value and the baseclass will take care of decoding the value for the plugin.

### TODO
- [x] provide a script to actually encode values
- [x] package everything correctly
- [x] add/update documentation

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
