### PR TITLE
core: sql_* add leading space to sql construct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: add build patch for `sprintf` in macos builds [PR #1636]
 - python-bareos: use socket.create_connection() to allow AF_INET6 [PR #1646]
 - Improve FreeBSD build [PR #1538]
+- core: sql_* add leading space to sql construct [PR #1656]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -55,4 +56,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1636]: https://github.com/bareos/bareos/pull/1636
 [PR #1637]: https://github.com/bareos/bareos/pull/1637
 [PR #1646]: https://github.com/bareos/bareos/pull/1646
+[PR #1656]: https://github.com/bareos/bareos/pull/1656
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -674,7 +674,7 @@ bool Bvfs::DropRestoreList(char* output_table)
 {
   PoolMem query(PM_MESSAGE);
   if (CheckTemp(output_table)) {
-    Mmsg(query, "DROP TABLE %s", output_table);
+    Mmsg(query, "DROP TABLE IF EXISTS %s", output_table);
     db->SqlQuery(query.c_str());
     return true;
   }
@@ -704,10 +704,10 @@ bool Bvfs::compute_restore_list(char* fileid,
   DbLocker _{db};
 
   /* Cleanup old tables first */
-  Mmsg(query, "DROP TABLE btemp%s", output_table);
+  Mmsg(query, "DROP TABLE IF EXISTS btemp%s", output_table);
   db->SqlQuery(query.c_str());
 
-  Mmsg(query, "DROP TABLE %s", output_table);
+  Mmsg(query, "DROP TABLE IF EXISTS %s", output_table);
   db->SqlQuery(query.c_str());
 
   Mmsg(query, "CREATE TABLE btemp%s AS ", output_table);
@@ -717,7 +717,7 @@ bool Bvfs::compute_restore_list(char* fileid,
     Mmsg(tmp,
          "SELECT Job.JobId, JobTDate, FileIndex, File.Name, "
          "PathId, FileId "
-         "FROM File JOIN Job USING (JobId) WHERE FileId IN (%s)",
+         "FROM File JOIN Job USING (JobId) WHERE FileId IN (%s) ",
          fileid);
     PmStrcat(query, tmp.c_str());
   }
@@ -834,7 +834,7 @@ bool Bvfs::compute_restore_list(char* fileid,
   retval = true;
 
 bail_out:
-  Mmsg(query, "DROP TABLE btemp%s", output_table);
+  Mmsg(query, "DROP TABLE IF EXISTS btemp%s", output_table);
   db->SqlQuery(query.c_str());
   return retval;
 }

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -825,7 +825,7 @@ bool BareosDb::WriteBatchFileRecords(JobControlRecord* jcr)
 
 
 bail_out:
-  SqlQuery("DROP TABLE batch");
+  SqlQuery("DROP TABLE IF EXISTS batch");
   jcr->batch_started = false;
   changes = 0;
 
@@ -1025,10 +1025,10 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
 void BareosDb::CleanupBaseFile(JobControlRecord* jcr)
 {
   PoolMem buf(PM_MESSAGE);
-  Mmsg(buf, "DROP TABLE new_basefile%lld", (uint64_t)jcr->JobId);
+  Mmsg(buf, "DROP TABLE IF EXISTS new_basefile%lld", (uint64_t)jcr->JobId);
   SqlQuery(buf.c_str());
 
-  Mmsg(buf, "DROP TABLE basefile%lld", (uint64_t)jcr->JobId);
+  Mmsg(buf, "DROP TABLE IF EXISTS basefile%lld", (uint64_t)jcr->JobId);
   SqlQuery(buf.c_str());
 }
 

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1377,7 +1377,7 @@ bool BareosDb::AccurateGetJobids(JobControlRecord* jcr,
   retval = true;
 
 bail_out:
-  Mmsg(query, "DROP TABLE btemp3%s", jobid);
+  Mmsg(query, "DROP TABLE IF EXISTS btemp3%s", jobid);
   SqlQuery(query.c_str());
   return retval;
 }

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -179,7 +179,7 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
   } else {
     Mmsg(cmd,
          "SELECT ClientId,Name,FileRetention,JobRetention "
-         "FROM Client %s ORDER BY ClientId",
+         "FROM Client %s ORDER BY ClientId ",
          clientfilter.c_str());
   }
 
@@ -271,14 +271,14 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
            "FirstIndex,LastIndex,StartFile,JobMedia.EndFile,StartBlock,"
            "JobMedia.EndBlock "
            "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId "
-           "AND JobMedia.JobId=%s",
+           "AND JobMedia.JobId=%s ",
            edit_int64(JobId, ed1));
     } else {
       Mmsg(cmd,
            "SELECT JobMediaId,JobId,Media.MediaId,Media.VolumeName,"
            "FirstIndex,LastIndex,StartFile,JobMedia.EndFile,StartBlock,"
            "JobMedia.EndBlock "
-           "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId");
+           "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId ");
     }
 
   } else {
@@ -286,12 +286,12 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
       Mmsg(cmd,
            "SELECT JobId,Media.VolumeName,FirstIndex,LastIndex "
            "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId "
-           "AND JobMedia.JobId=%s",
+           "AND JobMedia.JobId=%s ",
            edit_int64(JobId, ed1));
     } else {
       Mmsg(cmd,
            "SELECT JobId,Media.VolumeName,FirstIndex,LastIndex "
-           "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId");
+           "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId ");
     }
   }
   if (!QUERY_DB(jcr, cmd)) { return; }
@@ -318,13 +318,13 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
     Mmsg(cmd,
          "SELECT JobMediaId,JobId,Media.MediaId,Media.VolumeName "
          "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId "
-         "AND JobMedia.JobId=%s",
+         "AND JobMedia.JobId=%s ",
          edit_int64(JobId, ed1));
   } else {
     Mmsg(cmd,
          "SELECT DISTINCT Media.VolumeName "
          "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId "
-         "AND JobMedia.JobId=%s",
+         "AND JobMedia.JobId=%s ",
          edit_int64(JobId, ed1));
   }
   if (!QUERY_DB(jcr, cmd)) { return; }
@@ -357,7 +357,7 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
        "FROM Job "
        "JOIN JobMedia USING (JobId) "
        "JOIN Media USING (MediaId) "
-       "WHERE Job.Type = '%c' %s ORDER BY Job.PriorJobId DESC %s",
+       "WHERE Job.Type = '%c' %s ORDER BY Job.PriorJobId DESC %s ",
        (char)JT_JOB_COPY, str_jobids.c_str(), range);
 
   if (!QUERY_DB(jcr, cmd)) { return; }
@@ -399,7 +399,7 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
          "LEFT JOIN Client USING (ClientId) "
          "WHERE Job.Type != 'C' "
          "%s"
-         "ORDER BY Log.LogId DESC %s",
+         "ORDER BY Log.LogId DESC %s ",
          client_filter.c_str(), range);
   } else {
     Mmsg(cmd,
@@ -411,8 +411,8 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
          "LEFT JOIN Client USING (ClientId) "
          "WHERE Job.Type != 'C' "
          "%s"
-         "ORDER BY Log.LogId DESC %s"
-         ") AS sub ORDER BY LogId ASC",
+         "ORDER BY Log.LogId DESC %s "
+         ") AS sub ORDER BY LogId ASC ",
          client_filter.c_str(), range);
   }
 
@@ -520,7 +520,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
   PoolMem temp(PM_MESSAGE), selection(PM_MESSAGE), criteria(PM_MESSAGE);
 
   if (jr->JobId > 0) {
-    temp.bsprintf("AND Job.JobId=%s", edit_int64(jr->JobId, ed1));
+    temp.bsprintf("AND Job.JobId=%s ", edit_int64(jr->JobId, ed1));
     PmStrcat(selection, temp.c_str());
   }
 
@@ -654,7 +654,7 @@ void BareosDb::ListFilesForJob(JobControlRecord* jcr,
        "ON (BaseFiles.FileId = File.FileId) "
        "WHERE BaseFiles.JobId = %s"
        ") AS F, Path "
-       "WHERE Path.PathId=F.PathId",
+       "WHERE Path.PathId=F.PathId ",
        edit_int64(jobid, ed1), ed1);
 
   sendit->ArrayStart("filenames");
@@ -678,7 +678,7 @@ void BareosDb::ListBaseFilesForJob(JobControlRecord* jcr,
        "FROM BaseFiles, File, Path "
        "WHERE BaseFiles.JobId=%s AND BaseFiles.BaseJobId = File.JobId "
        "AND BaseFiles.FileId = File.FileId "
-       "AND Path.PathId=File.PathId",
+       "AND Path.PathId=File.PathId ",
        edit_int64(jobid, ed1));
 
   sendit->ArrayStart("files");
@@ -704,7 +704,7 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
          "CreateTime, FileSetText "
          "FROM Job, FileSet "
          "WHERE Job.FileSetId = FileSet.FileSetId "
-         "AND Job.Name='%s'%s",
+         "AND Job.Name='%s' %s",
          esc, range);
   } else if (jr->Job[0] != 0) {
     EscapeString(jcr, esc, jr->Job, strlen(jr->Job));
@@ -713,7 +713,7 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
          "CreateTime, FileSetText "
          "FROM Job, FileSet "
          "WHERE Job.FileSetId = FileSet.FileSetId "
-         "AND Job.Name='%s'%s",
+         "AND Job.Name='%s' %s",
          esc, range);
   } else if (jr->JobId != 0) {
     Mmsg(cmd,
@@ -721,19 +721,19 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
          "CreateTime, FileSetText "
          "FROM Job, FileSet "
          "WHERE Job.FileSetId = FileSet.FileSetId "
-         "AND Job.JobId='%s'%s",
+         "AND Job.JobId='%s' %s",
          edit_int64(jr->JobId, esc), range);
   } else if (jr->FileSetId != 0) {
     Mmsg(cmd,
          "SELECT FileSetId, FileSet, MD5, CreateTime, FileSetText "
          "FROM FileSet "
-         "WHERE  FileSetId=%s",
+         "WHERE FileSetId=%s ",
          edit_int64(jr->FileSetId, esc));
   } else { /* all records */
     Mmsg(cmd,
          "SELECT DISTINCT FileSet.FileSetId AS FileSetId, FileSet, MD5, "
          "CreateTime, FileSetText "
-         "FROM FileSet ORDER BY FileSetId ASC%s",
+         "FROM FileSet ORDER BY FileSetId ASC %s",
          range);
   }
 

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -303,8 +303,8 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
     ttime = mr->FirstWritten;
     bstrutime(dt, sizeof(dt), ttime);
     Mmsg(cmd,
-         "UPDATE Media SET FirstWritten='%s'"
-         " WHERE VolumeName='%s'",
+         "UPDATE Media SET FirstWritten='%s' "
+         "WHERE VolumeName='%s'",
          dt, esc_medianame);
     UPDATE_DB(jcr, cmd);
     Dmsg1(400, "Firstwritten=%d\n", mr->FirstWritten);
@@ -341,8 +341,8 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
        "MaxVolJobs=%d,MaxVolFiles=%d,Enabled=%d,LocationId=%s,"
        "ScratchPoolId=%s,RecyclePoolId=%s,RecycleCount=%d,Recycle=%d,"
        "ActionOnPurge=%d,"
-       "MinBlocksize=%u,MaxBlocksize=%u"
-       " WHERE VolumeName='%s'",
+       "MinBlocksize=%u,MaxBlocksize=%u "
+       "WHERE VolumeName='%s'",
        mr->VolJobs, mr->VolFiles, mr->VolBlocks, edit_uint64(mr->VolBytes, ed1),
        mr->VolMounts, mr->VolErrors, mr->VolWrites,
        edit_uint64(mr->MaxVolBytes, ed2), esc_status, mr->Slot, mr->InChanger,
@@ -383,8 +383,8 @@ bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET "
          "ActionOnPurge=%d,Recycle=%d,VolRetention=%s,VolUseDuration=%s,"
          "MaxVolJobs=%u,MaxVolFiles=%u,MaxVolBytes=%s,RecyclePoolId=%s,"
-         "MinBlocksize=%d,MaxBlocksize=%d"
-         " WHERE VolumeName='%s'",
+         "MinBlocksize=%d,MaxBlocksize=%d "
+         "WHERE VolumeName='%s'",
          mr->ActionOnPurge, mr->Recycle, edit_uint64(mr->VolRetention, ed1),
          edit_uint64(mr->VolUseDuration, ed2), mr->MaxVolJobs, mr->MaxVolFiles,
          edit_uint64(mr->MaxVolBytes, ed3), edit_uint64(mr->RecyclePoolId, ed4),
@@ -394,8 +394,8 @@ bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET "
          "ActionOnPurge=%d,Recycle=%d,VolRetention=%s,VolUseDuration=%s,"
          "MaxVolJobs=%u,MaxVolFiles=%u,MaxVolBytes=%s,RecyclePoolId=%s,"
-         "MinBlocksize=%d,MaxBlocksize=%d"
-         " WHERE PoolId=%s",
+         "MinBlocksize=%d,MaxBlocksize=%d "
+         "WHERE PoolId=%s",
          mr->ActionOnPurge, mr->Recycle, edit_uint64(mr->VolRetention, ed1),
          edit_uint64(mr->VolUseDuration, ed2), mr->MaxVolJobs, mr->MaxVolFiles,
          edit_uint64(mr->MaxVolBytes, ed3), edit_int64(mr->RecyclePoolId, ed4),
@@ -571,6 +571,6 @@ void BareosDb::UpgradeCopies(const char* jobids)
        JT_COPY);
   SqlQuery(query.c_str());
 
-  SqlQuery("DROP TABLE cpy_tmp");
+  SqlQuery("DROP TABLE IF EXISTS cpy_tmp");
 }
 #endif /* HAVE_POSTGRESQL */


### PR DESCRIPTION
This PR aims to:
- fix ERROR: trailing junk after numeric literal at or near "123A" in sql_list.cc
- Add IF EXISTS in DROP TABLE statement
- unifomize the query in sql_upgrade.cc
- control all sql function for missing space

OP#5667

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
