### PR TITLE
core: add build patch for `sprintf` in macos builds

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -86,10 +86,6 @@ OS:
       ARCH:
       - x86_64
   FreeBSD:
-    "12.4":
-      TYPE: freebsd
-      ARCH:
-        - amd64
     "13.2":
       TYPE: freebsd
       ARCH:

--- a/AUTHORS
+++ b/AUTHORS
@@ -171,6 +171,7 @@ Richard Mortimer
 Robert Nelson
 Roy Sigurd Karlsbakk
 Rudolf Cejka
+Rui Chen
 Russel Howe
 Ruth Ivimey-Cook
 Sam Verstraete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VMware Plugin: Run bareos_vadp_dumper with optimized parameters to increase backup performance [PR #1630]
 - pkglists: update SUSE to have vmware packages [PR #1632]
 - backup report: show negative compression [PR #1598]
+- core: add build patch for `sprintf` in macos builds [PR #1636]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -48,5 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1628]: https://github.com/bareos/bareos/pull/1628
 [PR #1630]: https://github.com/bareos/bareos/pull/1630
 [PR #1632]: https://github.com/bareos/bareos/pull/1632
+[PR #1636]: https://github.com/bareos/bareos/pull/1636
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/job_control_record.cc
+++ b/core/src/tests/job_control_record.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -59,7 +59,7 @@ void JobControlRecordTest::SetUp()
   for (int i = 0; i < 3; i++) {
     jobs.push_back(std::make_shared<JobControlRecord>());
     InitJcr(jobs[i], callback);
-    sprintf(jobs[i]->Job, "%d-test", 123 + i);
+    snprintf(jobs[i]->Job, sizeof(jobs[i]->Job), "%d-test", 123 + i);
     jobs[i]->JobId = 123 + i;
     jobs[i]->VolSessionId = 10 + i;
     jobs[i]->VolSessionTime = 100 + i;
@@ -118,7 +118,7 @@ TEST_F(JobControlRecordTest, get_job_by_partial_name)
 TEST_F(JobControlRecordTest, get_job_by_partial_name_not_found)
 {
   std::shared_ptr<JobControlRecord> jcr(std::make_shared<JobControlRecord>());
-  sprintf(jcr->Job, "987-654-321");
+  snprintf(jcr->Job, sizeof(jcr->Job), "987-654-321");
   InitJcr(jcr, callback);
 
   char name[12]{"654"};


### PR DESCRIPTION
This pr fixes the following build issue on macos

```
/tmp/bareos-client-20231217-15168-qlx505/bareos-Release-23.0.0/core/src/tests/job_control_record.cc:62:5: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
    sprintf(jobs[i]->Job, "%d-test", 123 + i);
    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
/tmp/bareos-client-20231217-15168-qlx505/bareos-Release-23.0.0/core/src/tests/job_control_record.cc:121:3: error: 'sprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead. [-Werror,-Wdeprecated-declarations]
  sprintf(jcr->Job, "987-654-321");
  ^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/stdio.h:188:1: note: 'sprintf' has been explicitly marked deprecated here
__deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use snprintf(3) instead.")
^
/Library/Developer/CommandLineTools/SDKs/MacOSX13.sdk/usr/include/sys/cdefs.h:215:48: note: expanded from macro '__deprecated_msg'
        #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
                                                      ^
```

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

---

relates to https://github.com/Homebrew/homebrew-core/pull/157558