### PR TITLE
PR template: remove backport hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - increase warning level on C/C++ compiler [PR #1689]
 - VMware Plugin: Backup and Restore NVRAM [PR #1727]
 - doc: add backtick around *.?* description  [PR #1752]
+- PR template: remove backport hints [PR #1762]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -133,4 +134,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1745]: https://github.com/bareos/bareos/pull/1745
 [PR #1746]: https://github.com/bareos/bareos/pull/1746
 [PR #1752]: https://github.com/bareos/bareos/pull/1752
+[PR #1762]: https://github.com/bareos/bareos/pull/1762
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,5 @@
 ### Thank you for contributing to the Bareos Project!
 
-**Backport of PR #0000 to bareos-2x** (remove this line if this is no backport; for backport use cherry-pick -x)
-
 #### Please check
 
 - [ ] Short description and the purpose of this PR is present _above this paragraph_
@@ -23,7 +21,6 @@ Make sure you check/merge the PR using `devtools/pr-tool` to have some simple au
 - [ ] Is the PR title usable as CHANGELOG entry?
 - [ ] Purpose of the PR is understood
 - [ ] Commit descriptions are understandable and well formatted
-- [ ] Check backport line
 - [ ] Required backport PRs have been created
 
 ##### Source code quality


### PR DESCRIPTION
Backports are now created by ``pr-tool backport``, which uses an own PR template.
Therefore the hints to distinguish between normal PR and backport PR are not required in this template.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- ~Required backport PRs have been created~