### PR TITLE
plugins: postgresql fix missing pg_backup_stop() call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python-bareos: use socket.create_connection() to allow AF_INET6 [PR #1646]
 - Improve FreeBSD build [PR #1538]
 - core: sql_* add leading space to sql construct [PR #1656]
+- plugins: postgresql fix missing pg_backup_stop() call [PR #1655]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1636]: https://github.com/bareos/bareos/pull/1636
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
 [PR #1646]: https://github.com/bareos/bareos/pull/1646
+[PR #1655]: https://github.com/bareos/bareos/pull/1655
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-default
@@ -210,4 +210,15 @@ else
    estat=1
 fi
 
+if (grep -q "WARN" database/log/postgresql-*.log)
+then
+   echo "Error: Database WARNING found in postgresql log"
+   estat=1
+fi
+if (grep -q "ERR" database/log/postgresql-*.log)
+then
+   echo "Error: Database ERRORS found in postgresql log"
+   estat=1
+fi
+
 end_test


### PR DESCRIPTION
- pg_backup_stop() is called in all job level
- add in testrunner-default checks of WARNING or ERROR in db logs

Fixes #1584: Incremental PostgreSQL backup will log an warning on
             the database server

OP#5669

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
