### PR TITLE
core: fix various data races (connection_pool/heartbeat_thread)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1700]
 - bareos-triggerjob: fix parameter handling [PR #1709]
 - fvec: add mmap based vector  [PR #1706]
+- core: fix various data races (connection_pool/heartbeat_thread) [PR #1711]
 
 ### Fixed
 - core: Fix compile errors on GCC 14 [PR #1693]
@@ -413,4 +414,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1703]: https://github.com/bareos/bareos/pull/1703
 [PR #1706]: https://github.com/bareos/bareos/pull/1706
 [PR #1709]: https://github.com/bareos/bareos/pull/1709
+[PR #1711]: https://github.com/bareos/bareos/pull/1711
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1073,34 +1073,14 @@ void DoClientResolve(UaContext* ua, ClientResource* client)
   return;
 }
 
-class SocketGuard {
- public:
-  ~SocketGuard()
-  {
-    if (owns_) {
-      fd_->close();
-      delete fd_;
-    }
-  }
-
-  explicit SocketGuard(BareosSocket* fd) : fd_{fd} {}
-  void Release() { owns_ = false; }
-
- private:
-  bool owns_{true};
-  BareosSocket* fd_;
-};
-
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version)
 {
-  ClientResource* client_resource;
-  Connection* connection = NULL;
-  SocketGuard socket_guard{fd};
+  connection conn{client_name, fd_protocol_version, fd};
 
-  client_resource
+  auto client_resource
       = (ClientResource*)my_config->GetResWithName(R_CLIENT, client_name);
   if (!client_resource) {
     Emsg1(M_WARNING, 0,
@@ -1121,18 +1101,12 @@ void* HandleFiledConnection(ConnectionPool* connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connection
-      = connections->add_connection(client_name, fd_protocol_version, fd, true);
-  if (!connection) {
-    Emsg0(M_ERROR, 0, "Failed to add connection to pool.\n");
-    return NULL;
-  }
+  connections.lock()->emplace_back(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 
   /* The connection is now kept in the connection_pool.
    * This thread is no longer required and will end now. */
-  socket_guard.Release();
   return NULL;
 }
 } /* namespace directordaemon */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -1101,7 +1101,7 @@ void* HandleFiledConnection(connection_pool& connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connections.lock()->emplace_back(std::move(conn));
+  connections.add_authenticated_connection(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,12 +54,12 @@ bool SendRestoreObjects(JobControlRecord* jcr, JobId_t JobId, bool send_global);
 bool CancelFileDaemonJob(UaContext* ua, JobControlRecord* jcr);
 void DoNativeClientStatus(UaContext* ua, ClientResource* client, char* cmd);
 void DoClientResolve(UaContext* ua, ClientResource* client);
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version);
 
-ConnectionPool* get_client_connections();
+connection_pool& get_client_connections();
 bool IsConnectingToClientAllowed(ClientResource* res);
 bool IsConnectingToClientAllowed(JobControlRecord* jcr);
 bool IsClientTlsRequired(JobControlRecord* jcr);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -406,7 +406,7 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;
-      jcr->authenticated = connection->authenticated;
+      jcr->authenticated = true;
       Jmsg(jcr, M_INFO, 0, T_("Using Client Initiated Connection (%s).\n"),
            jcr->dir_impl->res.client->resource_name_);
       result = true;

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -400,8 +400,9 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
           jcr->dir_impl->res.client->resource_name_);
   } else {
-    auto connection = take_by_name(
-        connections, jcr->dir_impl->res.client->resource_name_, timeout);
+    auto connection
+        = connections.take_by_name(jcr->dir_impl->res.client->resource_name_,
+                                   std::chrono::seconds{timeout});
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -52,7 +52,7 @@ static char hello_client[] = "Hello Client %127s calling";
 static ThreadList thread_list;
 static alist<s_sockfd*>* sock_fds = NULL;
 static pthread_t tcp_server_tid;
-static connection_pool client_connections{};
+static std::unique_ptr<connection_pool> client_connections{nullptr};
 
 static std::atomic<BnetServerState> server_state(BnetServerState::kUndefined);
 
@@ -65,7 +65,7 @@ struct s_addr_port {
 #define MIN_MSG_LEN 15
 #define MAX_MSG_LEN (int)sizeof(name) + 25
 
-connection_pool& get_client_connections() { return client_connections; }
+connection_pool& get_client_connections() { return *client_connections.get(); }
 
 static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
 {
@@ -110,7 +110,7 @@ static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
       || (sscanf(bs->msg, hello_client, name) == 1)) {
     Dmsg1(110, "Got a FD connection at %s\n",
           bstrftimes(tbuf, sizeof(tbuf), (utime_t)time(NULL)));
-    return HandleFiledConnection(client_connections, bs, name,
+    return HandleFiledConnection(*client_connections.get(), bs, name,
                                  fd_protocol_version);
   }
   return HandleUserAgentClientRequest(bs);
@@ -125,7 +125,10 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
-static void CleanupConnectionPool() { client_connections.cleanup(); }
+static void CleanupConnectionPool()
+{
+  if (client_connections) { client_connections->cleanup(); }
+}
 
 extern "C" void* connect_thread(void* arg)
 {
@@ -146,13 +149,11 @@ extern "C" void* connect_thread(void* arg)
  */
 bool StartSocketServer(dlist<IPADDR>* addrs)
 {
-  int status;
+  if (!client_connections) { client_connections.reset(new connection_pool{}); }
 
-  server_state.store(BnetServerState::kUndefined);
-
-  if ((status
-       = pthread_create(&tcp_server_tid, nullptr, connect_thread, (void*)addrs))
-      != 0) {
+  if (int status
+      = pthread_create(&tcp_server_tid, nullptr, connect_thread, (void*)addrs);
+      status != 0) {
     BErrNo be;
     Emsg1(M_ABORT, 0, T_("Cannot create UA thread: %s\n"),
           be.bstrerror(status));
@@ -166,7 +167,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    client_connections.clear();
+    client_connections->clear();
     return false;
   }
   return true;
@@ -179,6 +180,9 @@ void StopSocketServer()
     delete sock_fds;
     sock_fds = nullptr;
   }
-  client_connections.clear();
+  if (client_connections) {
+    // client_connections can be NULL if the socket server was never started.
+    client_connections->clear();
+  }
 }
 } /* namespace directordaemon */

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -52,7 +52,7 @@ static char hello_client[] = "Hello Client %127s calling";
 static ThreadList thread_list;
 static alist<s_sockfd*>* sock_fds = NULL;
 static pthread_t tcp_server_tid;
-static ConnectionPool* client_connections = NULL;
+static connection_pool client_connections{};
 
 static std::atomic<BnetServerState> server_state(BnetServerState::kUndefined);
 
@@ -65,7 +65,7 @@ struct s_addr_port {
 #define MIN_MSG_LEN 15
 #define MAX_MSG_LEN (int)sizeof(name) + 25
 
-ConnectionPool* get_client_connections() { return client_connections; }
+connection_pool& get_client_connections() { return client_connections; }
 
 static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
 {
@@ -127,7 +127,7 @@ static void* UserAgentShutdownCallback(void* bsock)
 
 static void CleanupConnectionPool()
 {
-  if (client_connections) { client_connections->cleanup(); }
+  cleanup_connection_pool(client_connections);
 }
 
 extern "C" void* connect_thread(void* arg)
@@ -151,10 +151,6 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
 {
   int status;
 
-  if (client_connections == nullptr) {
-    client_connections = new ConnectionPool();
-  }
-
   server_state.store(BnetServerState::kUndefined);
 
   if ((status
@@ -173,10 +169,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    if (client_connections) {
-      delete (client_connections);
-      client_connections = nullptr;
-    }
+    client_connections.lock()->clear();
     return false;
   }
   return true;
@@ -189,9 +182,6 @@ void StopSocketServer()
     delete sock_fds;
     sock_fds = nullptr;
   }
-  if (client_connections) {
-    delete (client_connections);
-    client_connections = nullptr;
-  }
+  client_connections.lock()->clear();
 }
 } /* namespace directordaemon */

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -125,10 +125,7 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
-static void CleanupConnectionPool()
-{
-  cleanup_connection_pool(client_connections);
-}
+static void CleanupConnectionPool() { client_connections.cleanup(); }
 
 extern "C" void* connect_thread(void* arg)
 {
@@ -169,7 +166,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    client_connections.lock()->clear();
+    client_connections.clear();
     return false;
   }
   return true;
@@ -182,6 +179,6 @@ void StopSocketServer()
     delete sock_fds;
     sock_fds = nullptr;
   }
-  client_connections.lock()->clear();
+  client_connections.clear();
 }
 } /* namespace directordaemon */

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1270,7 +1270,7 @@ static void ListConnectedClients(UaContext* ua)
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  auto conn_info = get_connection_info(get_client_connections());
+  auto conn_info = get_client_connections().info();
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1265,28 +1265,25 @@ static void ListTerminatedJobs(UaContext* ua)
 
 static void ListConnectedClients(UaContext* ua)
 {
-  Connection* connection = NULL;
-  alist<Connection*>* connections = NULL;
   const char* separator = "====================";
   char dt[MAX_TIME_LENGTH];
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  connections = get_client_connections()->get_as_alist();
+  auto conn_info = get_connection_info(get_client_connections());
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,
                        separator, separator, separator);
   ua->send->ArrayStart("client-connection");
-  foreach_alist (connection, connections) {
+  for (auto& info : conn_info) {
     ua->send->ObjectStart();
-    bstrftime_nc(dt, sizeof(dt), connection->ConnectTime());
+    bstrftime_nc(dt, sizeof(dt), info.connect_time);
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
-    ua->send->ObjectKeyValue("protocol_version", connection->protocol_version(),
+    ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", connection->authenticated(),
-                             "%-20d");
-    ua->send->ObjectKeyValue("name", connection->name(), "%-40s");
+    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");
   }

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1282,7 +1282,7 @@ static void ListConnectedClients(UaContext* ua)
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
     ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("authenticated", true, "%-20d");
     ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");

--- a/core/src/filed/heartbeat.cc
+++ b/core/src/filed/heartbeat.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -112,16 +112,15 @@ extern "C" void* sd_heartbeat_thread(void* arg)
 /* Startup the heartbeat thread -- see above */
 void StartHeartbeatMonitor(JobControlRecord* jcr)
 {
-  /*
-   * If no signals are set, do not start the heartbeat because
+  /* If no signals are set, do not start the heartbeat because
    * it gives a constant stream of TIMEOUT_SIGNAL signals that
-   * make debugging impossible.
-   */
+   * make debugging impossible. */
   if (!no_signals) {
     jcr->fd_impl->hb_bsock = NULL;
     jcr->fd_impl->hb_running = false;
     jcr->fd_impl->hb_initialized_once = false;
     jcr->fd_impl->hb_dir_bsock = NULL;
+    jcr->dir_bsock->SetLocking();
     pthread_create(&jcr->fd_impl->heartbeat_id, NULL, sd_heartbeat_thread,
                    (void*)jcr);
   }

--- a/core/src/lib/connection_pool.cc
+++ b/core/src/lib/connection_pool.cc
@@ -32,17 +32,6 @@
 #include <chrono>
 #include <thread>
 
-// connection
-connection::connection(std::string_view name,
-                       int protocol_version,
-                       BareosSocket* socket,
-                       bool authenticated)
-    : connection_info{std::string{name}, protocol_version, authenticated,
-                      time(nullptr)}
-    , socket{socket}
-{
-}
-
 void connection::socket_closer::operator()(BareosSocket* socket)
 {
   if (socket) {

--- a/core/src/lib/connection_pool.h
+++ b/core/src/lib/connection_pool.h
@@ -42,21 +42,21 @@ class BareosSocket;
 struct connection_info {
   std::string name{};
   int protocol_version{};
-  bool authenticated{};
   time_t connect_time{};
 };
 
 struct connection : public connection_info {
   struct socket_closer {
-    void operator()(BareosSocket*);
+    void operator()(BareosSocket* socket);
   };
   using sock_ptr = std::unique_ptr<BareosSocket, socket_closer>;
 
   connection() = default;
-  connection(std::string_view name,
-             int protocol_version,
-             BareosSocket* socket,
-             bool authenticated = true);
+  connection(std::string_view name, int protocol_version, BareosSocket* socket)
+      : connection_info{std::string{name}, protocol_version, time(nullptr)}
+      , socket{socket}
+  {
+  }
 
   connection(const connection&) = delete;
   connection& operator=(const connection&) = delete;

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2023-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,9 +54,15 @@ class locked {
   const T& operator*() const { return *data; }
   const T* operator->() const { return data; }
 
-  template <typename Pred> void wait(std::condition_variable& cv, Pred&& p)
+  template <typename CondVar, typename P> void wait(CondVar& cv, P&& pred)
   {
-    cv.wait(lock, [this, p = std::move(p)] { return p(*data); });
+    cv.wait(lock, [this, pred = std::move(pred)] { return pred(*data); });
+  }
+
+  template <typename CondVar, typename TimePoint>
+  std::cv_status wait_until(CondVar& cv, TimePoint tp)
+  {
+    return cv.wait_until(lock, tp);
   }
 
  private:


### PR DESCRIPTION
**Backport of PR #1685 to bareos-23**

I needed to remove the changes to the new socket server api since it is not available on bareos 23.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1685 is merged
- [x] All functional differences to the original PR are documented above
