### PR TITLE
  Fix bareos_tasks plugin for pgsql

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -94,6 +94,7 @@ Jan Görig
 Jan Huisink
 Jan Kesten
 Jin Zhanbing
+Jo Goossens
 Jo Simoens
 Joakim Tjernlund
 Joao Henrique Freitas

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - core: add build patch for `sprintf` in macos builds [PR #1651]
 - Improve FreeBSD build [PR #1643]
 - core: sql_* add leading space to sql construct [PR #1657]
+-   Fix bareos_tasks plugin for pgsql [PR #1660]
 
 ### Fixed
 - Fix continuation on colons in plugin baseclass [PR #1638]
@@ -374,4 +375,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1650]: https://github.com/bareos/bareos/pull/1650
 [PR #1651]: https://github.com/bareos/bareos/pull/1651
 [PR #1657]: https://github.com/bareos/bareos/pull/1657
+[PR #1660]: https://github.com/bareos/bareos/pull/1660
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/contrib/fd-plugins/bareos_tasks/BareosFdTaskClass.py
+++ b/contrib/fd-plugins/bareos_tasks/BareosFdTaskClass.py
@@ -155,7 +155,12 @@ class TaskProcess(Task):
     def pool(self):
         if self.use_stderr:
             try:
-                self.stderr_buffer.write(self.process.stderr.read())
+                while True:
+                    stderrtext=self.process.stderr.read()
+                    if stderrtext:
+                        self.stderr_buffer.write(stderrtext)
+                    else:
+                        break
             except IOError:
                 pass
 
@@ -172,7 +177,6 @@ class TaskProcess(Task):
             self.process = subprocess.Popen(sudo + self.command, shell=False, bufsize=-1,
                                             stdout=subprocess.PIPE if self.use_stdout else None,
                                             stderr=subprocess.PIPE if self.use_stderr else None)
-                                            #preexec_fn=self.pre_run_execute)
             if self.use_stderr:
                 fcntl(self.process.stderr, F_SETFL, fcntl(self.process.stderr, F_GETFL) | os.O_NONBLOCK)
         except (subprocess.CalledProcessError, OSError, ValueError) as e:

--- a/contrib/fd-plugins/bareos_tasks/pgsql/BareosFdPgSQLClass.py
+++ b/contrib/fd-plugins/bareos_tasks/pgsql/BareosFdPgSQLClass.py
@@ -27,13 +27,13 @@ class TaskQueryDatabase(TaskProcess):
 
     def __init__(self, psql=None, pg_user=None):
         self.run_as_user = pg_user
-        psql_options = 'postgres --expanded --no-align'
+        psql_options = '--expanded --no-align --no-psqlrc'
         self.command = [psql if psql else 'psql'] + shlex.split(psql_options)
         super(TaskQueryDatabase, self).__init__()
 
     def execute_query(self, query):
         items = list()
-        data = self.execute_command(self.command + ['--command=' + query])
+        data = self.execute_command(self.command + ['--command=' + query]).decode('utf-8')
         for record in data.split('\n\n'):
             item = dict(map(lambda x: x.split('|', 1), record.splitlines()))
             items.append(item)
@@ -88,7 +88,6 @@ class BareosFdPgSQLClass(BareosFdTaskClass):
         pg_user = self.options.get('pg_user', 'postgres')
 
         databases = self.config.get_list('databases', TaskQueryDatabase(psql, pg_user).get_databases())
-        self.job_message(bareosfd.M_INFO, "databases: {}".format(databases))
 
         if 'exclude' in self.config:
             exclude = self.config.get_list('exclude')

--- a/contrib/fd-plugins/bareos_tasks/pgsql/BareosFdPgSQLClass.py
+++ b/contrib/fd-plugins/bareos_tasks/pgsql/BareosFdPgSQLClass.py
@@ -25,10 +25,15 @@ from bareos_tasks.BareosFdTaskClass import TaskProcess, BareosFdTaskClass
 
 class TaskQueryDatabase(TaskProcess):
 
-    def __init__(self, psql=None, pg_user=None):
+    def __init__(self, psql='psql', pg_host=None, pg_port=None, pg_user=None):
         self.run_as_user = pg_user
         psql_options = '--expanded --no-align --no-psqlrc'
-        self.command = [psql if psql else 'psql'] + shlex.split(psql_options)
+        self.command = [ psql ]
+        if pg_host:
+            self.command.append("--host={}".format(pg_host))
+        if pg_port:
+            self.command.append("--port={}".format(pg_port))
+        self.command += shlex.split(psql_options)
         super(TaskQueryDatabase, self).__init__()
 
     def execute_query(self, query):
@@ -58,11 +63,19 @@ class TaskDumpDatabase(TaskProcess):
     task_name = 'dump-database'
     file_extension = 'sql'
 
-    def __init__(self, database, psql=None, pg_dump=None, pg_user=None, pg_dump_options=''):
+    def __init__(self, database, psql='psql', pg_dump='pg_dump', pg_host=None, pg_port=None, pg_user=None, pg_dump_options=''):
         self.database = database
         self.psql = psql
+        self.pg_host = pg_host
+        self.pg_port = pg_port
         self.run_as_user = pg_user
-        self.command = [pg_dump if pg_dump else 'pg_dump'] + shlex.split(pg_dump_options) + [self.database]
+        self.command = [ pg_dump ]
+        if pg_host:
+            self.command.append("--host={}".format(pg_host))
+        if pg_port:
+            self.command.append("--port={}".format(pg_port))
+        self.command += shlex.split(pg_dump_options)
+        self.command.append(self.database)
         super(TaskDumpDatabase, self).__init__()
 
     def get_name(self):
@@ -73,7 +86,7 @@ class TaskDumpDatabase(TaskProcess):
         # However, as the need the size before the dump command is executed,
         # this is the best estimation we got.
         # However, there will be warnings about incorrect sizes on restore.
-        return TaskQueryDatabase(self.psql, self.run_as_user).get_database_size(self.database)
+        return TaskQueryDatabase(self.psql, self.pg_host, self.pg_port, self.run_as_user).get_database_size(self.database)
 
 
 class BareosFdPgSQLClass(BareosFdTaskClass):
@@ -85,13 +98,19 @@ class BareosFdPgSQLClass(BareosFdTaskClass):
         psql = self.options.get('psql', 'psql')
         pg_dump = self.options.get('pg_dump', 'pg_dump')
         pg_dump_options = self.options.get('pg_dump_options', '--no-owner --no-acl')
+        pg_host = self.options.get('pg_host')
+        pg_port = self.options.get('pg_port')
         pg_user = self.options.get('pg_user', 'postgres')
+        # allow user to specify an empty string,
+        # to run the commands as the same user as bareos-fd.
+        if pg_user == "''":
+            pg_user = None
 
-        databases = self.config.get_list('databases', TaskQueryDatabase(psql, pg_user).get_databases())
+        databases = self.config.get_list('databases', TaskQueryDatabase(psql, pg_host, pg_port, pg_user).get_databases())
 
         if 'exclude' in self.config:
             exclude = self.config.get_list('exclude')
             databases = filter(lambda x: x not in exclude, databases)
 
         for database in databases:
-            self.tasks.append(TaskDumpDatabase(database, psql, pg_dump, pg_user, pg_dump_options))
+            self.tasks.append(TaskDumpDatabase(database, psql, pg_dump, pg_host, pg_port, pg_user, pg_dump_options))

--- a/contrib/fd-plugins/bareos_tasks/pgsql/README.md
+++ b/contrib/fd-plugins/bareos_tasks/pgsql/README.md
@@ -64,8 +64,18 @@ Command (with or without full path) to *pg_dump* tool. Default: *pg_dump*
 #### pg_dump_options
 Options to be used with the *pg_dump* tool. Default: *--no-owner --no-acl*
 
+#### pg_host
+Specifies the host name of the machine on which the server is running.
+If the value begins with a slash,
+it is used as the directory for the Unix-domain socket.
+
+#### pg_port
+Specifies the TCP port
+or the local Unix-domain socket file extension
+on which the server is listening for connections.
+
 #### pg_user
-Username of the system user running the *psql* and *pg_dump* tools. Default: *postgres*
+Specifies the user that will be used to run the *psql* and *pg_dump* tools.  If this option is not set, the default is *postgres*. If this option is set to the empty string (`pg_user=''`), then the user running *bareos-fd* is used.  Default: *postgres*
 
 #### databases
 Comma separated list of database names to backup, if unset all databases (except 'postgres', 'template1' and 'template0') are dumped. Default: unset

--- a/contrib/fd-plugins/bareos_tasks/pgsql/__init__.py
+++ b/contrib/fd-plugins/bareos_tasks/pgsql/__init__.py
@@ -17,15 +17,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import bareosfd
-from BareosFdPgSQLClass import BareosFdPgSQLClass
-
-# This module contains the wrapper functions called by the Bareos-FD, the
-# functions call the corresponding methods from your plugin class
 import BareosFdWrapper
+from bareosfd import bRC_OK
 from BareosFdWrapper import *
-
+from bareos_tasks.pgsql.BareosFdPgSQLClass import BareosFdPgSQLClass
 
 def load_bareos_plugin(plugin_def):
     BareosFdWrapper.bareos_fd_plugin_object = BareosFdPgSQLClass(plugin_def)
-    bareosfd.bRC_OK
+    return bRC_OK

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/bareos_tasks_pgsql.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/fileset/bareos_tasks_pgsql.conf.in
@@ -1,0 +1,13 @@
+FileSet {
+  Name = "bareos_tasks_pgsql"
+  Description = "Test the Plugin functionality with a Python Plugin."
+  Include {
+    Options {
+      signature = XXH128
+    }
+    Plugin = "@python_module_name@"
+             ":module_name=bareos_tasks.pgsql"
+             ":pg_host=@dbHost@"
+             ":pg_user=''"
+  }
+}

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/job/backup-bareos-fd-tasks-pgsql.conf
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-dir.d/job/backup-bareos-fd-tasks-pgsql.conf
@@ -1,0 +1,6 @@
+Job {
+  Name = "backup-bareos-fd-tasks-pgsql"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  FileSet = "bareos_tasks_pgsql"
+}

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-tasks-pgsql
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-tasks-pgsql
@@ -1,0 +1,145 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+set -u
+
+#
+# This systemtest tests the plugin functionality
+# of the bareos-fd with the tasks.pgsql plugin.
+#
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName="backup-bareos-fd-tasks-pgsql"
+#shellcheck source=../environment.in
+. ./environment
+. ./database/setup_local_db.sh
+
+# setup local database server
+DBNAME="db_tasks_pgsql"
+TESTPGHOST="${dbHost}"
+PSQL="${POSTGRES_BIN_PATH}/psql --host ${TESTPGHOST}"
+RESTORE_DIR="$tmp/bareos-restores/@PGSQL/"
+
+[ -d "${TESTPGHOST}" ] && rm -R  "${TESTPGHOST}"
+mkdir -p "${TESTPGHOST}"
+[ $EUID -eq 0 ] && chown postgres "${TESTPGHOST}"
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+
+start_test
+
+pushd database > /dev/null
+setup_local_db "${TESTPGHOST}"
+
+if [ $EUID -ne 0 ]; then
+    # Make sure, a database for the current user exists.
+    # Required by the psql command, when called without explicit database.
+    ${PSQL} postgres -c "create database ${USER}" || true
+fi
+
+# Create Test DB with table and 1 statement
+${PSQL} postgres -c "create database ${DBNAME}"
+${PSQL} ${DBNAME} -c "
+create table t(id serial primary key, text varchar(20), created_on timestamp);
+insert into t (text, created_on) values ('test for FULL backup', current_timestamp);
+select * from t;
+"
+popd > /dev/null
+
+echo "First full backup stage"
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/log1.out
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+run job=${JobName} level=Full yes
+wait
+setdebug level=0 client=bareos-fd
+status director
+status client
+status storage=File
+wait
+messages
+END_OF_DATA
+
+run_bconsole
+check_log $tmp/log1.out
+expect_grep "Backup OK" "${tmp}/log1.out" "Full Backup not found!"
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+echo "First incremental backup stage"
+# insert data and run incremental
+${PSQL} ${DBNAME} -c "insert into t (text, created_on) values ('test entry 2', current_timestamp)"
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out $tmp/log1i.out
+@# run incremental
+run job=$JobName yes
+wait
+status dir
+END_OF_DATA
+
+run_bconsole "$@"
+check_log $tmp/log1i.out
+
+# restore to file
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out /dev/null
+messages
+@$out ${tmp}/restore.log
+setdebug level=150 trace=1 timestamp=1 client=bareos-fd
+restore client=bareos-fd fileset=bareos_tasks_pgsql select all done yes
+wait
+setdebug level=0 client=bareos-fd
+messages
+END_OF_DATA
+
+echo "Restore stage"
+run_bconsole
+check_log $tmp/restore.log
+expect_grep "Restore OK" "${tmp}/restore.log" "Restore Backup not ok!"
+if [ ${estat} -ne 0 ]; then
+    exit ${estat}
+fi
+
+check_for_zombie_jobs storage=File
+
+check_two_logs "${tmp}/log1.out" "${tmp}/restore.log"
+
+# Check if some files are restored
+ls -lR "${RESTORE_DIR}"
+if [ -z "$(ls -A "${RESTORE_DIR}")" ]; then
+    echo "No restore data found"
+    estat=1
+fi
+
+# delete database
+${PSQL} postgres -c "drop database ${DBNAME};"
+
+if ${PSQL} ${DBNAME} -c "SELECT * FROM t WHERE id=2;" 2>/dev/null; then
+    echo "database ${DBNAME} should be deleted and command should fail."
+    estat=2
+fi
+
+# restore db
+${PSQL} postgres -c "create database ${DBNAME}"
+${PSQL} ${DBNAME} < "${RESTORE_DIR}/dump-database-${DBNAME}.sql"
+
+if ! ${PSQL} ${DBNAME} -c "SELECT * FROM t WHERE id=2;" 2>/dev/null; then
+    echo "test entry not found after restore"
+    estat=3
+fi
+
+# stop the database server
+pushd database/ > /dev/null
+local_db_stop_server "${TESTPGHOST}"
+popd > /dev/null
+
+end_test


### PR DESCRIPTION
Fix bareos_tasks plugin for pgsqlThe pgsql plugin from bareos_tasks is currently not working at all. There were a few errors which are now fixed and the plugin was testing and working properly on a few test machines.

**Backport of PR #1659  to bareos-23**

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
