### PR TITLE
fvec: add mmap based vector 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - windows: fix calculation of "job_metadata.xml" object size [PR #1695]
 - stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1688]
 - bareos-triggerjob: fix parameter handling [PR #1708]
+- fvec: add mmap based vector  [PR #1662]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -80,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659
 [PR #1661]: https://github.com/bareos/bareos/pull/1661
+[PR #1662]: https://github.com/bareos/bareos/pull/1662
 [PR #1665]: https://github.com/bareos/bareos/pull/1665
 [PR #1670]: https://github.com/bareos/bareos/pull/1670
 [PR #1671]: https://github.com/bareos/bareos/pull/1671

--- a/core/src/lib/channel.h
+++ b/core/src/lib/channel.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -209,6 +209,18 @@ template <typename T> class input {
     }
 
     return false;
+  }
+
+  void try_update_status()
+  {
+    if (did_close) { return; }
+
+    bool should_close = false;
+    if (auto result = shared->try_input_lock()) {
+      if (std::get_if<channel_closed>(&result.value())) { should_close = true; }
+    }
+
+    if (should_close) { close(); }
   }
 
   void close()

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,6 +22,7 @@
 #define BAREOS_LIB_EDIT_H_
 
 #include <vector>
+#include "include/bc_types.h"
 
 namespace edit {
 /* The biggest 64 bit number -- 2^64-1 -- has 20 digits.

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -198,6 +198,9 @@ template <typename T> class fvec : access {
 
     buffer = reinterpret_cast<T*>(res);
     cap = new_cap;
+#ifdef MADV_HUGEPAGE
+    madvise(buffer, cap * element_size, MADV_HUGEPAGE);
+#endif
   }
 
   T* alloc_uninit(std::size_t num)
@@ -316,6 +319,9 @@ template <typename T> class fvec : access {
       // this should not happen
       throw std::runtime_error("mmap returned nullptr.");
     }
+#ifdef MADV_HUGEPAGE
+    madvise(buffer, cap * element_size, MADV_HUGEPAGE);
+#endif
   }
 };
 

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -268,20 +268,9 @@ template <typename T> class fvec : access {
 
   void grow_file(std::size_t new_size)
   {
-    if (auto err = posix_fallocate(fd, 0, new_size); err != 0) {
-      // posix_fallocate does not set errno
-      if (err == EINVAL || err == EOPNOTSUPP) {
-        // some filesystems do not support posix_fallocate.  In these cases
-        // we fall back to ftruncate
-        if (ftruncate(fd, new_size) != 0) {
-          throw error("ftruncate/allocate (new size = "
-                      + std::to_string(new_size) + ")");
-        }
-      } else {
-        throw std::system_error(
-            err, std::generic_category(),
-            "posix_fallocate (new size = " + std::to_string(new_size) + ")");
-      }
+    if (ftruncate(fd, new_size) != 0) {
+      throw error("ftruncate/allocate (new size = " + std::to_string(new_size)
+                  + ")");
     }
   }
 

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -200,6 +200,14 @@ template <typename T> class fvec : access {
     cap = new_cap;
   }
 
+  T* alloc_uninit(std::size_t num)
+  {
+    reserve_extra(num);
+    count += num;
+
+    return buffer + (count - num);
+  }
+
   // think of (arr, size) as a span; then the name makes sense
   void append_range(const T* arr, std::size_t size)
   {

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -1,0 +1,165 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can modify it under the terms of
+   version three of the GNU Affero General Public License as published by the
+   Free Software Foundation, which is listed in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_STORED_BACKENDS_DEDUP_FVEC_H_
+#define BAREOS_STORED_BACKENDS_DEDUP_FVEC_H_
+
+#include <cstdlib>
+#include <stdexcept>
+
+extern "C" {
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+}
+
+template <typename T> class fvec {
+ public:
+  using size_type = std::size_t;
+  using value_type = T;
+  using reference = T&;
+  using const_reference = const T&;
+  using pointer = T*;
+  using const_pointer = const T*;
+  using iterator = T*;
+  using const_iterator = const T*;
+
+  static constexpr size_type element_size = sizeof(T);
+  static constexpr auto element_align = alignof(T);
+
+  fvec(int fd, size_type initial_size = 0) : count{initial_size}, fd{fd}
+  {
+    static_assert(element_align <= 4096, "Alignment too big.");
+    struct stat s;
+    if (fstat(fd, &s) != 0) { throw error("fstat"); }
+
+    cap = s.st_size / element_size;
+
+    if (count > cap) {
+      throw std::runtime_error("size > capacity (" + std::to_string(count)
+                               + " > " + std::to_string(cap) + ")");
+    }
+
+    if (cap == 0) {
+      auto new_cap = 1024;
+      grow_file(new_cap * element_size);
+      cap = new_cap;
+    }
+
+    buffer
+        = reinterpret_cast<T*>(mmap(nullptr, cap * element_size,
+                                    PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    if (buffer == MAP_FAILED) { throw error("mmap"); }
+    if (buffer == nullptr) {
+      // this should not happen
+      throw std::runtime_error("mmap returned nullptr.");
+    }
+  }
+
+  reference operator[](size_type idx) { return buffer[idx]; }
+
+  const_reference operator[](size_type idx) const { return buffer[idx]; }
+
+  template <typename... Args> reference emplace_back(Args&&... args)
+  {
+    if (count >= cap) {
+      // grow by ~50% each time
+      reserve(cap + (cap >> 1) + 1);
+    }
+    new (&buffer[count]) T(std::forward<Args>(args)...);
+    count += 1;
+    return buffer[count - 1];
+  }
+
+  void push_back(const T& val) { static_cast<void>(emplace_back(val)); }
+
+  void push_back(T&& val) { static_cast<void>(emplace_back(std::move(val))); }
+
+  size_type size() const { return count; }
+
+  size_type max_size() const { return std::numeric_limits<size_type>::max(); }
+
+  size_type capacity() const { return cap; }
+
+  pointer data() { return buffer; }
+
+  const_pointer data() const { return buffer; }
+
+  bool empty() const { return count == 0; }
+
+  iterator begin() { return &buffer[0]; }
+
+  iterator end() { return &buffer[count]; }
+
+  const_iterator begin() const { return &buffer[0]; }
+
+  const_iterator end() const { return &buffer[count]; }
+
+  void reserve(size_type new_cap)
+  {
+    if (new_cap <= cap) { return; }
+
+    grow_file(new_cap * element_size);
+
+    auto res = mremap(buffer, cap * element_size, new_cap * element_size,
+                      MREMAP_MAYMOVE, nullptr);
+
+    if (res != nullptr && res != MAP_FAILED) {
+      buffer = reinterpret_cast<T*>(res);
+      cap = new_cap;
+    } else {
+      throw error("mremap");
+    }
+  }
+
+  void reserve_extra(size_type additional) { reserve(additional + count); }
+
+  void clear() { count = 0; }
+
+  void resize_to_fit()
+  {
+    cap = count;
+    if (ftruncate(fd, cap * element_size) != 0) { throw error("ftruncate"); }
+  }
+
+  ~fvec() { munmap(buffer, cap * element_size); }
+
+ private:
+  T* buffer{nullptr};
+  size_type cap{0};
+  size_type count{0};
+  int fd{-1};
+
+  template <typename... Args> static std::system_error error(Args&&... args)
+  {
+    return std::system_error(errno, std::generic_category(),
+                             std::forward<Args>(args)...);
+  }
+
+  void grow_file(std::size_t new_size)
+  {
+    if (auto err = posix_fallocate(fd, 0, new_size); err != 0) {
+      // posix_fallocate does not set errno
+      throw std::system_error(err, std::generic_category(), "posix_fallocate");
+    }
+  }
+};
+
+#endif  // BAREOS_STORED_BACKENDS_DEDUP_FVEC_H_

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -160,6 +160,15 @@ template <typename T> class fvec : access {
     count += size;
   }
 
+  // does not initialize the new values if new_size > size
+  void resize_uninitialized(std::size_t new_size)
+  {
+    // does nothing if new_size <= cap
+    reserve(new_size);
+
+    count = new_size;
+  }
+
   void reserve_extra(size_type additional) { reserve(additional + count); }
 
   void clear() { count = 0; }

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -32,6 +32,7 @@ extern "C" {
 }
 #include <system_error>
 #include <limits>
+#include <cstring>
 
 namespace dedup {
 struct access {
@@ -149,6 +150,14 @@ template <typename T> class fvec : access {
     } else {
       throw error("mremap");
     }
+  }
+
+  // think of (arr, size) as a span; then the name makes sense
+  void append_range(const T* arr, std::size_t size)
+  {
+    reserve_extra(size);
+    std::memcpy(end(), arr, size * element_size);
+    count += size;
   }
 
   void reserve_extra(size_type additional) { reserve(additional + count); }

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -213,7 +213,14 @@ template <typename T> class fvec : access {
 
   fvec(int fd, size_type initial_size, int prot) : count{initial_size}, fd{fd}
   {
+    // we cannot ensure alignment bigger than page alignment
     static_assert(element_align <= 4096, "Alignment too big.");
+
+    // check for unaccounted for weirdness
+    static_assert(element_align > 0, "Weird struct");
+    static_assert(element_align <= element_size, "Weird struct");
+    static_assert(element_size % element_align == 0, "Weird struct");
+
     struct stat s;
     if (fstat(fd, &s) != 0) { throw error("fstat"); }
 

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -179,6 +179,13 @@ template <typename T> class fvec : access {
     if (ftruncate(fd, cap * element_size) != 0) { throw error("ftruncate"); }
   }
 
+  void flush()
+  {
+    if (msync(buffer, cap * element_size, MS_SYNC) < 0) {
+      throw error("msync");
+    }
+  }
+
   ~fvec()
   {
     if (buffer) { munmap(buffer, cap * element_size); }

--- a/core/src/stored/backends/dedup/fvec.h
+++ b/core/src/stored/backends/dedup/fvec.h
@@ -262,9 +262,18 @@ template <typename T> class fvec : access {
   {
     if (auto err = posix_fallocate(fd, 0, new_size); err != 0) {
       // posix_fallocate does not set errno
-      throw std::system_error(
-          err, std::generic_category(),
-          "posix_fallocate (new size = " + std::to_string(new_size) + ")");
+      if (err == EINVAL || err == EOPNOTSUPP) {
+        // some filesystems do not support posix_fallocate.  In these cases
+        // we fall back to ftruncate
+        if (ftruncate(fd, new_size) != 0) {
+          throw error("ftruncate/allocate (new size = "
+                      + std::to_string(new_size) + ")");
+        }
+      } else {
+        throw std::system_error(
+            err, std::generic_category(),
+            "posix_fallocate (new size = " + std::to_string(new_size) + ")");
+      }
     }
   }
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -514,3 +514,7 @@ bareos_add_test(version_strings LINK_LIBRARIES bareos GTest::gtest_main)
 bareos_add_test(
   channel LINK_LIBRARIES bareos Threads::Threads GTest::gtest_main
 )
+
+if(NOT HAVE_WIN32)
+  bareos_add_test(fvec LINK_LIBRARIES GTest::gtest_main)
+endif()

--- a/core/src/tests/fvec.cc
+++ b/core/src/tests/fvec.cc
@@ -1,0 +1,137 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#if defined(HAVE_MINGW)
+#  include "include/bareos.h"
+#endif
+
+#include "gtest/gtest.h"
+#include "stored/backends/dedup/fvec.h"
+
+#include <cstdio>
+#include <memory>
+#include <vector>
+#include <random>
+#include <cerrno>
+
+struct file_closer {
+  void operator()(FILE* f) const { std::fclose(f); }
+};
+
+std::unique_ptr<FILE, file_closer> backing;
+
+std::size_t file_size(int fd)
+{
+  struct stat s;
+  if (fstat(fd, &s) != 0) { return 0; }
+
+  return s.st_size;
+}
+
+std::vector<int> gen_rand_ints(std::size_t count)
+{
+  std::random_device rd;
+  std::default_random_engine gen(rd());
+  std::uniform_int_distribution<int> dist{};
+
+  std::vector<int> data;
+  for (std::size_t i = 0; i < count; ++i) { data.push_back(dist(gen)); }
+
+  return data;
+}
+
+std::vector<int> rand_ints = gen_rand_ints(1000);
+TEST(fvec, creation)
+{
+  backing = std::unique_ptr<FILE, file_closer>(std::tmpfile());
+
+  int fd = fileno(backing.get());
+
+  try {
+    fvec<int> v(fd);
+  } catch (std::system_error& ec) {
+    FAIL() << "Error: " << ec.code() << " - " << ec.what() << "\n";
+  }
+}
+
+TEST(fvec, pushing)
+{
+  try {
+    int fd = fileno(backing.get());
+    fvec<int> v(fd);
+
+    for (auto i : rand_ints) { v.push_back(i); }
+
+    EXPECT_EQ(v.size(), rand_ints.size());
+  } catch (std::system_error& ec) {
+    FAIL() << "Error: " << ec.code() << " - " << ec.what() << "\n";
+  }
+}
+
+TEST(fvec, push_consistency)
+{
+  try {
+    int fd = fileno(backing.get());
+
+    fvec<int> v(fd, rand_ints.size());
+
+    EXPECT_EQ(v.size(), rand_ints.size());
+
+    for (std::size_t i = 0; i < v.size(); ++i) {
+      EXPECT_EQ(v[i], rand_ints[i]);
+    }
+
+  } catch (std::system_error& ec) {
+    FAIL() << "Error: " << ec.code() << " - " << ec.what() << "\n";
+  }
+}
+
+TEST(fvec, operations)
+{
+  try {
+    int fd = fileno(backing.get());
+
+    fvec<int> v(fd, rand_ints.size());
+
+    EXPECT_EQ(v.size(), rand_ints.size());
+
+    v.clear();
+
+    EXPECT_EQ(v.size(), 0);
+
+    for (std::size_t i = 0; i < rand_ints.size(); ++i) {
+      v.push_back(i);
+      EXPECT_EQ(v.size(), i + 1);
+      EXPECT_LE(v.size(), v.capacity());
+      EXPECT_LE(v.capacity() * v.element_size, file_size(fd));
+      v.resize_to_fit();
+      EXPECT_EQ(v.capacity(), v.size());
+      EXPECT_EQ(v.capacity() * v.element_size, file_size(fd));
+    }
+
+  } catch (std::system_error& ec) {
+    FAIL() << "Error: " << ec.code() << " - " << ec.what() << "\n";
+  }
+}
+
+// TEST(fvec, consistency)
+// {
+
+// }

--- a/systemtests/tests/restore/testrunner-full-restore
+++ b/systemtests/tests/restore/testrunner-full-restore
@@ -31,7 +31,7 @@ wait
 messages
 @$out $log_home/jobs.out
 list jobs
-@$out $log_home/backup-full.out
+@$out $log_home/restore-full.out
 restore client=bareos-fd fileset=SelfTest where=$tmp/bareos-restores select all done yes
 wait
 messages
@@ -44,8 +44,12 @@ check_for_zombie_jobs storage=File
 check_preconditions
 
 expect_grep "Start Restore Job" \
-	    "$log_home/backup-full.out" \
+	    "$log_home/restore-full.out" \
 	    "Required restore job was not started."
+
+expect_grep "Restore OK" \
+	    "$log_home/restore-full.out" \
+	    "Restore job was not successful"
 
 check_restore_diff "${BackupDirectory}"
 end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR adds a utility class that resembles a vector, but it does not use regular memory but instead uses a memory mapped file instead.

This structure is needed to implement the dedup backend.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
