### PR TITLE
dird: disallow running always incremental virtual full jobs with empty jobid list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - build: enable building for Fedora40 and Ubuntu 24.04 [PR #1815]
 - ULC: build the universal linux client also for rpm based OS. [PR #1824]
 - consolidate: disable vfull duplicate job check [PR #1739]
+- dird: disallow running always incremental virtual full jobs with empty jobid list [PR #1738]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -182,6 +183,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1727]: https://github.com/bareos/bareos/pull/1727
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
 [PR #1732]: https://github.com/bareos/bareos/pull/1732
+[PR #1738]: https://github.com/bareos/bareos/pull/1738
 [PR #1739]: https://github.com/bareos/bareos/pull/1739
 [PR #1740]: https://github.com/bareos/bareos/pull/1740
 [PR #1744]: https://github.com/bareos/bareos/pull/1744

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -346,31 +346,28 @@ bool list_cmd(UaContext* ua, const char* cmd)
 
 static int GetJobidFromCmdline(UaContext* ua)
 {
-  int jobid;
-  JobDbRecord jr;
-  ClientDbRecord cr;
+  JobDbRecord jr{};
 
-  if (const char* ujobid = GetArgValue(ua, NT_("ujobid"))) {
-    bstrncpy(jr.Job, ujobid, MAX_NAME_LENGTH);
-    jr.JobId = 0;
-    if (ua->db->GetJobRecord(ua->jcr, &jr)) {
-      jobid = jr.JobId;
-    } else {
-      return -1;
-    }
-  } else if (const char* jobid_str = GetArgValue(ua, NT_("jobid"))) {
-    jr.JobId = str_to_int64(jobid_str);
-  } else {
-    return -1;
-  }
-
-  if (ua->db->GetJobRecord(ua->jcr, &jr)) {
-    jobid = jr.JobId;
-  } else {
-    Dmsg1(200, "GetJobidFromCmdline: Failed to get job record for JobId %d\n",
+  if (const char* jobname = GetArgValue(ua, NT_("ujobid"))) {
+    bstrncpy(jr.Job, jobname, MAX_NAME_LENGTH);
+    Dmsg1(200, "GetJobidFromCmdline: Selecting ujobid %s from cmdline.\n",
+          jr.Job);
+  } else if (const char* jobid = GetArgValue(ua, NT_("jobid"))) {
+    jr.JobId = str_to_int64(jobid);
+    Dmsg1(200, "GetJobidFromCmdline: Selecting jobid %d from cmdline.\n",
           jr.JobId);
+  } else {
+    Dmsg0(200, "GetJobidFromCmdline: No jobid specified on cmdline.\n");
+    return 0;
+  }
+
+  if (!ua->db->GetJobRecord(ua->jcr, &jr)) {
+    Dmsg0(200, "GetJobidFromCmdline: Failed to get job record.\n");
     return -1;
   }
+
+  Dmsg1(200, "GetJobidFromCmdline: Found job record with jobid %d.\n",
+        jr.JobId);
 
   if (!ua->AclAccessOk(Job_ACL, jr.Name, true)) {
     Dmsg1(200, "GetJobidFromCmdline: No access to Job %s\n", jr.Name);
@@ -378,22 +375,23 @@ static int GetJobidFromCmdline(UaContext* ua)
   }
 
   if (jr.ClientId) {
+    ClientDbRecord cr{};
     cr.ClientId = jr.ClientId;
-    if (ua->db->GetClientRecord(ua->jcr, &cr)) {
-      if (!ua->AclAccessOk(Client_ACL, cr.Name, true)) {
-        Dmsg1(200, "GetJobidFromCmdline: No access to Client %s\n", cr.Name);
-        return -1;
-      }
-    } else {
+    if (!ua->db->GetClientRecord(ua->jcr, &cr)) {
       Dmsg1(
           200,
           "GetJobidFromCmdline: Failed to get client record for ClientId %d\n",
           jr.ClientId);
       return -1;
     }
+
+    if (!ua->AclAccessOk(Client_ACL, cr.Name, true)) {
+      Dmsg1(200, "GetJobidFromCmdline: No access to Client %s\n", cr.Name);
+      return -1;
+    }
   }
 
-  return jobid;
+  return jr.JobId;
 }
 
 /**
@@ -813,7 +811,7 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     ua->db->ListFilesets(ua->jcr, &jr, query_range.c_str(), ua->send, llist);
   } else if (Bstrcasecmp(ua->argk[1], NT_("jobmedia"))) {
     // List JOBMEDIA
-    if (int jobid = GetJobidFromCmdline(ua); jobid > 0) {
+    if (int jobid = GetJobidFromCmdline(ua); jobid >= 0) {
       ua->db->ListJobmediaRecords(ua->jcr, jobid, ua->send, llist);
     } else {
       ua->ErrorMsg(
@@ -822,7 +820,7 @@ static bool DoListCmd(UaContext* ua, const char* cmd, e_list_type llist)
     }
   } else if (Bstrcasecmp(ua->argk[1], NT_("joblog"))) {
     // List JOBLOG
-    if (int jobid = GetJobidFromCmdline(ua); jobid > 0) {
+    if (int jobid = GetJobidFromCmdline(ua); jobid >= 0) {
       ua->db->ListJoblogRecords(ua->jcr, jobid, query_range.c_str(),
                                 optionslist.count, ua->send, llist);
     } else {

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -379,11 +379,6 @@ int DoRunCmd(UaContext* ua, const char*)
 
   if (!ScanCommandLineArguments(ua, rc)) { return 0; }
 
-  if (FindArg(ua, NT_("fdcalled")) > 0) {
-    jcr->file_bsock = ua->UA_sock->clone();
-    ua->quit = true;
-  }
-
   /* Create JobControlRecord to run job.  NOTE!!! after this point, FreeJcr()
    * before returning. */
   if (!jcr) {

--- a/core/src/dird/vbackup.cc
+++ b/core/src/dird/vbackup.cc
@@ -105,6 +105,12 @@ std::string GetVfJobids(JobControlRecord& jcr)
   if (jcr.dir_impl->vf_jobids) {
     Dmsg1(10, "jobids=%s\n", jcr.dir_impl->vf_jobids);
     return jcr.dir_impl->vf_jobids;
+  } else if (jcr.dir_impl->res.job->AlwaysIncremental) {
+    // jcr.dir_impl->vf_jobids is NULL here
+    Jmsg(&jcr, M_ERROR, 0,
+         "Cannot run always incremental job at level VirtualFull with no jobid "
+         "list.\n");
+    return std::string{};
   } else {
     db_list_ctx jobids_ctx;
     jcr.db->AccurateGetJobids(&jcr, &jcr.dir_impl->jr, &jobids_ctx);

--- a/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+#
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=ai-backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+# Check consolidate ai virtual full can't be rerun manually (without a jobid list).
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/ai2backups.out
+messages
+label volume=TestVolume002 storage=File pool=Full
+run job=$JobName level=Full yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-19'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-20'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-21'"
+run job=$JobName level=Incremental yes
+wait
+messages
+END_OF_DATA
+run_bconsole
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/consolidatevfs_canceled.out
+run job=Consolidate yes
+@sleep 2
+cancel all yes
+wait
+messages
+@$out ${tmp}/consolidatevfs_canceled_listjobs.out
+list jobs jobtype=B jobstatus=A,C
+quit
+END_OF_DATA
+run_bconsole
+
+last_jobid=$(awk '/^\| [ 0-9]/{a=$2}END{print a}' ${tmp}/consolidatevfs_canceled_listjobs.out)
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/consolidatevfs_rerun_canceled.out
+rerun jobid=${last_jobid} yes
+wait
+messages
+END_OF_DATA
+run_bconsole
+
+expect_grep "Cannot run always incremental job at level VirtualFull with no jobid" \
+            "${tmp}/consolidatevfs_rerun_canceled.out" \
+            "Aborting rerun without jobis not found"
+
+end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR prevents users from accidentally trying to restart a virtualfull job when always incremental is enabled.
Restarting a virtualfull job in that setting used to combine all backup points into one which is not what you want.

This also removes traces of the unfinished legacy feature 'fdcalled'.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
