### PR TITLE
core: add build patch for `sprintf` in macos builds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -171,6 +171,7 @@ Richard Mortimer
 Robert Nelson
 Roy Sigurd Karlsbakk
 Rudolf Cejka
+Rui Chen
 Russel Howe
 Ruth Ivimey-Cook
 Sam Verstraete

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - pkglists: update SUSE to have vmware packages [PR #1633]
 -  python-bareos: use socket.create_connection() to allow AF_INET6 [PR #1650]
+- core: add build patch for `sprintf` in macos builds [PR #1651]
 
 ### Fixed
 - Fix continuation on colons in plugin baseclass [PR #1638]
@@ -368,4 +369,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1638]: https://github.com/bareos/bareos/pull/1638
 [PR #1642]: https://github.com/bareos/bareos/pull/1642
 [PR #1650]: https://github.com/bareos/bareos/pull/1650
+[PR #1651]: https://github.com/bareos/bareos/pull/1651
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/job_control_record.cc
+++ b/core/src/tests/job_control_record.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -59,7 +59,7 @@ void JobControlRecordTest::SetUp()
   for (int i = 0; i < 3; i++) {
     jobs.push_back(std::make_shared<JobControlRecord>());
     InitJcr(jobs[i], callback);
-    sprintf(jobs[i]->Job, "%d-test", 123 + i);
+    snprintf(jobs[i]->Job, sizeof(jobs[i]->Job), "%d-test", 123 + i);
     jobs[i]->JobId = 123 + i;
     jobs[i]->VolSessionId = 10 + i;
     jobs[i]->VolSessionTime = 100 + i;
@@ -118,7 +118,7 @@ TEST_F(JobControlRecordTest, get_job_by_partial_name)
 TEST_F(JobControlRecordTest, get_job_by_partial_name_not_found)
 {
   std::shared_ptr<JobControlRecord> jcr(std::make_shared<JobControlRecord>());
-  sprintf(jcr->Job, "987-654-321");
+  snprintf(jcr->Job, sizeof(jcr->Job), "987-654-321");
   InitJcr(jcr, callback);
 
   char name[12]{"654"};


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

**Backport of PR #1636 to bareos-23**

Fix build issues on macos

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
