### PR TITLE
filed: fix vss during client initiated connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve FreeBSD build [PR #1538]
 - core: sql_* add leading space to sql construct [PR #1656]
 - plugins: postgresql fix missing pg_backup_stop() call [PR #1655]
+- filed: fix vss during client initiated connections [PR #1665]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -61,4 +62,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1655]: https://github.com/bareos/bareos/pull/1655
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659
+[PR #1665]: https://github.com/bareos/bareos/pull/1665
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -475,7 +475,7 @@ static bool ConfigureMessageThread(JobControlRecord* jcr)
  */
 bool DoNativeBackup(JobControlRecord* jcr)
 {
-  Jmsg(jcr, M_INFO, 0, T_("Start Backup JobId %llu, Job=%s\n"), jcr->JobId,
+  Jmsg(jcr, M_INFO, 0, T_("Start Backup JobId %u, Job=%s\n"), jcr->JobId,
        jcr->Job);
 
   jcr->setJobStatusWithPriorityCheck(JS_Running);

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -398,9 +398,12 @@ JobControlRecord* create_new_director_session(BareosSocket* dir)
   return jcr;
 }
 
-void* process_director_commands(void* p_jcr)
+void* process_fd_initiated_director_commands(void* p_jcr)
 {
   JobControlRecord* jcr = (JobControlRecord*)p_jcr;
+
+  SetJcrInThreadSpecificData(jcr);
+
   return process_director_commands(jcr, jcr->dir_bsock);
 }
 
@@ -494,8 +497,9 @@ static bool StartProcessDirectorCommands(JobControlRecord* jcr)
   int result = 0;
   pthread_t thread;
 
-  if ((result = pthread_create(&thread, nullptr, process_director_commands,
-                               (void*)jcr))
+  if ((result
+       = pthread_create(&thread, nullptr,
+                        process_fd_initiated_director_commands, (void*)jcr))
       != 0) {
     BErrNo be;
     Emsg1(M_ABORT, 0, T_("Cannot create Director connect thread: %s\n"),

--- a/core/src/tests/berrno_test.cc
+++ b/core/src/tests/berrno_test.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,10 +47,10 @@ const char* bind_error_message = "Bad file number";
 #elif defined HAVE_WIN32
 const char* open_error_message
     = "No such file or directory (errno=2 | win_error=0x00000002)";
-const char* win_open_error_message = "File not found.\r\n";
+const char* win_open_error_message = "File not found (0x00000002)";
 const char* socket_error_message
     = "No such file or directory (errno=2 | win_error=0x0000276D)";
-const char* win_socket_error_message = "Windows error 0x0000276D";
+const char* win_socket_error_message = "Unknown windows error (0x0000276D)";
 const char* bind_error_message
     = "No such file or directory (errno=2 | win_error=0x000027";
 #else


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Using client initiated connections lead to the filedaemon trying to open files on the live system and not on the shadow copy.   This was caused by not setting up the thread local jcr pointer correctly.  This pr fixes that issue.

It also includes:
* Bad format specifier for jobid in a jmsg
* list additional files to include/exclude in dmsgs.
* removing the double newline in some windows error messages.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

