### PR TITLE
dbcheck: fix dbcheck crash if password is not set in catalog resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Changed
+- dbcheck: fix dbcheck crash if password is not set in catalog resource [PR #1731]
+
 ## [22.1.4] - 2024-02-28
 
 ### Changed
@@ -653,4 +656,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1704]: https://github.com/bareos/bareos/pull/1704
 [PR #1712]: https://github.com/bareos/bareos/pull/1712
 [PR #1714]: https://github.com/bareos/bareos/pull/1714
+[PR #1731]: https://github.com/bareos/bareos/pull/1731
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -920,11 +920,11 @@ int main(int argc, char* argv[])
         exit(BEXIT_SUCCESS);
       }
 
-      db_name = catalog->db_name;
-      user = catalog->db_user;
-      password = catalog->db_password.value;
+      db_name = catalog->db_name ?: "";
+      user = catalog->db_user ?: "";
+      password = catalog->db_password.value ?: "";
+      db_driver = catalog->db_driver ?: "";
       if (catalog->db_address) { dbhost = catalog->db_address; }
-      db_driver = catalog->db_driver;
       if (!dbhost.empty() && dbhost[0] == 0) { dbhost = ""; }
       dbport = catalog->db_port;
     }


### PR DESCRIPTION
**Backport of PR #1710 to bareos-22**

This backport only contains the actual fixes to dbcheck as the other changes were not applicable.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1710 is merged
- [x] All functional differences to the original PR are documented above
