### PR TITLE
bnet-server-tcp: split socket creation from listening for unittests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve FreeBSD dependencies [PR #1670]
 - python-bareos: integrate usage of config files [PR #1678]
 - cmake: cleanup [PR #1661]
+- bnet-server-tcp: split socket creation from listening for unittests [PR #1649]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -70,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
 [PR #1646]: https://github.com/bareos/bareos/pull/1646
 [PR #1647]: https://github.com/bareos/bareos/pull/1647
+[PR #1649]: https://github.com/bareos/bareos/pull/1649
 [PR #1655]: https://github.com/bareos/bareos/pull/1655
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659

--- a/core/src/dird/socket_server.h
+++ b/core/src/dird/socket_server.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,12 +22,16 @@
 #ifndef BAREOS_DIRD_SOCKET_SERVER_H_
 #define BAREOS_DIRD_SOCKET_SERVER_H_
 
+#include <vector>
+#include "lib/bnet_server_tcp.h"
+
 template <typename T> class dlist;
 class IPADDR;
 
 namespace directordaemon {
 
 bool StartSocketServer(dlist<IPADDR>* addrs);
+bool StartSocketServer(std::vector<s_sockfd>&& bound_sockets);
 void StopSocketServer();
 
 } /* namespace directordaemon */

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -421,4 +421,11 @@ void BnetThreadServerTcp(
   if (server_state) { server_state->store(BnetServerState::kEnded); }
 }
 
-void close_socket(int fd) { close(fd); }
+void close_socket(int fd)
+{
+#ifdef HAVE_WIN32
+  closesocket(fd);
+#else
+  close(fd);
+#endif
+}

--- a/core/src/lib/thread_list.h
+++ b/core/src/lib/thread_list.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -46,10 +46,10 @@ class ThreadList {
   bool ShutdownAndWaitForThreadsToFinish();
   std::size_t Size() const;
 
-  ThreadList(const ThreadList& ohter) = delete;
-  ThreadList(const ThreadList&& ohter) = delete;
+  ThreadList(const ThreadList& other) = delete;
+  ThreadList(ThreadList&& other) = delete;
   ThreadList& operator=(const ThreadList& rhs) = delete;
-  ThreadList& operator=(const ThreadList&& rhs) = delete;
+  ThreadList& operator=(ThreadList&& rhs) = delete;
 
  private:
   std::unique_ptr<ThreadListPrivate> impl_;


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR splits up the socket binding & listening logic from the bnet server into two parts.  This way unit tests can bind the sockets themselves without using any configuration file.   This allows them to ask the operating system to choose ports for them instead of using hardcoded ports.

The ktls test is enhanced to take advantage of this fact.  Now you can run multiple ktls unit-tests in parallel without the tests complaining about the port being already in use.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted


##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
