### PR TITLE
webui: Backup Unit Report fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python-bareos: integrate usage of config files [PR #1678]
 - cmake: cleanup [PR #1661]
 - bnet-server-tcp: split socket creation from listening for unittests [PR #1649]
+- webui: Backup Unit Report fixes [PR #1696]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -83,4 +84,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1678]: https://github.com/bareos/bareos/pull/1678
 [PR #1683]: https://github.com/bareos/bareos/pull/1683
 [PR #1684]: https://github.com/bareos/bareos/pull/1684
+[PR #1696]: https://github.com/bareos/bareos/pull/1696
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -69,21 +69,21 @@ The maximum command line length is limited to 511 characters, so if you are scri
 Exit the Console Program
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-:index:`\ <single: Command; bconsole; exit>`\
+.. index::
+   single: Command; bconsole; exit
 
 Normally, you simply enter quit or exit and the Console program will terminate. However, it waits until the Director acknowledges the command. If the Director is already doing a lengthy command (e.g. prune), it may take some time. If you want to immediately terminate the Console program, enter the .quit command.
 
 There is currently no way to interrupt a Console command once issued (i.e. Ctrl-C does not work). However, if you are at a prompt that is asking you to select one of several possibilities and you would like to abort the command, you can enter a period (.), and in most cases, you will either be returned to the main command prompt or if appropriate the previous prompt (in the case of nested prompts). In a few places such as where it is asking for a Volume name, the period will be taken to be the
 Volume name. In that case, you will most likely be able to cancel at the next prompt.
 
+.. _scripting:
+
 Running the Console from a Shell Script
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-:index:`\ <single: Console; Running from a Shell>`\
-
-.. _scripting:
-
-
+.. index::
+   single: Console; Running from a Shell
 
 You can automate many Console tasks by running the console program from a shell script. For example, if you have created a file containing the following commands:
 
@@ -1324,8 +1324,13 @@ status scheduler
    days=number
       of days shows only the number of days in the scheduler preview. Positive numbers show the future, negative numbers show the past. days can be combined with the other selection criteria. days= can be combined with the other selection criteria.
 
+
+.. _status-subscription:
+
 status subscriptions
-   In case you have a service contract for Bareos, the command :bcommand:`status subscriptions`  can help you to keep the overview over the subscriptions that are used.
+   In case you have a service contract for Bareos,
+   the command :bcommand:`status subscriptions` (:sinceVersion:`21: status subscriptions`)
+   can help you to keep the overview over the subscriptions that are used.
 
    Using the console command :bcommand:`status subscriptions`, the status of the subscriptions can be checked any time interactively:
 
@@ -1412,12 +1417,13 @@ time
 trace
    :index:`\ <single: Console; Command; trace>`\  Turn on/off trace to file.
 
-truncate
-   :index:`\ <single: Console; Command; truncate>`\  :index:`\ <single: Disk; Freeing disk space>`\  :index:`\ <single: Disk; Freeing disk space>`\
 
 .. _bcommandTruncate:
 
-
+truncate
+   .. index::
+      single: Console; Command; truncate
+      single: Disk; Freeing disk space
 
    If the status of a volume is **Purged**, it normally still contains data, even so it can not easily be accessed.
 

--- a/webui/module/Director/src/Director/Controller/DirectorController.php
+++ b/webui/module/Director/src/Director/Controller/DirectorController.php
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (C) 2013-2023 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2013-2024 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/webui/module/Director/src/Director/Controller/DirectorController.php
+++ b/webui/module/Director/src/Director/Controller/DirectorController.php
@@ -185,7 +185,8 @@ class DirectorController extends AbstractActionController
         $response->getHeaders()->addHeaderLine('Content-Disposition', 'attachment; filename="bareos-backup-unit-report.json"');
 
         if (isset($result)) {
-            $response->setContent(JSON::prettyPrint(JSON::encode($result)));
+            $json_backupunitreport = json_encode($result, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+            $response->setContent($json_backupunitreport);
         }
 
         return $response;

--- a/webui/module/Director/view/director/director/subscription.phtml
+++ b/webui/module/Director/view/director/director/subscription.phtml
@@ -5,7 +5,7 @@
  * bareos-webui - Bareos Web-Frontend
  *
  * @link      https://github.com/bareos/bareos for the canonical source repository
- * @copyright Copyright (C) 2022-2023 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @copyright Copyright (C) 2022-2024 Bareos GmbH & Co. KG (http://www.bareos.org/)
  * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
  *
  * This program is free software: you can redistribute it and/or modify

--- a/webui/module/Director/view/director/director/subscription.phtml
+++ b/webui/module/Director/view/director/director/subscription.phtml
@@ -101,9 +101,9 @@ Please request a quote by sending the report via email to <a href="mailto:sales@
 </div>
 
 <?php
-   if ($this->directorOutput) {
-      echo '<a class="btn btn-primary" href="/director/backupunitreport">Download Backup Unit Report (JSON)</a>';
-   }
+    if ($this->directorOutput) {
+        echo '<a class="btn btn-primary" href="' . $this->url('director', array('action' => 'backupunitreport')) . '">' . $this->translate('Download Backup Unit Report (JSON)') . '</a>';
+    }
 ?>
 
 <?php endif; ?>


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Fix the URL of the Backup Unit Report and prevent some unnecessary escapes in the JSON file.

OP#5697

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

