### PR TITLE
python-bareos: use socket.create_connection() to allow AF_INET6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pkglists: update SUSE to have vmware packages [PR #1632]
 - backup report: show negative compression [PR #1598]
 - core: add build patch for `sprintf` in macos builds [PR #1636]
+- python-bareos: use socket.create_connection() to allow AF_INET6 [PR #1646]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -51,4 +52,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1632]: https://github.com/bareos/bareos/pull/1632
 [PR #1636]: https://github.com/bareos/bareos/pull/1636
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
+[PR #1646]: https://github.com/bareos/bareos/pull/1646
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -92,7 +92,7 @@ class LowLevel(object):
         self.logger.debug("init")
         self.status = None
         self.address = None
-        self.timeout = None
+        self.timeout = 30
         self.password = None
         self.pam_username = None
         self.pam_password = None
@@ -162,7 +162,8 @@ class LowLevel(object):
             self.dirname = dirname
         else:
             self.dirname = address
-        self.timeout = timeout
+        if timeout:
+            self.timeout = timeout
         self.connection_type = connection_type
         self.name = name
         if password is None:
@@ -236,12 +237,11 @@ class LowLevel(object):
         return auth
 
     def __connect_plain(self):
-        self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # initialize
         try:
-            if self.timeout:
-                self.socket.settimeout(self.timeout)
-            self.socket.connect((self.address, self.port))
+            self.socket = socket.create_connection(
+                (self.address, self.port), timeout=self.timeout
+            )
         except (socket.error, socket.gaierror) as e:
             self._handleSocketError(e)
             raise bareos.exceptions.ConnectionError(


### PR DESCRIPTION
This PR remove the hard-coded restriction on AF_INET Familly by using use a higher-level function socket.create_connection() .
This allow connection to bareos daemon with AF_INET6 familly.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
