### PR TITLE
cats: fixes BigSqlQuery header fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - stored: fix authentication race condition / deadlock [PR #1742]
+- cats: fixes BigSqlQuery header fetching [PR #1751]
 
 ### Changed
 - systemtests: backport `wait for jobs to terminate` function [PR #1747]
@@ -733,4 +734,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1705]: https://github.com/bareos/bareos/pull/1705
 [PR #1742]: https://github.com/bareos/bareos/pull/1742
 [PR #1747]: https://github.com/bareos/bareos/pull/1747
+[PR #1751]: https://github.com/bareos/bareos/pull/1751
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/bdb_postgresql.h
+++ b/core/src/cats/bdb_postgresql.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -89,7 +89,7 @@ class BareosDbPostgresql : public BareosDbPrivateInterface {
   bool SqlCopyEnd() override;
 
   bool CheckDatabaseEncoding(JobControlRecord* jcr);
-  
+
  public:
   BareosDbPostgresql(JobControlRecord* jcr,
                      const char* db_driver,

--- a/core/src/cats/bdb_postgresql.h
+++ b/core/src/cats/bdb_postgresql.h
@@ -75,6 +75,7 @@ class BareosDbPostgresql : public BareosDbPrivateInterface {
   int SqlAffectedRows(void) override;
   uint64_t SqlInsertAutokeyRecord(const char* query,
                                   const char* table_name) override;
+  void SqlUpdateField(int column);
   SQL_FIELD* SqlFetchField(void) override;
   bool SqlFieldIsNotNull(int field_type) override;
   bool SqlFieldIsNumeric(int field_type) override;
@@ -88,7 +89,7 @@ class BareosDbPostgresql : public BareosDbPrivateInterface {
   bool SqlCopyEnd() override;
 
   bool CheckDatabaseEncoding(JobControlRecord* jcr);
-
+  
  public:
   BareosDbPostgresql(JobControlRecord* jcr,
                      const char* db_driver,

--- a/core/src/cats/bdb_priv.h
+++ b/core/src/cats/bdb_priv.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2011-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,15 +32,16 @@ class JobControlRecord;
 
 class BareosDbPrivateInterface : public BareosDb {
  protected:
-  int status_ = 0;              /**< Status */
-  bool fields_fetched_ = false;         /**< Marker, if field descriptions are already fetched */
-  int num_fields_ = 0;          /**< Number of fields returned by last query */
-  int rows_size_ = 0;           /**< Size of malloced rows */
-  int fields_size_ = 0;         /**< Size of malloced fields */
-  int row_number_ = 0;          /**< Row number from xx_data_seek */
-  int field_number_ = 0;        /**< Field number from SqlFieldSeek */
-  SQL_ROW rows_ = nullptr;      /**< Defined rows */
-  SQL_FIELD* fields_ = nullptr; /**< Defined fields */
+  int status_ = 0; /**< Status */
+  bool fields_fetched_
+      = false;         /**< Marker, if field descriptions are already fetched */
+  int num_fields_ = 0; /**< Number of fields returned by last query */
+  int rows_size_ = 0;  /**< Size of malloced rows */
+  int fields_size_ = 0;             /**< Size of malloced fields */
+  int row_number_ = 0;              /**< Row number from xx_data_seek */
+  int field_number_ = 0;            /**< Field number from SqlFieldSeek */
+  SQL_ROW rows_ = nullptr;          /**< Defined rows */
+  SQL_FIELD* fields_ = nullptr;     /**< Defined fields */
   bool allow_transactions_ = false; /**< Transactions allowed ? */
   bool transaction_ = false;        /**< Transaction started ? */
 
@@ -51,22 +52,26 @@ class BareosDbPrivateInterface : public BareosDb {
   virtual SQL_ROW SqlFetchRow(void) override = 0;
   virtual bool SqlQueryWithHandler(const char* query,
                                    DB_RESULT_HANDLER* ResultHandler,
-                                   void* ctx) override = 0;
-  virtual bool SqlQueryWithoutHandler(const char* query,
-                                      int flags = 0) override = 0;
+                                   void* ctx) override
+      = 0;
+  virtual bool SqlQueryWithoutHandler(const char* query, int flags = 0) override
+      = 0;
   virtual const char* sql_strerror(void) override = 0;
   virtual void SqlDataSeek(int row) override = 0;
   virtual int SqlAffectedRows(void) override = 0;
   virtual uint64_t SqlInsertAutokeyRecord(const char* query,
-                                          const char* table_name) override = 0;
+                                          const char* table_name) override
+      = 0;
   virtual SQL_FIELD* SqlFetchField(void) override = 0;
   virtual bool SqlFieldIsNotNull(int field_type) override = 0;
   virtual bool SqlFieldIsNumeric(int field_type) override = 0;
   virtual bool SqlBatchStartFileTable(JobControlRecord* jcr) override = 0;
   virtual bool SqlBatchEndFileTable(JobControlRecord* jcr,
-                                    const char* error) override = 0;
+                                    const char* error) override
+      = 0;
   virtual bool SqlBatchInsertFileTable(JobControlRecord* jcr,
-                                       AttributesDbRecord* ar) override = 0;
+                                       AttributesDbRecord* ar) override
+      = 0;
 
  public:
   BareosDbPrivateInterface() = default;

--- a/core/src/cats/bdb_priv.h
+++ b/core/src/cats/bdb_priv.h
@@ -33,6 +33,7 @@ class JobControlRecord;
 class BareosDbPrivateInterface : public BareosDb {
  protected:
   int status_ = 0;              /**< Status */
+  bool fields_fetched_ = false;         /**< Marker, if field descriptions are already fetched */
   int num_fields_ = 0;          /**< Number of fields returned by last query */
   int rows_size_ = 0;           /**< Size of malloced rows */
   int fields_size_ = 0;         /**< Size of malloced fields */

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -157,10 +157,8 @@ bool BareosDbPostgresql::CheckDatabaseEncoding(JobControlRecord* jcr)
     retval = bstrcmp(row[0], "SQL_ASCII");
 
     if (retval) {
-      /*
-       * If we are in SQL_ASCII, we can force the client_encoding to SQL_ASCII
-       * too
-       */
+      /* If we are in SQL_ASCII, we can force the client_encoding to SQL_ASCII
+       * too */
       SqlQueryWithoutHandler("SET client_encoding TO 'SQL_ASCII'");
     } else {
       // Something is wrong with database encoding
@@ -243,11 +241,9 @@ bool BareosDbPostgresql::OpenDatabase(JobControlRecord* jcr)
   SqlQueryWithoutHandler("SET datestyle TO 'ISO, YMD'");
   SqlQueryWithoutHandler("SET cursor_tuple_fraction=1");
 
-  /*
-   * Tell PostgreSQL we are using standard conforming strings
+  /* Tell PostgreSQL we are using standard conforming strings
    * and avoid warnings such as:
-   *  WARNING:  nonstandard use of \\ in a string literal
-   */
+   *  WARNING:  nonstandard use of \\ in a string literal */
   SqlQueryWithoutHandler("SET standard_conforming_strings=on");
 
   // Check that encoding is SQL_ASCII
@@ -441,10 +437,8 @@ void BareosDbPostgresql::StartTransaction(JobControlRecord* jcr)
     jcr->ar = (AttributesDbRecord*)malloc(sizeof(AttributesDbRecord));
   }
 
-  /*
-   * This is turned off because transactions break
-   * if multiple simultaneous jobs are run.
-   */
+  /* This is turned off because transactions break
+   * if multiple simultaneous jobs are run. */
   if (!allow_transactions_) { return; }
 
   DbLock(this);
@@ -641,11 +635,9 @@ retry_query:
       }
 
       if (try_reconnect_ && !transaction_) {
-        /*
-         * Only try reconnecting when no transaction is pending.
+        /* Only try reconnecting when no transaction is pending.
          * Reconnecting within a transaction will lead to an aborted
-         * transaction anyway so we better follow our old error path.
-         */
+         * transaction anyway so we better follow our old error path. */
         if (retry) {
           PQreset(db_handle_);
 
@@ -783,8 +775,7 @@ uint64_t BareosDbPostgresql::SqlInsertAutokeyRecord(const char* query,
 
   changes++;
 
-  /*
-   * Obtain the current value of the sequence that
+  /* Obtain the current value of the sequence that
    * provides the serial value for primary key of the table.
    *
    * currval is local to our session.  It is not affected by
@@ -798,8 +789,7 @@ uint64_t BareosDbPostgresql::SqlInsertAutokeyRecord(const char* query,
    * Except for basefiles which has a primary key on baseid.
    * Therefore, we need to special case that one table.
    *
-   * everything else can use the PostgreSQL formula.
-   */
+   * everything else can use the PostgreSQL formula. */
   if (Bstrcasecmp(table_name, "basefiles")) {
     bstrncpy(sequence, "basefiles_baseid", sizeof(sequence));
   } else {

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -605,6 +605,7 @@ retry_query:
   num_rows_ = -1;
   row_number_ = -1;
   field_number_ = -1;
+  fields_fetched_ = false;
 
   if (result_) {
     PQclear(result_); /* hmm, someone forgot to free?? */
@@ -698,6 +699,7 @@ void BareosDbPostgresql::SqlFreeResult(void)
     free(fields_);
     fields_ = NULL;
   }
+  fields_fetched_ = false;
   num_rows_ = num_fields_ = 0;
   DbUnlock(this);
 }
@@ -841,15 +843,46 @@ bail_out:
   return id;
 }
 
+void BareosDbPostgresql::SqlUpdateField(int i)
+{
+  Dmsg1(500, "filling field %d\n", i);
+  fields_[i].name = PQfname(result_, i);
+  fields_[i].type = PQftype(result_, i);
+  fields_[i].flags = 0;
+
+  // For a given column, find the max length.
+  int max_length = 0;
+  int this_length = 0;
+  for (int j = 0; j < num_rows_; j++) {
+    if (PQgetisnull(result_, j, i)) {
+      this_length = 4; /* "NULL" */
+    } else {
+      this_length = cstrlen(PQgetvalue(result_, j, i));
+    }
+
+    if (max_length < this_length) { max_length = this_length; }
+  }
+  fields_[i].max_length = max_length;
+
+  Dmsg4(500,
+        "SqlUpdateField finds field '%s' has length='%d' type='%d' and "
+        "IsNull=%d\n",
+        fields_[i].name, fields_[i].max_length, fields_[i].type,
+        fields_[i].flags);
+}
+
 SQL_FIELD* BareosDbPostgresql::SqlFetchField(void)
 {
-  int i, j;
-  int max_length;
-  int this_length;
-
   Dmsg0(500, "SqlFetchField starts\n");
 
+  if (field_number_ >= num_fields_) {
+    Dmsg1(100, "requesting field number %d, but only %d fields given\n",
+          field_number_, num_fields_);
+    return nullptr;
+  }
+
   if (!fields_ || fields_size_ < num_fields_) {
+    fields_fetched_ = false;
     if (fields_) {
       free(fields_);
       fields_ = NULL;
@@ -857,32 +890,11 @@ SQL_FIELD* BareosDbPostgresql::SqlFetchField(void)
     Dmsg1(500, "allocating space for %d fields\n", num_fields_);
     fields_ = (SQL_FIELD*)malloc(sizeof(SQL_FIELD) * num_fields_);
     fields_size_ = num_fields_;
+  }
 
-    for (i = 0; i < num_fields_; i++) {
-      Dmsg1(500, "filling field %d\n", i);
-      fields_[i].name = PQfname(result_, i);
-      fields_[i].type = PQftype(result_, i);
-      fields_[i].flags = 0;
-
-      // For a given column, find the max length.
-      max_length = 0;
-      for (j = 0; j < num_rows_; j++) {
-        if (PQgetisnull(result_, j, i)) {
-          this_length = 4; /* "NULL" */
-        } else {
-          this_length = cstrlen(PQgetvalue(result_, j, i));
-        }
-
-        if (max_length < this_length) { max_length = this_length; }
-      }
-      fields_[i].max_length = max_length;
-
-      Dmsg4(500,
-            "SqlFetchField finds field '%s' has length='%d' type='%d' and "
-            "IsNull=%d\n",
-            fields_[i].name, fields_[i].max_length, fields_[i].type,
-            fields_[i].flags);
-    }
+  if (!fields_fetched_) {
+    for (int i = 0; i < num_fields_; i++) { SqlUpdateField(i); }
+    fields_fetched_ = true;
   }
 
   // Increment field number for the next time around


### PR DESCRIPTION
**Backport of PR #1750 to bareos-21**

- Does not contain the python-bareos test

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

The extended testing from the original PR is left out, as the test functionality did not exist in bareos-21.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1746/#1750 is merged
- [x] All functional differences to the original PR are documented above
