### PR TITLE
core: fix various data races (connection_pool/heartbeat_thread)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - webui: Backup Unit Report fixes [PR #1699]
 - windows: fix calculation of "job_metadata.xml" object size [PR #1704]
 - stored: fix storage daemon crash if passive client is unreachable, create better session keys [PR #1701]
+- core: fix various data races (connection_pool/heartbeat_thread) [PR #1712]
 
 ### Fixed
 - core: Fix compile errors on GCC 14 [PR #1714]
@@ -647,5 +648,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1699]: https://github.com/bareos/bareos/pull/1699
 [PR #1701]: https://github.com/bareos/bareos/pull/1701
 [PR #1704]: https://github.com/bareos/bareos/pull/1704
+[PR #1712]: https://github.com/bareos/bareos/pull/1712
 [PR #1714]: https://github.com/bareos/bareos/pull/1714
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/btraceback.in
+++ b/core/scripts/btraceback.in
@@ -22,19 +22,21 @@ MDB="@MDB@"
 # Try to generate a core dump for postmortem analyzing.
 #
 POSTMORTEM="NONE"
-if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
-   POSTMORTEM="${WD}/${PNAME}.core"
-   ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
-   POSTMORTEM="${POSTMORTEM}.$2"
-   echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
-else
-   which gcore > /dev/null 2>&1 && GCORE="`which gcore`" || GCORE=''
-   if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
-      POSTMORTEM="${WD}/${PNAME}.core"
-      ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
-      POSTMORTEM="${POSTMORTEM}.$2"
-      echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
-   fi
+if [ -n "${DUMPCORE+x}" ]; then
+    if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
+        POSTMORTEM="${WD}/${PNAME}.core"
+        ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
+        POSTMORTEM="${POSTMORTEM}.$2"
+        echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
+    else
+        which gcore > /dev/null 2>&1 && GCORE="`which gcore`" || GCORE=''
+        if [ ! -z "${GCORE}" -a -x "${GCORE}" ]; then
+            POSTMORTEM="${WD}/${PNAME}.core"
+            ${GCORE} -o ${POSTMORTEM} $2 > /dev/null 2>&1
+            POSTMORTEM="${POSTMORTEM}.$2"
+            echo "Created ${POSTMORTEM} for doing postmortem debugging" > ${WD}/bareos.$2.traceback
+        fi
+    fi
 fi
 
 #

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1303,34 +1303,14 @@ void DoClientResolve(UaContext* ua, ClientResource* client)
   return;
 }
 
-class SocketGuard {
- public:
-  ~SocketGuard()
-  {
-    if (owns_) {
-      fd_->close();
-      delete fd_;
-    }
-  }
-
-  explicit SocketGuard(BareosSocket* fd) : fd_{fd} {}
-  void Release() { owns_ = false; }
-
- private:
-  bool owns_{true};
-  BareosSocket* fd_;
-};
-
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version)
 {
-  ClientResource* client_resource;
-  Connection* connection = NULL;
-  SocketGuard socket_guard{fd};
+  connection conn{client_name, fd_protocol_version, fd};
 
-  client_resource
+  auto client_resource
       = (ClientResource*)my_config->GetResWithName(R_CLIENT, client_name);
   if (!client_resource) {
     Emsg1(M_WARNING, 0,
@@ -1351,18 +1331,12 @@ void* HandleFiledConnection(ConnectionPool* connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connection
-      = connections->add_connection(client_name, fd_protocol_version, fd, true);
-  if (!connection) {
-    Emsg0(M_ERROR, 0, "Failed to add connection to pool.\n");
-    return NULL;
-  }
+  connections.lock()->emplace_back(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 
   /* The connection is now kept in the connection_pool.
    * This thread is no longer required and will end now. */
-  socket_guard.Release();
   return NULL;
 }
 } /* namespace directordaemon */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -1331,7 +1331,7 @@ void* HandleFiledConnection(connection_pool& connections,
 
   Dmsg1(20, "Connected to file daemon %s\n", client_name);
 
-  connections.lock()->emplace_back(std::move(conn));
+  connections.add_authenticated_connection(std::move(conn));
 
   RunOnIncomingConnectInterval(client_name).Run();
 

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -52,12 +52,12 @@ bool SendRestoreObjects(JobControlRecord* jcr, JobId_t JobId, bool send_global);
 bool CancelFileDaemonJob(UaContext* ua, JobControlRecord* jcr);
 void DoNativeClientStatus(UaContext* ua, ClientResource* client, char* cmd);
 void DoClientResolve(UaContext* ua, ClientResource* client);
-void* HandleFiledConnection(ConnectionPool* connections,
+void* HandleFiledConnection(connection_pool& connections,
                             BareosSocket* fd,
                             char* client_name,
                             int fd_protocol_version);
 
-ConnectionPool* get_client_connections();
+connection_pool& get_client_connections();
 bool IsConnectingToClientAllowed(ClientResource* res);
 bool IsConnectingToClientAllowed(JobControlRecord* jcr);
 bool IsClientTlsRequired(JobControlRecord* jcr);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -407,7 +407,7 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;
-      jcr->authenticated = connection->authenticated;
+      jcr->authenticated = true;
       Jmsg(jcr, M_INFO, 0, _("Using Client Initiated Connection (%s).\n"),
            jcr->dir_impl->res.client->resource_name_);
       result = true;

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -395,20 +395,18 @@ bool IsConnectFromClientAllowed(JobControlRecord* jcr)
 bool UseWaitingClient(JobControlRecord* jcr, int timeout)
 {
   bool result = false;
-  Connection* connection = NULL;
-  ConnectionPool* connections = get_client_connections();
+  auto& connections = get_client_connections();
 
   if (!IsConnectFromClientAllowed(jcr)) {
     Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
           jcr->dir_impl->res.client->resource_name_);
   } else {
-    connection = connections->remove(jcr->dir_impl->res.client->resource_name_,
-                                     timeout);
+    auto connection = take_by_name(
+        connections, jcr->dir_impl->res.client->resource_name_, timeout);
     if (connection) {
-      jcr->file_bsock = connection->bsock();
-      jcr->dir_impl->FDVersion = connection->protocol_version();
-      jcr->authenticated = connection->authenticated();
-      delete (connection);
+      jcr->file_bsock = connection->socket.release();
+      jcr->dir_impl->FDVersion = connection->protocol_version;
+      jcr->authenticated = connection->authenticated;
       Jmsg(jcr, M_INFO, 0, _("Using Client Initiated Connection (%s).\n"),
            jcr->dir_impl->res.client->resource_name_);
       result = true;

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -401,8 +401,9 @@ bool UseWaitingClient(JobControlRecord* jcr, int timeout)
     Dmsg1(120, "Connection from client \"%s\" to director is not allowed.\n",
           jcr->dir_impl->res.client->resource_name_);
   } else {
-    auto connection = take_by_name(
-        connections, jcr->dir_impl->res.client->resource_name_, timeout);
+    auto connection
+        = connections.take_by_name(jcr->dir_impl->res.client->resource_name_,
+                                   std::chrono::seconds{timeout});
     if (connection) {
       jcr->file_bsock = connection->socket.release();
       jcr->dir_impl->FDVersion = connection->protocol_version;

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -52,7 +52,7 @@ static char hello_client[] = "Hello Client %127s calling";
 static ThreadList thread_list;
 static alist<s_sockfd*>* sock_fds = NULL;
 static pthread_t tcp_server_tid;
-static ConnectionPool* client_connections = NULL;
+static connection_pool client_connections{};
 
 static std::atomic<BnetServerState> server_state(BnetServerState::kUndefined);
 
@@ -65,7 +65,7 @@ struct s_addr_port {
 #define MIN_MSG_LEN 15
 #define MAX_MSG_LEN (int)sizeof(name) + 25
 
-ConnectionPool* get_client_connections() { return client_connections; }
+connection_pool& get_client_connections() { return client_connections; }
 
 static void* HandleConnectionRequest(ConfigurationParser* config, void* arg)
 {
@@ -127,7 +127,7 @@ static void* UserAgentShutdownCallback(void* bsock)
 
 static void CleanupConnectionPool()
 {
-  if (client_connections) { client_connections->cleanup(); }
+  cleanup_connection_pool(client_connections);
 }
 
 extern "C" void* connect_thread(void* arg)
@@ -151,10 +151,6 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
 {
   int status;
 
-  if (client_connections == nullptr) {
-    client_connections = new ConnectionPool();
-  }
-
   server_state.store(BnetServerState::kUndefined);
 
   if ((status
@@ -172,10 +168,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    if (client_connections) {
-      delete (client_connections);
-      client_connections = nullptr;
-    }
+    client_connections.lock()->clear();
     return false;
   }
   return true;
@@ -188,9 +181,6 @@ void StopSocketServer()
     delete sock_fds;
     sock_fds = nullptr;
   }
-  if (client_connections) {
-    delete (client_connections);
-    client_connections = nullptr;
-  }
+  client_connections.lock()->clear();
 }
 } /* namespace directordaemon */

--- a/core/src/dird/socket_server.cc
+++ b/core/src/dird/socket_server.cc
@@ -125,10 +125,7 @@ static void* UserAgentShutdownCallback(void* bsock)
   return nullptr;
 }
 
-static void CleanupConnectionPool()
-{
-  cleanup_connection_pool(client_connections);
-}
+static void CleanupConnectionPool() { client_connections.cleanup(); }
 
 extern "C" void* connect_thread(void* arg)
 {
@@ -168,7 +165,7 @@ bool StartSocketServer(dlist<IPADDR>* addrs)
   } while (--tries);
 
   if (server_state != BnetServerState::kStarted) {
-    client_connections.lock()->clear();
+    client_connections.clear();
     return false;
   }
   return true;
@@ -181,6 +178,6 @@ void StopSocketServer()
     delete sock_fds;
     sock_fds = nullptr;
   }
-  client_connections.lock()->clear();
+  client_connections.clear();
 }
 } /* namespace directordaemon */

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -269,9 +269,7 @@ static void DoAllStatus(UaContext* ua)
   /* Count Storage items */
   LockRes(my_config);
   i = 0;
-  foreach_res (store, R_STORAGE) {
-    i++;
-  }
+  foreach_res (store, R_STORAGE) { i++; }
   unique_store = (StorageResource**)malloc(i * sizeof(StorageResource));
   /* Find Unique Storage address/port */
   i = 0;
@@ -304,9 +302,7 @@ static void DoAllStatus(UaContext* ua)
   /* Count Client items */
   LockRes(my_config);
   i = 0;
-  foreach_res (client, R_CLIENT) {
-    i++;
-  }
+  foreach_res (client, R_CLIENT) { i++; }
   unique_client = (ClientResource**)malloc(i * sizeof(ClientResource));
   /* Find Unique Client address/port */
   i = 0;
@@ -394,30 +390,24 @@ static bool show_scheduled_preview(UaContext*,
       tm.tm_min = run->minute;         /* Set run minute */
       tm.tm_sec = 0;                   /* Zero secs */
 
-      /*
-       * Convert the time into a user parsable string.
+      /* Convert the time into a user parsable string.
        * As we use locale specific strings for weekday and month we
-       * need to keep track of the longest data string used.
-       */
+       * need to keep track of the longest data string used. */
       runtime = mktime(&tm);
       bstrftime_wd(dt, sizeof(dt), runtime);
       date_len = strlen(dt);
       if (date_len > *max_date_len) {
         if (*max_date_len == 0) {
-          /*
-           * When the datelen changes during the loop the locale generates a
+          /* When the datelen changes during the loop the locale generates a
            * date string that is variable. Only thing we can do about that is
            * start from scratch again. We invoke this by return false from this
-           * function.
-           */
+           * function. */
           *max_date_len = date_len;
           PmStrcpy(overview, "");
           return false;
         } else {
-          /*
-           * This is the first determined length we use this until we are proven
-           * wrong.
-           */
+          /* This is the first determined length we use this until we are proven
+           * wrong. */
           *max_date_len = date_len;
         }
       }
@@ -471,10 +461,8 @@ static bool show_scheduled_preview(UaContext*,
     }
   }
 
-  /*
-   * If we make it till here the length of the datefield is constant or didn't
-   * change.
-   */
+  /* If we make it till here the length of the datefield is constant or didn't
+   * change. */
   return true;
 }
 
@@ -948,9 +936,7 @@ static void ListScheduledJobs(UaContext* ua)
     }
   } /* end for loop over resources */
   UnlockRes(my_config);
-  foreach_dlist (sp, sched) {
-    PrtRuntime(ua, sp);
-  }
+  foreach_dlist (sp, sched) { PrtRuntime(ua, sp); }
   if (num_jobs == 0 && !ua->api) { ua->SendMsg(_("No Scheduled Jobs.\n")); }
   if (!ua->api) ua->SendMsg("====\n");
   Dmsg0(200, "Leave list_sched_jobs_runs()\n");
@@ -1275,28 +1261,25 @@ static void ListTerminatedJobs(UaContext* ua)
 
 static void ListConnectedClients(UaContext* ua)
 {
-  Connection* connection = NULL;
-  alist<Connection*>* connections = NULL;
   const char* separator = "====================";
   char dt[MAX_TIME_LENGTH];
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  connections = get_client_connections()->get_as_alist();
+  auto conn_info = get_connection_info(get_client_connections());
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,
                        separator, separator, separator);
   ua->send->ArrayStart("client-connection");
-  foreach_alist (connection, connections) {
+  for (auto& info : conn_info) {
     ua->send->ObjectStart();
-    bstrftime_nc(dt, sizeof(dt), connection->ConnectTime());
+    bstrftime_nc(dt, sizeof(dt), info.connect_time);
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
-    ua->send->ObjectKeyValue("protocol_version", connection->protocol_version(),
+    ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", connection->authenticated(),
-                             "%-20d");
-    ua->send->ObjectKeyValue("name", connection->name(), "%-40s");
+    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");
   }
@@ -1457,10 +1440,8 @@ static void StatusContentApi(UaContext* ua, StorageResource* store)
             }
             break;
           case slot_status_t::kSlotStatusEmpty:
-            /*
-             * See if this empty slot is empty because the volume is loaded
-             * in one of the drives.
-             */
+            /* See if this empty slot is empty because the volume is loaded
+             * in one of the drives. */
             vl2 = vol_is_loaded_in_drive(store, vol_list,
                                          vl1->bareos_slot_number);
             if (vl2) {
@@ -1562,10 +1543,8 @@ static void StatusContentJson(UaContext* ua, StorageResource* store)
             }
             break;
           case slot_status_t::kSlotStatusEmpty:
-            /*
-             * See if this empty slot is empty because the volume is loaded
-             * in one of the drives.
-             */
+            /* See if this empty slot is empty because the volume is loaded
+             * in one of the drives. */
             vl2 = vol_is_loaded_in_drive(store, vol_list,
                                          vl1->bareos_slot_number);
             if (vl2) {
@@ -1664,10 +1643,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
       _("------+------------------+-----------+----------------+---------------"
         "-----------|\n"));
 
-  /*
-   * Walk through the list getting the media records
-   * Slots start numbering at 1.
-   */
+  /* Walk through the list getting the media records
+   * Slots start numbering at 1. */
   foreach_dlist (vl1, vol_list->contents) {
     vl2 = NULL;
     switch (vl1->slot_type) {
@@ -1690,10 +1667,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
         switch (vl1->slot_status) {
           case slot_status_t::kSlotStatusEmpty:
             if (vl1->slot_type == slot_type_t::kSlotTypeStorage) {
-              /*
-               * See if this empty slot is empty because the volume is loaded
-               * in one of the drives.
-               */
+              /* See if this empty slot is empty because the volume is loaded
+               * in one of the drives. */
               vl2 = vol_is_loaded_in_drive(store, vol_list,
                                            vl1->bareos_slot_number);
               if (!vl2) {
@@ -1708,10 +1683,8 @@ static void StatusSlots(UaContext* ua, StorageResource* store)
             }
             FALLTHROUGH_INTENDED;
           case slot_status_t::kSlotStatusFull: {
-            /*
-             * We get here for all slots with content and for empty
-             * slots with their volume loaded in a drive.
-             */
+            /* We get here for all slots with content and for empty
+             * slots with their volume loaded in a drive. */
             MediaDbRecord mr;
             if (vl1->slot_status == slot_status_t::kSlotStatusFull) {
               if (!vl1->VolName) {

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1278,7 +1278,7 @@ static void ListConnectedClients(UaContext* ua)
     ua->send->ObjectKeyValue("ConnectTime", dt, "%-20s");
     ua->send->ObjectKeyValue("protocol_version", info.protocol_version,
                              "%-20d");
-    ua->send->ObjectKeyValue("authenticated", info.authenticated, "%-20d");
+    ua->send->ObjectKeyValue("authenticated", true, "%-20d");
     ua->send->ObjectKeyValue("name", info.name.c_str(), "%-40s");
     ua->send->ObjectEnd();
     ua->send->Decoration("\n");

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -1266,7 +1266,7 @@ static void ListConnectedClients(UaContext* ua)
 
   ua->send->Decoration("\n");
   ua->send->Decoration("Client Initiated Connections (waiting for jobs):\n");
-  auto conn_info = get_connection_info(get_client_connections());
+  auto conn_info = get_client_connections().info();
   ua->send->Decoration("%-20s%-20s%-20s%-40s\n", "Connect time", "Protocol",
                        "Authenticated", "Name");
   ua->send->Decoration("%-20s%-20s%-20s%-20s%-20s\n", separator, separator,

--- a/core/src/filed/heartbeat.cc
+++ b/core/src/filed/heartbeat.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -112,16 +112,15 @@ extern "C" void* sd_heartbeat_thread(void* arg)
 /* Startup the heartbeat thread -- see above */
 void StartHeartbeatMonitor(JobControlRecord* jcr)
 {
-  /*
-   * If no signals are set, do not start the heartbeat because
+  /* If no signals are set, do not start the heartbeat because
    * it gives a constant stream of TIMEOUT_SIGNAL signals that
-   * make debugging impossible.
-   */
+   * make debugging impossible. */
   if (!no_signals) {
     jcr->fd_impl->hb_bsock = NULL;
     jcr->fd_impl->hb_running = false;
     jcr->fd_impl->hb_initialized_once = false;
     jcr->fd_impl->hb_dir_bsock = NULL;
+    jcr->dir_bsock->SetLocking();
     pthread_create(&jcr->fd_impl->heartbeat_id, NULL, sd_heartbeat_thread,
                    (void*)jcr);
   }

--- a/core/src/lib/connection_pool.cc
+++ b/core/src/lib/connection_pool.cc
@@ -32,17 +32,6 @@
 #include <chrono>
 #include <thread>
 
-// connection
-connection::connection(std::string_view name,
-                       int protocol_version,
-                       BareosSocket* socket,
-                       bool authenticated)
-    : connection_info{std::string{name}, protocol_version, authenticated,
-                      time(nullptr)}
-    , socket{socket}
-{
-}
-
 void connection::socket_closer::operator()(BareosSocket* socket)
 {
   if (socket) {

--- a/core/src/lib/connection_pool.h
+++ b/core/src/lib/connection_pool.h
@@ -42,21 +42,21 @@ class BareosSocket;
 struct connection_info {
   std::string name{};
   int protocol_version{};
-  bool authenticated{};
   time_t connect_time{};
 };
 
 struct connection : public connection_info {
   struct socket_closer {
-    void operator()(BareosSocket*);
+    void operator()(BareosSocket* socket);
   };
   using sock_ptr = std::unique_ptr<BareosSocket, socket_closer>;
 
   connection() = default;
-  connection(std::string_view name,
-             int protocol_version,
-             BareosSocket* socket,
-             bool authenticated = true);
+  connection(std::string_view name, int protocol_version, BareosSocket* socket)
+      : connection_info{std::string{name}, protocol_version, time(nullptr)}
+      , socket{socket}
+  {
+  }
 
   connection(const connection&) = delete;
   connection& operator=(const connection&) = delete;

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -1,0 +1,143 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#ifndef BAREOS_LIB_THREAD_UTIL_H_
+#define BAREOS_LIB_THREAD_UTIL_H_
+
+#include <mutex>
+#include <shared_mutex>
+#include <optional>
+#include <condition_variable>
+
+template <typename T, typename Mutex, template <typename> typename Lock>
+class locked {
+ public:
+  locked(Mutex& mut, T* data) : lock{mut}, data(data) {}
+  locked(Lock<Mutex> lock, T* data) : lock{std::move(lock)}, data(data) {}
+
+  locked(const locked&) = delete;
+  locked& operator=(const locked&) = delete;
+  locked(locked&& that) : lock(std::move(that.lock)), data(that.data)
+  {
+    that.data = nullptr;
+  }
+
+  locked& operator=(locked&& that)
+  {
+    std::swap(lock, that.lock);
+    std::swap(data, that.data);
+    return *this;
+  }
+
+  T& get() { return *data; }
+  T& operator*() { return *data; }
+  T* operator->() { return data; }
+
+  const T& get() const { return *data; }
+  const T& operator*() const { return *data; }
+  const T* operator->() const { return data; }
+
+  template <typename Pred> void wait(std::condition_variable& cv, Pred&& p)
+  {
+    cv.wait(lock, [this, p = std::move(p)] { return p(*data); });
+  }
+
+ private:
+  Lock<Mutex> lock;
+  T* data;
+};
+
+template <typename T>
+using unique_locked = locked<T, std::mutex, std::unique_lock>;
+template <typename T>
+using read_locked = locked<const T, std::shared_mutex, std::shared_lock>;
+template <typename T>
+using write_locked = locked<T, std::shared_mutex, std::unique_lock>;
+
+template <typename T> class synchronized {
+ public:
+  template <typename... Args>
+  synchronized(Args... args) : data{std::forward<Args>(args)...}
+  {
+  }
+
+  ~synchronized()
+  {
+    /* obviously nobody should hold the lock while this object is getting
+     * destroyed, but we still need to ensure that the thread that
+     * is destroying this object has a synchronized view of the contained data
+     * so that data's destructor can run with no race conditions. */
+    std::unique_lock _{mut};
+  }
+
+  [[nodiscard]] unique_locked<T> lock() { return {mut, &data}; }
+
+  [[nodiscard]] std::optional<unique_locked<T>> try_lock()
+  {
+    std::unique_lock l(mut, std::try_to_lock);
+    if (l.owns_lock()) {
+      return unique_locked<T>{std::move(l), &data};
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  [[nodiscard]] unique_locked<const T> lock() const { return {mut, &data}; }
+
+ private:
+  mutable std::mutex mut{};
+  T data;
+};
+
+template <typename T> class rw_synchronized {
+ public:
+  template <typename... Args>
+  rw_synchronized(Args... args) : data{std::forward<Args>(args)...}
+  {
+  }
+
+  [[nodiscard]] write_locked<T> wlock() { return {mut, &data}; }
+  [[nodiscard]] std::optional<write_locked<T>> try_wlock()
+  {
+    std::unique_lock l(mut, std::try_to_lock);
+    if (l.owns_lock()) {
+      return {std::move(l), &data};
+    } else {
+      return std::nullopt;
+    }
+  }
+
+  [[nodiscard]] read_locked<T> rlock() const { return {mut, &data}; }
+  [[nodiscard]] std::optional<read_locked<T>> try_rlock() const
+  {
+    std::shared_lock l(mut, std::try_to_lock);
+    if (l.owns_lock()) {
+      return {std::move(l), &data};
+    } else {
+      return std::nullopt;
+    }
+  }
+
+ private:
+  mutable std::shared_mutex mut{};
+  T data;
+};
+
+#endif  // BAREOS_LIB_THREAD_UTIL_H_

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -54,9 +54,15 @@ class locked {
   const T& operator*() const { return *data; }
   const T* operator->() const { return data; }
 
-  template <typename Pred> void wait(std::condition_variable& cv, Pred&& p)
+  template <typename CondVar, typename P> void wait(CondVar& cv, P&& pred)
   {
-    cv.wait(lock, [this, p = std::move(p)] { return p(*data); });
+    cv.wait(lock, [this, pred = std::move(pred)] { return pred(*data); });
+  }
+
+  template <typename CondVar, typename TimePoint>
+  std::cv_status wait_until(CondVar& cv, TimePoint tp)
+  {
+    return cv.wait_until(lock, tp);
   }
 
  private:


### PR DESCRIPTION
**Backport of PR #1685 to bareos-22**

Differences:
* backport of thread_util.h (was already in master)
* not backported update to new socket server api (not available in 22)
* backported disabling of core file writing in btraceback by default
* added `Backend Directory` to director configuration in test

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1685 is merged
- [x] All functional differences to the original PR are documented above
