### PR TITLE
doc: add backtick around *.?* description 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: put generated files into CMAKE_BINARY_DIR [PR #1707]
 - increase warning level on C/C++ compiler [PR #1689]
 - VMware Plugin: Backup and Restore NVRAM [PR #1727]
+- doc: add backtick around *.?* description  [PR #1752]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -131,4 +132,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1732]: https://github.com/bareos/bareos/pull/1732
 [PR #1745]: https://github.com/bareos/bareos/pull/1745
 [PR #1746]: https://github.com/bareos/bareos/pull/1746
+[PR #1752]: https://github.com/bareos/bareos/pull/1752
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/scripts/generate-resource-descriptions.py
+++ b/docs/manuals/scripts/generate-resource-descriptions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -260,7 +260,12 @@ class BareosConfigurationSchema2Sphinx(BareosConfigurationSchema):
     def getDescription(self, data):
         description = ""
         if data.get("description"):
-            description = self.indent(data.get("description"), 3)
+            # Some descriptions contains text surrounded by '*'.
+            # This regex puts backticks around these texts.
+            description_rst = re.sub(
+                "(\*.*?\*)", ":strong:`\\1`", data.get("description")
+            )
+            description = self.indent(description_rst, 3)
         return description
 
     def getConvertedResourceDirectives(self, daemon, resourcename):

--- a/systemtests/tests/bareos-acl/etc/bareos/bareos-dir.d/console/bareos-acl-restricted.conf.in
+++ b/systemtests/tests/bareos-acl/etc/bareos/bareos-dir.d/console/bareos-acl-restricted.conf.in
@@ -4,11 +4,11 @@ Console {
   Password = "@dir_password@"
   CommandACL = restore, cancel, enable, disable, estimate, exit, gui, help, list, llist, messages, memory, quit, release, reload, rerun, restore, run, show, status, time, version, wait, whoami
   Job ACL = *all*
-  Schedule ACL = all
-  Catalog ACL = all
-  Pool ACL = all
-  Storage ACL = all
-  Client ACL = all
-  FileSet ACL = all
-  Where ACL = all
+  Schedule ACL = *all*
+  Catalog ACL = *all*
+  Pool ACL = *all*
+  Storage ACL = *all*
+  Client ACL = *all*
+  FileSet ACL = *all*
+  Where ACL = *all*
 }


### PR DESCRIPTION
this PR fix our documentation, where The special acl value `*all*` gets printed as _all_ when printed in our documentation (in the normal text flow). 

- we adapt the documentation description generator to include :strong:` ` around this value
- fix systemtests with *all* instead all

OP#5543

### Thank you for contributing to the Bareos Project!

**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Check backport line
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
