### PR TITLE
Disable automated package-tests for SLES 12

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -37,6 +37,7 @@ OS:
     "12_SP5":
       TYPE: rpm
       IMAGE: sles12sp5
+      CUSTOM_TEST_IMAGES: []
       ARCH:
       - x86_64
   Fedora:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugins: postgresql fix missing pg_backup_stop() call [PR #1655]
 - filed: fix vss during client initiated connections [PR #1665]
 - bareos-config: fix output of deploy_config [PR #1672]
+- Disable automated package-tests for SLES 12 [PR #1671]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -64,5 +65,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1656]: https://github.com/bareos/bareos/pull/1656
 [PR #1659]: https://github.com/bareos/bareos/pull/1659
 [PR #1665]: https://github.com/bareos/bareos/pull/1665
+[PR #1671]: https://github.com/bareos/bareos/pull/1671
 [PR #1672]: https://github.com/bareos/bareos/pull/1672
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
As SLES 12 is the only remaining system that cannot run the
package-tests in a podman container due to its very old systemd version,
we disable the testing here so we can finally move to plain podman for
the tests.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created


##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

