### PR TITLE
windows: fix calculation of "job_metadata.xml" object size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: cleanup [PR #1661]
 - bnet-server-tcp: split socket creation from listening for unittests [PR #1649]
 - webui: Backup Unit Report fixes [PR #1696]
+- windows: fix calculation of "job_metadata.xml" object size [PR #1695]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -84,5 +85,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1678]: https://github.com/bareos/bareos/pull/1678
 [PR #1683]: https://github.com/bareos/bareos/pull/1683
 [PR #1684]: https://github.com/bareos/bareos/pull/1684
+[PR #1695]: https://github.com/bareos/bareos/pull/1695
 [PR #1696]: https://github.com/bareos/bareos/pull/1696
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1851,7 +1851,7 @@ static void CloseVssBackupSession(JobControlRecord* jcr)
       ff_pkt->LinkFI = 0;
       ff_pkt->object_name = (char*)"job_metadata.xml";
       ff_pkt->object = BSTR_2_str(metadata);
-      ff_pkt->object_len = (wcslen(metadata) + 1) * sizeof(wchar_t);
+      ff_pkt->object_len = strlen(ff_pkt->object) + 1;
       ff_pkt->object_index = (int)time(NULL);
       SaveFile(jcr, ff_pkt, true);
     }

--- a/core/src/win32/compat/glob.cc
+++ b/core/src/win32/compat/glob.cc
@@ -1,7 +1,7 @@
 /**
  * @file glob.c
  * Copyright (C) 2011-2013, MinGW.org project.
- * Copyright (C) 2016-2022 Bareos GmbH & Co. KG
+ * Copyright (C) 2016-2024 Bareos GmbH & Co. KG
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -59,10 +59,8 @@ enum
    */
   __GLOB_DIRONLY_OFFSET = __GLOB_FLAG_OFFSET_HIGH_WATER_MARK,
   __GLOB_PERIOD_PRIVATE_OFFSET,
-  /*
-   * For congruency, set a new high water mark above the private data
-   * range, (which we don't otherwise use).
-   */
+  /* For congruency, set a new high water mark above the private data
+   * range, (which we don't otherwise use). */
   __GLOB_PRIVATE_FLAGS_HIGH_WATER_MARK
 };
 
@@ -75,7 +73,6 @@ enum
 #  define GLOB_INLINE static __inline__ __attribute__((__always_inline__))
 #endif
 
-//#define GLOB_HARD_ESC __CRT_GLOB_ESCAPE_CHAR__
 #define GLOB_HARD_ESC (char)(127)
 
 #if defined _WIN32 || defined __MS_DOS__
@@ -142,48 +139,38 @@ static int IsGlobPattern(const char* pattern, int flags)
        */
       if (((flags & GLOB_NOESCAPE) == 0) && (c == glob_escape_char)
           && (*p++ == '\0'))
-        /*
-         * We found an escape character, (and the escape mechanism has
+        /* We found an escape character, (and the escape mechanism has
          * not been disabled), but there is no following character to
          * escape; it may be malformed, but this certainly doesn't look
-         * like a candidate globbing pattern.
-         */
+         * like a candidate globbing pattern. */
         return 0;
 
       else if (bracket == 0) {
         /* Still outside of any bracketted character set...
          */
         if ((c == '*') || (c == '?'))
-          /*
-           * ...either of these makes "pattern" an explicit
-           * globbing pattern...
-           */
+          /* ...either of these makes "pattern" an explicit
+           * globbing pattern... */
           return 1;
 
         if (c == '[')
-          /*
-           * ...while this marks the start of a bracketted
-           * character set.
-           */
+          /* ...while this marks the start of a bracketted
+           * character set. */
           bracket++;
       }
 
       else if ((bracket > 1) && (c == ']'))
-        /*
-         * Within a bracketted character set, where it is not
+        /* Within a bracketted character set, where it is not
          * the first character, ']' marks the end of the set,
-         * making "pattern" a globbing pattern.
-         */
+         * making "pattern" a globbing pattern. */
         return 1;
 
       else if (c != '!')
-        /*
-         * Also within a bracketted character set, '!' is special
+        /* Also within a bracketted character set, '!' is special
          * when the first character, and shouldn't be counted; note
          * that it should be counted when not the first character,
          * but the short count resulting from ignoring it doesn't
-         * affect our desired outcome.
-         */
+         * affect our desired outcome. */
         bracket++;
     }
   }
@@ -212,17 +199,13 @@ static const char* glob_set_adjusted(const char* pattern, int flags)
     /* We haven't found it yet; advance by one character...
      */
     if ((*p == glob_escape_char) && ((flags & GLOB_NOESCAPE) == 0))
-      /*
-       * ...or maybe even two, when we identify a need to
-       * step over any character which has been escaped...
-       */
+      /* ...or maybe even two, when we identify a need to
+       * step over any character which has been escaped... */
       p++;
 
     if (*p++ == '\0')
-      /*
-       * ...but if we find a NUL on the way, then the pattern
-       * is malformed, so we return NULL to report a bad match.
-       */
+      /* ...but if we find a NUL on the way, then the pattern
+       * is malformed, so we return NULL to report a bad match. */
       return NULL;
   }
   /* We found the expected ']'; return a pointer to the NEXT
@@ -303,24 +286,18 @@ static const char* glob_in_set(const char* set, int test, int flags)
      */
 
     if ((c == '\0')
-        /*
-         * This is a malformed set; (not closed before the end of
-         * the pattern)...
-         */
+        /* This is a malformed set; (not closed before the end of
+         * the pattern)... */
         || glob_is_dirsep(c))
-      /*
-       * ...or it attempts to explicitly match a directory separator,
+      /* ...or it attempts to explicitly match a directory separator,
        * which is invalid in this context.  We MUST fail it, in either
-       * case, reporting a mismatch.
-       */
+       * case, reporting a mismatch. */
       return NULL;
 
     if (c == test)
-      /*
-       * We found the test character within the set; adjust the pattern
+      /* We found the test character within the set; adjust the pattern
        * reference, to resume after the end of the set, and return the
-       * successful match.
-       */
+       * successful match. */
       return glob_set_adjusted(set, flags);
 
     /* If we get to here, we haven't yet found the test character within
@@ -361,12 +338,10 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
   int c;
 
   if ((*t == '.') && (*p != '.') && ((flags & GLOB_PERIOD) == 0))
-    /*
-     * The special GNU extension allowing wild cards to match a period
+    /* The special GNU extension allowing wild cards to match a period
      * as first character is NOT in effect; "text" DOES have an initial
      * period character AND "pattern" DOES NOT match it EXPLICITLY, so
-     * this comparison must report a MISMATCH.
-     */
+     * this comparison must report a MISMATCH. */
     return *p - *t;
 
   /* Attempt to match "pattern", character by character...
@@ -395,11 +370,9 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
         /* ...and if we've exhausted the pattern...
          */
         if (*p == '\0')
-          /*
-           * ...then we simply match all remaining characters,
+          /* ...then we simply match all remaining characters,
            * to the end of "text", so we may return immediately,
-           * reporting a successful match.
-           */
+           * reporting a successful match. */
           return 0;
 
         /* When we haven't exhausted the pattern, then we may
@@ -414,10 +387,8 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
         do {
           c = GlobStrcmp(p, t, flags | GLOB_PERIOD);
         } while ((c != 0) && (*t++ != '\0'));
-        /*
-         * ...and ultimately, we return the result of this
-         * recursive attempt to find a match.
-         */
+        /* ...and ultimately, we return the result of this
+         * recursive attempt to find a match. */
         return c;
 
       case '[':
@@ -426,10 +397,8 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
          * a set of characters in the pattern...
          */
         if ((c = *t++) == '\0')
-          /*
-           * ...but, we must return a mismatch if there is no
-           * candidate character left to match.
-           */
+          /* ...but, we must return a mismatch if there is no
+           * candidate character left to match. */
           return '[';
 
         if (*p == '!') {
@@ -446,10 +415,8 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
           p = glob_in_set(p, c, flags);
         }
         if (p == NULL)
-          /*
-           * The character under test didn't satisfy the SET
-           * matching criterion; return as unmatched.
-           */
+          /* The character under test didn't satisfy the SET
+           * matching criterion; return as unmatched. */
           return ']';
         break;
 
@@ -461,15 +428,11 @@ static int GlobStrcmp(const char* pattern, const char* text, int flags)
          * glob() call...
          */
         if (((flags & GLOB_NOESCAPE) == 0)
-            /*
-             * ...but when it is active, and we find an escape
-             * character without exhausting the pattern...
-             */
+            /* ...but when it is active, and we find an escape
+             * character without exhausting the pattern... */
             && (c == glob_escape_char) && ((c = *p) != 0))
-          /*
-           * ...then we handle the escaped character here, as
-           * a literal, and step over it, within the pattern.
-           */
+          /* ...then we handle the escaped character here, as
+           * a literal, and step over it, within the pattern. */
           ++p;
 
         /* When we get to here, a successful match requires that
@@ -591,10 +554,8 @@ static int GlobStoreEntry(char* path, glob_t* gl_buf)
      */
     gl_buf->gl_pathv = pathv;
     gl_buf->gl_pathv[gl_buf->gl_offs + gl_buf->gl_pathc++] = path;
-    /*
-     * ...then place a further NULL pointer into the newly allocated
-     * slot, to mark the new end of the vector...
-     */
+    /* ...then place a further NULL pointer into the newly allocated
+     * slot, to mark the new end of the vector... */
     gl_buf->gl_pathv[gl_buf->gl_offs + gl_buf->gl_pathc] = NULL;
     // ...before returning a successful completion status.
     return GLOB_SUCCESS;
@@ -677,10 +638,8 @@ static void glob_store_collated_entries(struct glob_collator* collator,
    * data contained thereon.
    */
   if (collator->prev != NULL)
-    /*
-     * Recurse into the sub-tree of entries which collate before the
-     * root of the current (sub-)tree.
-     */
+    /* Recurse into the sub-tree of entries which collate before the
+     * root of the current (sub-)tree. */
     glob_store_collated_entries(collator->prev, gl_buf);
 
   /* Store the path name entry at the root of the current (sub-)tree.
@@ -688,10 +647,8 @@ static void glob_store_collated_entries(struct glob_collator* collator,
   GlobStoreEntry(collator->entry, gl_buf);
 
   if (collator->next != NULL)
-    /*
-     * Recurse into the sub-tree of entries which collate after the
-     * root of the current (sub-)tree.
-     */
+    /* Recurse into the sub-tree of entries which collate after the
+     * root of the current (sub-)tree. */
     glob_store_collated_entries(collator->next, gl_buf);
 
   /* Finally, delete the root node of the current (sub-)tree; since
@@ -717,8 +674,8 @@ static int glob_match(const char* pattern,
 
   /* Begin by separating out any path prefix from the glob pattern.
    */
-  char dirbuf[1 + strlen(pattern)];
-  const char* dir = dirname((char*)memcpy(dirbuf, pattern, sizeof(dirbuf)));
+  std::string dirbuf(pattern);
+  const char* dir = dirname(dirbuf.data());
   char **dirp, preferred_dirsep = GLOB_DIRSEP;
 
   /* Initialise a temporary local glob_t structure, to capture the
@@ -732,10 +689,8 @@ static int glob_match(const char* pattern,
   /* Check if there are any globbing tokens in the path prefix...
    */
   if (IsGlobPattern(dir, flags))
-    /*
-     * ...and recurse to identify all possible matching prefixes,
-     * as may be necessary...
-     */
+    /* ...and recurse to identify all possible matching prefixes,
+     * as may be necessary... */
     status = glob_match(dir, flags | GLOB_DIRONLY, errfn, &local_gl_buf);
 
   else
@@ -810,10 +765,8 @@ static int glob_match(const char* pattern,
            * directory, in turn, then...
            */
           if ((((flags & GLOB_DIRONLY) == 0) || GLOB_ISDIR(*dirp, entry))
-              /*
-               * ...provided we don't require it to be a subdirectory,
-               * or it actually is one...
-               */
+              /* ...provided we don't require it to be a subdirectory,
+               * or it actually is one... */
               && (GlobStrcmp(pattern, entry->d_name, flags) == 0)) {
             /* ...and it is a globbed match for the pattern, then
              * we allocate a temporary local buffer of sufficient
@@ -839,10 +792,8 @@ static int glob_match(const char* pattern,
              * the heap, for assignment into gl_buf->gl_pathv...
              */
             if ((found = glob_strdup(matchpath)) == NULL)
-              /*
-               * ...setting the appropriate error code, in the
-               * event that the heap memory has been exhausted.
-               */
+              /* ...setting the appropriate error code, in the
+               * event that the heap memory has been exhausted. */
               status = GLOB_NOSPACE;
 
             else { /* This glob match has been successfully recorded on
@@ -877,23 +828,19 @@ static int glob_match(const char* pattern,
       /* In the event of failure to open the candidate prefix directory...
        */
       else if ((flags & GLOB_ERR) || ((errfn != NULL) && errfn(*dirp, errno)))
-        /*
-         * ...and when the caller has set the GLOB_ERR flag, or has provided
+        /* ...and when the caller has set the GLOB_ERR flag, or has provided
          * an error handler which returns non-zero for the failure condition,
-         * then we schedule an abort.
-         */
+         * then we schedule an abort. */
         status = GLOB_ABORTED;
 
       /* When we diverted the glob results for collation...
        */
       if (collator != NULL)
-        /*
-         * ...then we redirect them to gl_buf->gl_pathv now, before we
+        /* ...then we redirect them to gl_buf->gl_pathv now, before we
          * begin a new cycle, to process any further prefix directories
          * which may have been identified; note that we do this even if
          * we scheduled an abort, so that we may return any results we
-         * may have already collected before the error occurred.
-         */
+         * may have already collected before the error occurred. */
         glob_store_collated_entries(collator, gl_buf);
     }
   }
@@ -995,11 +942,9 @@ int __mingw_glob(const char* pattern,
    */
   status = glob_match(pattern, flags, errfn, gl_data);
   if ((status == GLOB_NOMATCH) && ((flags & GLOB_NOCHECK) != 0))
-    /*
-     * ...ultimately delegating to glob_strdup() and GlobStoreEntry()
+    /* ...ultimately delegating to glob_strdup() and GlobStoreEntry()
      * to handle any unmatched globbing pattern which the user specified
-     * options may require to be stored anyway.
-     */
+     * options may require to be stored anyway. */
     GlobStoreEntry(glob_strdup(pattern), gl_data);
 
   /* We always return the status reported by glob_match().


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR fixes an issue on windows that causes bareos to miscalculate the size of a restore object.  This may cause the fd to crash.

This PR also removes the use of a vla inside our glob compability layer.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
