### PR TITLE
Fix continuation on colons in plugin baseclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - dird: fix `purge oldest volume` [PR #1628]
+- Fix continuation on colons in plugin baseclass [PR #1637]
 
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
 [PR #1587]: https://github.com/bareos/bareos/pull/1587
@@ -43,4 +44,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1628]: https://github.com/bareos/bareos/pull/1628
 [PR #1630]: https://github.com/bareos/bareos/pull/1630
 [PR #1632]: https://github.com/bareos/bareos/pull/1632
+[PR #1637]: https://github.com/bareos/bareos/pull/1637
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
+++ b/core/src/plugins/filed/python/pyfiles/BareosFdPluginBaseclass.py
@@ -49,7 +49,7 @@ def parse_plugindef_string(plugindef):
             continue
         # See if the last character is a escape of the value string
         while val[-1:] == "\\":
-            val = val[:-1] + ":" + plugin_options.pop(0)
+            val = val[:-1] + ":" + parts.pop(0)
         if key not in options:
             options[key] = val
     return options

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-dir.d/fileset/PluginConfigTestNoFile.conf.in
@@ -13,5 +13,6 @@ FileSet {
     ":option3=value3"
     ":option4=value4"
     ":password#enc=aA9+EcW-iJ"
+    ":masked-colon=one\\:two\\:three"
   }
 }

--- a/systemtests/tests/py3plug-fd-basic/testrunner-config
+++ b/systemtests/tests/py3plug-fd-basic/testrunner-config
@@ -66,6 +66,7 @@ for i in 1 2 3 4; do
   check_option "option$i" "value$i" nofile
 done
 check_option "password" "password" nofile
+check_option "masked-colon" 'one:two:three' nofile
 
 for i in 1 6 7 8; do
   check_not_option "option$i" "override-value$i" defaults-file


### PR DESCRIPTION
Due to an oversight PR #1605 broke continuation of option-values in the plugindef like this:

`Plugin = "python3-fd:module_name=whatever::masked-colon=one\\:two\\:three"`

This PR improves the systemtest and contains the (rather trivial) fix.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
