### PR TITLE
Improve FreeBSD dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bareos-config: fix output of deploy_config [PR #1672]
 - Disable automated package-tests for SLES 12 [PR #1671]
 - Make BareosDirPluginPrometheusExporter.py work with python3 [PR #1647]
+- Improve FreeBSD dependencies [PR #1670]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -67,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659
 [PR #1665]: https://github.com/bareos/bareos/pull/1665
+[PR #1670]: https://github.com/bareos/bareos/pull/1670
 [PR #1671]: https://github.com/bareos/bareos/pull/1671
 [PR #1672]: https://github.com/bareos/bareos/pull/1672
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -44,17 +44,12 @@ STORAGE_DAEMON_GROUP=operator
 PLIST_SUB+=	LIBVERSION=${DISTVERSION:C/\..*//} # major version
 PLIST_SUB+=	DISTVERSION=${DISTVERSION:C/(.{6}).*/\1/} # full version
 
-DEFAULT_VERSIONS+=ssl=openssl
 USES+=ssl
 USES+=gettext-runtime
 USES+=readline
 USES+=libtool
 USES+=pkgconfig
-
-USES+=gettext-runtime
-USES+=readline
-
-USES+=		libtool:keepla pkgconfig readline:port
+USES+=libtool:keepla pkgconfig readline:port
 USES+=cmake:noninja
 USES+=shebangfix
 USES+=python:env

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-database-postgresql/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-database-postgresql/Makefile
@@ -8,8 +8,6 @@ MASTERDIR=	${.CURDIR}/../bareos.com-common
 LIB_DEPENDS+=  libbareos.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossql.so:sysutils/bareos.com-database-common
 
-USES+=pgsql
-
 # optional overrides, used by build system.
 .-include "overrides.mk"
 


### PR DESCRIPTION
This PR tries to improve the existing FreeBSD dependencies.

# Remove USES=pgsql
An explicit dependency on pgsql would make the resulting packages require the exact PostgreSQL version that was used during the build. As we only really require the library and a few tool to be present, the library dependency seems to be sufficient.
So now the use can finally use any PostgreSQL version from ports with Bareos.

# Remove DEFAULT_VERSIONS+=ssl=openssl
Previously we forced using openssl from ports. As OpenSSL is already in base it should be possible to build against that (which our binary packages will do in the future) while still retaining support for custom builds with OpenSSL from ports.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
