### PR TITLE
jcr: fix some compiler warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fvec: add mmap based vector  [PR #1662]
 - core: fix various data races (connection_pool/heartbeat_thread) [PR #1685]
 - filed: skip stripped top level directories [PR #1686]
+- jcr: fix some compiler warnings [PR #1648]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -79,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
 [PR #1646]: https://github.com/bareos/bareos/pull/1646
 [PR #1647]: https://github.com/bareos/bareos/pull/1647
+[PR #1648]: https://github.com/bareos/bareos/pull/1648
 [PR #1649]: https://github.com/bareos/bareos/pull/1649
 [PR #1655]: https://github.com/bareos/bareos/pull/1655
 [PR #1656]: https://github.com/bareos/bareos/pull/1656

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -68,6 +68,7 @@
 #include "lib/thread_specific_data.h"
 #include "lib/tree.h"
 #include "lib/util.h"
+#include "lib/version.h"
 #include "lib/watchdog.h"
 #include "include/protocol_types.h"
 #include "include/allow_deprecated.h"
@@ -444,6 +445,9 @@ static void* job_thread(void* arg)
 
   // Let the statistics subsystem know a new Job was started.
   stats_job_started();
+
+  Jmsg(jcr, M_INFO, 0, T_("Version: %s (%s) %s\n"), kBareosVersionStrings.Full,
+       kBareosVersionStrings.Date, kBareosVersionStrings.GetOsInfo());
 
   if (jcr->dir_impl->res.job->MaxStartDelay != 0
       && jcr->dir_impl->res.job->MaxStartDelay

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -217,8 +217,8 @@ bail_out:
 
 bool DoReloadConfig()
 {
-  // NOTE(ssura): ATOMIC_FLAG_INIT is needed until we switch to
-  //              C++20; but it can be kept even after that.
+  // ATOMIC_FLAG_INIT is needed until we switch to C++20;
+  // but it can be kept even after that.
   static std::atomic_flag is_reloading = ATOMIC_FLAG_INIT;
   bool reloaded = false;
 

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -148,7 +148,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
                            AccurateCheckFile);
   }
 
-  StartHeartbeatMonitor(jcr);
+  auto hb_send = MakeHeartbeatMonitor(jcr);
 
   if (have_acl) {
     jcr->fd_impl->acl_data = std::make_unique<AclData>();
@@ -190,7 +190,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
 
   AccurateFinish(jcr); /* send deleted or base file list to SD */
 
-  StopHeartbeatMonitor(jcr);
+  hb_send.reset();
 
   sd->signal(BNET_EOD); /* end of sending data */
 

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -48,6 +48,7 @@
 #include "lib/btimers.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"
+#include "lib/version.h"
 #include "lib/serial.h"
 #include "lib/compression.h"
 
@@ -114,6 +115,8 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
   sd = jcr->store_bsock;
 
   jcr->setJobStatusWithPriorityCheck(JS_Running);
+  Jmsg(jcr, M_INFO, 0, T_("Version: %s (%s) %s\n"), kBareosVersionStrings.Full,
+       kBareosVersionStrings.Date, kBareosVersionStrings.GetOsInfo());
 
   Dmsg1(300, "filed: opened data connection %d to stored\n", sd->fd_);
   ClientResource* client = nullptr;

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -431,6 +431,7 @@ void* process_director_commands(JobControlRecord* jcr, BareosSocket* dir)
           break;
         }
         Dmsg1(100, "Executing %s command.\n", cmds[i].cmd);
+
         if (!cmds[i].func(jcr)) { /* do command */
           quit = true;            /* error or fully terminated, get out */
           Dmsg1(100, "Quit command loop. Canceled=%d\n", jcr->IsJobCanceled());

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -2011,11 +2011,11 @@ static bool VerifyCmd(JobControlRecord* jcr)
     case L_VERIFY_CATALOG:
       DoVerify(jcr);
       break;
-    case L_VERIFY_VOLUME_TO_CATALOG:
+    case L_VERIFY_VOLUME_TO_CATALOG: {
       if (!OpenSdReadSession(jcr)) { return false; }
-      StartDirHeartbeat(jcr);
+      auto send_hb = MakeDirHeartbeat(jcr);
       DoVerifyVolume(jcr);
-      StopDirHeartbeat(jcr);
+      send_hb.reset();
       // Send Close session command to Storage daemon
       sd->fsend(read_close, jcr->fd_impl->Ticket);
       Dmsg1(130, "filed>stored: %s", sd->msg);
@@ -2025,8 +2025,7 @@ static bool VerifyCmd(JobControlRecord* jcr)
 
       /* Inform Storage daemon that we are done */
       sd->signal(BNET_TERMINATE);
-
-      break;
+    } break;
     case L_VERIFY_DISK_TO_CATALOG:
       DoVerify(jcr);
       break;
@@ -2193,32 +2192,35 @@ static bool RestoreCmd(JobControlRecord* jcr)
   jcr->setJobStatusWithPriorityCheck(JS_Running);
 
   // Do restore of files and data
-  StartDirHeartbeat(jcr);
-  GeneratePluginEvent(jcr, bEventStartRestoreJob);
+  {
+    auto hb_send = MakeDirHeartbeat(jcr);
+
+    GeneratePluginEvent(jcr, bEventStartRestoreJob);
 
 #if defined(WIN32_VSS)
-  // START VSS ON WIN32
-  if (jcr->fd_impl->pVSSClient) {
-    if (!jcr->fd_impl->pVSSClient->InitializeForRestore(jcr)) {
-      BErrNo be;
-      Jmsg(jcr, M_WARNING, 0,
-           T_("VSS was not initialized properly. VSS support is disabled. "
-              "ERR=%s\n"),
-           be.bstrerror());
+    // START VSS ON WIN32
+    if (jcr->fd_impl->pVSSClient) {
+      if (!jcr->fd_impl->pVSSClient->InitializeForRestore(jcr)) {
+        BErrNo be;
+        Jmsg(jcr, M_WARNING, 0,
+             T_("VSS was not initialized properly. VSS support is disabled. "
+                "ERR=%s\n"),
+             be.bstrerror());
+      }
+
+      GeneratePluginEvent(jcr, bEventVssRestoreLoadComponentMetadata);
+
+      RunScripts(jcr, jcr->fd_impl->RunScripts, "ClientAfterVSS",
+                 (jcr->fd_impl->director
+                  && jcr->fd_impl->director->allowed_script_dirs)
+                     ? jcr->fd_impl->director->allowed_script_dirs
+                     : me->allowed_script_dirs);
     }
-
-    GeneratePluginEvent(jcr, bEventVssRestoreLoadComponentMetadata);
-
-    RunScripts(
-        jcr, jcr->fd_impl->RunScripts, "ClientAfterVSS",
-        (jcr->fd_impl->director && jcr->fd_impl->director->allowed_script_dirs)
-            ? jcr->fd_impl->director->allowed_script_dirs
-            : me->allowed_script_dirs);
-  }
 #endif
 
-  DoRestore(jcr);
-  StopDirHeartbeat(jcr);
+    DoRestore(jcr);
+    hb_send.reset();
+  }
 
   if (jcr->JobWarnings) {
     jcr->setJobStatusWithPriorityCheck(JS_Warnings);

--- a/core/src/filed/filed_jcr_impl.h
+++ b/core/src/filed/filed_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -72,10 +72,6 @@ struct FiledJcrImpl {
   uint32_t StartBlock{};
   uint32_t EndBlock{};
   pthread_t heartbeat_id{};       /**< Id of heartbeat thread */
-  std::atomic<bool> hb_initialized_once{};    /**< Heartbeat initialized */
-  std::atomic<bool> hb_running{};             /**< Heartbeat running */
-  std::shared_ptr<BareosSocket> hb_bsock;     /**< Duped SD socket */
-  std::shared_ptr<BareosSocket> hb_dir_bsock; /**< Duped DIR socket */
   alist<RunScript*>* RunScripts{};            /**< Commands to run before and after job */
   CryptoContext crypto;           /**< Crypto ctx */
   filedaemon::DirectorResource* director{}; /**< Director resource */

--- a/core/src/filed/heartbeat.h
+++ b/core/src/filed/heartbeat.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -24,12 +24,50 @@
 #ifndef BAREOS_FILED_HEARTBEAT_H_
 #define BAREOS_FILED_HEARTBEAT_H_
 
+#include <thread>
+#include <atomic>
+#include <optional>
+
 namespace filedaemon {
 
-void StartHeartbeatMonitor(JobControlRecord* jcr);
-void StopHeartbeatMonitor(JobControlRecord* jcr);
-void StartDirHeartbeat(JobControlRecord* jcr);
-void StopDirHeartbeat(JobControlRecord* jcr);
+class heartbeat_sd_dir {
+  std::atomic<bool> stop_requested{false};
+  std::thread thread;
+
+ protected:
+  void send_heartbeat(BareosSocket* sd, BareosSocket* dir, time_t interval);
+
+ public:
+  heartbeat_sd_dir(BareosSocket* sd, BareosSocket* dir, time_t interval);
+
+  heartbeat_sd_dir(const heartbeat_sd_dir&) = delete;
+  heartbeat_sd_dir& operator=(const heartbeat_sd_dir&) = delete;
+  heartbeat_sd_dir(heartbeat_sd_dir&&) = delete;
+  heartbeat_sd_dir& operator=(heartbeat_sd_dir&&) = delete;
+
+  ~heartbeat_sd_dir();
+};
+
+class heartbeat_dir {
+  std::atomic<bool> stop_requested{false};
+  std::thread thread;
+
+ protected:
+  void send_heartbeat(BareosSocket* dir, time_t interval);
+
+ public:
+  heartbeat_dir(BareosSocket* dir, time_t interval);
+
+  heartbeat_dir(const heartbeat_dir&) = delete;
+  heartbeat_dir& operator=(const heartbeat_dir&) = delete;
+  heartbeat_dir(heartbeat_dir&&) = delete;
+  heartbeat_dir& operator=(heartbeat_dir&&) = delete;
+
+  ~heartbeat_dir();
+};
+
+std::optional<heartbeat_sd_dir> MakeHeartbeatMonitor(JobControlRecord* jcr);
+std::optional<heartbeat_dir> MakeDirHeartbeat(JobControlRecord* jcr);
 
 } /* namespace filedaemon */
 #endif  // BAREOS_FILED_HEARTBEAT_H_

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -51,6 +51,7 @@
 #include "lib/base64.h"
 #include "lib/serial.h"
 #include "lib/compression.h"
+#include "lib/version.h"
 
 #ifdef HAVE_WIN32
 #  include "win32/findlib/win32.h"
@@ -391,6 +392,9 @@ bail_out:
 // Restore the requested files.
 void DoRestore(JobControlRecord* jcr)
 {
+  Jmsg(jcr, M_INFO, 0, T_("Version: %s (%s) %s\n"), kBareosVersionStrings.Full,
+       kBareosVersionStrings.Date, kBareosVersionStrings.GetOsInfo());
+
   BareosSocket* sd;
   uint32_t VolSessionId, VolSessionTime;
   int32_t file_index;

--- a/core/src/lib/bsock_tcp.cc
+++ b/core/src/lib/bsock_tcp.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -528,7 +528,7 @@ int32_t BareosSocketTCP::recv()
   message_length = 0;
   if (errors || IsTerminated()) { return BNET_HARDEOF; }
 
-  if (mutex_) { mutex_->lock(); }
+  LockMutex();
 
   read_seqno++;                /* bump sequence number */
   timer_start = watchdog_time; /* set start wait time */
@@ -627,7 +627,7 @@ int32_t BareosSocketTCP::recv()
    * debugging. */
 
 get_out:
-  if (mutex_) { mutex_->unlock(); }
+  UnlockMutex();
 
   return nbytes; /* return actual length of message */
 }

--- a/core/src/lib/bsys.cc
+++ b/core/src/lib/bsys.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -977,7 +977,7 @@ bool PathCreate(const char* apath, mode_t mode)
 
   if (stat(apath, &statp) == 0) { /* Does dir exist? */
     if (!S_ISDIR(statp.st_mode)) {
-      Emsg1(M_ERROR, 0, "%s exists but is not a directory.\n", path);
+      Emsg1(M_ERROR, 0, "%s exists but is not a directory.\n", apath);
       return false;
     }
     return true;

--- a/core/src/plugins/filed/bpipe/bpipe-fd.cc
+++ b/core/src/plugins/filed/bpipe/bpipe-fd.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -776,7 +776,7 @@ static bRC plugin_has_all_arguments(PluginContext* ctx)
   bRC retval = bRC_OK;
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
 
-  if (!p_ctx) { retval = bRC_Error; }
+  if (!p_ctx) { return bRC_Error; }
 
   if (!p_ctx->fname) {
     Jmsg(ctx, M_FATAL, T_("bpipe-fd: Plugin File argument not specified.\n"));

--- a/core/src/stored/backends/droplet_device.cc
+++ b/core/src/stored/backends/droplet_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2014-2017 Planets Communications B.V.
-   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -840,7 +840,7 @@ bool DropletDevice::initialize()
       sysmd_.mask |= DPL_SYSMD_MASK_STORAGE_CLASS;
       sysmd_.storage_class = dpl_storage_class(temp.c_str());
       if (sysmd_.storage_class == -1) {
-        Mmsg2(errmsg, T_("Illegal storage_class argument %s for device %s%s\n"),
+        Mmsg2(errmsg, T_("Illegal storage_class argument %s for device %s\n"),
               temp.c_str(), archive_device_string);
         goto bail_out;
       }

--- a/core/src/stored/fd_cmds.cc
+++ b/core/src/stored/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,6 +44,7 @@
 #include "lib/bnet.h"
 #include "lib/bsock.h"
 #include "lib/edit.h"
+#include "lib/version.h"
 #include "include/jcr.h"
 
 namespace storagedaemon {
@@ -170,6 +171,9 @@ void RunJob(JobControlRecord* jcr)
   jcr->start_time = time(NULL);
   jcr->run_time = jcr->start_time;
   jcr->sendJobStatus(JS_Running);
+
+  Jmsg(jcr, M_INFO, 0, T_("Version: %s (%s) %s\n"), kBareosVersionStrings.Full,
+       kBareosVersionStrings.Date, kBareosVersionStrings.GetOsInfo());
 
   DoFdCommands(jcr);
 

--- a/core/src/tests/ktls.cc
+++ b/core/src/tests/ktls.cc
@@ -197,68 +197,144 @@ static void EnsureKtlsRecv(BareosSocket* sock)
   EXPECT_TRUE(sock->tls_conn->KtlsRecvStatus());
 }
 
+enum test
+{
+  test_v12_send,
+  test_v12_recv,
+  test_v13_send,
+  test_v13_recv,
+  test_v12_256_send,
+  test_v13_256_send,
+};
+
+#if HAVE_LINUX_OS
+bool IsTlsModuleLoaded()
+{
+  static bool warning_given = false;
+
+  int res = system("lsmod | grep -w tls > /dev/null");
+
+  if (res != 0 && !warning_given) {
+    fprintf(stderr, "Could not detect loaded tls module. Skipping tests.\n");
+    warning_given = true;
+  }
+
+  return (res == 0);
+}
+#endif
+
+bool IsTestDisabled(test T)
+{
+#if HAVE_LINUX_OS
+  if (!IsTlsModuleLoaded()) { return true; }
+#endif
+
+  switch (T) {
+#if defined(DISABLE_KTLS_12_SEND)
+    case test_v12_send: {
+      return true;
+    }
+#endif
+#if defined(DISABLE_KTLS_12_RECV)
+    case test_v12_recv: {
+      return true;
+    }
+#endif
+#if defined(DISABLE_KTLS_13_SEND)
+    case test_v13_send: {
+      return true;
+    }
+#endif
+#if defined(DISABLE_KTLS_13_RECV)
+    case test_v13_recv: {
+      return true;
+    }
+#endif
+#if defined(DISABLE_KTLS_12_256_SEND)
+    case test_v12_256_send: {
+      return true;
+    }
+#endif
+#if defined(DISABLE_KTLS_13_256_SEND)
+    case test_v13_256_send: {
+      return true;
+    }
+#endif
+
+    default: {
+      return false;
+    }
+  }
+}
+
 TEST(ktls, v12_send)
 {
-#if defined(DISABLE_KTLS_12_SEND)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12/",
-                     [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  if (IsTestDisabled(test_v12_send)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12/",
+                       [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  }
 }
 
 TEST(ktls, v12_recv)
 {
-#if defined(DISABLE_KTLS_12_RECV)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12/",
-                     [](BareosSocket* sock) { EnsureKtlsRecv(sock); });
+  if (IsTestDisabled(test_v12_recv)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12/",
+                       [](BareosSocket* sock) { EnsureKtlsRecv(sock); });
+  }
 }
 
 TEST(ktls, v13_send)
 {
-#if defined(DISABLE_KTLS_13_SEND)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13/",
-                     [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  if (IsTestDisabled(test_v13_send)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13/",
+                       [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  }
 }
 
 TEST(ktls, v13_recv)
 {
-#if defined(DISABLE_KTLS_13_RECV)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13/",
-                     [](BareosSocket* sock) { EnsureKtlsRecv(sock); });
+  if (IsTestDisabled(test_v13_recv)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13/",
+                       [](BareosSocket* sock) { EnsureKtlsRecv(sock); });
+  }
 }
 
 TEST(ktls, v12_256_send)
 {
-#if defined(DISABLE_KTLS_12_256_SEND)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12-256/",
-                     [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  if (IsTestDisabled(test_v12_256_send)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/12-256/",
+                       [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  }
 }
 
 TEST(ktls, v13_256_send)
 {
-#if defined(DISABLE_KTLS_13_256_SEND)
-  GTEST_SKIP();
-#endif
-  InitOpenSsl();
-  do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
-                     RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13-256/",
-                     [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  if (IsTestDisabled(test_v13_256_send)) {
+    GTEST_SKIP();
+  } else {
+    InitOpenSsl();
+    do_connection_test(RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/bareos/",
+                       RELATIVE_PROJECT_SOURCE_DIR "/configs/ktls/13-256/",
+                       [](BareosSocket* sock) { EnsureKtlsSend(sock); });
+  }
 }

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -89,7 +89,6 @@ set(ALL_BINARIES_BEING_USED_BY_SYSTEMTESTS
     bls
     bscan
     bconsole
-    bsmtp
     bwild
     bpluginfo
     bsmtp

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -186,14 +186,19 @@ function(configurefilestosystemtest srcbasedir dirname globexpression
   endif()
   set(COUNT 1)
   file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/${dirname})
-  file(GLOB_RECURSE ALL_FILES
-       "${CMAKE_SOURCE_DIR}/${srcbasedir}/${srcdirname}/${globexpression}"
+  file(
+    GLOB_RECURSE ALL_FILES
+    RELATIVE "${CMAKE_SOURCE_DIR}"
+    "${CMAKE_SOURCE_DIR}/${srcbasedir}/${srcdirname}/${globexpression}"
   )
-  foreach(CURRENT_FILE ${ALL_FILES})
+  foreach(TARGET_FILE ${ALL_FILES})
     math(EXPR COUNT "${COUNT}+1")
-    string(REPLACE "${CMAKE_SOURCE_DIR}/" "" TARGET_FILE ${CURRENT_FILE})
-    string(REGEX REPLACE ".in$" "" TARGET_FILE ${TARGET_FILE}) # do not mess
-                                                               # with .ini files
+    set(CURRENT_FILE "${CMAKE_SOURCE_DIR}/")
+    string(APPEND CURRENT_FILE ${TARGET_FILE})
+
+    # do not mess with .ini files
+    string(REGEX REPLACE ".in$" "" TARGET_FILE "${TARGET_FILE}")
+
     string(REPLACE "${srcbasedir}/${srcdirname}" "" TARGET_FILE ${TARGET_FILE})
     get_filename_component(DIR_NAME ${TARGET_FILE} DIRECTORY)
 

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -7,8 +7,8 @@ wait_for_jobs_to_terminate ()
 {
   status_of_what=$1
   max_wait_in_seconds=$2
-  count=max_wait_in_seconds
-  while (( --count >= 0 )); do
+  start_time=$SECONDS
+  while (( SECONDS - start_time <= max_wait_in_seconds )); do
     if  "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" <<< "status ${status_of_what}" | grep "No Jobs running.";
     then
       break

--- a/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
+++ b/systemtests/tests/checkpoints/testrunner-checkpoints-on-cancel
@@ -29,6 +29,7 @@ slowjob="slow-backup-bareos-fd"
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out /dev/null
 messages
+setdebug level=100 trace=1 all
 @$out $backup_log
 run job=$slowjob fileset=bigfileset level=Full yes
 quit
@@ -71,6 +72,7 @@ messages
 restore jobid=${slowjobid} where=$restore_directory all done yes
 wait
 messages
+setdebug trace=0 all
 quit
 END_OF_DATA
 
@@ -81,7 +83,12 @@ expect_grep "Termination:            Backup Canceled" \
             "$backup_log" \
             "Job was not canceled!"
 
-NumberOfBackedUpFiles=$(grep 'FD Files Written:       ' "$backup_log" | sed -n -e 's/^.*Written:       //p')
+NumberOfBackedUpFiles=0
+while read -a nums; do
+    for num in "${nums[@]}"; do
+	(( NumberOfBackedUpFiles += num ))
+    done
+done <<< "$(grep "entries start" "$backup_log" | cut -d" " -f12)"
 
 # Check that part of the files were written despite the cancel
 if [ "$NumberOfBackedUpFiles" -le 0 ]; then


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR fixes some compiler warnings related to `std::find_if()` now being marked as `[[nodiscard]]`.
It also fixes some race conditions.
It also makes every daemon send a jobmessage with its version at the start of each job.
Additionally it adds tls kernel module detection the the ktls test.  Now the test gets skipped if the module is not loaded.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
~~Required backport PRs have been created~~

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

