### PR TITLE
core: fix various data races (connection_pool/heartbeat_thread)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1688]
 - bareos-triggerjob: fix parameter handling [PR #1708]
 - fvec: add mmap based vector  [PR #1662]
+- core: fix various data races (connection_pool/heartbeat_thread) [PR #1685]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -89,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1678]: https://github.com/bareos/bareos/pull/1678
 [PR #1683]: https://github.com/bareos/bareos/pull/1683
 [PR #1684]: https://github.com/bareos/bareos/pull/1684
+[PR #1685]: https://github.com/bareos/bareos/pull/1685
 [PR #1688]: https://github.com/bareos/bareos/pull/1688
 [PR #1695]: https://github.com/bareos/bareos/pull/1695
 [PR #1696]: https://github.com/bareos/bareos/pull/1696

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1073,34 +1073,14 @@ void DoClientResolve(UaContext* ua, ClientResource* client)
   return;
 }
 
-class SocketGuard {
- public:
-  ~SocketGuard()
-  {
-    if (owns_) {
-      fd_->close();
-      delete fd_;
-    }
-  }
-
-  explicit SocketGuard(BareosSocket* fd) : fd_{fd} {}
-  void Release() { owns_ = false; }
-
- private:
-  bool owns_{true};
-  BareosSocket* fd_;
-};
-
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version)
 {
-  ClientResource* client_resource;
-  Connection* connection = NULL;
-  SocketGuard socket_guard{fd};
+  connection conn{client_name, fd_protocol_version, fd};
 
-  client_resource
+  auto client_resource
       = (ClientResource*)my_config->GetResWithName(R_CLIENT, client_name);
   if (!client_resource) {
     Emsg1(M_WARNING, 0,
@@ -1121,18 +1101,12 @@ void* HandleFiledConnection(ConnectionPool* connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connection
-      = connections->add_connection(client_name, fd_protocol_version, fd, true);
-  if (!connection) {
-    Emsg0(M_ERROR, 0, "Failed to add connection to pool.\n");
-    return NULL;
-  }
+  connections.lock()->emplace_back(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 
   /* The connection is now kept in the connection_pool.
    * This thread is no longer required and will end now. */
-  socket_guard.Release();
   return NULL;
 }
 } /* namespace directordaemon */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -1101,7 +1101,7 @@ void* HandleFiledConnection(connection_pool& connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connections.lock()->emplace_back(std::move(conn));
+  connections.add_authenticated_connection(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,12 +54,12 @@ bool SendRestoreObjects(JobControlRecord* jcr, JobId_t JobId, bool send_global);
 bool CancelFileDaemonJob(UaContext* ua, JobControlRecord* jcr);
 void DoNativeClientStatus(UaContext* ua, ClientResource* client, char* cmd);
 void DoClientResolve(UaContext* ua, ClientResource* client);
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version);
 
-ConnectionPool* get_client_connections();
+connection_pool& get_client_connections();
 bool IsConnectingToClientAllowed(ClientResource* res);
 bool IsConnectingToClientAllowed(JobControlRecord* jcr);
 bool IsClientTlsRequired(JobControlRecord* jcr);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -406,7 +406,7 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;
-      jcr->authenticated = connection->authenticated;
+      jcr->authenticated = true;
       Jmsg(jcr, M_INFO, 0, T_("Using Client Initiated Connection (%s).\n"),
            jcr->dir_impl->res.client->resource_name_);
       result = true;

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -400,8 +400,9 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
           jcr->dir_impl->res.client->resource_name_);
   } else {
-    auto connection = take_by_name(
-        connections, jcr->dir_impl->res.client->resource_name_, timeout);
+    auto connection
+        = connections.take_by_name(jcr->dir_impl->res.client->resource_name_,
+                                   std::chrono::seconds{timeout});
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -52,7 +52,7 @@ static char hello_client[] = "Hello Client %127s calling";
 static ThreadList thread_list;
 static std::atomic<bool> server_running;
 static pthread_t tcp_server_tid;
-static connection_pool client_connections{};
+static std::unique_ptr<connection_pool> client_connections{nullptr};
 
 static std::atomic<BnetServerState> server_state(BnetServerState::kUndefined);
 
@@ -65,7 +65,7 @@ struct s_addr_port {
 #define MIN_MSG_LEN 15
 #define MAX_MSG_LEN (int)sizeof(name) + 25
 
-connection_pool& get_client_connections() { return client_connections; }
+connection_pool& get_client_connections() { return *client_connections.get(); }
 
 static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
 {
@@ -110,7 +110,7 @@ static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
       || (sscanf(bs->msg, hello_client, name) == 1)) {
     Dmsg1(110, "Got a FD connection at %s\n",
           bstrftimes(tbuf, sizeof(tbuf), (utime_t)time(NULL)));
-    return HandleFiledConnection(client_connections, bs, name,
+    return HandleFiledConnection(*client_connections.get(), bs, name,
                                  fd_protocol_version);
   }
   return HandleUserAgentClientRequest(bs);
@@ -125,7 +125,10 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
-static void CleanupConnectionPool() { client_connections.cleanup(); }
+static void CleanupConnectionPool()
+{
+  if (client_connections) { client_connections->cleanup(); }
+}
 
 extern "C" void* connect_thread(void* arg)
 {
@@ -170,13 +173,11 @@ extern "C" void* connect_with_bound_thread(void* arg)
  */
 bool StartSocketServer(dlist<IPADDR>* addrs)
 {
-  int status;
+  if (!client_connections) { client_connections.reset(new connection_pool{}); }
 
-  server_state.store(BnetServerState::kUndefined);
-
-  if ((status
-       = pthread_create(&tcp_server_tid, nullptr, connect_thread, (void*)addrs))
-      != 0) {
+  if (int status
+      = pthread_create(&tcp_server_tid, nullptr, connect_thread, (void*)addrs);
+      status != 0) {
     BErrNo be;
     Emsg1(M_ABORT, 0, T_("Cannot create UA thread: %s\n"),
           be.bstrerror(status));
@@ -190,7 +191,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    client_connections.clear();
+    client_connections->clear();
     return false;
   }
   return true;
@@ -200,9 +201,7 @@ bool StartSocketServer(std::vector<s_sockfd>&& bound_sockets)
 {
   int status;
 
-  if (client_connections == nullptr) {
-    client_connections = new ConnectionPool();
-  }
+  if (!client_connections) { client_connections.reset(new connection_pool()); }
 
   server_state.store(BnetServerState::kUndefined);
 
@@ -223,10 +222,7 @@ bool StartSocketServer(std::vector<s_sockfd>&& bound_sockets)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    if (client_connections) {
-      delete (client_connections);
-      client_connections = nullptr;
-    }
+    if (client_connections) { client_connections.reset(nullptr); }
     return false;
   }
   return true;
@@ -238,6 +234,9 @@ void StopSocketServer()
     BnetStopAndWaitForThreadServerTcp(tcp_server_tid);
     server_running = false;
   }
-  client_connections.clear();
+  if (client_connections) {
+    // client_connections can be NULL if the socket server was never started.
+    client_connections->clear();
+  }
 }
 } /* namespace directordaemon */

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -125,10 +125,7 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
-static void CleanupConnectionPool()
-{
-  cleanup_connection_pool(client_connections);
-}
+static void CleanupConnectionPool() { client_connections.cleanup(); }
 
 extern "C" void* connect_thread(void* arg)
 {
@@ -193,7 +190,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    client_connections.lock()->clear();
+    client_connections.clear();
     return false;
   }
   return true;
@@ -241,6 +238,6 @@ void StopSocketServer()
     BnetStopAndWaitForThreadServerTcp(tcp_server_tid);
     server_running = false;
   }
-  client_connections.lock()->clear();
+  client_connections.clear();
 }
 } /* namespace directordaemon */

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1270,7 +1270,7 @@ static void ListConnectedClients(UaContext* ua)
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  auto conn_info = get_connection_info(get_client_connections());
+  auto conn_info = get_client_connections().info();
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1265,28 +1265,25 @@ static void ListTerminatedJobs(UaContext* ua)
 
 static void ListConnectedClients(UaContext* ua)
 {
-  Connection* connection = NULL;
-  alist<Connection*>* connections = NULL;
   const char* separator = "====================";
   char dt[MAX_TIME_LENGTH];
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  connections = get_client_connections()->get_as_alist();
+  auto conn_info = get_connection_info(get_client_connections());
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,
                        separator, separator, separator);
   ua->send->ArrayStart("client-connection");
-  foreach_alist (connection, connections) {
+  for (auto& info : conn_info) {
     ua->send->ObjectStart();
-    bstrftime_nc(dt, sizeof(dt), connection->ConnectTime());
+    bstrftime_nc(dt, sizeof(dt), info.connect_time);
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
-    ua->send->ObjectKeyValue("protocol_version", connection->protocol_version(),
+    ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", connection->authenticated(),
-                             "%-20d");
-    ua->send->ObjectKeyValue("name", connection->name(), "%-40s");
+    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");
   }

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1282,7 +1282,7 @@ static void ListConnectedClients(UaContext* ua)
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
     ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("authenticated", true, "%-20d");
     ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");

--- a/core/src/filed/heartbeat.cc
+++ b/core/src/filed/heartbeat.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -112,16 +112,15 @@ extern "C" void* sd_heartbeat_thread(void* arg)
 /* Startup the heartbeat thread -- see above */
 void StartHeartbeatMonitor(JobControlRecord* jcr)
 {
-  /*
-   * If no signals are set, do not start the heartbeat because
+  /* If no signals are set, do not start the heartbeat because
    * it gives a constant stream of TIMEOUT_SIGNAL signals that
-   * make debugging impossible.
-   */
+   * make debugging impossible. */
   if (!no_signals) {
     jcr->fd_impl->hb_bsock = NULL;
     jcr->fd_impl->hb_running = false;
     jcr->fd_impl->hb_initialized_once = false;
     jcr->fd_impl->hb_dir_bsock = NULL;
+    jcr->dir_bsock->SetLocking();
     pthread_create(&jcr->fd_impl->heartbeat_id, NULL, sd_heartbeat_thread,
                    (void*)jcr);
   }

--- a/core/src/lib/connection_pool.cc
+++ b/core/src/lib/connection_pool.cc
@@ -32,17 +32,6 @@
 #include <chrono>
 #include <thread>
 
-// connection
-connection::connection(std::string_view name,
-                       int protocol_version,
-                       BareosSocket* socket,
-                       bool authenticated)
-    : connection_info{std::string{name}, protocol_version, authenticated,
-                      time(nullptr)}
-    , socket{socket}
-{
-}
-
 void connection::socket_closer::operator()(BareosSocket* socket)
 {
   if (socket) {

--- a/core/src/lib/connection_pool.h
+++ b/core/src/lib/connection_pool.h
@@ -42,21 +42,21 @@ class BareosSocket;
 struct connection_info {
   std::string name{};
   int protocol_version{};
-  bool authenticated{};
   time_t connect_time{};
 };
 
 struct connection : public connection_info {
   struct socket_closer {
-    void operator()(BareosSocket*);
+    void operator()(BareosSocket* socket);
   };
   using sock_ptr = std::unique_ptr<BareosSocket, socket_closer>;
 
   connection() = default;
-  connection(std::string_view name,
-             int protocol_version,
-             BareosSocket* socket,
-             bool authenticated = true);
+  connection(std::string_view name, int protocol_version, BareosSocket* socket)
+      : connection_info{std::string{name}, protocol_version, time(nullptr)}
+      , socket{socket}
+  {
+  }
 
   connection(const connection&) = delete;
   connection& operator=(const connection&) = delete;

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,9 +54,15 @@ class locked {
   const T& operator*() const { return *data; }
   const T* operator->() const { return data; }
 
-  template <typename Pred> void wait(std::condition_variable& cv, Pred&& p)
+  template <typename CondVar, typename P> void wait(CondVar& cv, P&& pred)
   {
-    cv.wait(lock, [this, p = std::move(p)] { return p(*data); });
+    cv.wait(lock, [this, pred = std::move(pred)] { return pred(*data); });
+  }
+
+  template <typename CondVar, typename TimePoint>
+  std::cv_status wait_until(CondVar& cv, TimePoint tp)
+  {
+    return cv.wait_until(lock, tp);
   }
 
  private:

--- a/core/src/plugins/filed/CMakeLists.txt
+++ b/core/src/plugins/filed/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -75,6 +75,11 @@ endif()
 if(NOT HAVE_WIN32)
   add_library(example-plugin-fd MODULE example/example-plugin-fd.cc)
   set_target_properties(example-plugin-fd PROPERTIES PREFIX "")
+endif()
+
+if(NOT HAVE_WIN32)
+  add_library(spam-plugin-fd MODULE spam/spam.cc)
+  set_target_properties(spam-plugin-fd PROPERTIES PREFIX "")
 endif()
 
 option(ENABLE_GFAPI_FD "Build gfapi-fd plugin if possible" ON)

--- a/core/src/plugins/filed/spam/spam.cc
+++ b/core/src/plugins/filed/spam/spam.cc
@@ -1,0 +1,140 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#define BUILD_PLUGIN
+#define BUILDING_DLL /* required for Windows plugin */
+
+#include <cinttypes>
+#include <ctime>
+#include "include/bareos.h"
+#include "filed/fd_plugins.h"
+
+#define PLUGIN_LICENSE "Bareos AGPLv3"
+#define PLUGIN_AUTHOR "Sebastian Sura"
+#define PLUGIN_DATE "January 2024"
+#define PLUGIN_VERSION "1"
+#define PLUGIN_DESCRIPTION "Spamming File Daemon Plugin"
+
+namespace filedaemon {
+namespace {
+CoreFunctions* bareos = NULL;
+thread_local std::size_t num_messages = 0;
+
+#define Jmsg(ctx, type, fmt, ...)                                           \
+  bareos->JobMessage((ctx), __FILE__, __LINE__, (type), std::time(nullptr), \
+                     (fmt), __VA_ARGS__)
+
+template <typename... Events>
+void RegisterEvents(PluginContext* ctx, Events... events)
+{
+  bareos->registerBareosEvents(ctx, sizeof...(events), events...);
+}
+
+bRC newPlugin(PluginContext* ctx)
+{
+  RegisterEvents(ctx, bEventBackupCommand);
+  return bRC_OK;
+}
+bRC freePlugin(PluginContext*) { return bRC_OK; }
+bRC getPluginValue(PluginContext*, pVariable, void*) { return bRC_OK; }
+bRC setPluginValue(PluginContext*, pVariable, void*) { return bRC_OK; }
+bRC handlePluginEvent(PluginContext*, bEvent*, void*) { return bRC_OK; }
+bRC startBackupFile(PluginContext* ctx, save_pkt*)
+{
+  if (num_messages < 50'000) {
+    Jmsg(ctx, M_INFO, "I am spamming (%llu)\n", num_messages++);
+    return bRC_Skip;
+  }
+
+  return bRC_Stop;
+}
+bRC endBackupFile(PluginContext*) { return bRC_OK; }
+bRC pluginIO(PluginContext*, io_pkt* io)
+{
+  io->status = 0;
+  io->io_errno = 0;
+  return bRC_OK;
+}
+
+bRC startRestoreFile(PluginContext*, const char*) { return bRC_OK; }
+bRC endRestoreFile(PluginContext*) { return bRC_OK; }
+bRC createFile(PluginContext*, restore_pkt*) { return bRC_OK; }
+bRC setFileAttributes(PluginContext*, restore_pkt*) { return bRC_OK; }
+bRC getAcl(PluginContext*, acl_pkt*) { return bRC_OK; }
+bRC setAcl(PluginContext*, acl_pkt*) { return bRC_OK; }
+bRC getXattr(PluginContext*, xattr_pkt*) { return bRC_OK; }
+bRC setXattr(PluginContext*, xattr_pkt*) { return bRC_OK; }
+bRC checkFile(PluginContext*, char*) { return bRC_OK; }
+
+PluginInformation pluginInfo = {sizeof(pluginInfo),
+                                FD_PLUGIN_INTERFACE_VERSION,
+                                FD_PLUGIN_MAGIC,
+                                PLUGIN_LICENSE,
+                                PLUGIN_AUTHOR,
+                                PLUGIN_DATE,
+                                PLUGIN_VERSION,
+                                PLUGIN_DESCRIPTION,
+                                nullptr};
+
+PluginFunctions pluginFuncs = {sizeof(pluginFuncs),
+                               FD_PLUGIN_INTERFACE_VERSION,
+                               &newPlugin,
+                               &freePlugin,
+                               &getPluginValue,
+                               &setPluginValue,
+                               &handlePluginEvent,
+                               &startBackupFile,
+                               &endBackupFile,
+                               &startRestoreFile,
+                               &endRestoreFile,
+                               &pluginIO,
+                               &createFile,
+                               &setFileAttributes,
+                               &checkFile,
+                               &getAcl,
+                               &setAcl,
+                               &getXattr,
+                               &setXattr};
+};  // namespace
+
+extern "C" {
+
+// Plugin called here when it is first loaded
+bRC loadPlugin(PluginApiDefinition*,
+               CoreFunctions* bareos_core_functions,
+               PluginInformation** plugin_information,
+               PluginFunctions** plugin_functions)
+{
+  bareos = bareos_core_functions;
+  *plugin_information = &pluginInfo;
+  *plugin_functions = &pluginFuncs;
+
+  return bRC_OK;
+}
+
+/*
+ * Plugin called here when it is unloaded, normally when
+ *  Bareos is going to exit.
+ */
+bRC unloadPlugin() { return bRC_OK; }
+}
+
+} /* namespace filedaemon */

--- a/systemtests/tests/CMakeLists.txt
+++ b/systemtests/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -48,6 +48,7 @@ add_subdirectory(fileset-multiple-blocks)
 add_subdirectory(filesets)
 add_subdirectory(gfapi-fd)
 add_subdirectory(glusterfs-backend)
+add_subdirectory(heartbeat-interval)
 add_subdirectory(list-backups)
 add_subdirectory(messages)
 add_subdirectory(multiplied-device)

--- a/systemtests/tests/heartbeat-interval/CMakeLists.txt
+++ b/systemtests/tests/heartbeat-interval/CMakeLists.txt
@@ -1,0 +1,26 @@
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
+
+if(TARGET python3-fd)
+  create_systemtest(${SYSTEMTEST_PREFIX} "${BASENAME}")
+else()
+  create_systemtest(${SYSTEMTEST_PREFIX} "${BASENAME}" DISABLED)
+endif()

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/catalog/MyCatalog.conf.in
@@ -1,0 +1,6 @@
+Catalog {
+  Name = MyCatalog
+  dbname = "@db_name@"
+  dbuser = "@db_user@"
+  dbpassword = "@db_password@"
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -1,0 +1,7 @@
+Client {
+  Name = bareos-fd
+  Description = "Client resource of the Director itself."
+  Address = localhost
+  Password = "@fd_password@"          # password for FileDaemon
+  FD PORT = @fd_port@
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/director/bareos-dir.conf.in
@@ -1,0 +1,11 @@
+Director {
+  Name = bareos-dir
+  QueryFile = "@scriptdir@/query.sql"
+  Maximum Concurrent Jobs = 10
+  Password = "@dir_password@"
+  Messages = Daemon
+  Auditing = yes
+
+  Working Directory =  "@working_dir@"
+  DirPort = @dir_port@
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/Catalog.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "Catalog"
+  Description = "Backup the catalog dump and Bareos configuration files."
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    File = "@working_dir@/@db_name@.sql" # database dump
+    File = "@confdir@"                   # configuration
+  }
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/PluginTest.conf.in
@@ -1,0 +1,7 @@
+FileSet {
+  Name = "PluginTest"
+  Description = "Another fileset."
+  Include {
+    Plugin = "spam-plugin"
+  }
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/fileset/SelfTest.conf.in
@@ -1,0 +1,10 @@
+FileSet {
+  Name = "SelfTest"
+  Description = "fileset just to backup some files for selftest"
+  Include {
+    Options {
+      Signature = XXH128
+    }
+    File=<@tmpdir@/file-list
+  }
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/job/RestoreFiles.conf.in
@@ -1,0 +1,11 @@
+Job {
+  Name = "RestoreFiles"
+  Description = "Standard Restore template. Only one such job is needed for all standard Jobs/Clients/Storage ..."
+  Type = Restore
+  Client = bareos-fd
+  FileSet = SelfTest
+  Storage = File
+  Pool = Incremental
+  Messages = Standard
+  Where = @tmp@/bareos-restores
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
@@ -1,0 +1,6 @@
+Job {
+  Name = "backup-bareos-fd"
+  JobDefs = "DefaultJob"
+  Client = "bareos-fd"
+  FileSet = "PluginTest"
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/jobdefs/DefaultJob.conf.in
@@ -1,0 +1,15 @@
+JobDefs {
+  Name = "DefaultJob"
+  Type = Backup
+  Level = Incremental
+  Client = bareos-fd
+  FileSet = "SelfTest"
+  Storage = File
+  Messages = Standard
+  Pool = Incremental
+  Priority = 10
+  Write Bootstrap = "@working_dir@/%c.bsr"
+  Full Backup Pool = Full                  # write Full Backups into "Full" Pool
+  Differential Backup Pool = Differential  # write Diff Backups into "Differential" Pool
+  Incremental Backup Pool = Incremental    # write Incr Backups into "Incremental" Pool
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Daemon.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Daemon
+  Description = "Message delivery for daemon messages (no job)."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !audit
+  append = "@logdir@/bareos-audit.log" = audit
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -1,0 +1,7 @@
+Messages {
+  Name = Standard
+  Description = "Reasonable message delivery -- send most everything to email address and to the console."
+  console = all, !skipped, !saved, !audit
+  append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
+  catalog = all, !skipped, !saved, !audit
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Differential.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Differential.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Differential
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 90 days          # How long should the Differential Backups be kept? (#09)
+  Maximum Volume Bytes = 10G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Differential-"      # Volumes will be labeled "Differential-<volume-id>"
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Full.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Full.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Full
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 365 days         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Incremental.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Incremental.conf
@@ -1,0 +1,10 @@
+Pool {
+  Name = Incremental
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 30 days          # How long should the Incremental Backups be kept?  (#12)
+  Maximum Volume Bytes = 1G           # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Incremental-"       # Volumes will be labeled "Incremental-<volume-id>"
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Scratch.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/pool/Scratch.conf
@@ -1,0 +1,4 @@
+Pool {
+  Name = Scratch
+  Pool Type = Scratch
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/profile/operator.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/profile/operator.conf
@@ -1,0 +1,18 @@
+Profile {
+   Name = operator
+   Description = "Profile allowing normal Bareos operations."
+
+   Command ACL = !.bvfs_clear_cache, !.exit, !.sql
+   Command ACL = !configure, !create, !delete, !purge, !prune, !sqlquery, !umount, !unmount
+   Command ACL = *all*
+
+   Catalog ACL = *all*
+   Client ACL = *all*
+   FileSet ACL = *all*
+   Job ACL = *all*
+   Plugin Options ACL = *all*
+   Pool ACL = *all*
+   Schedule ACL = *all*
+   Storage ACL = *all*
+   Where ACL = *all*
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/storage/File.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/storage/File.conf.in
@@ -1,0 +1,8 @@
+Storage {
+  Name = File
+  Address = @hostname@
+  Password = "@sd_password@"
+  Device = FileStorage
+  Media Type = File
+  SD Port = @sd_port@
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,0 +1,16 @@
+Client {
+  Name = @basename@-fd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all filedaemon plugins (*-fd.so) from the "Plugin Directory".
+  #
+  Plugin Directory = "@FD_PLUGINS_DIR_TO_TEST@"
+  Plugin Names = "spam-plugin"
+
+  Working Directory =  "@working_dir@"
+  FD Port = @fd_port@
+
+  Heartbeat Interval = 1s
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@fd_password@"
+  Description = "Allow the configured Director to access this file daemon."
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/messages/Standard.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all, !skipped, !restored
+  Description = "Send relevant messages to the Director."
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/device/FileStorage.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/device/FileStorage.conf
@@ -1,0 +1,12 @@
+Device {
+  Name = FileStorage
+  Media Type = File
+  Archive Device = storage
+  LabelMedia = yes;                   # lets Bareos label unlabeled media
+  Random Access = yes;
+  AutomaticMount = yes;               # when device opened, read it
+  RemovableMedia = no;
+  AlwaysOpen = no;
+  Description = "File device. A connecting Director must have the same Name and MediaType."
+  Maximum Concurrent Jobs = 1
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/director/bareos-dir.conf.in
@@ -1,0 +1,5 @@
+Director {
+  Name = bareos-dir
+  Password = "@sd_password@"
+  Description = "Director, who is permitted to contact this storage daemon."
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/messages/Standard.conf
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/messages/Standard.conf
@@ -1,0 +1,5 @@
+Messages {
+  Name = Standard
+  Director = bareos-dir = all
+  Description = "Send all messages to the Director."
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,0 +1,14 @@
+Storage {
+  Name = bareos-sd
+  Maximum Concurrent Jobs = 20
+
+  # remove comment from "Plugin Directory" to load plugins from specified directory.
+  # if "Plugin Names" is defined, only the specified plugins will be loaded,
+  # otherwise all storage plugins (*-sd.so) from the "Plugin Directory".
+  #
+  # Plugin Directory = "@python_plugin_module_src_sd@"
+  # Plugin Names = ""
+  Working Directory =  "@working_dir@"
+  SD Port = @sd_port@
+  @sd_backend_config@
+}

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bconsole.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bconsole.conf.in
@@ -1,0 +1,10 @@
+#
+# Bareos User Agent (or Console) Configuration File
+#
+
+Director {
+  Name = @basename@-dir
+  DIRport = @dir_port@
+  Address = @hostname@
+  Password = "@dir_password@"
+}

--- a/systemtests/tests/heartbeat-interval/functions
+++ b/systemtests/tests/heartbeat-interval/functions
@@ -1,0 +1,8 @@
+#!/bin/bash -x
+#
+# Utility functions for the testrunners
+#
+runner_name="$(basename "$0")"
+log_home="${tmp}/${runner_name}"
+mkdir -p "${log_home}"
+default_joblist="${log_home}/jobs.out"

--- a/systemtests/tests/heartbeat-interval/test-setup
+++ b/systemtests/tests/heartbeat-interval/test-setup
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+"${rscripts}"/cleanup
+"${rscripts}"/setup
+
+bin/bareos start
+bin/bareos status
+
+# make sure, director is up and running.
+print_debug "$(bin/bconsole <<< "status dir")"

--- a/systemtests/tests/heartbeat-interval/testrunner-check
+++ b/systemtests/tests/heartbeat-interval/testrunner-check
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+#
+# Run a simple "backup" and check for backup errors
+#    hopefully caused by heartbeat interval
+#
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+#shellcheck source=functions
+. functions
+
+start_test
+
+cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out /dev/null
+messages
+@$out $log_home/create-backup.out
+setdebug level=100 all trace=1
+label volume=TestVolume001 storage=File pool=Full
+run job=$JobName yes
+status director
+status client
+status storage=File
+wait
+messages
+@$out $log_home/jobs.out
+list jobs
+quit
+END_OF_DATA
+
+run_bconsole
+check_for_zombie_jobs storage=File
+
+expect_grep "Backup OK" \
+	    "$log_home/create-backup.out" \
+	    "Backup was not created correctly."
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr fixes data races related to the connection_pool on the director and the heartbeat threads and the fd.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
