### PR TITLE
cats: fixes BigSqlQuery header fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stored: fix authentication race condition / deadlock [PR #1732]
 - Fix warning about missing delcandidates table in director [PR #1721]
 - stored: fix not counting files correctly in mac jobs when autoxflate is enabled [PR #1745]
+- cats: fixes BigSqlQuery header fetching [PR #1746]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -129,4 +130,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1728]: https://github.com/bareos/bareos/pull/1728
 [PR #1732]: https://github.com/bareos/bareos/pull/1732
 [PR #1745]: https://github.com/bareos/bareos/pull/1745
+[PR #1746]: https://github.com/bareos/bareos/pull/1746
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/postgresql.h
+++ b/core/src/cats/postgresql.h
@@ -92,6 +92,7 @@ class BareosDbPostgresql : public BareosDb {
   int SqlAffectedRows(void) override;
   uint64_t SqlInsertAutokeyRecord(const char* query,
                                   const char* table_name) override;
+  void SqlUpdateField(int column);
   SQL_FIELD* SqlFetchField(void) override;
   bool SqlFieldIsNotNull(int field_type) override;
   bool SqlFieldIsNumeric(int field_type) override;
@@ -106,14 +107,16 @@ class BareosDbPostgresql : public BareosDb {
 
   bool CheckDatabaseEncoding(JobControlRecord* jcr);
 
-  int status_ = 0;              /**< Status */
-  int num_fields_ = 0;          /**< Number of fields returned by last query */
-  int rows_size_ = 0;           /**< Size of malloced rows */
-  int fields_size_ = 0;         /**< Size of malloced fields */
-  int row_number_ = 0;          /**< Row number from xx_data_seek */
-  int field_number_ = 0;        /**< Field number from SqlFieldSeek */
-  SQL_ROW rows_ = nullptr;      /**< Defined rows */
-  SQL_FIELD* fields_ = nullptr; /**< Defined fields */
+  int status_ = 0; /**< Status */
+  bool fields_fetched_
+      = false;         /**< Marker, if field descriptions are already fetched */
+  int num_fields_ = 0; /**< Number of fields returned by last query */
+  int rows_size_ = 0;  /**< Size of malloced rows */
+  int fields_size_ = 0;             /**< Size of malloced fields */
+  int row_number_ = 0;              /**< Row number from xx_data_seek */
+  int field_number_ = 0;            /**< Field number from SqlFieldSeek */
+  SQL_ROW rows_ = nullptr;          /**< Defined rows */
+  SQL_FIELD* fields_ = nullptr;     /**< Defined fields */
   bool allow_transactions_ = false; /**< Transactions allowed ? */
   bool transaction_ = false;        /**< Transaction started ? */
 

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/fileset/NumberedFiles.conf.in
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/fileset/NumberedFiles.conf.in
@@ -1,0 +1,11 @@
+FileSet {
+  Name = "NumberedFiles"
+  Description = "fileset to backup some numbered filesjust to backup some files"
+  Include {
+    Options {
+      Signature = XXH128
+      xattrsupport = no
+    }
+    File = "@tmpdir@/backup-data-numbered-files/"
+  }
+}

--- a/systemtests/tests/python-bareos/test-setup
+++ b/systemtests/tests/python-bareos/test-setup
@@ -15,6 +15,11 @@ export TestName="$(get_test_name "$0")"
 
 # Fill ${BackupDirectory} with data.
 setup_data
+# Extra backup data with number of files.
+mkdir -p ${tmp}/backup-data-numbered-files
+for i in `seq 1000 2000`; do
+    echo $i > ${tmp}/backup-data-numbered-files/${i}.txt
+done
 
 # Create a list of paths to backup,
 # containing only simple file types.


### PR DESCRIPTION
BigSqlQuery fetches data in 100 row chunks.
This change makes sure, that subsequent chunks
also have valid header information.

Fixes: https://bugs.bareos.org/view.php?id=1007 JSON API: 'list files' returns malformed json

OP#5753

### Thank you for contributing to the Bareos Project!

**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Check backport line~~
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
