### PR TITLE
stored: fix storage daemon crash if passive client is unreachable, create better session keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bnet-server-tcp: split socket creation from listening for unittests [PR #1649]
 - webui: Backup Unit Report fixes [PR #1696]
 - windows: fix calculation of "job_metadata.xml" object size [PR #1695]
+- stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1688]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -85,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1678]: https://github.com/bareos/bareos/pull/1678
 [PR #1683]: https://github.com/bareos/bareos/pull/1683
 [PR #1684]: https://github.com/bareos/bareos/pull/1684
+[PR #1688]: https://github.com/bareos/bareos/pull/1688
 [PR #1695]: https://github.com/bareos/bareos/pull/1695
 [PR #1696]: https://github.com/bareos/bareos/pull/1696
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -691,35 +691,24 @@ int DoShellExpansion(char* name, int name_len)
 }
 #endif
 
-/*
- * MAKESESSIONKEY  --  Generate session key with optional start
- *                     key.  If mode is TRUE, the key will be
- *                     translated to a string, otherwise it is
- *                     returned as 16 binary bytes.
- *
- *  from SpeakFreely by John Walker
- */
-void MakeSessionKey(char* key, char*, int mode)
+/* Create a new session key. key needs to be able to hold at least
+ * 32 + 7 (separator) + 1 (null) = 40 bytes. */
+void MakeSessionKey(char key[40])
 {
   unsigned char s[16];
   RAND_bytes(s, sizeof(s));
 
-  if (mode) {
-    for (int j = 0; j < 16; j++) {
-      unsigned char rb = s[j];
+  for (int j = 0; j < 16; j++) {
+    char low = (s[j] & 0x0F);
+    char high = (s[j] & 0xF0) >> 4;
 
-#define Rad16(x) ((x) + 'A')
-      *key++ = Rad16((rb >> 4) & 0xF);
-      *key++ = Rad16(rb & 0xF);
-#undef Rad16
-      if (j & 1) { *key++ = '-'; }
-    }
-    *--key = 0;
-  } else {
-    for (int j = 0; j < 16; j++) { key[j] = s[j]; }
+    *key++ = 'A' + low;
+    *key++ = 'A' + high;
+
+    if (j & 1) { *key++ = '-'; }
   }
+  *--key = 0;
 }
-#undef nextrand
 
 /*
  * Edit job codes into main command line

--- a/core/src/lib/util.cc
+++ b/core/src/lib/util.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,6 +43,8 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <openssl/rand.h>
 
 // Various BAREOS Utility subroutines
 
@@ -697,76 +699,24 @@ int DoShellExpansion(char* name, int name_len)
  *
  *  from SpeakFreely by John Walker
  */
-void MakeSessionKey(char* key, char* seed, int mode)
+void MakeSessionKey(char* key, char*, int mode)
 {
-  int j, k;
-  MD5_CTX md5c;
-  unsigned char md5key[16], md5key1[16];
-  char s[1024];
-  constexpr int32_t ss = sizeof(s);
+  unsigned char s[16];
+  RAND_bytes(s, sizeof(s));
 
-  s[0] = 0;
-  if (seed != NULL) { bstrncat(s, seed, sizeof(s)); }
-
-  /* The following creates a seed for the session key generator
-   * based on a collection of volatile and environment-specific
-   * information unlikely to be vulnerable (as a whole) to an
-   * exhaustive search attack.  If one of these items isn't
-   * available on your machine, replace it with something
-   * equivalent or, if you like, just delete it. */
-#if defined(HAVE_WIN32)
-  {
-    LARGE_INTEGER li;
-    DWORD length;
-    FILETIME ft;
-
-    Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)GetCurrentProcessId());
-    (void)!getcwd(s + strlen(s), 256);
-    Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)GetTickCount());
-    QueryPerformanceCounter(&li);
-    Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)li.LowPart);
-    GetSystemTimeAsFileTime(&ft);
-    Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)ft.dwLowDateTime);
-    Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)ft.dwHighDateTime);
-    length = 256;
-    GetComputerName(s + strlen(s), &length);
-    length = 256;
-    GetUserName(s + strlen(s), &length);
-  }
-#else
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)getpid());
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)getppid());
-  (void)!getcwd(s + strlen(s), 256);
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)clock());
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)time(NULL));
-#  if defined(Solaris)
-  sysinfo(SI_HW_SERIAL, s + strlen(s), 12);
-#  endif
-  gethostname(s + strlen(s), 256);
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)getuid());
-  Bsnprintf(s + strlen(s), ss, "%lu", (uint32_t)getgid());
-#endif
-  ALLOW_DEPRECATED(MD5_Init(&md5c); MD5_Update(&md5c, (uint8_t*)s, strlen(s));
-                   MD5_Final(md5key, &md5c);
-                   Bsnprintf(s + strlen(s), ss, "%lu",
-                             (uint32_t)((time(NULL) + 65121) ^ 0x375F));
-                   MD5_Init(&md5c); MD5_Update(&md5c, (uint8_t*)s, strlen(s));
-                   MD5_Final(md5key1, &md5c);)
-
-#define nextrand (md5key[j] ^ md5key1[j])
   if (mode) {
-    for (j = k = 0; j < 16; j++) {
-      unsigned char rb = nextrand;
+    for (int j = 0; j < 16; j++) {
+      unsigned char rb = s[j];
 
 #define Rad16(x) ((x) + 'A')
-      key[k++] = Rad16((rb >> 4) & 0xF);
-      key[k++] = Rad16(rb & 0xF);
+      *key++ = Rad16((rb >> 4) & 0xF);
+      *key++ = Rad16(rb & 0xF);
 #undef Rad16
-      if (j & 1) { key[k++] = '-'; }
+      if (j & 1) { *key++ = '-'; }
     }
-    key[--k] = 0;
+    *--key = 0;
   } else {
-    for (j = 0; j < 16; j++) { key[j] = nextrand; }
+    for (int j = 0; j < 16; j++) { key[j] = s[j]; }
   }
 }
 #undef nextrand

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -67,7 +67,7 @@ const char* job_type_to_str(int type);
 const char* job_replace_to_str(int relace);
 const char* job_status_to_str(int stat);
 const char* job_level_to_str(int level);
-void MakeSessionKey(char key[40]);
+bool MakeSessionKey(char key[120]);
 POOLMEM* edit_job_codes(JobControlRecord* jcr,
                         char* omsg,
                         const char* imsg,

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -67,7 +67,7 @@ const char* job_type_to_str(int type);
 const char* job_replace_to_str(int relace);
 const char* job_status_to_str(int stat);
 const char* job_level_to_str(int level);
-void MakeSessionKey(char* key, char* seed, int mode);
+void MakeSessionKey(char key[40]);
 POOLMEM* edit_job_codes(JobControlRecord* jcr,
                         char* omsg,
                         const char* imsg,

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -394,7 +394,8 @@ static bool SetdebugCmd(JobControlRecord* jcr)
     scan = sscanf(dir->msg, setdebugv0cmd, &level, &trace_flag);
   }
   if ((scan != 3 && scan != 2) || level < 0) {
-    dir->fsend(BADcmd, "setdebug", dir->msg);
+    std::string cpy{dir->msg};
+    dir->fsend(BADcmd, "setdebug", cpy.c_str());
     return false;
   }
 
@@ -432,7 +433,8 @@ static bool SetdeviceCmd(JobControlRecord* jcr)
   int scan = sscanf(dir->msg, setdevice_autoselect, device_name.data(),
                     &autoselect_value);
   if (scan != 2) {
-    dir->fsend(BADcmd, "setdevice", dir->msg);
+    std::string cpy{dir->msg};
+    dir->fsend(BADcmd, "setdevice", cpy.c_str());
     return false;
   }
 
@@ -1579,7 +1581,8 @@ class ReplicateCmdConnectState {
         || state_ == ReplicateCmdState::kError) {
       if (!jcr_) { return; }
       if (jcr_->dir_bsock) {
-        jcr_->dir_bsock->fsend(BADcmd, "replicate", jcr_->dir_bsock->msg);
+        std::string cpy{jcr_->dir_bsock->msg};
+        jcr_->dir_bsock->fsend(BADcmd, "replicate", cpy.c_str());
       }
       jcr_->store_bsock = nullptr;
     }
@@ -1605,7 +1608,8 @@ static bool ReplicateCmd(JobControlRecord* jcr)
   if (sscanf(dir->msg, replicatecmd, &JobId, JobName, stored_addr, &stored_port,
              &tls_policy, sd_auth_key.c_str())
       != 6) {
-    dir->fsend(BADcmd, "replicate", dir->msg);
+    std::string cpy{dir->msg};
+    dir->fsend(BADcmd, "replicate", cpy.c_str());
     return false;
   }
 
@@ -1700,11 +1704,13 @@ static bool PassiveCmd(JobControlRecord* jcr)
   char filed_addr[MAX_NAME_LENGTH];
   BareosSocket* dir = jcr->dir_bsock;
   BareosSocket* fd; /* file daemon bsock */
+  std::string cpy{dir->msg};
 
-  Dmsg1(100, "PassiveClientCmd: %s", dir->msg);
-  if (sscanf(dir->msg, passiveclientcmd, filed_addr, &filed_port, &tls_policy)
+  Dmsg1(100, "PassiveClientCmd: %s", cpy.c_str());
+  if (sscanf(cpy.c_str(), passiveclientcmd, filed_addr, &filed_port,
+             &tls_policy)
       != 3) {
-    PmStrcpy(jcr->errmsg, dir->msg);
+    PmStrcpy(jcr->errmsg, cpy.c_str());
     Jmsg(jcr, M_FATAL, 0, T_("Bad passiveclientcmd command: %s"), jcr->errmsg);
     goto bail_out;
   }
@@ -1769,7 +1775,7 @@ static bool PassiveCmd(JobControlRecord* jcr)
   return dir->fsend(OKpassive);
 
 bail_out:
-  dir->fsend(BADcmd, "passive client");
+  dir->fsend(BADcmd, "passive client", cpy.c_str());
   return false;
 }
 
@@ -1777,10 +1783,11 @@ static bool PluginoptionsCmd(JobControlRecord* jcr)
 {
   BareosSocket* dir = jcr->dir_bsock;
   char plugin_options[2048];
+  std::string cpy{dir->msg};
 
-  Dmsg1(100, "PluginOptionsCmd: %s", dir->msg);
-  if (sscanf(dir->msg, pluginoptionscmd, plugin_options) != 1) {
-    PmStrcpy(jcr->errmsg, dir->msg);
+  Dmsg1(100, "PluginOptionsCmd: %s", cpy.c_str());
+  if (sscanf(cpy.c_str(), pluginoptionscmd, plugin_options) != 1) {
+    PmStrcpy(jcr->errmsg, cpy.c_str());
     Jmsg(jcr, M_FATAL, 0, T_("Bad pluginoptionscmd command: %s"), jcr->errmsg);
     goto bail_out;
   }
@@ -1795,7 +1802,7 @@ static bool PluginoptionsCmd(JobControlRecord* jcr)
   return dir->fsend(OKpluginoptions);
 
 bail_out:
-  dir->fsend(BADcmd, "plugin options");
+  dir->fsend(BADcmd, "plugin options", cpy.c_str());
   return false;
 }
 

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -154,7 +154,11 @@ bool job_cmd(JobControlRecord* jcr)
   Dmsg1(50, "Quota set as %llu\n", quota);
 
   // Pass back an authorization key for the File daemon
-  MakeSessionKey(auth_key);
+  if (!MakeSessionKey(auth_key)) {
+    Jmsg2(jcr, M_FATAL, 0, "Could not generate authentication key: %s.\n",
+          auth_key);
+    return false;
+  }
   jcr->sd_auth_key = strdup(auth_key);
   dir->fsend(OK_job, jcr->VolSessionId, jcr->VolSessionTime, auth_key);
   memset(auth_key, 0, sizeof(auth_key));
@@ -251,7 +255,11 @@ bool nextRunCmd(JobControlRecord* jcr)
       jcr->authenticated = false;
 
       // Pass back a new authorization key for the File daemon
-      MakeSessionKey(auth_key);
+      if (!MakeSessionKey(auth_key)) {
+        Jmsg1(jcr, M_FATAL, 0, "Could not generate authentication key: %s.\n",
+              auth_key);
+        return false;
+      }
       if (jcr->sd_auth_key) { free(jcr->sd_auth_key); }
       jcr->sd_auth_key = strdup(auth_key);
       dir->fsend(OK_nextrun, auth_key);

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -76,7 +76,6 @@ bool job_cmd(JobControlRecord* jcr)
 {
   int32_t JobId;
   char auth_key[MAX_NAME_LENGTH];
-  char seed[MAX_NAME_LENGTH];
   char spool_size[MAX_NAME_LENGTH];
   BareosSocket* dir = jcr->dir_bsock;
   PoolMem job_name, client_name, job, fileset_name, fileset_md5, backup_format;
@@ -155,8 +154,7 @@ bool job_cmd(JobControlRecord* jcr)
   Dmsg1(50, "Quota set as %llu\n", quota);
 
   // Pass back an authorization key for the File daemon
-  Bsnprintf(seed, sizeof(seed), "%p%d", jcr, JobId);
-  MakeSessionKey(auth_key, seed, 1);
+  MakeSessionKey(auth_key);
   jcr->sd_auth_key = strdup(auth_key);
   dir->fsend(OK_job, jcr->VolSessionId, jcr->VolSessionTime, auth_key);
   memset(auth_key, 0, sizeof(auth_key));
@@ -240,7 +238,6 @@ bool DoJobRun(JobControlRecord* jcr)
 bool nextRunCmd(JobControlRecord* jcr)
 {
   char auth_key[MAX_NAME_LENGTH];
-  char seed[MAX_NAME_LENGTH];
   BareosSocket* dir = jcr->dir_bsock;
   struct timeval tv;
   struct timezone tz;
@@ -254,8 +251,7 @@ bool nextRunCmd(JobControlRecord* jcr)
       jcr->authenticated = false;
 
       // Pass back a new authorization key for the File daemon
-      Bsnprintf(seed, sizeof(seed), "%p%d", jcr, jcr->JobId);
-      MakeSessionKey(auth_key, seed, 1);
+      MakeSessionKey(auth_key);
       if (jcr->sd_auth_key) { free(jcr->sd_auth_key); }
       jcr->sd_auth_key = strdup(auth_key);
       dir->fsend(OK_nextrun, auth_key);

--- a/systemtests/tests/passive/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
+++ b/systemtests/tests/passive/etc/bareos/bareos-dir.d/client/bareos-fd.conf.in
@@ -4,4 +4,6 @@ Client {
   Address = @hostname@
   Password = "@fd_password@"          # password for FileDaemon
   FD PORT = @fd_port@
+
+  Passive = Yes
 }

--- a/systemtests/tests/passive/testrunner
+++ b/systemtests/tests/passive/testrunner
@@ -54,4 +54,13 @@ check_for_zombie_jobs storage=File
 
 check_two_logs
 check_restore_diff ${BackupDirectory}
+
+expect_grep "bareos-sd JobId 1: Connected File Daemon at" \
+	    "$tmp/log1.out" \
+	    "Client was not passive during backup"
+
+expect_grep "bareos-sd JobId 2: Connected File Daemon at" \
+	    "$tmp/log2.out" \
+	    "Client was not passive during restore"
+
 end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr fixes some crashes related to passive clients.
It also slightly alters how the sd generates session keys. 

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
