### PR TITLE
bareos-triggerjob: fix parameter handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: Backup Unit Report fixes [PR #1696]
 - windows: fix calculation of "job_metadata.xml" object size [PR #1695]
 - stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1688]
+- bareos-triggerjob: fix parameter handling [PR #1708]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -89,4 +90,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1688]: https://github.com/bareos/bareos/pull/1688
 [PR #1695]: https://github.com/bareos/bareos/pull/1695
 [PR #1696]: https://github.com/bareos/bareos/pull/1696
+[PR #1708]: https://github.com/bareos/bareos/pull/1708
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/directorconsole.py
+++ b/python-bareos/bareos/bsock/directorconsole.py
@@ -22,7 +22,6 @@ Send and receive the response to Bareos Director Daemon Console interface.
 """
 
 from bareos.bsock.connectiontype import ConnectionType
-from bareos.bsock.constants import Constants
 from bareos.bsock.lowlevel import LowLevel
 from bareos.bsock.protocolmessageids import ProtocolMessageIds
 from bareos.bsock.protocolmessages import ProtocolMessages
@@ -64,14 +63,16 @@ class DirectorConsole(LowLevel):
           argparser (ArgParser or ConfigArgParser): (Config)ArgParser instance.
         """
 
-        argparser.add_argument(
+        group = argparser.add_argument_group(title="Bareos Director connection options")
+
+        group.add_argument(
             "--name",
             default="*UserAgent*",
             help='use this to access a specific Bareos director named console. Otherwise it connects to the default console ("*UserAgent*").',
             dest="BAREOS_name",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "-p",
             "--password",
             help="Password to authenticate to a Bareos Director console.",
@@ -79,7 +80,7 @@ class DirectorConsole(LowLevel):
             dest="BAREOS_password",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--port",
             default=9101,
             help="Bareos Director network port.",
@@ -87,50 +88,48 @@ class DirectorConsole(LowLevel):
         )
 
         # argparser.add_argument('--dirname', help="Bareos Director name")
-        argparser.add_argument(
+        group.add_argument(
             "--address",
             default="localhost",
             help="Bareos Director network address.",
             dest="BAREOS_address",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--timeout",
             type=int,
             help="Timeout (in seconds) for the connection to the Bareos Director.",
             dest="BAREOS_timeout",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--protocolversion",
             default=ProtocolVersions.last,
             type=int,
-            help="Specify the Bareos console protocol version. Default: {0} (current).".format(
-                ProtocolVersions.last
-            ),
+            help="Specify the Bareos console protocol version. Default: %(default)s (current).",
             dest="BAREOS_protocolversion",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--pam-username",
             help="Username to authenticate against PAM on top off the normal authentication.",
             dest="BAREOS_pam_username",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--pam-password",
             help="Password to authenticate against PAM on top off the normal authentication.",
             dest="BAREOS_pam_password",
         )
 
-        argparser.add_argument(
+        group.add_argument(
             "--tls-psk-require",
             help="Allow only encrypted connections. Default: False.",
             action="store_true",
             dest="BAREOS_tls_psk_require",
         )
 
-        TlsVersionParser().add_argument(argparser)
+        TlsVersionParser().add_argument(group)
 
     def __init__(
         self,


### PR DESCRIPTION
Fix parameter handling of bareos-triggerjob (contrib)
and improve parameter help string of standard parameter.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

