### PR TITLE
Fix warning about missing delcandidates table in director

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -179,6 +179,7 @@ Sam Verstraete
 Samuel Börlin
 Scott Bailey
 Sebastian Lederer
+Sebastian Marsching
 Sebastian Sura
 Serefhan Yeter
 Sergey Svishchev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bareos_tasks plugin for pgsql [PR #1659]
 - core: Fix compile errors on GCC 14 [PR #1687]
 - stored: fix authentication race condition / deadlock [PR #1732]
+- Fix warning about missing delcandidates table in director [PR #1721]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -119,6 +120,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1717]: https://github.com/bareos/bareos/pull/1717
 [PR #1718]: https://github.com/bareos/bareos/pull/1718
 [PR #1719]: https://github.com/bareos/bareos/pull/1719
+[PR #1721]: https://github.com/bareos/bareos/pull/1721
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
 [PR #1732]: https://github.com/bareos/bareos/pull/1732
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -952,7 +952,6 @@ class BareosDb : public BareosDbQueryEnum {
   /* Pure virtual low level methods */
   virtual bool OpenDatabase(JobControlRecord* jcr) = 0;
   virtual void CloseDatabase(JobControlRecord* jcr) = 0;
-  virtual bool ValidateConnection(void) = 0;
   virtual void StartTransaction(JobControlRecord* jcr) = 0;
   virtual void EndTransaction(JobControlRecord* jcr) = 0;
 

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -238,6 +238,7 @@ bool BareosDbPostgresql::OpenDatabase(JobControlRecord* jcr)
 
   SqlQueryWithoutHandler("SET datestyle TO 'ISO, YMD'");
   SqlQueryWithoutHandler("SET cursor_tuple_fraction=1");
+  SqlQueryWithoutHandler("SET client_min_messages TO WARNING");
 
   /* Tell PostgreSQL we are using standard conforming strings
    * and avoid warnings such as:

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -287,28 +287,6 @@ void BareosDbPostgresql::CloseDatabase(JobControlRecord* jcr)
     }
   }
   unlock_mutex(mutex);
-}
-
-bool BareosDbPostgresql::ValidateConnection(void)
-{
-  // Perform a null query to see if the connection is still valid.
-  DbLocker _{this};
-  if (!SqlQueryWithoutHandler("SELECT 1", true)) {
-    // Try resetting the connection.
-    PQreset(db_handle_);
-    if (PQstatus(db_handle_) != CONNECTION_OK) { return false; }
-
-    SqlQueryWithoutHandler("SET datestyle TO 'ISO, YMD'");
-    SqlQueryWithoutHandler("SET cursor_tuple_fraction=1");
-    SqlQueryWithoutHandler("SET standard_conforming_strings=on");
-
-    // Retry the null query.
-    if (!SqlQueryWithoutHandler("SELECT 1", true)) { return false; }
-  }
-
-  SqlFreeResult();
-
-  return true;
 }
 
 /**
@@ -631,6 +609,7 @@ retry_query:
             // Reset the connection settings.
             PQexec(db_handle_, "SET datestyle TO 'ISO, YMD'");
             PQexec(db_handle_, "SET cursor_tuple_fraction=1");
+            PQexec(db_handle_, "SET client_min_messages TO WARNING");
             result_ = PQexec(db_handle_, "SET standard_conforming_strings=on");
 
             switch (PQresultStatus(result_)) {

--- a/core/src/cats/postgresql.h
+++ b/core/src/cats/postgresql.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -62,7 +62,6 @@ class BareosDbPostgresql : public BareosDb {
   int SqlNumFields(void) override { return num_fields_; }
   bool OpenDatabase(JobControlRecord* jcr) override;
   void CloseDatabase(JobControlRecord* jcr) override;
-  bool ValidateConnection(void) override;
   void EscapeString(JobControlRecord* jcr,
                     char* snew,
                     const char* old,

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -198,7 +198,6 @@ class MockDatabase : public BareosDb {
 
   bool OpenDatabase(JobControlRecord* /*jcr*/) override { return false; }
   void CloseDatabase(JobControlRecord* /*jcr*/) override {}
-  bool ValidateConnection() override { return false; }
   void StartTransaction(JobControlRecord* /*jcr*/) override {}
   void EndTransaction(JobControlRecord* /*jcr*/) override {}
   bool SqlCopyStart(const std::string&,


### PR DESCRIPTION
Pruning jobs would cause the following warning in the output of the director (e.g. visible through `systemctl status bareos-director.service`):

    table "delcandidates" does not exist, skipping

This warning is harmless but clutters the output. With this PR, this problem is fixed by disabling warnings for the PostgreSQL connection that is established by the director.

See https://bugs.bareos.org/view.php?id=1561 and https://bugs.bareos.org/view.php?id=1606.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR