### PR TITLE
stored: fix not counting files correctly in mac jobs when autoxflate is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: Fix compile errors on GCC 14 [PR #1687]
 - stored: fix authentication race condition / deadlock [PR #1732]
 - Fix warning about missing delcandidates table in director [PR #1721]
+- stored: fix not counting files correctly in mac jobs when autoxflate is enabled [PR #1745]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -123,4 +124,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1721]: https://github.com/bareos/bareos/pull/1721
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
 [PR #1732]: https://github.com/bareos/bareos/pull/1732
+[PR #1745]: https://github.com/bareos/bareos/pull/1745
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/jcr.cc
+++ b/core/src/lib/jcr.cc
@@ -862,8 +862,8 @@ int JobCount()
   int count = 0;
 
   LockJcrChain();
-  for (jcr = (JobControlRecord*)job_control_record_chain->first();
-       (jcr = (JobControlRecord*)job_control_record_chain->next(jcr));) {
+  for (jcr = (JobControlRecord*)job_control_record_chain->first(); jcr;
+       (jcr = (JobControlRecord*)job_control_record_chain->next(jcr))) {
     if (jcr->JobId > 0) { count++; }
   }
   UnlockJcrChain();

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -800,7 +800,10 @@ bool DeviceControlRecord::WriteBlockToDev()
   dcr->VolMediaId = dev->VolCatInfo.VolMediaId;
   if (dcr->VolFirstIndex == 0 && block->FirstIndex > 0) {
     dcr->WroteVol = true;
-    ASSERT(dcr->DirCreateJobmediaRecord(true));
+    if (!dcr->DirCreateJobmediaRecord(true)) {
+      Jmsg(dcr->jcr, M_ERROR, 0,
+           "Was not able to create dummy job media record.\n");
+    }
     dcr->VolFirstIndex = block->FirstIndex;
     uint64_t addr = dev->file_addr;
 

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2006-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -131,25 +131,24 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
         Dmsg0(200, "Found first SOS_LABEL and adopting job info\n");
         found_first_sos_label = true;
 
-        static Session_Label the_label;
-        static Session_Label* label = &the_label;
+        Session_Label sos_label;
 
-        UnserSessionLabel(label, rec);
+        UnserSessionLabel(&sos_label, rec);
 
         if (jcr->is_JobType(JT_MIGRATE) || jcr->is_JobType(JT_COPY)) {
-          bstrncpy(jcr->Job, label->Job, sizeof(jcr->Job));
-          PmStrcpy(jcr->sd_impl->job_name, label->JobName);
-          PmStrcpy(jcr->client_name, label->ClientName);
-          PmStrcpy(jcr->sd_impl->fileset_name, label->FileSetName);
-          PmStrcpy(jcr->sd_impl->fileset_md5, label->FileSetMD5);
+          bstrncpy(jcr->Job, sos_label.Job, sizeof(jcr->Job));
+          PmStrcpy(jcr->sd_impl->job_name, sos_label.JobName);
+          PmStrcpy(jcr->client_name, sos_label.ClientName);
+          PmStrcpy(jcr->sd_impl->fileset_name, sos_label.FileSetName);
+          PmStrcpy(jcr->sd_impl->fileset_md5, sos_label.FileSetMD5);
         }
-        jcr->setJobType(label->JobType);
-        jcr->setJobLevel(label->JobLevel);
-        Dmsg1(200, "joblevel from SOS_LABEL is now %c\n", label->JobLevel);
+        jcr->setJobType(sos_label.JobType);
+        jcr->setJobLevel(sos_label.JobLevel);
+        Dmsg1(200, "joblevel from SOS_LABEL is now %c\n", sos_label.JobLevel);
 
         // make sure this volume wasn't written by bacula 1.26 or earlier
-        ASSERT(label->VerNum >= 11);
-        jcr->sched_time = BtimeToUnix(label->write_btime);
+        ASSERT(sos_label.VerNum >= 11);
+        jcr->sched_time = BtimeToUnix(sos_label.write_btime);
 
         jcr->start_time = jcr->sched_time;
 
@@ -188,6 +187,7 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
     }
     rec->FileIndex = jcr->JobFiles; /* set sequential output FileIndex */
   }
+
 
   // Modify record SessionId and SessionTime to correspond to output.
   rec->VolSessionId = jcr->VolSessionId;
@@ -230,13 +230,7 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
     Dmsg2(200, "===== Wrote block new pos %u:%u\n", dev->file, dev->block_num);
   }
 
-  // Restore packet
-  jcr->sd_impl->dcr->after_rec->VolSessionId
-      = jcr->sd_impl->dcr->after_rec->last_VolSessionId;
-  jcr->sd_impl->dcr->after_rec->VolSessionTime
-      = jcr->sd_impl->dcr->after_rec->last_VolSessionTime;
-
-  if (jcr->sd_impl->dcr->after_rec->FileIndex < 0) {
+  if (rec->FileIndex < 0) {
     retval = true; /* don't send LABELs to Dir */
     goto bail_out;
   }
@@ -258,6 +252,13 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
   retval = true;
 
 bail_out:
+
+  /* Restore packet -- the read record function uses this information
+   * to check if the job changed, so we need to restore it to how it was;
+   * otherwise the record will get zeroed on job change. */
+  rec->VolSessionId = rec->last_VolSessionId;
+  rec->VolSessionTime = rec->last_VolSessionTime;
+
   if (translated_record) {
     FreeRecord(jcr->sd_impl->dcr->after_rec);
     jcr->sd_impl->dcr->after_rec = NULL;

--- a/core/src/stored/mac.cc
+++ b/core/src/stored/mac.cc
@@ -65,9 +65,14 @@ static char ReplicateData[] = "replicate data %d\n";
 static char end_replicate[] = "end replicate\n";
 
 
-/* get information from first original SOS label for our job */
-static bool found_first_sos_label = false;
-
+/* last callback information of our job */
+struct cb_data {
+  bool found_first_sos_label{false};
+  uint32_t last_VolSessionId{0};
+  uint32_t last_VolSessionTime{0};
+  int32_t last_FileIndex{0};
+  int32_t last_Stream{0};
+};
 
 /**
  * Get response from Storage daemon to a command we sent.
@@ -109,7 +114,9 @@ static bool response(JobControlRecord* jcr,
  * Returns: true if OK
  *           false if error
  */
-static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
+static bool CloneRecordInternally(DeviceControlRecord* dcr,
+                                  DeviceRecord* rec,
+                                  cb_data* data)
 {
   bool retval = false;
   bool translated_record = false;
@@ -127,9 +134,9 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
 
   if (rec->FileIndex < 0) {
     if (rec->FileIndex == SOS_LABEL) {
-      if (!found_first_sos_label) {
+      if (!data->found_first_sos_label) {
         Dmsg0(200, "Found first SOS_LABEL and adopting job info\n");
-        found_first_sos_label = true;
+        data->found_first_sos_label = true;
 
         Session_Label sos_label;
 
@@ -177,13 +184,13 @@ static bool CloneRecordInternally(DeviceControlRecord* dcr, DeviceRecord* rec)
    *  JobFiles, which we then use as the output FileIndex. */
   if (rec->FileIndex >= 0) {
     // If something changed, increment FileIndex
-    if (rec->VolSessionId != rec->last_VolSessionId
-        || rec->VolSessionTime != rec->last_VolSessionTime
-        || rec->FileIndex != rec->last_FileIndex) {
+    if (rec->VolSessionId != data->last_VolSessionId
+        || rec->VolSessionTime != data->last_VolSessionTime
+        || rec->FileIndex != data->last_FileIndex) {
       jcr->JobFiles++;
-      rec->last_VolSessionId = rec->VolSessionId;
-      rec->last_VolSessionTime = rec->VolSessionTime;
-      rec->last_FileIndex = rec->FileIndex;
+      data->last_VolSessionId = rec->VolSessionId;
+      data->last_VolSessionTime = rec->VolSessionTime;
+      data->last_FileIndex = rec->FileIndex;
     }
     rec->FileIndex = jcr->JobFiles; /* set sequential output FileIndex */
   }
@@ -256,8 +263,8 @@ bail_out:
   /* Restore packet -- the read record function uses this information
    * to check if the job changed, so we need to restore it to how it was;
    * otherwise the record will get zeroed on job change. */
-  rec->VolSessionId = rec->last_VolSessionId;
-  rec->VolSessionTime = rec->last_VolSessionTime;
+  rec->VolSessionId = data->last_VolSessionId;
+  rec->VolSessionTime = data->last_VolSessionTime;
 
   if (translated_record) {
     FreeRecord(jcr->sd_impl->dcr->after_rec);
@@ -275,7 +282,9 @@ bail_out:
  * Returns: true if OK
  *           false if error
  */
-static bool CloneRecordToRemoteSd(DeviceControlRecord* dcr, DeviceRecord* rec)
+static bool CloneRecordToRemoteSd(DeviceControlRecord* dcr,
+                                  DeviceRecord* rec,
+                                  cb_data* data)
 {
   POOLMEM* msgsave;
   JobControlRecord* jcr = dcr->jcr;
@@ -287,13 +296,13 @@ static bool CloneRecordToRemoteSd(DeviceControlRecord* dcr, DeviceRecord* rec)
   if (rec->FileIndex < 0) { return true; }
 
   // See if this is the first record being processed.
-  if (rec->last_FileIndex == 0) {
+  if (data->last_FileIndex == 0) {
     /* Initialize the last counters so we can compare
      * things in the next run through here. */
-    rec->last_VolSessionId = rec->VolSessionId;
-    rec->last_VolSessionTime = rec->VolSessionTime;
-    rec->last_FileIndex = rec->FileIndex;
-    rec->last_Stream = rec->Stream;
+    data->last_VolSessionId = rec->VolSessionId;
+    data->last_VolSessionTime = rec->VolSessionTime;
+    data->last_FileIndex = rec->FileIndex;
+    data->last_Stream = rec->Stream;
     jcr->JobFiles = 1;
 
     // Need to send both a new header only.
@@ -301,19 +310,19 @@ static bool CloneRecordToRemoteSd(DeviceControlRecord* dcr, DeviceRecord* rec)
     send_header = true;
   } else {
     // See if we are changing file or stream type.
-    if (rec->VolSessionId != rec->last_VolSessionId
-        || rec->VolSessionTime != rec->last_VolSessionTime
-        || rec->FileIndex != rec->last_FileIndex
-        || rec->Stream != rec->last_Stream) {
+    if (rec->VolSessionId != data->last_VolSessionId
+        || rec->VolSessionTime != data->last_VolSessionTime
+        || rec->FileIndex != data->last_FileIndex
+        || rec->Stream != data->last_Stream) {
       /* See if we are changing the FileIndex e.g.
        * start processing the next file in the backup stream. */
-      if (rec->FileIndex != rec->last_FileIndex) { jcr->JobFiles++; }
+      if (rec->FileIndex != data->last_FileIndex) { jcr->JobFiles++; }
 
       // Keep track of the new state.
-      rec->last_VolSessionId = rec->VolSessionId;
-      rec->last_VolSessionTime = rec->VolSessionTime;
-      rec->last_FileIndex = rec->FileIndex;
-      rec->last_Stream = rec->Stream;
+      data->last_VolSessionId = rec->VolSessionId;
+      data->last_VolSessionTime = rec->VolSessionTime;
+      data->last_FileIndex = rec->FileIndex;
+      data->last_Stream = rec->Stream;
 
       // Need to send both a EOD and a new header.
       send_eod = true;
@@ -545,9 +554,10 @@ bool DoMacRun(JobControlRecord* jcr)
     now = (utime_t)time(NULL);
     UpdateJobStatistics(jcr, now);
 
+    cb_data data{};
     // Read all data and send it to remote SD.
     ok = ReadRecords(jcr->sd_impl->read_dcr, CloneRecordToRemoteSd,
-                     MountNextReadVolume);
+                     MountNextReadVolume, &data);
 
     /* Send the last EOD to close the last data transfer and a next EOD to
      * signal the remote we are done. */
@@ -641,9 +651,10 @@ bool DoMacRun(JobControlRecord* jcr)
     SetStartVolPosition(jcr->sd_impl->dcr);
     jcr->JobFiles = 0;
 
+    cb_data data{};
     // Read all data and make a local clone of it.
     ok = ReadRecords(jcr->sd_impl->read_dcr, CloneRecordInternally,
-                     MountNextReadVolume);
+                     MountNextReadVolume, &data);
   }
 
 bail_out:

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -359,7 +359,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
     } else {
       // Read the next block into our buffers.
       if (!ReadNextBlockFromDevice(dcr, &rctx->sessrec, NULL,
-                                   MountNextReadVolume, &ok)) {
+                                   MountNextReadVolume, NULL, &ok)) {
         return false;
       }
 
@@ -687,7 +687,7 @@ extern "C" ndmp9_error bndmp_tape_open(struct ndm_session* sess,
 
       // Read the first block and setup record processing.
       if (!ReadNextBlockFromDevice(dcr, &rctx->sessrec, NULL,
-                                   MountNextReadVolume, &ok)) {
+                                   MountNextReadVolume, NULL, &ok)) {
         Jmsg1(jcr, M_FATAL, 0, T_("Read session label failed. ERR=%s\n"),
               dcr->dev->bstrerror());
         goto bail_out;

--- a/core/src/stored/read_record.cc
+++ b/core/src/stored/read_record.cc
@@ -187,8 +187,10 @@ void ReadContextSetRecord(DeviceControlRecord* dcr, READ_CTX* rctx)
 bool ReadNextBlockFromDevice(DeviceControlRecord* dcr,
                              Session_Label* sessrec,
                              bool RecordCb(DeviceControlRecord* dcr,
-                                           DeviceRecord* rec),
+                                           DeviceRecord* rec,
+                                           void* user_data),
                              bool mount_cb(DeviceControlRecord* dcr),
+                             void* user_data,
                              bool* status)
 {
   JobControlRecord* jcr = dcr->jcr;
@@ -214,7 +216,7 @@ bool ReadNextBlockFromDevice(DeviceControlRecord* dcr,
             trec = new_record();
             trec->FileIndex = EOT_LABEL;
             trec->File = dcr->dev->file;
-            *status = RecordCb(dcr, trec);
+            *status = RecordCb(dcr, trec, user_data);
             if (jcr->sd_impl->read_session.mount_next_volume) {
               jcr->sd_impl->read_session.mount_next_volume = false;
               dcr->dev->ClearEot();
@@ -232,7 +234,7 @@ bool ReadNextBlockFromDevice(DeviceControlRecord* dcr,
         trec = new_record();
         ReadRecordFromBlock(dcr, trec);
         HandleSessionRecord(dcr->dev, trec, sessrec);
-        if (RecordCb) { RecordCb(dcr, trec); }
+        if (RecordCb) { RecordCb(dcr, trec, user_data); }
 
         FreeRecord(trec);
         PositionDeviceToFirstFile(jcr, dcr);
@@ -382,8 +384,11 @@ bool ReadNextRecordFromBlock(DeviceControlRecord* dcr,
  * You must not change any values in the DeviceRecord packet
  */
 bool ReadRecords(DeviceControlRecord* dcr,
-                 bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec),
-                 bool mount_cb(DeviceControlRecord* dcr))
+                 bool RecordCb(DeviceControlRecord* dcr,
+                               DeviceRecord* rec,
+                               void* user_data),
+                 bool mount_cb(DeviceControlRecord* dcr),
+                 void* user_data)
 {
   JobControlRecord* jcr = dcr->jcr;
   READ_CTX* rctx;
@@ -402,7 +407,7 @@ bool ReadRecords(DeviceControlRecord* dcr,
 
     // Read the next block into our buffers.
     if (!ReadNextBlockFromDevice(dcr, &rctx->sessrec, RecordCb, mount_cb,
-                                 &ok)) {
+                                 user_data, &ok)) {
       break;
     }
 
@@ -432,7 +437,7 @@ bool ReadRecords(DeviceControlRecord* dcr,
         /* Note, we pass *all* labels to the callback routine. If
          *  he wants to know if they matched the bsr, then he must
          *  check the match_stat in the record */
-        ok = RecordCb(dcr, rctx->rec);
+        ok = RecordCb(dcr, rctx->rec, user_data);
       } else {
         Dmsg6(debuglevel,
               "OK callback. recno=%d state_bits=%s blk=%d SI=%d ST=%d FI=%d\n",
@@ -463,11 +468,11 @@ bool ReadRecords(DeviceControlRecord* dcr,
         auto* brec = dcr->before_rec;
         auto* arec = dcr->after_rec;
         if (arec) {
-          ok = RecordCb(dcr, arec);
+          ok = RecordCb(dcr, arec, user_data);
           FreeRecord(arec);
           arec = nullptr;
         } else {
-          ok = RecordCb(dcr, dcr->before_rec);
+          ok = RecordCb(dcr, dcr->before_rec, user_data);
         }
         dcr->after_rec = arec;
         dcr->before_rec = brec;
@@ -483,6 +488,25 @@ bool ReadRecords(DeviceControlRecord* dcr,
   PrintBlockReadErrors(jcr, dcr->block);
 
   return ok;
+}
+
+static bool NoUserData(DeviceControlRecord* dcr,
+                       DeviceRecord* rec,
+                       void* user_data)
+{
+  auto* RecordCb
+      = reinterpret_cast<bool (*)(DeviceControlRecord* dcr, DeviceRecord* rec)>(
+          user_data);
+
+  return RecordCb(dcr, rec);
+}
+
+bool ReadRecords(DeviceControlRecord* dcr,
+                 bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec),
+                 bool mount_cb(DeviceControlRecord* dcr))
+{
+  return ReadRecords(dcr, &NoUserData, mount_cb,
+                     reinterpret_cast<void*>(RecordCb));
 }
 
 } /* namespace storagedaemon */

--- a/core/src/stored/read_record.cc
+++ b/core/src/stored/read_record.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -458,13 +458,19 @@ bool ReadRecords(DeviceControlRecord* dcr,
          * calling the bSdEventReadRecordTranslation plugin event. If no
          * translation has taken place we just point the rec pointer to same
          * DeviceRecord as in the before_rec pointer. */
-        if (dcr->after_rec) {
-          ok = RecordCb(dcr, dcr->after_rec);
-          FreeRecord(dcr->after_rec);
-          dcr->after_rec = nullptr;
+        // callbacks happily overwrite the dcr->*_rec pointers, so we need to
+        // make sure that we actually free the correct thing.
+        auto* brec = dcr->before_rec;
+        auto* arec = dcr->after_rec;
+        if (arec) {
+          ok = RecordCb(dcr, arec);
+          FreeRecord(arec);
+          arec = nullptr;
         } else {
           ok = RecordCb(dcr, dcr->before_rec);
         }
+        dcr->after_rec = arec;
+        dcr->before_rec = brec;
       }
     }
     Dmsg2(debuglevel, "After end recs in block. pos=%u:%u\n", dcr->dev->file,

--- a/core/src/stored/read_record.h
+++ b/core/src/stored/read_record.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,8 +31,10 @@ void ReadContextSetRecord(DeviceControlRecord* dcr, READ_CTX* rctx);
 bool ReadNextBlockFromDevice(DeviceControlRecord* dcr,
                              Session_Label* sessrec,
                              bool RecordCb(DeviceControlRecord* dcr,
-                                           DeviceRecord* rec),
+                                           DeviceRecord* rec,
+                                           void* user_data),
                              bool mount_cb(DeviceControlRecord* dcr),
+                             void* user_data,
                              bool* status);
 bool ReadNextRecordFromBlock(DeviceControlRecord* dcr,
                              READ_CTX* rctx,
@@ -40,6 +42,36 @@ bool ReadNextRecordFromBlock(DeviceControlRecord* dcr,
 bool ReadRecords(DeviceControlRecord* dcr,
                  bool RecordCb(DeviceControlRecord* dcr, DeviceRecord* rec),
                  bool mount_cb(DeviceControlRecord* dcr));
+
+bool ReadRecords(DeviceControlRecord* dcr,
+                 bool RecordCb(DeviceControlRecord* dcr,
+                               DeviceRecord* rec,
+                               void* user_data),
+                 bool mount_cb(DeviceControlRecord* dcr),
+                 void* user_data);
+
+template <typename T>
+inline bool ReadRecords(DeviceControlRecord* dcr,
+                        bool RecordCb(DeviceControlRecord* dcr,
+                                      DeviceRecord* rec,
+                                      T* user_data),
+                        bool mount_cb(DeviceControlRecord* dcr),
+                        T* user_data)
+{
+  auto capture = [RecordCb, user_data](DeviceControlRecord* inner_dcr,
+                                       DeviceRecord* inner_rec) -> bool {
+    return RecordCb(inner_dcr, inner_rec, user_data);
+  };
+
+  return ReadRecords(
+      dcr,
+      +[](DeviceControlRecord* inner_dcr, DeviceRecord* inner_rec,
+          void* impl) -> bool {
+        auto* lambda = reinterpret_cast<decltype(&capture)>(impl);
+        return (*lambda)(inner_dcr, inner_rec);
+      },
+      mount_cb, reinterpret_cast<void*>(&capture));
+}
 
 } /* namespace storagedaemon */
 

--- a/core/src/stored/record.cc
+++ b/core/src/stored/record.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -519,10 +519,6 @@ void DumpRecord(const char* tag, const DeviceRecord* rec)
   Dmsg2(100, "%-14s %p\n", "bsr", rec->bsr);
   Dmsg2(100, "%-14s %p\n", "data", rec->data);
   Dmsg2(100, "%-14s %d\n", "match_stat", rec->match_stat);
-  Dmsg2(100, "%-14s %u\n", "last_VolSessionId", rec->last_VolSessionId);
-  Dmsg2(100, "%-14s %u\n", "last_VolSessionTime", rec->last_VolSessionTime);
-  Dmsg2(100, "%-14s %d\n", "last_FileIndex", rec->last_FileIndex);
-  Dmsg2(100, "%-14s %d\n", "last_Stream", rec->last_Stream);
   Dmsg2(100, "%-14s %s\n", "own_mempool", rec->own_mempool ? "true" : "false");
 }
 

--- a/core/src/stored/record.h
+++ b/core/src/stored/record.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -121,12 +121,8 @@ struct DeviceRecord {
   char state_bits[REC_STATE_BYTES]{}; /**< State bits */
   rec_state state{st_none};           /**< State of WriteRecordToBlock */
   BootStrapRecord* bsr{nullptr};      /**< Pointer to bsr that matched */
-  POOLMEM* data{nullptr}; /**< Record data. This MUST be a memory pool item */
-  int32_t match_stat{0};  /**< BootStrapRecord match status */
-  uint32_t last_VolSessionId{0}; /**< Used in sequencing FI for Vbackup */
-  uint32_t last_VolSessionTime{0};
-  int32_t last_FileIndex{0};
-  int32_t last_Stream{0};  /**< Used in SD-SD replication */
+  POOLMEM* data{nullptr};  /**< Record data. This MUST be a memory pool item */
+  int32_t match_stat{0};   /**< BootStrapRecord match status */
   bool own_mempool{false}; /**< Do we own the POOLMEM pointed to in data ? */
 };
 
@@ -150,17 +146,13 @@ struct DeviceRecord {
  * ser_volume_label() and UnserVolumeLabel() and is slightly different.
  */
 struct Volume_Label {
-  /*
-   * The first items in this structure are saved
+  /* The first items in this structure are saved
    * in the Device buffer, but are not actually written
-   * to the tape.
-   */
+   * to the tape. */
   int32_t LabelType{};  /**< This is written in header only */
   uint32_t LabelSize{}; /**< length of serialized label */
-  /*
-   * The items below this line are stored on
-   * the tape
-   */
+  /* The items below this line are stored on
+   * the tape */
   char Id[32]{}; /**< Bareos Immortal ... */
 
   uint32_t VerNum{}; /**< Label version number */


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This PR fixes a bug that causes the sd to miscount the number of files during a internal mac job, if autoxflate is enabled.
The basic problem is that the VSId & VSTime are not reset correctly in the callback in that case, leading to splitting up files on block boundaries (i.e. 1 file becomes 2, if split on blocks), because the ReadRecords() routine thinks that we start reading data from a different job.

Also fixes a mistake in the last msgchan refactor that leads stops all sd<>sd jobs that take more than 30 seconds.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
