### PR TITLE
dird: fix `purge oldest volume`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - github actions: update/fix publish to PyPI workflows [PR #1572]
 - github actions: PyPi: install setuptools [PR #1604]
 - scripts: config-lib improve setup_sd_user [PR #1448]
+- dird: fix `purge oldest volume` [PR #1629]
 
 ### Documentation
 - add explanation about binary version numbers [PR #1354]
@@ -347,4 +348,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1619]: https://github.com/bareos/bareos/pull/1619
 [PR #1620]: https://github.com/bareos/bareos/pull/1620
 [PR #1626]: https://github.com/bareos/bareos/pull/1626
+[PR #1629]: https://github.com/bareos/bareos/pull/1629
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/ua_input.cc
+++ b/core/src/dird/ua_input.cc
@@ -160,14 +160,12 @@ bool GetYesno(UaContext* ua, const char* prompt)
  *                 or user enters "yes"
  *           false otherwise
  */
-bool GetConfirmation(UaContext* ua, const char* prompt)
+bool GetConfirmation(UaContext* ua, const char* prompt, bool fallback_value)
 {
   if (FindArg(ua, NT_("yes")) >= 0) { return true; }
-
+  if (!ua->UA_sock) { return fallback_value; }
   if (ua->api || ua->batch) { return false; }
-
   if (GetYesno(ua, prompt)) { return (ua->pint32_val == 1); }
-
   return false;
 }
 

--- a/core/src/dird/ua_input.h
+++ b/core/src/dird/ua_input.h
@@ -29,7 +29,8 @@ bool GetPint(UaContext* ua, const char* prompt);
 bool GetYesno(UaContext* ua, const char* prompt);
 bool IsYesno(char* val, bool* ret);
 bool GetConfirmation(UaContext* ua,
-                     const char* prompt = T_("Confirm (yes/no): "));
+                     const char* prompt = T_("Confirm (yes/no): "),
+                     bool fallback_value = false);
 int GetEnabled(UaContext* ua, const char* val);
 void ParseUaArgs(UaContext* ua);
 bool IsCommentLegal(UaContext* ua, const char* name);

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -538,7 +538,7 @@ bool PurgeJobsFromVolume(UaContext* ua, MediaDbRecord* mr, bool force)
   } else {
     ua->InfoMsg(T_("Found %d Jobs for media \"%s\" in catalog \"%s\".\n"),
                 lst.size(), mr->VolumeName, client->catalog->resource_name_);
-    if (!GetConfirmation(ua, "Purge (yes/no)? ")) {
+    if (!GetConfirmation(ua, "Purge (yes/no)? ", true)) {
       ua->InfoMsg(T_("Purge canceled.\n"));
     } else {
       PurgeJobsFromCatalog(ua, jobids.c_str());

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/job/purge-oldest-job.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/job/purge-oldest-job.conf
@@ -1,0 +1,11 @@
+Job {
+  Name = "purge-oldest-job"
+  Type = Backup
+  Level = Full
+  Client = "bareos-fd"
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = purgeoldest
+  Priority = 10
+}

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/pool/purgeoldest.conf
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-dir.d/pool/purgeoldest.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = purgeoldest
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 1 year           # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 2M           # Limit Volume size to something reasonable
+  Maximum Volumes = 12                # Limit number of Volumes in Pool
+  Label Format = "purgeoldest-"
+  Purge Oldest Volume = yes
+}

--- a/systemtests/tests/bareos-basic/testrunner-purge-oldest
+++ b/systemtests/tests/bareos-basic/testrunner-purge-oldest
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -e
+set -o pipefail
+set -u
+#
+# Run multiple backups in parallel and
+#   then restore them.
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+backupjob="purge-oldest-job"
+recycle_backuplog="$tmp/purge-oldest-backuplog.out"
+recycle_restorelog="$tmp/purge-oldest-restorelog.out"
+recyle_restoredirectory="$tmp/purge-oldest-restore"
+
+rm -f $recycle_backuplog
+rm -f $recycle_restorelog
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $recycle_backuplog
+run job=$backupjob level=Full yes
+wait
+@sleep 2
+run job=$backupjob level=Full yes
+wait
+@sleep 2
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+backup_with_recycled_volume=$(awk '/Job queued./{i++}i==2 {print; exit;}' "$recycle_backuplog" | sed -n -e 's/^.*JobId=//p')
+volume_tobe_recycled=$(grep "Labeled new Volume" $recycle_backuplog | sed -n -e 's/^.*Labeled new Volume "//p' | sed -n -e 's/" on device .*//p')
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $recycle_restorelog
+restore jobid=$backup_with_recycled_volume client=bareos-fd fileset=SelfTest where=$recyle_restoredirectory select all done yes
+wait
+messages
+quit
+END_OF_DATA
+
+run_bconsole
+
+expect_grep "Recycled volume \"$volume_tobe_recycled\"" \
+            "$recycle_backuplog" \
+            "Volume was not recycled!"
+
+expect_grep "New volume \"$volume_tobe_recycled\" mounted on device \"FileStorage\"" \
+            "$recycle_backuplog" \
+            "Recycled volume was not reused!"
+
+check_two_logs "$recycle_backuplog" "$recycle_restorelog"
+check_restore_diff "${BackupDirectory}" "$recyle_restoredirectory"
+
+end_test


### PR DESCRIPTION
Fixes 0001580: Purge Oldest Volume stops working since update

When we introduced confirmation for the purge volume command we accidentially broke purge oldest volume. This patch fixes the problem and adds a test.

(cherry picked from commit acde2d184ad71eb0de360f62e08328e43611fd8a)

### Thank you for contributing to the Bareos Project!

**Backport of PR #1628 to bareos-23**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
