### PR TITLE
python-bareos: integrate usage of config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - filed: fix vss during client initiated connections [PR #1666]
 - Make BareosDirPluginPrometheusExporter.py work with python3 [PR #1679]
 - Improve FreeBSD dependencies [PR #1680]
+- python-bareos: integrate usage of config files [PR #1690]
 
 ## [23.0.1] - 2024-01-17
 
@@ -393,4 +394,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1675]: https://github.com/bareos/bareos/pull/1675
 [PR #1679]: https://github.com/bareos/bareos/pull/1679
 [PR #1680]: https://github.com/bareos/bareos/pull/1680
+[PR #1690]: https://github.com/bareos/bareos/pull/1690
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/contrib/misc/bareos_pam_integration/pam_exec_add_bareos_user.py
+++ b/contrib/misc/bareos_pam_integration/pam_exec_add_bareos_user.py
@@ -7,8 +7,7 @@ It can be used to auto-create users that do already exist as PAM users as Bareos
 Requires Bareos >= 19.2.4.
 """
 
-from __future__ import print_function
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 import bareos.exceptions
 import logging

--- a/contrib/misc/bareos_pam_integration/pam_exec_add_bareos_user.py
+++ b/contrib/misc/bareos_pam_integration/pam_exec_add_bareos_user.py
@@ -8,7 +8,7 @@ Requires Bareos >= 19.2.4.
 """
 
 from __future__ import print_function
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 import bareos.exceptions
 import logging

--- a/contrib/misc/triggerjob/bareos-triggerjob.py
+++ b/contrib/misc/triggerjob/bareos-triggerjob.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 import logging
 import sys

--- a/contrib/misc/triggerjob/bareos-triggerjob.py
+++ b/contrib/misc/triggerjob/bareos-triggerjob.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 import logging
 import sys

--- a/docs/pkglists/Debian_10.x86_64
+++ b/docs/pkglists/Debian_10.x86_64
@@ -1,5 +1,4 @@
 all/bareos-webui
-all/python-bareos
 all/python3-bareos
 amd64/bareos
 amd64/bareos-bconsole

--- a/docs/pkglists/Debian_11.x86_64
+++ b/docs/pkglists/Debian_11.x86_64
@@ -1,5 +1,4 @@
 all/bareos-webui
-all/python-bareos
 all/python3-bareos
 amd64/bareos
 amd64/bareos-bconsole

--- a/docs/pkglists/Debian_12.x86_64
+++ b/docs/pkglists/Debian_12.x86_64
@@ -1,5 +1,4 @@
 all/bareos-webui
-all/python-bareos
 all/python3-bareos
 amd64/bareos
 amd64/bareos-bconsole

--- a/docs/pkglists/xUbuntu_20.04.x86_64
+++ b/docs/pkglists/xUbuntu_20.04.x86_64
@@ -1,5 +1,4 @@
 all/bareos-webui
-all/python-bareos
 all/python3-bareos
 amd64/bareos
 amd64/bareos-bconsole

--- a/docs/pkglists/xUbuntu_22.04.x86_64
+++ b/docs/pkglists/xUbuntu_22.04.x86_64
@@ -1,5 +1,4 @@
 all/bareos-webui
-all/python-bareos
 all/python3-bareos
 amd64/bareos
 amd64/bareos-bconsole

--- a/python-bareos/bareos/bsock/directorconsole.py
+++ b/python-bareos/bareos/bsock/directorconsole.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -61,8 +61,9 @@ class DirectorConsole(LowLevel):
            >>> director = DirectorConsole(**bareos_args)
 
         Args:
-          argparser (ArgParser): ArgParser instance.
+          argparser (ArgParser or ConfigArgParser): (Config)ArgParser instance.
         """
+
         argparser.add_argument(
             "--name",
             default="*UserAgent*",

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -71,7 +71,7 @@ class LowLevel(object):
     def argparser_get_bareos_parameter(args):
         """Extract arguments.
 
-        This method is usally used together with the method :py:func:`argparser_add_default_command_line_arguments`.
+        This method is usually used together with the method :py:func:`argparser_add_default_command_line_arguments`.
 
         Args:
            args (ArgParser.Namespace): Arguments retrieved by :py:func:`ArgumentParser.parse_args`.

--- a/python-bareos/bareos/util/argparse.py
+++ b/python-bareos/bareos/util/argparse.py
@@ -17,19 +17,28 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-have_configargparse = False
+"""
+ArgumentParser wrapper.
+
+Uses configargparse, if available,
+otherwise, falls back to argparse.
+"""
+
+HAVE_CONFIG_ARG_PARSE_MODULE = False
 try:
     import configargparse as argparse
 
-    have_configargparse = True
+    HAVE_CONFIG_ARG_PARSE_MODULE = True
 except ImportError:
     import argparse
 
 
 class ArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser wrapper"""
+
     def __init__(self, *args, **kwargs):
-        super(ArgumentParser, self).__init__(*args, **kwargs)
-        if have_configargparse:
+        super().__init__(*args, **kwargs)
+        if HAVE_CONFIG_ARG_PARSE_MODULE:
             self.add_argument(
                 "-c", "--config", is_config_file=True, help="Config file path."
             )

--- a/python-bareos/bareos/util/argparse.py
+++ b/python-bareos/bareos/util/argparse.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -17,14 +17,19 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-"""
-Bareos utility classes.
-"""
+have_configargparse = False
+try:
+    import configargparse as argparse
 
-from bareos.util.argparse import ArgumentParser
-from bareos.util.bareosbase64 import BareosBase64
-from bareos.util.password import Password
-from bareos.util.path import Path
-from bareos.util.version import Version
+    have_configargparse = True
+except ImportError:
+    import argparse
 
-__all__ = ["ArgumentParser", "BareosBase64", "Password", "Path", "Version"]
+
+class ArgumentParser(argparse.ArgumentParser):
+    def __init__(self, *args, **kwargs):
+        super(ArgumentParser, self).__init__(*args, **kwargs)
+        if have_configargparse:
+            self.add_argument(
+                "-c", "--config", is_config_file=True, help="Config file path."
+            )

--- a/python-bareos/bareos/util/path.py
+++ b/python-bareos/bareos/util/path.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -20,8 +20,6 @@
 """
 Handle file paths.
 """
-
-from copy import copy
 
 
 class Path(object):
@@ -55,7 +53,7 @@ class Path(object):
         self.path = None
 
     def set_path(self, path):
-        if path == None:
+        if path is None:
             self.__set_defaults()
         elif isinstance(path, str):
             self.path_orig = path
@@ -76,10 +74,9 @@ class Path(object):
             pass
 
     def get(self, index=None):
-        if index == None:
+        if index is None:
             return self.path
-        else:
-            return self.path[index]
+        return self.path[index]
 
     def shift(self):
         """

--- a/python-bareos/bin/bareos-fd-connect.py
+++ b/python-bareos/bin/bareos-fd-connect.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -18,8 +19,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 from bareos.bsock.filedaemon import FileDaemon
 import logging
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     logger.debug("options: %s" % (bareos_args))
     try:
         bsock = FileDaemon(**bareos_args)
-    except (bareos.exceptions.Error) as e:
+    except bareos.exceptions.Error as e:
         print(str(e))
         sys.exit(1)
     logger.debug("authentication successful")

--- a/python-bareos/bin/bareos-fd-connect.py
+++ b/python-bareos/bin/bareos-fd-connect.py
@@ -19,7 +19,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 from bareos.bsock.filedaemon import FileDaemon
 import logging

--- a/python-bareos/bin/bareos-jsonrpc-server.py
+++ b/python-bareos/bin/bareos-jsonrpc-server.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -20,7 +21,7 @@
 
 
 from __future__ import print_function
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 import bareos.exceptions
 import inspect
@@ -116,7 +117,7 @@ if __name__ == "__main__":
     logger.debug("options: %s" % (bareos_args))
     try:
         director = bareos.bsock.DirectorConsoleJson(**bareos_args)
-    except (bareos.exceptions.ConnectionError) as e:
+    except bareos.exceptions.ConnectionError as e:
         print(str(e))
         sys.exit(1)
     logger.debug("authentication successful")

--- a/python-bareos/bin/bareos-jsonrpc-server.py
+++ b/python-bareos/bin/bareos-jsonrpc-server.py
@@ -20,8 +20,7 @@
 #   02110-1301, USA.
 
 
-from __future__ import print_function
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 import bareos.exceptions
 import inspect

--- a/python-bareos/bin/bconsole-json.py
+++ b/python-bareos/bin/bconsole-json.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -20,7 +21,7 @@
 
 
 from __future__ import print_function
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 import bareos.exceptions
 import logging
@@ -53,7 +54,7 @@ if __name__ == "__main__":
     logger.debug("options: %s" % (bareos_args))
     try:
         director = bareos.bsock.DirectorConsoleJson(**bareos_args)
-    except (bareos.exceptions.Error) as e:
+    except bareos.exceptions.Error as e:
         print(str(e))
         sys.exit(1)
 

--- a/python-bareos/bin/bconsole-json.py
+++ b/python-bareos/bin/bconsole-json.py
@@ -20,8 +20,7 @@
 #   02110-1301, USA.
 
 
-from __future__ import print_function
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 import bareos.exceptions
 import logging

--- a/python-bareos/bin/bconsole.py
+++ b/python-bareos/bin/bconsole.py
@@ -19,8 +19,7 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-from __future__ import print_function
-import bareos.util.argparse as argparse
+from bareos.util import argparse
 import bareos.bsock
 import bareos.exceptions
 import logging

--- a/python-bareos/bin/bconsole.py
+++ b/python-bareos/bin/bconsole.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -18,9 +19,8 @@
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
 
-
 from __future__ import print_function
-import argparse
+import bareos.util.argparse as argparse
 import bareos.bsock
 import bareos.exceptions
 import logging
@@ -34,6 +34,8 @@ def getArguments():
     )
     bareos.bsock.DirectorConsole.argparser_add_default_command_line_arguments(argparser)
     args = argparser.parse_args()
+    if args.debug:
+        print(argparser.format_values())
     return args
 
 
@@ -51,7 +53,7 @@ if __name__ == "__main__":
     logger.debug("options: %s" % (bareos_args))
     try:
         director = bareos.bsock.DirectorConsole(**bareos_args)
-    except (bareos.exceptions.Error) as e:
+    except bareos.exceptions.Error as e:
         print(str(e))
         sys.exit(1)
 

--- a/python-bareos/debian/control
+++ b/python-bareos/debian/control
@@ -3,21 +3,22 @@ Maintainer: Bareos Team <packager@bareos.com>
 Section: python
 Priority: optional
 Build-Depends: debhelper (>= 7.4.3),
-  python-all (>= 2.6.6-3) <bullseye> <buster> <stretch> <xenial> <bionic>,
-  python-setuptools (>= 0.6b3) <bullseye> <buster> <stretch> <xenial> <bionic>,
+  python-all        <buster> <bullseye> <bionic> <jammy>,
+  python-setuptools <buster> <bullseye> <bionic> <jammy>,
   python3-all, python3-setuptools
 Standards-Version: 3.9.1
 
 Package: python-bareos
 Architecture: all
 Depends: ${misc:Depends}, ${python:Depends}
+Recommends: python-configargparse
 Description: Backup Archiving REcovery Open Sourced - python module (Python 2)
  This packages contains a python module to interact with a Bareos backup system.
  It also includes some tools based on this module.
 
 Package: python3-bareos
 Architecture: all
-Depends: ${misc:Depends}, ${python3:Depends}
+Depends: ${misc:Depends}, ${python3:Depends}, python3-configargparse
 Description: Backup Archiving REcovery Open Sourced - python module (Python 3)
  This packages contains a python module to interact with a Bareos backup system.
  It also includes some tools based on this module.

--- a/python-bareos/debian/control
+++ b/python-bareos/debian/control
@@ -2,19 +2,8 @@ Source: python-bareos
 Maintainer: Bareos Team <packager@bareos.com>
 Section: python
 Priority: optional
-Build-Depends: debhelper (>= 7.4.3),
-  python-all        <buster> <bullseye> <bionic> <jammy>,
-  python-setuptools <buster> <bullseye> <bionic> <jammy>,
-  python3-all, python3-setuptools
+Build-Depends: debhelper (>= 7.4.3), python3-all, python3-setuptools
 Standards-Version: 3.9.1
-
-Package: python-bareos
-Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}
-Recommends: python-configargparse
-Description: Backup Archiving REcovery Open Sourced - python module (Python 2)
- This packages contains a python module to interact with a Bareos backup system.
- It also includes some tools based on this module.
 
 Package: python3-bareos
 Architecture: all

--- a/python-bareos/debian/rules
+++ b/python-bareos/debian/rules
@@ -4,4 +4,4 @@
 export PYBUILD_NAME = bareos
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild

--- a/python-bareos/packaging/python-bareos.spec
+++ b/python-bareos/packaging/python-bareos.spec
@@ -4,18 +4,6 @@
 
 # based on
 # https://docs.fedoraproject.org/en-US/packaging-guidelines/Python_Appendix/
-# specifically on
-# https://pagure.io/packaging-committee/blob/ae14fdb50cc6665a94bc32f7d984906ce1eece45/f/guidelines/modules/ROOT/pages/Python_Appendix.adoc
-#
-
-#
-# For current distribution, create
-# python2-bareos and python3-bareos packages.
-#
-# CentOS 6 supports only Python2.
-#
-# CentOS <= 7 and SLES <= 12,
-# the Python2 package is namend python-bareos (instead of python2-bareos).
 #
 
 %global srcname bareos
@@ -48,6 +36,10 @@ It also includes some tools based on this module.}
 Summary:        %{summary}
 BuildRequires:  %{python3_build_requires}
 %{?python_provide:%python_provide python3-%{srcname}}
+%if 0%{?fedora} || 0%{?rhel} >= 8 || 0%{?suse_version} || 0%{?sle_version}
+# Recommends is not supported on RHEL <= 7.
+Recommends:     python3-configargparse
+%endif
 
 %description -n python3-%{srcname} %_description
 

--- a/python-bareos/setup.py
+++ b/python-bareos/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -61,11 +61,8 @@ setup(
     description="Client library and tools for Bareos console access.",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    # Python 2.6 is used by RHEL/Centos 6.
-    # When RHEL/Centos 6 is no longer supported (End of 2020),
-    # Python 2.6 will no longer be supported by python-bareos.
-    python_requires=">=2.6",
-    extras_require={"TLS-PSK": ["sslpsk"]},
+    python_requires=">=2.7",
+    extras_require={"TLS-PSK": ["sslpsk"], "configfile": ["configargparse"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",

--- a/python-bareos/setup.py
+++ b/python-bareos/setup.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python
+#
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
 #   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
@@ -61,7 +62,8 @@ setup(
     description="Client library and tools for Bareos console access.",
     long_description=open("README.rst").read(),
     long_description_content_type="text/x-rst",
-    python_requires=">=2.7",
+    # RHEL7: python-3.6
+    python_requires=">=3.6",
     extras_require={"TLS-PSK": ["sslpsk"], "configfile": ["configargparse"]},
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/systemtests/tests/py3plug-fd-postgresql/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgresql/database/setup_local_db.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -78,9 +78,11 @@ local_db_start_server() {
 local_db_create_superuser_role() {
   if [ $UID -eq 0 ]; then
     su postgres -c "${POSTGRES_BIN_PATH}/psql -h \"$1\" -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'"
+    su postgres -c "${POSTGRES_BIN_PATH}/psql -h \"$1\" -d postgres -c 'CREATE DATABASE root WITH OWNER root'"
   else
     # create role and db root for podman test.
     ${POSTGRES_BIN_PATH}/psql -h "$1" -d postgres -c 'CREATE ROLE root WITH SUPERUSER CREATEDB CREATEROLE REPLICATION LOGIN'
+    ${POSTGRES_BIN_PATH}/psql -h "$1" -d postgres -c 'CREATE DATABASE root WITH OWNER root'
   fi
 }
 


### PR DESCRIPTION
**Backport of PR #1678 to bareos-23**

Adding excluding packaging for python2

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
- [x] Original PR #1678 is merged
- [x] All functional differences to the original PR are documented above
