### PR TITLE
core: Fix compile errors on GCC 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix continuation on colons in plugin baseclass [PR #1637]
 - plugins: fix cancel handling crash [PR #1595]
 - Fix bareos_tasks plugin for pgsql [PR #1659]
+- core: Fix compile errors on GCC 14 [PR #1687]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -93,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1684]: https://github.com/bareos/bareos/pull/1684
 [PR #1685]: https://github.com/bareos/bareos/pull/1685
 [PR #1686]: https://github.com/bareos/bareos/pull/1686
+[PR #1687]: https://github.com/bareos/bareos/pull/1687
 [PR #1688]: https://github.com/bareos/bareos/pull/1688
 [PR #1695]: https://github.com/bareos/bareos/pull/1695
 [PR #1696]: https://github.com/bareos/bareos/pull/1696

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -31,6 +31,7 @@
  */
 
 #include "include/bareos.h"
+#include <algorithm>
 
 #if HAVE_POSTGRESQL
 

--- a/core/src/dird/ua_prune.cc
+++ b/core/src/dird/ua_prune.cc
@@ -40,6 +40,8 @@
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
 
+#include <algorithm>
+
 namespace directordaemon {
 
 /* Forward referenced functions */

--- a/core/src/dird/ua_prune.cc
+++ b/core/src/dird/ua_prune.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -42,6 +42,7 @@
 #include "lib/berrno.h"
 #include "lib/crypto.h"
 
+#include <algorithm>
 #include <thread>
 #include <variant>
 #include <deque>

--- a/core/src/tests/addresses_and_ports_config.cc
+++ b/core/src/tests/addresses_and_ports_config.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,7 @@
 #include "lib/address_conf.h"
 #include "lib/watchdog.h"
 #include "lib/berrno.h"
+#include <algorithm>
 
 static bool create_and_bind_v4socket(int test_fd, int port)
 {


### PR DESCRIPTION
Starting in GCC 14, it will no longer include `<algorithm>` by default, resulting in compile errors for various projects.

https://gcc.gnu.org/gcc-14/porting_to.html

Errors:
```
core/src/cats/sql_get.cc:1309:42: error: cannot convert 'std::vector<std::__cxx11::basic_string<char> >::iterator' to `const char*'

  1309 | jobids.erase(std::remove(jobids.begin(), jobids.end(),
    remove_jobid),

core/src/stored/append.cc:78:3: error: `for_each' was not declared in this scope

 78 |   for_each(attributes_.begin(), attributes_.end(),

core/src/dird/ua_prune.cc:897:27: error: `remove_if' is not a member of `std'; did you mean `remove_cv'?

  897 |     prune_list.erase(std::remove_if(prune_list.begin(),
     prune_list.end(),
```

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- ~Your name is present in the AUTHORS file (optional)~

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
