### PR TITLE
fix sql error on bad virtualfull; detect parsing errors with strtod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix missing DLL in windows packaging [PR #1807]
 - VMware Plugin: Adapt to older urllib3 versions [PR #1810]
 - fix various memory leaks [PR #1723]
+- fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1725]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -156,6 +157,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1722]: https://github.com/bareos/bareos/pull/1722
 [PR #1723]: https://github.com/bareos/bareos/pull/1723
 [PR #1724]: https://github.com/bareos/bareos/pull/1724
+[PR #1725]: https://github.com/bareos/bareos/pull/1725
 [PR #1727]: https://github.com/bareos/bareos/pull/1727
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
 [PR #1732]: https://github.com/bareos/bareos/pull/1732

--- a/core/src/dird/bsr.cc
+++ b/core/src/dird/bsr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -237,8 +237,8 @@ bool AddVolumeInformationToBsr(UaContext* ua, RestoreBootstrapRecord* bsr)
       bsr->VolCount = 0;    /*   there are no volumes */
       continue;
     }
-    if ((bsr->VolCount = ua->db->GetJobVolumeParameters(ua->jcr, bsr->JobId,
-                                                        &(bsr->VolParams)))
+    if ((bsr->VolCount
+         = ua->db->GetJobVolumeParameters(ua->jcr, bsr->JobId, &bsr->VolParams))
         == 0) {
       ua->ErrorMsg(T_("Unable to get Job Volume Parameters. ERR=%s\n"),
                    ua->db->strerror());

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3141,8 +3141,8 @@ std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
       }
       break;
     case 'O': /* Migration/copy job prev jobid */
-      if (jcr && jcr->dir_impl && jcr->dir_impl->previous_jr.JobId) {
-        return std::to_string(jcr->dir_impl->previous_jr.JobId);
+      if (jcr && jcr->dir_impl && jcr->dir_impl->previous_jr) {
+        return std::to_string(jcr->dir_impl->previous_jr->JobId);
       } else {
         return none;
       }

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -24,6 +24,8 @@
 #ifndef BAREOS_DIRD_DIRECTOR_JCR_IMPL_H_
 #define BAREOS_DIRD_DIRECTOR_JCR_IMPL_H_
 
+#include <optional>
+
 #include "cats/cats.h"
 #include "lib/mem_pool.h"
 #include "dird/client_connection_handshake_mode.h"
@@ -126,7 +128,7 @@ struct DirectorJcrImpl {
   uint32_t FileIndex{};           /**< Last FileIndex processed */
   utime_t MaxRunSchedTime{};      /**< Max run time in seconds from Initial Scheduled time */
   JobDbRecord jr;                 /**< Job DB record for current job */
-  JobDbRecord previous_jr;        /**< Previous job database record */
+  std::optional<JobDbRecord> previous_jr;        /**< Previous job database record */
   JobControlRecord* mig_jcr{};    /**< JobControlRecord for migration/copy job */
   char FSCreateTime[MAX_TIME_LENGTH]{}; /**< FileSet CreateTime as returned from DB */
   char since[MAX_TIME_LENGTH]{};        /**< Since time */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -421,8 +421,9 @@ bool SendPreviousRestoreObjects(JobControlRecord* jcr)
   switch (JobLevel) {
     case L_DIFFERENTIAL:
     case L_INCREMENTAL:
-      if (jcr->dir_impl->previous_jr.JobId > 0) {
-        if (!SendRestoreObjects(jcr, jcr->dir_impl->previous_jr.JobId, false)) {
+      if (jcr->dir_impl->previous_jr) {
+        if (!SendRestoreObjects(jcr, jcr->dir_impl->previous_jr->JobId,
+                                false)) {
           return false;
         }
       }

--- a/core/src/dird/fd_cmds.h
+++ b/core/src/dird/fd_cmds.h
@@ -41,7 +41,8 @@ bool SendBwlimitToFd(JobControlRecord* jcr, const char* Job);
 bool SendSecureEraseReqToFd(JobControlRecord* jcr);
 bool SendPreviousRestoreObjects(JobControlRecord* jcr);
 int GetAttributesAndPutInCatalog(JobControlRecord* jcr);
-void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId);
+void GetAttributesAndCompareToCatalog(JobControlRecord* jcr,
+                                      JobDbRecord* prev_jr);
 int put_file_into_catalog(JobControlRecord* jcr,
                           long file_index,
                           char* fname,

--- a/core/src/dird/job.h
+++ b/core/src/dird/job.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,6 +23,8 @@
 #define BAREOS_DIRD_JOB_H_
 
 class JobControlRecord;
+
+#include "cats/cats.h"
 
 namespace directordaemon {
 
@@ -50,7 +52,7 @@ void UpdateJobEnd(JobControlRecord* jcr, int TermCode);
 bool SetupJob(JobControlRecord* jcr, bool suppress_output = false);
 void ExecuteJob(JobControlRecord* jcr);
 void CreateClones(JobControlRecord* jcr);
-int CreateRestoreBootstrapFile(JobControlRecord* jcr);
+int CreateRestoreBootstrapFile(JobControlRecord* jcr, const JobDbRecord& jobid);
 void DirdFreeJcr(JobControlRecord* jcr);
 void DirdFreeJcrPointers(JobControlRecord* jcr);
 void CancelStorageDaemonJob(JobControlRecord* jcr);

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1018,37 +1018,38 @@ bool DoMigrationInit(JobControlRecord* jcr)
     Dmsg1(dbglevel, "At Job start previous jobid=%u\n",
           jcr->dir_impl->MigrateJobId);
 
-    jcr->dir_impl->previous_jr.JobId = jcr->dir_impl->MigrateJobId;
-    Dmsg1(dbglevel, "Previous jobid=%d\n",
-          (int)jcr->dir_impl->previous_jr.JobId);
+    {
+      JobDbRecord jr{};
+      jr.JobId = jcr->dir_impl->MigrateJobId;
+      Dmsg1(dbglevel, "Previous jobid=%d\n", jr.JobId);
 
-    if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->previous_jr)) {
-      Jmsg(jcr, M_FATAL, 0,
-           T_("Could not get job record for JobId %s to %s. ERR=%s\n"),
-           edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
-           jcr->get_ActionName(), jcr->db->strerror());
-      return false;
+      if (!jcr->db->GetJobRecord(jcr, &jr)) {
+        Jmsg(jcr, M_FATAL, 0,
+             T_("Could not get job record for JobId %s to %s. ERR=%s\n"),
+             edit_int64(jr.JobId, ed1), jcr->get_ActionName(),
+             jcr->db->strerror());
+        return false;
+      }
+      jcr->dir_impl->previous_jr.emplace(std::move(jr));
     }
 
+    auto& prev_jr = jcr->dir_impl->previous_jr.value();
+
     Jmsg(jcr, M_INFO, 0, T_("%s using JobId=%s Job=%s\n"),
-         jcr->get_OperationName(),
-         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
-         jcr->dir_impl->previous_jr.Job);
+         jcr->get_OperationName(), edit_int64(prev_jr.JobId, ed1), prev_jr.Job);
     Dmsg4(dbglevel, "%s JobId=%d  using JobId=%s Job=%s\n",
-          jcr->get_OperationName(), jcr->JobId,
-          edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
-          jcr->dir_impl->previous_jr.Job);
+          jcr->get_OperationName(), jcr->JobId, edit_int64(prev_jr.JobId, ed1),
+          prev_jr.Job);
 
     if (CreateRestoreBootstrapFile(jcr) < 0) {
       Jmsg(jcr, M_FATAL, 0, T_("Create bootstrap file failed.\n"));
       return false;
     }
 
-    if (jcr->dir_impl->previous_jr.JobId == 0
-        || jcr->dir_impl->ExpectedFiles == 0) {
+    if (prev_jr.JobId == 0 || jcr->dir_impl->ExpectedFiles == 0) {
       jcr->setJobStatusWithPriorityCheck(JS_Terminated);
       Dmsg1(dbglevel, "JobId=%d expected files == 0\n", (int)jcr->JobId);
-      if (jcr->dir_impl->previous_jr.JobId == 0) {
+      if (prev_jr.JobId == 0) {
         Jmsg(jcr, M_INFO, 0, T_("No previous Job found to %s.\n"),
              jcr->get_ActionName());
       } else {
@@ -1065,8 +1066,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
 
     job = (JobResource*)my_config->GetResWithName(R_JOB,
                                                   jcr->dir_impl->jr.Name);
-    prev_job = (JobResource*)my_config->GetResWithName(
-        R_JOB, jcr->dir_impl->previous_jr.Name);
+    prev_job = (JobResource*)my_config->GetResWithName(R_JOB, prev_jr.Name);
 
     if (!job) {
       Jmsg(jcr, M_FATAL, 0, T_("Job resource not found for \"%s\".\n"),
@@ -1076,7 +1076,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
 
     if (!prev_job) {
       Jmsg(jcr, M_FATAL, 0, T_("Previous Job resource not found for \"%s\".\n"),
-           jcr->dir_impl->previous_jr.Name);
+           prev_jr.Name);
       return false;
     }
 
@@ -1108,8 +1108,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
     // Create a migration jcr
     mig_jcr = NewDirectorJcr(DirdFreeJcr);
     jcr->dir_impl->mig_jcr = mig_jcr;
-    memcpy(&mig_jcr->dir_impl->previous_jr, &jcr->dir_impl->previous_jr,
-           sizeof(mig_jcr->dir_impl->previous_jr));
+    mig_jcr->dir_impl->previous_jr = prev_jr;
 
     /* Turn the mig_jcr into a "real" job that takes on the aspects of
      * the previous backup job "prev_job". We only don't want it to
@@ -1143,8 +1142,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
     mig_jcr->cjcr = jcr;
 
     // Now reset the job record from the previous job
-    memcpy(&mig_jcr->dir_impl->jr, &jcr->dir_impl->previous_jr,
-           sizeof(mig_jcr->dir_impl->jr));
+    mig_jcr->dir_impl->jr = prev_jr;
 
     // Update the jr to reflect the new values of PoolId and JobId.
     mig_jcr->dir_impl->jr.PoolId = jcr->dir_impl->jr.PoolId;
@@ -1175,7 +1173,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
         jcr->dir_impl->res.read_storage, jcr->dir_impl->res.write_storage);
 
     // set the JobLevel to what the original job was
-    mig_jcr->setJobLevel(mig_jcr->dir_impl->previous_jr.JobLevel);
+    mig_jcr->setJobLevel(mig_jcr->dir_impl->previous_jr->JobLevel);
 
 
     Dmsg4(dbglevel, "mig_jcr: Name=%s JobId=%d Type=%c Level=%c\n",
@@ -1222,14 +1220,17 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
 
   ASSERT(mig_jcr);
 
+  auto prev_id
+      = jcr->dir_impl->previous_jr ? jcr->dir_impl->previous_jr->JobId : 0;
   // Make sure this job was not already migrated
-  if (jcr->dir_impl->previous_jr.JobType != JT_BACKUP
-      && jcr->dir_impl->previous_jr.JobType != JT_JOB_COPY
-      && jcr->dir_impl->previous_jr.JobType != JT_ARCHIVE) {
+  if (jcr->dir_impl->previous_jr
+      && jcr->dir_impl->previous_jr->JobType != JT_BACKUP
+      && jcr->dir_impl->previous_jr->JobType != JT_JOB_COPY
+      && jcr->dir_impl->previous_jr->JobType != JT_ARCHIVE) {
     Jmsg(jcr, M_INFO, 0,
          T_("JobId %s already %s probably by another Job. %s stopped.\n"),
-         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
-         jcr->get_ActionName(true), jcr->get_OperationName());
+         edit_int64(prev_id, ed1), jcr->get_ActionName(true),
+         jcr->get_OperationName());
     jcr->setJobStatusWithPriorityCheck(JS_Terminated);
     MigrationCleanup(jcr, jcr->getJobStatus());
     return true;
@@ -1238,8 +1239,7 @@ static inline bool DoActualMigration(JobControlRecord* jcr)
   if (SameStorage(jcr)) {
     Jmsg(jcr, M_FATAL, 0,
          T_("JobId %s cannot %s using the same read and write storage.\n"),
-         edit_int64(jcr->dir_impl->previous_jr.JobId, ed1),
-         jcr->get_OperationName());
+         edit_int64(prev_id, ed1), jcr->get_OperationName());
     jcr->setJobStatusWithPriorityCheck(JS_Terminated);
     MigrationCleanup(jcr, jcr->getJobStatus());
     return true;
@@ -1528,7 +1528,7 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
   RunTime = jcr->dir_impl->jr.EndTime - jcr->dir_impl->jr.StartTime;
 
   std::string sd_term_msg = JobstatusToAscii(jcr->dir_impl->SDJobStatus);
-  if (jcr->dir_impl->previous_jr.JobId != 0) {
+  if (jcr->dir_impl->previous_jr) {
     // Copy/Migrate worker Job.
     if (RunTime <= 0) {
       kbps = 0;
@@ -1571,8 +1571,8 @@ static inline void GenerateMigrateSummary(JobControlRecord* jcr,
             "  Termination:            %s\n\n"),
          BAREOS, my_name, kBareosVersionStrings.Full,
          kBareosVersionStrings.ShortDate, kBareosVersionStrings.GetOsInfo(),
-         edit_uint64(jcr->dir_impl->previous_jr.JobId, ec6),
-         jcr->dir_impl->previous_jr.Job,
+         edit_uint64(jcr->dir_impl->previous_jr->JobId, ec6),
+         jcr->dir_impl->previous_jr->Job,
          mig_jcr ? edit_uint64(mig_jcr->dir_impl->jr.JobId, ec7) : T_("*None*"),
          edit_uint64(jcr->dir_impl->jr.JobId, ec8), jcr->dir_impl->jr.Job,
          JobLevelToString(jcr->getJobLevel()),
@@ -1648,10 +1648,10 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
 
   /* Check if we actually did something.
    * mig_jcr is jcr of the newly migrated job. */
-  if (mig_jcr) {
+  if (mig_jcr && jcr->dir_impl->previous_jr) {
     char old_jobid[50], new_jobid[50];
 
-    edit_uint64(jcr->dir_impl->previous_jr.JobId, old_jobid);
+    edit_uint64(jcr->dir_impl->previous_jr->JobId, old_jobid);
     edit_uint64(mig_jcr->dir_impl->jr.JobId, new_jobid);
 
     // use the PriorJobId field to store the migrated jobid in order to keep
@@ -1673,7 +1673,7 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
       mig_jcr->VolSessionTime = jcr->VolSessionTime;
     }
     mig_jcr->dir_impl->jr.RealEndTime = 0;
-    mig_jcr->dir_impl->jr.PriorJobId = jcr->dir_impl->previous_jr.JobId;
+    mig_jcr->dir_impl->jr.PriorJobId = jcr->dir_impl->previous_jr->JobId;
 
     if (jcr->is_JobStatus(JS_Terminated)
         && (jcr->JobErrors || jcr->dir_impl->SDErrors)) {
@@ -1686,9 +1686,9 @@ void MigrationCleanup(JobControlRecord* jcr, int TermCode)
     Mmsg(query,
          "UPDATE Job SET StartTime='%s',EndTime='%s',"
          "JobTDate=%s WHERE JobId=%s",
-         jcr->dir_impl->previous_jr.cStartTime,
-         jcr->dir_impl->previous_jr.cEndTime,
-         edit_uint64(jcr->dir_impl->previous_jr.JobTDate, ec1), new_jobid);
+         jcr->dir_impl->previous_jr->cStartTime,
+         jcr->dir_impl->previous_jr->cEndTime,
+         edit_uint64(jcr->dir_impl->previous_jr->JobTDate, ec1), new_jobid);
     jcr->db->SqlQuery(query.c_str());
 
     if (jcr->IsTerminatedOk()) {

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1041,7 +1041,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
           jcr->get_OperationName(), jcr->JobId, edit_int64(prev_jr.JobId, ed1),
           prev_jr.Job);
 
-    if (CreateRestoreBootstrapFile(jcr) < 0) {
+    if (CreateRestoreBootstrapFile(jcr, prev_jr) < 0) {
       Jmsg(jcr, M_FATAL, 0, T_("Create bootstrap file failed.\n"));
       return false;
     }

--- a/core/src/dird/verify.cc
+++ b/core/src/dird/verify.cc
@@ -198,7 +198,7 @@ bool DoVerify(JobControlRecord* jcr)
       /* Note: negative status is an error, zero status, means
        *  no files were backed up, so skip calling SD and
        *  client. */
-      status = CreateRestoreBootstrapFile(jcr);
+      status = CreateRestoreBootstrapFile(jcr, prev_jr);
       if (status < 0) { /* error */
         return false;
       } else if (status == 0) {            /* No files, nothing to do */

--- a/core/src/dird/verify.cc
+++ b/core/src/dird/verify.cc
@@ -115,14 +115,12 @@ bool DoVerify(JobControlRecord* jcr)
   BareosSocket* sd = NULL;
   int status;
   char ed1[100];
-  JobDbRecord jr;
+  JobDbRecord prev_jr{};
+  JobDbRecord jr{};
   JobId_t verify_jobid = 0;
   const char* Name;
 
   FreeWstorage(jcr); /* we don't write */
-
-  new (&jcr->dir_impl->previous_jr)
-      JobDbRecord();  // placement new instead of memset
 
   /* Find JobId of last job that ran. Note, we do this when
    *   the job actually starts running, not at schedule time,
@@ -173,22 +171,22 @@ bool DoVerify(JobControlRecord* jcr)
 
       /* Now get the job record for the previous backup that interests
        *   us. We use the verify_jobid that we found above. */
-      jcr->dir_impl->previous_jr.JobId = verify_jobid;
-      if (!jcr->db->GetJobRecord(jcr, &jcr->dir_impl->previous_jr)) {
+      prev_jr.JobId = verify_jobid;
+      if (!jcr->db->GetJobRecord(jcr, &prev_jr)) {
         Jmsg(jcr, M_FATAL, 0,
              T_("Could not get job record for previous Job. ERR=%s\n"),
              jcr->db->strerror());
         return false;
       }
-      if (!(jcr->dir_impl->previous_jr.JobStatus == JS_Terminated
-            || jcr->dir_impl->previous_jr.JobStatus == JS_Warnings)) {
+      if (!(prev_jr.JobStatus == JS_Terminated
+            || prev_jr.JobStatus == JS_Warnings)) {
         Jmsg(jcr, M_FATAL, 0,
              T_("Last Job %d did not Terminate normally. JobStatus=%c\n"),
-             verify_jobid, jcr->dir_impl->previous_jr.JobStatus);
+             verify_jobid, prev_jr.JobStatus);
         return false;
       }
       Jmsg(jcr, M_INFO, 0, T_("Verifying against JobId=%d Job=%s\n"),
-           jcr->dir_impl->previous_jr.JobId, jcr->dir_impl->previous_jr.Job);
+           prev_jr.JobId, prev_jr.Job);
   }
 
   /* If we are verifying a Volume, we need the Storage
@@ -217,8 +215,7 @@ bool DoVerify(JobControlRecord* jcr)
       break;
   }
 
-  Dmsg2(100, "ClientId=%u JobLevel=%c\n", jcr->dir_impl->previous_jr.ClientId,
-        JobLevel);
+  Dmsg2(100, "ClientId=%u JobLevel=%c\n", prev_jr.ClientId, JobLevel);
 
   if (!jcr->db->UpdateJobStartRecord(jcr, &jcr->dir_impl->jr)) {
     Jmsg(jcr, M_FATAL, 0, "%s", jcr->db->strerror());
@@ -384,12 +381,12 @@ bool DoVerify(JobControlRecord* jcr)
       jcr->dir_impl->sd_msg_thread_done
           = true; /* no SD msg thread, so it is done */
       jcr->dir_impl->SDJobStatus = JS_Terminated;
-      GetAttributesAndCompareToCatalog(jcr, jcr->dir_impl->previous_jr.JobId);
+      GetAttributesAndCompareToCatalog(jcr, &prev_jr);
       break;
     case L_VERIFY_VOLUME_TO_CATALOG:
       // Verify Volume to catalog entries
       Dmsg0(10, "Verify level=volume\n");
-      GetAttributesAndCompareToCatalog(jcr, jcr->dir_impl->previous_jr.JobId);
+      GetAttributesAndCompareToCatalog(jcr, &prev_jr);
       break;
     case L_VERIFY_DISK_TO_CATALOG:
       // Verify Disk attributes to catalog
@@ -397,7 +394,7 @@ bool DoVerify(JobControlRecord* jcr)
       jcr->dir_impl->sd_msg_thread_done
           = true; /* no SD msg thread, so it is done */
       jcr->dir_impl->SDJobStatus = JS_Terminated;
-      GetAttributesAndCompareToCatalog(jcr, jcr->dir_impl->previous_jr.JobId);
+      GetAttributesAndCompareToCatalog(jcr, &prev_jr);
       break;
     case L_VERIFY_INIT:
       // Build catalog
@@ -495,6 +492,9 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
   std::string fd_term_msg = JobstatusToAscii(jcr->dir_impl->FDJobStatus);
   std::string sd_term_msg = JobstatusToAscii(jcr->dir_impl->SDJobStatus);
 
+  auto prev_id
+      = jcr->dir_impl->previous_jr ? jcr->dir_impl->previous_jr->JobId : 0;
+
   switch (JobLevel) {
     case L_VERIFY_VOLUME_TO_CATALOG:
       Jmsg(jcr, msg_type, 0,
@@ -522,8 +522,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
            jcr->dir_impl->jr.JobId, jcr->dir_impl->jr.Job,
            jcr->dir_impl->res.fileset->resource_name_,
            JobLevelToString(JobLevel),
-           jcr->dir_impl->res.client->resource_name_,
-           jcr->dir_impl->previous_jr.JobId, Name, sdt, edt,
+           jcr->dir_impl->res.client->resource_name_, prev_id, Name, sdt, edt,
            edit_uint64_with_commas(jcr->dir_impl->ExpectedFiles, ec1),
            edit_uint64_with_commas(jcr->JobFiles, ec2), jcr->JobErrors,
            fd_term_msg.c_str(), sd_term_msg.c_str(),
@@ -554,8 +553,7 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
            jcr->dir_impl->jr.JobId, jcr->dir_impl->jr.Job,
            jcr->dir_impl->res.fileset->resource_name_,
            JobLevelToString(JobLevel),
-           jcr->dir_impl->res.client->resource_name_,
-           jcr->dir_impl->previous_jr.JobId, Name, sdt, edt,
+           jcr->dir_impl->res.client->resource_name_, prev_id, Name, sdt, edt,
            edit_uint64_with_commas(jcr->JobFiles, ec1), jcr->JobErrors,
            fd_term_msg.c_str(), kBareosVersionStrings.JoblogMessage,
            JobTriggerToString(jcr->dir_impl->job_trigger).c_str(), TermMsg);
@@ -566,7 +564,8 @@ void VerifyCleanup(JobControlRecord* jcr, int TermCode)
 }
 
 // This routine is called only during a Verify
-void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId)
+void GetAttributesAndCompareToCatalog(JobControlRecord* jcr,
+                                      JobDbRecord* prev_jr)
 {
   BareosSocket* fd;
   int n, len;
@@ -579,7 +578,7 @@ void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId)
   int32_t file_index = 0;
 
   fd = jcr->file_bsock;
-  fdbr.JobId = JobId;
+  fdbr.JobId = prev_jr->JobId;
   jcr->dir_impl->FileIndex = 0;
 
   Dmsg0(20, "dir: waiting to receive file attributes\n");
@@ -632,7 +631,7 @@ void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId)
         jcr->JobFiles++;
         jcr->dir_impl->FileIndex
             = file_index; /* remember attribute file_index */
-        jcr->dir_impl->previous_jr.FileIndex = file_index;
+        prev_jr->FileIndex = file_index;
         DecodeStat(attr, &statf, sizeof(statf),
                    &LinkFIf); /* decode file stat packet */
         do_Digest = CRYPTO_DIGEST_NONE;
@@ -647,8 +646,7 @@ void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId)
         // Find equivalent record in the database
         fdbr.FileId = 0;
         if (!jcr->db->GetFileAttributesRecord(jcr, jcr->dir_impl->fname.c_str(),
-                                              &jcr->dir_impl->previous_jr,
-                                              &fdbr)) {
+                                              prev_jr, &fdbr)) {
           Jmsg(jcr, M_INFO, 0, T_("New file: %s\n"),
                jcr->dir_impl->fname.c_str());
           Dmsg1(020, T_("File not in catalog: %s\n"),
@@ -823,7 +821,7 @@ void GetAttributesAndCompareToCatalog(JobControlRecord* jcr, JobId_t JobId)
        "SELECT Path.Path,File.Name FROM File,Path "
        "WHERE File.JobId=%d AND File.FileIndex > 0 "
        "AND File.MarkId!=%d AND File.PathId=Path.PathId ",
-       JobId, jcr->JobId);
+       prev_jr->JobId, jcr->JobId);
   /* MissingHandler is called for each file found */
   jcr->db->SqlQuery(buf.c_str(), MissingHandler, (void*)jcr);
   if (jcr->dir_impl->fn_printed) {

--- a/core/src/include/baconfig.h
+++ b/core/src/include/baconfig.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -177,6 +177,10 @@ inline constexpr std::size_t DEFAULT_NETWORK_BUFFER_SIZE = 256 * 1024;
 #define B_ISALPHA(c) (isascii((int)(c)) && isalpha((int)(c)))
 #define B_ISUPPER(c) (isascii((int)(c)) && isupper((int)(c)))
 #define B_ISDIGIT(c) (isascii((int)(c)) && isdigit((int)(c)))
+inline constexpr bool b_isjunkchar(int c)
+{
+  return (c == '\n' || c == '\r' || c == ' ');
+}
 
 /** For multiplying by 10 with shift and addition */
 #define B_TIMES10(d) ((d << 3) + (d << 1))
@@ -186,7 +190,7 @@ typedef void(HANDLER)();
 typedef int(INTHANDLER)();
 
 #ifndef S_ISLNK
-#  define S_ISLNK(m) (((m)&S_IFM) == S_IFLNK)
+#  define S_ISLNK(m) (((m) & S_IFM) == S_IFLNK)
 #endif
 
 /** Added by KES to deal with Win32 systems */

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -291,6 +291,16 @@ static std::pair<std::uint64_t, const char*> parse_number_with_mod(
   return {total, str};
 }
 
+// returns wether the string only contains junk characters
+static bool IsJunk(const char* str)
+{
+  for (auto* head = str; *head; ++head) {
+    if (!b_isjunkchar(*head)) { return false; }
+  }
+
+  return true;
+}
+
 /*
  * Convert a string duration to utime_t (64 bit seconds)
  * Returns false: if error
@@ -314,7 +324,8 @@ bool DurationToUtime(const char* str, utime_t* value)
                                 3600 * 24 * 365,
                                 0};
 
-  if (auto [total, rest] = parse_number_with_mod(str, mod, mult); *rest == 0) {
+  if (auto [total, rest] = parse_number_with_mod(str, mod, mult);
+      IsJunk(rest)) {
     *value = static_cast<utime_t>(total);
     return true;
   } else {
@@ -396,7 +407,8 @@ static bool strunit_to_uint64(const char* str,
 
   };
 
-  if (auto [total, rest] = parse_number_with_mod(str, mod, mult); *rest == 0) {
+  if (auto [total, rest] = parse_number_with_mod(str, mod, mult);
+      IsJunk(rest)) {
     *value = total;
     return true;
   } else {

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -29,6 +29,8 @@
 #include "include/bareos.h"
 #include "lib/edit.h"
 #include <math.h>
+#include <cstdlib>
+#include <algorithm>
 
 // We assume ASCII input and don't worry about overflow
 uint64_t str_to_uint64(const char* str)
@@ -191,59 +193,100 @@ char* edit_int64_with_commas(int64_t val, char* buf)
  * Given a string "str", separate the numeric part into str, and the modifier
  * into mod.
  */
-static bool GetModifier(char* str,
-                        char* num,
-                        int num_len,
-                        char* mod,
-                        int mod_len)
+struct modifier_parse_result {
+  double number;
+  std::string_view modifier;
+  const char* rest;
+};
+
+static std::string_view TrimLeft(std::string_view input)
 {
-  int i, len, num_begin, num_end, mod_begin, mod_end;
-
-  StripTrailingJunk(str);
-  len = strlen(str);
-
-  for (i = 0; i < len; i++) {
-    if (!B_ISSPACE(str[i])) { break; }
+  while (input.size() > 0 && B_ISSPACE(input.front())) {
+    input.remove_prefix(1);
   }
-  num_begin = i;
+  return input;
+}
 
-  // Walk through integer part
-  for (; i < len; i++) {
-    if (!B_ISDIGIT(str[i]) && str[i] != '.') { break; }
-  }
-
-  num_end = i;
-  if (num_len > (num_end - num_begin + 1)) {
-    num_len = num_end - num_begin + 1;
-  }
-  if (num_len == 0) { return false; }
-
-  // Eat any spaces in front of modifier
-  for (; i < len; i++) {
-    if (!B_ISSPACE(str[i])) { break; }
+static std::optional<modifier_parse_result> GetModifier(const char* input)
+{
+  Dmsg2(900, "parsing \"%s\"\n", input);
+  char* num_end;
+  errno = 0;
+  // strtod takes care of leading space
+  auto number = strtod(input, &num_end);
+  if (number == 0 && errno != 0) {
+    Dmsg0(900, "parse error: \"%s\" ERR=%s\n", input, strerror(errno));
+    return std::nullopt;
   }
 
-  mod_begin = i;
-  for (; i < len; i++) {
-    if (!B_ISALPHA(str[i])) { break; }
+  if (num_end == input) {
+    // we do not accept empty inputs (but strtod does!)
+    Dmsg0(900, "parse error: \"%s\" ERR=no number\n", input);
+    return std::nullopt;
   }
 
-  mod_end = i;
-  if (mod_len > (mod_end - mod_begin + 1)) {
-    mod_len = mod_end - mod_begin + 1;
+  std::string_view rest{num_end};
+
+  auto trimmed = TrimLeft(rest);
+
+  auto mod_end = std::find_if(trimmed.begin(), trimmed.end(), [](auto c) {
+    return B_ISDIGIT(c) || B_ISSPACE(c);
+  });
+  auto mod = trimmed.substr(0, mod_end - trimmed.begin());
+
+  const char* rest_input = mod.end();
+
+  Dmsg2(900, "num=%lf mod=\"%.*s\" rest=\"%s\"\n", number, (int)mod.size(),
+        mod.data(), rest_input);
+  // empty mod is ok, so no need to check!
+  return modifier_parse_result{number, mod, rest_input};
+}
+
+// mults needs to be at least as big as mods; mods needs to be NULL terminated.
+static std::optional<std::uint64_t> parse_number_with_mod(
+    const char* str,
+    const char* const mods[],
+    const double mults[])
+{
+  std::uint64_t total = 0;
+
+  while (*str) {
+    double number;
+    std::string_view modifier;
+    const char* rest;
+    if (auto res = GetModifier(str); !res) {
+      return std::nullopt;
+    } else {
+      number = res->number;
+      modifier = res->modifier;
+      rest = res->rest;
+    }
+
+    if (modifier.size() == 0) {
+      total += static_cast<std::uint64_t>(number);
+    } else {
+      bool found = false;
+      for (int i = 0; mods[i]; ++i) {
+        if (bstrncasecmp(modifier.data(), mods[i], modifier.size())) {
+          // without the static_cast, this will first cast total to double,
+          // then add the doubles, and then finally cast back to uint64,
+          // which we do not want!  doubles lose precision to quickly:
+          // 1 exabyte + 1 == 1 exabyte for doubles
+          total += static_cast<std::uint64_t>(number * mults[i]);
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        Dmsg1(900, "Unknown modifier: \"%.*s\"\n", modifier.size(),
+              modifier.data());
+        return std::nullopt;
+      }
+    }
+
+    str = rest;
   }
-
-  Dmsg5(900, "str=%s: num_beg=%d num_end=%d mod_beg=%d mod_end=%d\n", str,
-        num_begin, num_end, mod_begin, mod_end);
-  bstrncpy(num, &str[num_begin], num_len);
-  bstrncpy(mod, &str[mod_begin], mod_len);
-
-  if (!Is_a_number(num)) { return false; }
-
-  bstrncpy(str, &str[mod_end], len);
-  Dmsg2(900, "num=%s mod=%s\n", num, mod);
-
-  return true;
+  return total;
 }
 
 /*
@@ -251,55 +294,30 @@ static bool GetModifier(char* str,
  * Returns false: if error
  *         true:  if OK, and value stored in value
  */
-bool DurationToUtime(char* str, utime_t* value)
+bool DurationToUtime(const char* str, utime_t* value)
 {
-  int i, mod_len;
-  double val, total = 0.0;
-  char mod_str[20];
-  char num_str[50];
   // The "n" = mins and months appears before minutes so that m maps to months.
   static const char* mod[]
       = {"n",    "seconds", "months",   "minutes", "mins",     "hours",
          "days", "weeks",   "quarters", "years",   (char*)NULL};
-  static const int32_t mult[] = {60,
-                                 1,
-                                 60 * 60 * 24 * 30,
-                                 60,
-                                 60,
-                                 3600,
-                                 3600 * 24,
-                                 3600 * 24 * 7,
-                                 3600 * 24 * 91,
-                                 3600 * 24 * 365,
-                                 0};
+  static const double mult[] = {60,
+                                1,
+                                60 * 60 * 24 * 30,
+                                60,
+                                60,
+                                3600,
+                                3600 * 24,
+                                3600 * 24 * 7,
+                                3600 * 24 * 91,
+                                3600 * 24 * 365,
+                                0};
 
-  while (*str) {
-    if (!GetModifier(str, num_str, sizeof(num_str), mod_str, sizeof(mod_str))) {
-      return false;
-    }
-
-    // Now find the multiplier corresponding to the modifier
-    mod_len = strlen(mod_str);
-    if (mod_len == 0) {
-      i = 1; /* Default to seconds */
-    } else {
-      for (i = 0; mod[i]; i++) {
-        if (bstrncasecmp(mod_str, mod[i], mod_len)) { break; }
-      }
-      if (mod[i] == NULL) { return false; }
-    }
-
-    Dmsg2(900, "str=%s: mult=%d\n", num_str, mult[i]);
-    errno = 0;
-    val = strtod(num_str, NULL);
-
-    if (errno != 0 || val < 0) { return false; }
-
-    total += val * mult[i];
+  if (auto res = parse_number_with_mod(str, mod, mult)) {
+    *value = (utime_t)res.value();
+    return true;
+  } else {
+    return false;
   }
-  *value = (utime_t)total;
-
-  return true;
 }
 
 // Edit a utime "duration" into ASCII
@@ -349,13 +367,11 @@ char* edit_pthread(pthread_t val, char* buf, int buf_len)
   return buf;
 }
 
-static bool strunit_to_uint64(char* str, uint64_t* value, const char** mod)
+static bool strunit_to_uint64(const char* str,
+                              uint64_t* value,
+                              const char** mod)
 {
-  int i, mod_len;
-  double val;
-  char mod_str[20];
-  char num_str[50];
-  static const uint64_t mult[] = {
+  static const double mult[] = {
       1,     // Byte
       1024,  // KiB Kibibyte
       1000,  // kB Kilobyte
@@ -378,29 +394,12 @@ static bool strunit_to_uint64(char* str, uint64_t* value, const char** mod)
 
   };
 
-  if (!GetModifier(str, num_str, sizeof(num_str), mod_str, sizeof(mod_str))) {
-    return 0;
-  }
-
-  // Now find the multiplier corresponding to the modifier
-  mod_len = strlen(mod_str);
-  if (mod_len == 0) {
-    i = 0; /* Default with no modifier = 1 */
+  if (auto res = parse_number_with_mod(str, mod, mult)) {
+    *value = res.value();
+    return true;
   } else {
-    for (i = 0; mod[i]; i++) {
-      if (bstrncasecmp(mod_str, mod[i], mod_len)) { break; }
-    }
-    if (mod[i] == NULL) { return false; }
+    return false;
   }
-
-  Dmsg2(900, "str=%s: mult=%d\n", str, mult[i]);
-  errno = 0;
-  val = strtod(num_str, NULL);
-
-  if (errno != 0 || val < 0) { return false; }
-  *value = (utime_t)(val * mult[i]);
-
-  return true;
 }
 
 // convert uint64 number to size string
@@ -442,7 +441,7 @@ std::string SizeAsSiPrefixFormat(uint64_t value_in)
  * Returns false: if error
  *         true:  if OK, and value stored in value
  */
-bool size_to_uint64(char* str, uint64_t* value)
+bool size_to_uint64(const char* str, uint64_t* value)
 {
   // not used
   // clang-format off
@@ -470,7 +469,7 @@ bool size_to_uint64(char* str, uint64_t* value)
  * Returns false: if error
  *         true:  if OK, and value stored in value
  */
-bool speed_to_uint64(char* str, uint64_t* value)
+bool speed_to_uint64(const char* str, uint64_t* value)
 {
   // not used
   static const char* mod[] = {"*", "k/s", "kb/s", "m/s", "mb/s", NULL};

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -22,6 +22,7 @@
 #define BAREOS_LIB_EDIT_H_
 
 #include <vector>
+#include <string>
 #include "include/bc_types.h"
 
 namespace edit {
@@ -49,9 +50,9 @@ char* edit_int64(int64_t val, char* buf);
 char* edit_int64_with_commas(int64_t val, char* buf);
 
 char* add_commas(char* val, char* buf);
-bool DurationToUtime(char* str, utime_t* value);
-bool size_to_uint64(char* str, uint64_t* value);
-bool speed_to_uint64(char* str, uint64_t* value);
+bool DurationToUtime(const char* str, utime_t* value);
+bool size_to_uint64(const char* str, uint64_t* value);
+bool speed_to_uint64(const char* str, uint64_t* value);
 char* edit_utime(utime_t val, char* buf, int buf_len);
 char* edit_pthread(pthread_t val, char* buf, int buf_len);
 bool Is_a_number(const char* num);
@@ -61,7 +62,6 @@ bool IsNameValid(const char* name, std::string& msg);
 bool IsNameValid(const char* name);
 bool IsAclEntryValid(const char* acl, std::vector<char>& msg);
 bool IsAclEntryValid(const char* acl);
-bool size_to_uint64(char* str, uint64_t* value);
 std::string SizeAsSiPrefixFormat(uint64_t value_in);
 
 #endif  // BAREOS_LIB_EDIT_H_

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -27,8 +27,8 @@
 
 namespace edit {
 /* The biggest 64 bit number -- 2^64-1 -- has 20 digits.
- * As such one needs 27 = 20 + 6 + 1 chracters to safely format 64 bit numbers
- * with commata every 3 digits and a nul terminator.
+ * As such one needs 27 = 20 + 6 + 1 characters to safely format 64 bit numbers
+ * with commata every 3 digits and a null terminator.
  * 64 bit signed integers have at most 19 digits so this also works for them. */
 inline constexpr int32_t min_buffer_size{27};
 };  // namespace edit

--- a/core/src/lib/scan.cc
+++ b/core/src/lib/scan.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -45,7 +45,7 @@ void StripTrailingJunk(char* cmd)
 
   // Strip trailing junk from command
   p = cmd + strlen(cmd) - 1;
-  while ((p >= cmd) && (*p == '\n' || *p == '\r' || *p == ' ')) { *p-- = 0; }
+  while ((p >= cmd) && b_isjunkchar(*p)) { *p-- = 0; }
 }
 
 // Strip any trailing newline characters from the string
@@ -272,13 +272,11 @@ void SplitPathAndFilename(const char* fname,
   int slen;
   int len = slen = strlen(fname);
 
-  /*
-   * Find path without the filename.
+  /* Find path without the filename.
    * I.e. everything after the last / is a "filename".
    * OK, maybe it is a directory name, but we treat it like
    * a filename. If we don't find a / then the whole name
-   * must be a path name (e.g. c:).
-   */
+   * must be a path name (e.g. c:). */
   f = fname + len - 1;
   /* "strip" any trailing slashes */
   while (slen > 1 && IsPathSeparator(*f)) {

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -150,15 +150,12 @@ TEST(edit, convert_siunits_to_numbers)
     size_to_uint64(str, &retvalue);
     ASSERT_EQ(retvalue, 1'000'000'000'000'000'000);
   }
-  // size_to_uint64 only checks for first modifier so the following does not
-  // work
-  /*
-    {
-      char str[] = "1 e 1 p 1 t 1 g 1 m 1 k 1";
-      uint64_t retvalue = 0;
-      size_to_uint64(str, &retvalue);
-      ASSERT_EQ(retvalue, 1152921504606846976 + 1125899906842624 + 1099511627776
-    + 1073741824 + 1048576 + 1024 + 1);
-    }
-  */
+  // combined specification
+  {
+    char str[] = "1 e 1 p 1 t 1 g 1 m 1 k 1";
+    uint64_t retvalue = 0;
+    size_to_uint64(str, &retvalue);
+    ASSERT_EQ(retvalue, 1152921504606846976 + 1125899906842624 + 1099511627776
+                            + 1073741824 + 1048576 + 1024 + 1);
+  }
 }

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -28,23 +28,34 @@
 
 #include "lib/edit.h"
 
+constexpr std::uint64_t kibi = 1024;
+constexpr std::uint64_t mebi = 1024 * kibi;
+constexpr std::uint64_t gibi = 1024 * mebi;
+constexpr std::uint64_t tebi = 1024 * gibi;
+constexpr std::uint64_t pebi = 1024 * tebi;
+constexpr std::uint64_t exi = 1024 * pebi;
+
+constexpr std::uint64_t kilo = 1000;
+constexpr std::uint64_t mega = 1000 * kilo;
+constexpr std::uint64_t giga = 1000 * mega;
+constexpr std::uint64_t tera = 1000 * giga;
+constexpr std::uint64_t peta = 1000 * tera;
+constexpr std::uint64_t exa = 1000 * peta;
+
 TEST(edit, convert_number_to_siunits)
 {
   ASSERT_STREQ(SizeAsSiPrefixFormat(0).c_str(), "0");
   ASSERT_STREQ(SizeAsSiPrefixFormat(1).c_str(), "1");
   ASSERT_STREQ(SizeAsSiPrefixFormat(123).c_str(), "123");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1024).c_str(), "1 k");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(2050).c_str(), "2 k 2");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1048576).c_str(), "1 m");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1073741824).c_str(), "1 g");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1099511627776).c_str(), "1 t");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1125899906842624).c_str(), "1 p");
-  ASSERT_STREQ(SizeAsSiPrefixFormat(1152921504606846976).c_str(), "1 e");
-
+  ASSERT_STREQ(SizeAsSiPrefixFormat(kibi).c_str(), "1 k");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(2 * kibi + 2).c_str(), "2 k 2");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(mebi).c_str(), "1 m");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(gibi).c_str(), "1 g");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(tebi).c_str(), "1 t");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(pebi).c_str(), "1 p");
+  ASSERT_STREQ(SizeAsSiPrefixFormat(exi).c_str(), "1 e");
   ASSERT_STREQ(
-      SizeAsSiPrefixFormat(1152921504606846976 + 1125899906842624
-                           + 1099511627776 + 1073741824 + 1048576 + 1024 + 1)
-          .c_str(),
+      SizeAsSiPrefixFormat(exi + pebi + tebi + gibi + mebi + kibi + 1).c_str(),
       "1 e 1 p 1 t 1 g 1 m 1 k 1");
 }
 
@@ -52,110 +63,116 @@ TEST(edit, convert_number_to_siunits)
 TEST(edit, convert_siunits_to_numbers)
 {
   {
-    char str[] = "1 k";
+    const char* str = "1";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1024);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, 1);
+  }
+
+  {
+    const char* str = "1 k";
+    uint64_t retvalue = 0;
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, kibi);
   }
 
 
   // kilobyte
   {
-    char str[] = "1 kb";
+    const char* str = "1 kb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, kilo);
   }
   {
-    char str[] = "1 KB";
+    const char* str = "1 KB";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, kilo);
   }
 
   // mebibyte
   {
-    char str[] = "1 m";
+    const char* str = "1 m";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1024 * 1024);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, mebi);
   }
 
   // megabyte
   {
-    char str[] = "1 mb";
+    const char* str = "1 mb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000 * 1000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, mega);
   }
 
 
   // gibibyte
   {
-    char str[] = "1 g";
+    const char* str = "1 g";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1024 * 1024 * 1024);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, gibi);
   }
   // gigabyte
   {
-    char str[] = "1 gb";
+    const char* str = "1 gb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1000 * 1000 * 1000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, giga);
   }
 
 
   // tebibyte
   {
-    char str[] = "1 t";
+    const char* str = "1 t";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1099511627776);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, tebi);
   }
   // terabyte
   {
-    char str[] = "1 tb";
+    const char* str = "1 tb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1'000'000'000'000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, tera);
   }
 
   // pebibyte
   {
-    char str[] = "1 p";
+    const char* str = "1 p";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1'125'899'906'842'624);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, pebi);
   }
   // petabyte
   {
-    char str[] = "1 pb";
+    const char* str = "1 pb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1'000'000'000'000'000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, peta);
   }
 
   // exbibyte
   {
-    char str[] = "1 e";
+    const char* str = "1 e";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1'152'921'504'606'846'976);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, exi);
   }
   // exabyte
   {
-    char str[] = "1 eb";
+    const char* str = "1 eb";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1'000'000'000'000'000'000);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, exa);
   }
   // combined specification
   {
-    char str[] = "1 e 1 p 1 t 1 g 1 m 1 k 1";
+    const char* str = "1 e 1 p 1 t 1 g 1 m 1 k 1";
     uint64_t retvalue = 0;
-    size_to_uint64(str, &retvalue);
-    ASSERT_EQ(retvalue, 1152921504606846976 + 1125899906842624 + 1099511627776
-                            + 1073741824 + 1048576 + 1024 + 1);
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, exi + pebi + tebi + gibi + mebi + kibi + 1);
   }
 }

--- a/core/src/tests/test_edit.cc
+++ b/core/src/tests/test_edit.cc
@@ -63,6 +63,13 @@ TEST(edit, convert_number_to_siunits)
 TEST(edit, convert_siunits_to_numbers)
 {
   {
+    const char* str = "";
+    uint64_t retvalue = 0;
+    ASSERT_TRUE(size_to_uint64(str, &retvalue));
+    ASSERT_EQ(retvalue, 0);
+  }
+
+  {
     const char* str = "1";
     uint64_t retvalue = 0;
     ASSERT_TRUE(size_to_uint64(str, &retvalue));
@@ -174,5 +181,29 @@ TEST(edit, convert_siunits_to_numbers)
     uint64_t retvalue = 0;
     ASSERT_TRUE(size_to_uint64(str, &retvalue));
     ASSERT_EQ(retvalue, exi + pebi + tebi + gibi + mebi + kibi + 1);
+  }
+}
+
+TEST(edit, check_bad_parse)
+{
+  {
+    const char* str = "ei";
+    uint64_t retvalue = 0;
+    ASSERT_FALSE(size_to_uint64(str, &retvalue));
+  }
+  {
+    const char* str = "-";
+    uint64_t retvalue = 0;
+    ASSERT_FALSE(size_to_uint64(str, &retvalue));
+  }
+  {
+    const char* str = "+";
+    uint64_t retvalue = 0;
+    ASSERT_FALSE(size_to_uint64(str, &retvalue));
+  }
+  {
+    const char* str = "M";
+    uint64_t retvalue = 0;
+    ASSERT_FALSE(size_to_uint64(str, &retvalue));
   }
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr makes it so prev_jr an optional, so that code can check whether this particular member was initialized or not.
Previously the cleanup did not check whether prev_jr was  initialised before it tried to clean it up (this happened if the
job ended in an error quickly).

It also changes the number parsing code somewhat.   Now we check that everything is parsed, not just that something was parsed.  In particular, with certain locales, we used to parse `1,5` as `1` and did not emit any errors since we managed to parse _something_.
Now we actually check if any characters are left over and fail the parsing if so.

Additionally a small enhancement was added to the parsing routines.  Previously we could parse durations like
`1 Year 5 Days 10 Hours` correctly, but we could not parse numbers like `1 TB 500 GB`, since the code did not loop until every token was consumed.   This PR unified the duration/number parsing somewhat so that now even numbers can be split like above.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
