### PR TITLE
stored: fix authentication race condition / deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugins: fix cancel handling crash [PR #1595]
 - Fix bareos_tasks plugin for pgsql [PR #1659]
 - core: Fix compile errors on GCC 14 [PR #1687]
+- stored: fix authentication race condition / deadlock [PR #1732]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -119,4 +120,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1718]: https://github.com/bareos/bareos/pull/1718
 [PR #1719]: https://github.com/bareos/bareos/pull/1719
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
+[PR #1732]: https://github.com/bareos/bareos/pull/1732
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/bareos-ctl-dir.in
+++ b/core/scripts/bareos-ctl-dir.in
@@ -55,7 +55,8 @@ case "$1" in
     stop)
         if [ -x "${BAREOS_DIRECTOR_BINARY}" ]; then
             printf "Stopping the Bareos Director daemon: "
-            killproc "${BAREOS_DIRECTOR_BINARY}" "${BAREOS_DIRECTOR_PORT}"
+	    shift # shift away the stop
+            killproc "${BAREOS_DIRECTOR_BINARY}" "${BAREOS_DIRECTOR_PORT}" "${@}"
         fi
         ;;
 

--- a/core/scripts/bareos-ctl-fd.in
+++ b/core/scripts/bareos-ctl-fd.in
@@ -54,7 +54,8 @@ case "$1" in
     stop)
         if [ -x ${BAREOS_FILEDAEMON_BINARY} ]; then
             printf "Stopping the Bareos File daemon: "
-            killproc ${BAREOS_FILEDAEMON_BINARY} ${BAREOS_FD_PORT}
+	    shift # shift away the stop
+            killproc ${BAREOS_FILEDAEMON_BINARY} ${BAREOS_FD_PORT} "${@}"
         fi
         ;;
 

--- a/core/scripts/bareos-ctl-sd.in
+++ b/core/scripts/bareos-ctl-sd.in
@@ -53,7 +53,8 @@ case "$1" in
     stop)
         if [ -x ${BAREOS_STORAGEDAEMON_BINARY} ]; then
             printf "Stopping the Bareos Storage daemon: "
-            killproc ${BAREOS_STORAGEDAEMON_BINARY} ${BAREOS_SD_PORT}
+	    shift # shift away the stop
+            killproc ${BAREOS_STORAGEDAEMON_BINARY} ${BAREOS_SD_PORT} "${@}"
         fi
         ;;
 

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -27,6 +27,8 @@
 #include "cats/cats.h"
 #include "dird/client_connection_handshake_mode.h"
 #include "dird/job_trigger.h"
+
+#include <condition_variable>
 
 typedef struct s_tree_root TREE_ROOT;
 
@@ -105,7 +107,7 @@ struct DirectorJcrImpl {
   std::shared_ptr<ConfigResourcesContainer> job_config_resources_container_;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */
-  pthread_cond_t term_wait = PTHREAD_COND_INITIALIZER;      /**< Wait for job termination */
+  std::condition_variable term_wait{}; /**< Wait for job termination */
   pthread_cond_t nextrun_ready = PTHREAD_COND_INITIALIZER;  /**< Wait for job next run to become ready */
   Resources res;                  /**< Resources assigned */
   TREE_ROOT* restore_tree_root{}; /**< Selected files to restore (some protocols need this info) */
@@ -151,7 +153,6 @@ struct DirectorJcrImpl {
   int32_t max_concurrent_jobs{};        /**< Maximum concurrent jobs */
   bool spool_data{};                    /**< Spool data in SD */
   bool acquired_resource_locks{};       /**< Set if resource locks acquired */
-  bool term_wait_inited{};              /**< Set when cond var inited */
   bool nextrun_ready_inited{};          /**< Set when cond var inited */
   bool fn_printed{};                    /**< Printed filename */
   bool needs_sd{};                      /**< Set if SD needed by Job */

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -140,37 +140,30 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
 {
   int errstat;
 
-  std::unique_lock l(jcr->mutex_guard());
+  {
+    std::unique_lock l(jcr->mutex_guard());
 
-  // See if we should suppress all output.
-  if (!suppress_output) {
-    InitMsg(jcr, jcr->dir_impl->res.messages, job_code_callback_director);
-  } else {
-    jcr->suppress_output = true;
+    // See if we should suppress all output.
+    if (!suppress_output) {
+      InitMsg(jcr, jcr->dir_impl->res.messages, job_code_callback_director);
+    } else {
+      jcr->suppress_output = true;
+    }
+
+    // Initialize nextrun ready condition variable
+    if ((errstat = pthread_cond_init(&jcr->dir_impl->nextrun_ready, NULL))
+        != 0) {
+      BErrNo be;
+      Jmsg1(jcr, M_FATAL, 0,
+            T_("Unable to init job nextrun cond variable: ERR=%s\n"),
+            be.bstrerror(errstat));
+      goto bail_out;
+    }
+    jcr->dir_impl->nextrun_ready_inited = true;
+
+    CreateUniqueJobName(jcr, jcr->dir_impl->res.job->resource_name_);
+    jcr->setJobStatusWithPriorityCheck(JS_Created);
   }
-
-  // Initialize termination condition variable
-  if ((errstat = pthread_cond_init(&jcr->dir_impl->term_wait, NULL)) != 0) {
-    BErrNo be;
-    Jmsg1(jcr, M_FATAL, 0, T_("Unable to init job cond variable: ERR=%s\n"),
-          be.bstrerror(errstat));
-    goto bail_out;
-  }
-  jcr->dir_impl->term_wait_inited = true;
-
-  // Initialize nextrun ready condition variable
-  if ((errstat = pthread_cond_init(&jcr->dir_impl->nextrun_ready, NULL)) != 0) {
-    BErrNo be;
-    Jmsg1(jcr, M_FATAL, 0,
-          T_("Unable to init job nextrun cond variable: ERR=%s\n"),
-          be.bstrerror(errstat));
-    goto bail_out;
-  }
-  jcr->dir_impl->nextrun_ready_inited = true;
-
-  CreateUniqueJobName(jcr, jcr->dir_impl->res.job->resource_name_);
-  jcr->setJobStatusWithPriorityCheck(JS_Created);
-  l.unlock();
 
   // Open database
   Dmsg0(100, "Open database\n");
@@ -1524,11 +1517,6 @@ void DirdFreeJcr(JobControlRecord* jcr)
   }
 
   DirdFreeJcrPointers(jcr);
-
-  if (jcr->dir_impl->term_wait_inited) {
-    pthread_cond_destroy(&jcr->dir_impl->term_wait);
-    jcr->dir_impl->term_wait_inited = false;
-  }
 
   if (jcr->dir_impl->nextrun_ready_inited) {
     pthread_cond_destroy(&jcr->dir_impl->nextrun_ready);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -140,7 +140,7 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
 {
   int errstat;
 
-  jcr->lock();
+  std::unique_lock l(jcr->mutex_guard());
 
   // See if we should suppress all output.
   if (!suppress_output) {
@@ -154,7 +154,6 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
     BErrNo be;
     Jmsg1(jcr, M_FATAL, 0, T_("Unable to init job cond variable: ERR=%s\n"),
           be.bstrerror(errstat));
-    jcr->unlock();
     goto bail_out;
   }
   jcr->dir_impl->term_wait_inited = true;
@@ -165,14 +164,13 @@ bool SetupJob(JobControlRecord* jcr, bool suppress_output)
     Jmsg1(jcr, M_FATAL, 0,
           T_("Unable to init job nextrun cond variable: ERR=%s\n"),
           be.bstrerror(errstat));
-    jcr->unlock();
     goto bail_out;
   }
   jcr->dir_impl->nextrun_ready_inited = true;
 
   CreateUniqueJobName(jcr, jcr->dir_impl->res.job->resource_name_);
   jcr->setJobStatusWithPriorityCheck(JS_Created);
-  jcr->unlock();
+  l.unlock();
 
   // Open database
   Dmsg0(100, "Open database\n");
@@ -654,13 +652,12 @@ static void* job_thread(void* arg)
 
 void SdMsgThreadSendSignal(JobControlRecord* jcr, int sig)
 {
-  jcr->lock();
+  std::unique_lock l(jcr->mutex_guard());
   if (!jcr->dir_impl->sd_msg_thread_done && jcr->dir_impl->SD_msg_chan_started
       && !pthread_equal(jcr->dir_impl->SD_msg_chan, pthread_self())) {
     Dmsg1(800, "Send kill to SD msg chan jid=%d\n", jcr->JobId);
     pthread_kill(jcr->dir_impl->SD_msg_chan, sig);
   }
-  jcr->unlock();
 }
 
 /**

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -205,17 +205,6 @@ int JobqAdd(jobq_t* jq, JobControlRecord* jcr)
   time_t wtime = jcr->sched_time - time(NULL);
   pthread_t id;
   wait_pkt* sched_pkt;
-
-  if (!jcr->dir_impl->term_wait_inited) {
-    // Initialize termination condition variable
-    if ((status = pthread_cond_init(&jcr->dir_impl->term_wait, NULL)) != 0) {
-      BErrNo be;
-      Jmsg1(jcr, M_FATAL, 0, T_("Unable to init job cond variable: ERR=%s\n"),
-            be.bstrerror(status));
-      return status;
-    }
-    jcr->dir_impl->term_wait_inited = true;
-  }
 
   Dmsg3(2300, "JobqAdd jobid=%d jcr=0x%x UseCount=%d\n", jcr->JobId, jcr,
         jcr->UseCount());

--- a/core/src/dird/ndmp_fhdb_common.cc
+++ b/core/src/dird/ndmp_fhdb_common.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -41,9 +41,10 @@ extern "C" int BndmpFhdbAddFile(struct ndmlog* ixlog,
 {
   NIS* nis = (NIS*)ixlog->ctx;
 
-  nis->jcr->lock();
-  nis->jcr->JobFiles++;
-  nis->jcr->unlock();
+  {
+    std::unique_lock l(nis->jcr->mutex_guard());
+    nis->jcr->JobFiles++;
+  }
 
   if (nis->save_filehist) {
     int8_t FileType = 0;

--- a/core/src/dird/ndmp_fhdb_lmdb.cc
+++ b/core/src/dird/ndmp_fhdb_lmdb.cc
@@ -159,9 +159,10 @@ extern "C" int bndmp_fhdb_lmdb_add_node(struct ndmlog* ixlog,
   NIS* nis;
   nis = (NIS*)ixlog->ctx;
 
-  nis->jcr->lock();
-  nis->jcr->JobFiles++;
-  nis->jcr->unlock();
+  {
+    std::unique_lock l(nis->jcr->mutex_guard());
+    nis->jcr->JobFiles++;
+  }
 
   if (nis->save_filehist) {
     int result;

--- a/core/src/dird/ndmp_fhdb_mem.cc
+++ b/core/src/dird/ndmp_fhdb_mem.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2015-2015 Planets Communications B.V.
-   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -576,9 +576,10 @@ extern "C" int bndmp_fhdb_mem_add_node(struct ndmlog* ixlog,
 {
   NIS* nis = (NIS*)ixlog->ctx;
 
-  nis->jcr->lock();
-  nis->jcr->JobFiles++;
-  nis->jcr->unlock();
+  {
+    std::unique_lock l(nis->jcr->mutex_guard());
+    nis->jcr->JobFiles++;
+  }
 
   if (nis->save_filehist) {
     int attr_size;

--- a/core/src/dird/next_vol.cc
+++ b/core/src/dird/next_vol.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -357,7 +357,8 @@ void CheckIfVolumeValidOrRecyclable(JobControlRecord* jcr,
   }
 }
 
-static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+// Only one thread at a time can pull from the scratch pool
+static pthread_mutex_t scratch_volume_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 bool GetScratchVolume(JobControlRecord* jcr,
                       bool InChanger,
@@ -370,7 +371,7 @@ bool GetScratchVolume(JobControlRecord* jcr,
   bool found = false;
 
   // Only one thread at a time can pull from the scratch pool
-  lock_mutex(mutex);
+  lock_mutex(scratch_volume_mutex);
 
   /* Get Pool record for Scratch Pool
    * choose between ScratchPoolId and Scratch
@@ -447,7 +448,7 @@ bool GetScratchVolume(JobControlRecord* jcr,
   }
 
 bail_out:
-  unlock_mutex(mutex);
+  unlock_mutex(scratch_volume_mutex);
   return ok;
 }
 } /* namespace directordaemon */

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -1597,11 +1597,12 @@ bool EncodeAndSendAttributes(JobControlRecord* jcr,
   Dmsg3(300, "File %s\nattribs=%s\nattribsEx=%s\n", ff_pkt->fname,
         attribs.c_str(), attribsEx);
 
-  jcr->lock();
-  jcr->JobFiles++;                   /* increment number of files sent */
-  ff_pkt->FileIndex = jcr->JobFiles; /* return FileIndex */
-  PmStrcpy(jcr->fd_impl->last_fname, ff_pkt->fname);
-  jcr->unlock();
+  {
+    std::unique_lock l(jcr->mutex_guard());
+    jcr->JobFiles++;                   /* increment number of files sent */
+    ff_pkt->FileIndex = jcr->JobFiles; /* return FileIndex */
+    PmStrcpy(jcr->fd_impl->last_fname, ff_pkt->fname);
+  }
 
   // Debug code: check if we must hangup
   if (hangup && (jcr->JobFiles > (uint32_t)hangup)) {

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -409,71 +409,74 @@ void* process_fd_initiated_director_commands(void* p_jcr)
 
 void* process_director_commands(JobControlRecord* jcr, BareosSocket* dir)
 {
-  bool found;
-  bool quit = false;
+  // only do the cleanup if dir is not authenticated
+  if (jcr->authenticated) {
+    bool quit = 0;
 
-  /**********FIXME******* add command handler error code */
+    /**********FIXME******* add command handler error code */
 
-  while (jcr->authenticated && (!quit)) {
-    // Read command
-    if (dir->recv() < 0) { break; /* connection terminated */ }
+    while (!quit) {
+      // Read command
+      if (dir->recv() < 0) { break; /* connection terminated */ }
 
-    dir->msg[dir->message_length] = 0;
-    Dmsg1(100, "<dird: %s\n", dir->msg);
-    found = false;
-    for (int i = 0; cmds[i].cmd; i++) {
-      if (bstrncmp(cmds[i].cmd, dir->msg, strlen(cmds[i].cmd))) {
-        found = true; /* indicate command found */
-        if ((!cmds[i].monitoraccess) && (jcr->fd_impl->director->monitor)) {
-          Dmsg1(100, "Command \"%s\" is invalid.\n", cmds[i].cmd);
-          dir->fsend(invalid_cmd);
-          dir->signal(BNET_EOD);
+      dir->msg[dir->message_length] = 0;
+      Dmsg1(100, "<dird: %s\n", dir->msg);
+      bool found = false;
+      for (int i = 0; cmds[i].cmd; i++) {
+        if (bstrncmp(cmds[i].cmd, dir->msg, strlen(cmds[i].cmd))) {
+          found = true; /* indicate command found */
+          if ((!cmds[i].monitoraccess) && (jcr->fd_impl->director->monitor)) {
+            Dmsg1(100, "Command \"%s\" is invalid.\n", cmds[i].cmd);
+            dir->fsend(invalid_cmd);
+            dir->signal(BNET_EOD);
+            break;
+          }
+          Dmsg1(100, "Executing %s command.\n", cmds[i].cmd);
+
+          if (!cmds[i].func(jcr)) { /* do command */
+            quit = true;            /* error or fully terminated, get out */
+            Dmsg1(100, "Quit command loop. Canceled=%d\n", jcr->IsJobCanceled());
+          }
           break;
         }
-        Dmsg1(100, "Executing %s command.\n", cmds[i].cmd);
-
-        if (!cmds[i].func(jcr)) { /* do command */
-          quit = true;            /* error or fully terminated, get out */
-          Dmsg1(100, "Quit command loop. Canceled=%d\n", jcr->IsJobCanceled());
-        }
+      }
+      if (!found) { /* command not found */
+        dir->fsend(errmsg);
+        quit = true;
         break;
       }
     }
-    if (!found) { /* command not found */
-      dir->fsend(errmsg);
-      quit = true;
-      break;
+
+    // Inform Storage daemon that we are done
+    if (jcr->store_bsock) { jcr->store_bsock->signal(BNET_TERMINATE); }
+
+    // Run the after job
+    if (jcr->fd_impl->RunScripts) {
+      RunScripts(
+                 jcr, jcr->fd_impl->RunScripts, "ClientAfterJob",
+                 (jcr->fd_impl->director && jcr->fd_impl->director->allowed_script_dirs)
+                 ? jcr->fd_impl->director->allowed_script_dirs
+                 : me->allowed_script_dirs);
     }
+
+    if (jcr->JobId) { /* send EndJob if running a job */
+      char ed1[50], ed2[50];
+      // Send termination status back to Dir
+      dir->fsend(EndJob, jcr->getJobStatus(), jcr->JobFiles,
+                 edit_uint64(jcr->ReadBytes, ed1),
+                 edit_uint64(jcr->JobBytes, ed2), jcr->JobErrors,
+                 jcr->fd_impl->enable_vss, jcr->fd_impl->crypto.pki_encrypt);
+      Dmsg1(110, "End FD msg: %s\n", dir->msg);
+    }
+
+    GeneratePluginEvent(jcr, bEventJobEnd);
+
+    DequeueMessages(jcr); /* send any queued messages */
+
+    // Inform Director that we are done
+    dir->signal(BNET_TERMINATE);
   }
 
-  // Inform Storage daemon that we are done
-  if (jcr->store_bsock) { jcr->store_bsock->signal(BNET_TERMINATE); }
-
-  // Run the after job
-  if (jcr->fd_impl->RunScripts) {
-    RunScripts(
-        jcr, jcr->fd_impl->RunScripts, "ClientAfterJob",
-        (jcr->fd_impl->director && jcr->fd_impl->director->allowed_script_dirs)
-            ? jcr->fd_impl->director->allowed_script_dirs
-            : me->allowed_script_dirs);
-  }
-
-  if (jcr->JobId) { /* send EndJob if running a job */
-    char ed1[50], ed2[50];
-    // Send termination status back to Dir
-    dir->fsend(EndJob, jcr->getJobStatus(), jcr->JobFiles,
-               edit_uint64(jcr->ReadBytes, ed1),
-               edit_uint64(jcr->JobBytes, ed2), jcr->JobErrors,
-               jcr->fd_impl->enable_vss, jcr->fd_impl->crypto.pki_encrypt);
-    Dmsg1(110, "End FD msg: %s\n", dir->msg);
-  }
-
-  GeneratePluginEvent(jcr, bEventJobEnd);
-
-  DequeueMessages(jcr); /* send any queued messages */
-
-  // Inform Director that we are done
-  dir->signal(BNET_TERMINATE);
   jcr->EnterFinish();
 
   FreePlugins(jcr); /* release instantiated plugins */

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -587,10 +587,14 @@ void DoRestore(JobControlRecord* jcr)
         if (status == CF_CORE) {
           status = CreateFile(jcr, attr, &rctx.bfd, jcr->fd_impl->replace);
         }
-        jcr->lock();
-        PmStrcpy(jcr->fd_impl->last_fname, attr->ofname);
-        jcr->fd_impl->last_type = attr->type;
-        jcr->unlock();
+
+        {
+          // NOTE: This should probably be a lock in jcr->fd_impl instead
+          std::unique_lock l(jcr->mutex_guard());
+          PmStrcpy(jcr->fd_impl->last_fname, attr->ofname);
+          jcr->fd_impl->last_type = attr->type;
+        }
+
         Dmsg2(130, "Outfile=%s CreateFile status=%d\n", attr->ofname, status);
         switch (status) {
           case CF_ERROR:

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
 
    This program is Free Software; you can redistribute it and/or
@@ -207,10 +207,11 @@ static void ListRunningJobsPlain(StatusPacket* sp)
                edit_uint64_with_commas(njcr->fd_impl->num_files_examined, b1));
     sp->send(msg, len);
     if (njcr->JobFiles > 0) {
-      njcr->lock();
-      len = Mmsg(msg, T_("    Processing file: %s\n"),
-                 njcr->fd_impl->last_fname);
-      njcr->unlock();
+      {
+        std::unique_lock l(njcr->mutex_guard());
+        len = Mmsg(msg, T_("    Processing file: %s\n"),
+                   njcr->fd_impl->last_fname);
+      }
       sp->send(msg, len);
     }
 
@@ -278,9 +279,10 @@ static void ListRunningJobsApi(StatusPacket* sp)
                edit_uint64(njcr->fd_impl->num_files_examined, b1));
     sp->send(msg, len);
     if (njcr->JobFiles > 0) {
-      njcr->lock();
-      len = Mmsg(msg, " Processing file=%s\n", njcr->fd_impl->last_fname);
-      njcr->unlock();
+      {
+        std::unique_lock l(njcr->mutex_guard());
+        len = Mmsg(msg, " Processing file=%s\n", njcr->fd_impl->last_fname);
+      }
       sp->send(msg, len);
     }
 

--- a/core/src/filed/verify.cc
+++ b/core/src/filed/verify.cc
@@ -199,10 +199,11 @@ static int VerifyFile(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
              ff_pkt->LinkFI, 0);
   encode_attribsEx(jcr, attribsEx.c_str(), ff_pkt);
 
-  jcr->lock();
-  jcr->JobFiles++; /* increment number of files sent */
-  PmStrcpy(jcr->fd_impl->last_fname, ff_pkt->fname);
-  jcr->unlock();
+  {
+    std::unique_lock l(jcr->mutex_guard());
+    jcr->JobFiles++; /* increment number of files sent */
+    PmStrcpy(jcr->fd_impl->last_fname, ff_pkt->fname);
+  }
 
   /* Path needs to be stripped just like during the
    * backup. The director catalog only knows about the

--- a/core/src/filed/verify_vol.cc
+++ b/core/src/filed/verify_vol.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -168,11 +168,13 @@ void DoVerifyVolume(JobControlRecord* jcr)
         } else {
           *lname = 0;
         }
-        jcr->lock();
-        jcr->JobFiles++;
-        jcr->fd_impl->num_files_examined++;
-        PmStrcpy(jcr->fd_impl->last_fname, fname); /* last file examined */
-        jcr->unlock();
+
+        {
+          std::unique_lock l(jcr->mutex_guard());
+          jcr->JobFiles++;
+          jcr->fd_impl->num_files_examined++;
+          PmStrcpy(jcr->fd_impl->last_fname, fname); /* last file examined */
+        }
 
         /* Send file attributes to Director
          *   File_index
@@ -258,11 +260,11 @@ void DoVerifyVolume(JobControlRecord* jcr)
               dir->msg);
         break;
 
-      case STREAM_RESTORE_OBJECT:
-        jcr->lock();
+      case STREAM_RESTORE_OBJECT: {
+        std::unique_lock l(jcr->mutex_guard());
         jcr->JobFiles++;
         jcr->fd_impl->num_files_examined++;
-        jcr->unlock();
+      }
 
         Dmsg2(400, "send inx=%d STREAM_RESTORE_OBJECT-%d\n", jcr->JobFiles,
               STREAM_RESTORE_OBJECT);

--- a/core/src/include/jcr.h
+++ b/core/src/include/jcr.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -77,7 +77,7 @@ typedef void(JCR_free_HANDLER)(JobControlRecord* jcr);
 /* clang-format off */
 class JobControlRecord {
  private:
-  pthread_mutex_t mutex_ = PTHREAD_MUTEX_INITIALIZER; /**< Jcr mutex */
+  std::mutex mutex_; /**< Jcr mutex */
   std::atomic<int32_t> use_count_{};                   /**< Use count */
   std::atomic<int32_t> JobStatus_{}; /**< ready, running, blocked, terminated */
   int32_t JobType_{};            /**< Backup, restore, verify ... */
@@ -110,8 +110,8 @@ class JobControlRecord {
   JobControlRecord& operator=(const JobControlRecord& other) = delete;
   JobControlRecord& operator=(const JobControlRecord&& other) = delete;
 
-  void lock() { lock_mutex(mutex_); }
-  void unlock() { unlock_mutex(mutex_); }
+  [[nodiscard]] std::mutex& mutex_guard() { return mutex_; }
+
   void IncUseCount(void)
   {
     ++use_count_;
@@ -121,8 +121,6 @@ class JobControlRecord {
     --use_count_;
   }
   int32_t UseCount() const { return use_count_; }
-  void InitMutex(void) { pthread_mutex_init(&mutex_, NULL); }
-  void DestroyMutex(void) { pthread_mutex_destroy(&mutex_); }
   bool IsJobCanceled() { return  JobStatus_ == JS_Canceled
                               || JobStatus_ == JS_ErrorTerminated
                               || JobStatus_ == JS_FatalError; }

--- a/core/src/lib/thread_util.h
+++ b/core/src/lib/thread_util.h
@@ -61,6 +61,13 @@ class locked {
     cv.wait(lock, [this, pred = std::move(pred)] { return pred(*data); });
   }
 
+  template <typename CondVar, typename TimePoint, typename P>
+  bool wait_until(CondVar& cv, TimePoint tp, P&& pred)
+  {
+    return cv.wait_until(
+        lock, tp, [this, pred = std::move(pred)] { return pred(*data); });
+  }
+
   template <typename CondVar, typename TimePoint>
   std::cv_status wait_until(CondVar& cv, TimePoint tp)
   {

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -254,16 +254,6 @@ void* HandleDirectorConnection(BareosSocket* dir)
   jcr->dir_bsock = dir; /* save Director bsock */
   jcr->dir_bsock->SetJcr(jcr);
 
-  // Initialize Start Job condition variable
-  errstat = pthread_cond_init(&jcr->sd_impl->job_start_wait, NULL);
-  if (errstat != 0) {
-    BErrNo be;
-    Jmsg1(jcr, M_FATAL, 0,
-          T_("Unable to init job start cond variable: ERR=%s\n"),
-          be.bstrerror(errstat));
-    goto bail_out;
-  }
-
   // Initialize End Job condition variable
   errstat = pthread_cond_init(&jcr->sd_impl->job_end_wait, NULL);
   if (errstat != 0) {
@@ -495,8 +485,7 @@ static bool CancelCmd(JobControlRecord* cjcr)
   Dmsg2(800, "Cancel JobId=%d %p\n", jcr->JobId, jcr);
   if (!jcr->authenticated
       && (oldStatus == JS_WaitFD || oldStatus == JS_WaitSD)) {
-    pthread_cond_signal(
-        &jcr->sd_impl->job_start_wait); /* wake waiting thread */
+    jcr->sd_impl->job_start_wait.notify_one(); /* wake waiting thread */
   }
 
   if (jcr->file_bsock) {
@@ -506,7 +495,7 @@ static bool CancelCmd(JobControlRecord* cjcr)
   } else {
     if (oldStatus != JS_WaitSD) {
       // Still waiting for FD to connect, release it
-      pthread_cond_signal(&jcr->sd_impl->job_start_wait); /* wake waiting job */
+      jcr->sd_impl->job_start_wait.notify_one(); /* wake waiting job */
       Dmsg2(800, "Signal FD connect jid=%d %p\n", jcr->JobId, jcr);
     }
   }
@@ -1765,6 +1754,7 @@ static bool PassiveCmd(JobControlRecord* jcr)
     utime_t now;
 
     Dmsg0(110, "Authenticated with FD.\n");
+    *jcr->sd_impl->client_available.lock() = true;
 
     // Update the initial Job Statistics.
     now = (utime_t)time(NULL);

--- a/core/src/stored/fd_cmds.cc
+++ b/core/src/stored/fd_cmds.cc
@@ -137,7 +137,7 @@ void* HandleFiledConnection(BareosSocket* fd, char* job_name)
   } else {
     utime_t now;
 
-    jcr->authenticated = true;
+    *jcr->sd_impl->client_available.lock() = true;
     Dmsg2(50, "OK Authentication jid=%u Job %s\n", (uint32_t)jcr->JobId,
           jcr->Job);
 
@@ -146,7 +146,7 @@ void* HandleFiledConnection(BareosSocket* fd, char* job_name)
     UpdateJobStatistics(jcr, now);
   }
 
-  pthread_cond_signal(&jcr->sd_impl->job_start_wait); /* wake waiting job */
+  jcr->sd_impl->job_start_wait.notify_one(); /* wake waiting job */
   FreeJcr(jcr);
 
   return NULL;

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -545,7 +545,8 @@ extern "C" ndmp9_error bndmp_tape_open(struct ndm_session* sess,
   /* There is a native storage daemon session waiting for the FD to connect.
    * In NDMP terms this is the same as a FD connecting so wake any waiting
    * threads.  */
-  pthread_cond_signal(&jcr->sd_impl->job_start_wait);
+  *jcr->sd_impl->client_available.lock() = true;
+  jcr->sd_impl->job_start_wait.notify_one();
 
   /* Save the JobControlRecord to ndm_session binding so everything furher
    * knows which JobControlRecord belongs to which NDMP session. We have

--- a/core/src/stored/sd_cmds.cc
+++ b/core/src/stored/sd_cmds.cc
@@ -2,7 +2,7 @@
    BAREOS - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -45,8 +45,6 @@
 #include "include/jcr.h"
 
 namespace storagedaemon {
-
-static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 
 /* Imported variables */
 
@@ -127,7 +125,7 @@ void* handle_stored_connection(BareosSocket* sd, char* job_name)
     Dmsg1(50, "Authentication failed Job %s\n", jcr->Job);
     Jmsg(jcr, M_FATAL, 0, T_("Unable to authenticate Storage daemon\n"));
   } else {
-    jcr->authenticated = true;
+    *jcr->sd_impl->client_available.lock() = true;
     Dmsg2(50, "OK Authentication jid=%u Job %s\n", (uint32_t)jcr->JobId,
           jcr->Job);
   }
@@ -136,7 +134,7 @@ void* handle_stored_connection(BareosSocket* sd, char* job_name)
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
   }
 
-  pthread_cond_signal(&jcr->sd_impl->job_start_wait); /* wake waiting job */
+  jcr->sd_impl->job_start_wait.notify_one(); /* wake waiting job */
   FreeJcr(jcr);
 
   return NULL;
@@ -209,7 +207,6 @@ static void DoSdCommands(JobControlRecord* jcr)
 bool DoListenRun(JobControlRecord* jcr)
 {
   char ec1[30];
-  int errstat = 0;
   BareosSocket* dir = jcr->dir_bsock;
 
   jcr->sendJobStatus(JS_WaitSD); /* wait for SD to connect */
@@ -220,15 +217,13 @@ bool DoListenRun(JobControlRecord* jcr)
 
   /* Wait for the Storage daemon to contact us to start the Job, when he does,
    * we will be released. */
-  lock_mutex(mutex);
-  while (!jcr->authenticated && !jcr->IsJobCanceled()) {
-    errstat = pthread_cond_wait(&jcr->sd_impl->job_start_wait, &mutex);
-    if (errstat == EINVAL || errstat == EPERM) { break; }
-    Dmsg1(800, "=== Auth cond errstat=%d\n", errstat);
+  {
+    auto locked = jcr->sd_impl->client_available.lock();
+    locked.wait(jcr->sd_impl->job_start_wait, [jcr](bool started) {
+      return started || jcr->IsJobCanceled();
+    });
   }
-  Dmsg3(50, "Auth=%d canceled=%d errstat=%d\n", jcr->authenticated,
-        jcr->IsJobCanceled(), errstat);
-  unlock_mutex(mutex);
+  Dmsg3(50, "Auth=%d canceled=%d\n", jcr->authenticated, jcr->IsJobCanceled());
 
   if (!jcr->authenticated || !jcr->store_bsock) {
     Dmsg2(800, "Auth fail or cancel for jid=%d %p\n", jcr->JobId, jcr);

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -738,9 +738,10 @@ static inline void SendDriveReserveMessages(JobControlRecord* jcr,
   alist<const char*>* msgs;
   char* msg;
 
-  jcr->lock();
+  std::unique_lock l(jcr->mutex_guard());
+
   msgs = jcr->sd_impl->reserve_msgs;
-  if (!msgs || msgs->size() == 0) { goto bail_out; }
+  if (!msgs || msgs->size() == 0) { return; }
   for (i = msgs->size() - 1; i >= 0; i--) {
     msg = (char*)msgs->get(i);
     if (msg) {
@@ -750,9 +751,6 @@ static inline void SendDriveReserveMessages(JobControlRecord* jcr,
       break;
     }
   }
-
-bail_out:
-  jcr->unlock();
 }
 
 static void ListJobsWaitingOnReservation(StatusPacket* sp)

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -500,15 +500,6 @@ extern "C" void* device_initialization(void*)
   NewPlugins(jcr); /* instantiate plugins */
   jcr->setJobType(JT_SYSTEM);
 
-  // Initialize job start condition variable
-  errstat = pthread_cond_init(&jcr->sd_impl->job_start_wait, nullptr);
-  if (errstat != 0) {
-    BErrNo be;
-    Jmsg1(jcr, M_ABORT, 0,
-          T_("Unable to init job start cond variable: ERR=%s\n"),
-          be.bstrerror(errstat));
-  }
-
   // Initialize job end condition variable
   errstat = pthread_cond_init(&jcr->sd_impl->job_end_wait, nullptr);
   if (errstat != 0) {

--- a/core/src/stored/stored_jcr_impl.h
+++ b/core/src/stored/stored_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,7 @@
 
 #include "stored/read_ctx.h"
 #include "stored/stored_conf.h"
+#include "lib/thread_util.h"
 
 #define SD_APPEND 1
 #define SD_READ 0
@@ -68,8 +69,9 @@ struct DeviceWaitTimes {
 struct StoredJcrImpl {
   JobControlRecord* next_dev{}; /**< Next JobControlRecord attached to device */
   JobControlRecord* prev_dev{}; /**< Previous JobControlRecord attached to device */
-  pthread_cond_t job_start_wait = PTHREAD_COND_INITIALIZER; /**< Wait for FD to start Job */
   pthread_cond_t job_end_wait = PTHREAD_COND_INITIALIZER;   /**< Wait for Job to end */
+  synchronized<bool> client_available;
+  std::condition_variable job_start_wait; /**< Wait for Client (FD/SD) to start Job */
   storagedaemon::DeviceControlRecord* read_dcr{}; /**< Device context for reading */
   storagedaemon::DeviceControlRecord* dcr{};      /**< Device context record */
   POOLMEM* job_name{};            /**< Base Job name (not unique) */

--- a/systemtests/scripts/cleanup
+++ b/systemtests/scripts/cleanup
@@ -22,6 +22,8 @@ rm -rf /tmp/chrome-user-data-*
 
 "${rscripts}/bareos" stop >/dev/null
 
+tail -n +1 ${working:?}/*.traceback || true
+
 ${scripts}/drop_bareos_database ${DBTYPE} >/dev/null 2>&1
 
 exit 0

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -495,6 +495,7 @@ run_bconsole()
 	fi
     fi
     if (( error_code == 124 )); then
+        timeout 10s "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" <<< "messages" || :
 	traceback "${BAREOS_FILEDAEMON_BINARY}" || :
 	traceback "${BAREOS_STORAGEDAEMON_BINARY}" || :
 	traceback "${BAREOS_DIRECTOR_BINARY}" || :

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -473,15 +473,21 @@ run_bareos()
 
 run_bconsole()
 {
-   bconsole_file="${1:-${tmp}/bconcmds}"
-   if [ -f "$bconsole_file" ]; then
-      if test "$debug" -eq 1 ; then
-        "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" < "$bconsole_file"
-      else
-        "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" < "$bconsole_file" 2>&1 >/dev/null
-      fi
-   fi
-   return $?
+    bconsole_file="${1:-${tmp}/bconcmds}"
+    local error_code=0
+    if [ -f "$bconsole_file" ]; then
+	# 'cmd || ec=$?' is used to prevent "set -e" from killing the script
+	# before we had the chance to kill the daemons (in case of timeout)
+	if test "$debug" -eq 1 ; then
+            timeout 100s "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" < "$bconsole_file" || error_code=$?
+	else
+            timeout 100s "${BAREOS_BCONSOLE_BINARY}" -c "${conf}" < "$bconsole_file" 2>&1 >/dev/null || error_code=$?
+	fi
+    fi
+    if (( error_code == 124 )); then
+	bin/bareos stop -SEGV
+    fi
+    return "$error_code"
 }
 
 run_btape()

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -164,6 +164,7 @@ start_test()
    dstat=0
    # marker for cleanup()
    echo "$STARTDATE" > "${working}/CLEANUPMARKER"
+   bin/bareos status || true
 }
 
 require_root()
@@ -471,6 +472,15 @@ run_bareos()
    return $?
 }
 
+traceback()
+{
+    name="$(basename "$1")"
+    pid=$(pidof "$name")
+    if [ "$pid" != "" ]; then
+	"${rscripts}/btraceback" "$1" "$pid" "${BAREOS_WORKING_DIR}"
+    fi
+}
+
 run_bconsole()
 {
     bconsole_file="${1:-${tmp}/bconcmds}"
@@ -485,7 +495,9 @@ run_bconsole()
 	fi
     fi
     if (( error_code == 124 )); then
-	bin/bareos stop -SEGV
+	traceback "${BAREOS_FILEDAEMON_BINARY}" || :
+	traceback "${BAREOS_STORAGEDAEMON_BINARY}" || :
+	traceback "${BAREOS_DIRECTOR_BINARY}" || :
     fi
     return "$error_code"
 }

--- a/systemtests/tests/parallel-jobs/CMakeLists.txt
+++ b/systemtests/tests/parallel-jobs/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/parallel-jobs/CMakeLists.txt
+++ b/systemtests/tests/parallel-jobs/CMakeLists.txt
@@ -19,3 +19,12 @@
 
 get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
 create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
+
+set_tests_properties(
+  system:parallel-jobs:parallel-jobs
+  PROPERTIES FIXTURES_SETUP "system:parallel-jobs:parallel-jobs-fixture"
+)
+set_tests_properties(
+  system:parallel-jobs:reservation-order
+  PROPERTIES DEPENDS "system:parallel-jobs:parallel-jobs-fixture"
+)


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Sometimes the fd and sd do not agree on the authentication status of the connection, which leads to both of them waiting for the other.
This is in part caused by not using condition variables correctly, which causes the sd to not notice that the `authenticated` condition changed from false to true.

This PR also adds an additional timeout check to our systemtests.  If a single run_bconsole invocation takes more than 100 seconds, then the testrunner will create backtraces of the currently running daemons and exit the test with exit code 124.

This should make it easier to debug hangs (like the one above) in our ci pipeline.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
