### PR TITLE
stored: fix some sd error messages; add additional check during restore; split up always-incremental-consolidate test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - dbcheck: fix dbcheck crash if password is not set in catalog resource [PR #1731]
+- stored: fix some sd error messages; add additional check during restore; split up always-incremental-consolidate test [PR #1770]
 
 ### Fixed
 - stored: fix authentication race condition / deadlock [PR #1736]
@@ -663,4 +664,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1731]: https://github.com/bareos/bareos/pull/1731
 [PR #1736]: https://github.com/bareos/bareos/pull/1736
 [PR #1750]: https://github.com/bareos/bareos/pull/1750
+[PR #1770]: https://github.com/bareos/bareos/pull/1770
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/ansi_label.cc
+++ b/core/src/stored/ansi_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2005-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -63,10 +63,8 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
   char* VolName = dcr->VolumeName;
   bool ok = false;
 
-  /*
-   * Read VOL1, HDR1, HDR2 labels, but ignore the data
-   * If tape read the following EOF mark, on disk do not read.
-   */
+  /* Read VOL1, HDR1, HDR2 labels, but ignore the data
+   * If tape read the following EOF mark, on disk do not read. */
   Dmsg0(100, "Read ansi label.\n");
   if (!dcr->dev->IsTape()) { return VOL_OK; }
 
@@ -84,7 +82,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
       Dmsg1(100, "Read device got: ERR=%s\n", be.bstrerror());
       Mmsg2(jcr->errmsg, _("Read error on device %s in ANSI label. ERR=%s\n"),
             dcr->dev->archive_device_string, be.bstrerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", dcr->dev->errmsg);
+      Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
       dcr->dev->VolCatInfo.VolCatErrors++;
       return VOL_IO_ERROR;
     }
@@ -299,10 +297,8 @@ bool WriteAnsiIbmLabels(DeviceControlRecord* dcr, int type, const char* VolName)
   time_t now;
   int len, status, label_type;
 
-  /*
-   * If the Device requires a specific label type use it,
-   * otherwise, use the type requested by the Director
-   */
+  /* If the Device requires a specific label type use it,
+   * otherwise, use the type requested by the Director */
   if (dcr->device_resource->label_type != B_BAREOS_LABEL) {
     label_type = dcr->device_resource->label_type; /* force label type */
   } else {
@@ -324,10 +320,8 @@ bool WriteAnsiIbmLabels(DeviceControlRecord* dcr, int type, const char* VolName)
         return false;
       }
 
-      /*
-       * ANSI labels have 6 characters, and are padded with spaces 'vol1\0' =>
-       * 'vol1   \0'
-       */
+      /* ANSI labels have 6 characters, and are padded with spaces 'vol1\0' =>
+       * 'vol1   \0' */
       strcpy(ansi_volname, VolName);
       for (int i = len; i < 6; i++) { ansi_volname[i] = ' '; }
       ansi_volname[6] = '\0'; /* only for debug */

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -513,6 +513,8 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
       Dmsg0(200, "VOL_NO_MEDIA or default.\n");
       /* Send error message */
       if (!dev->poll) {
+        Jmsg(jcr, M_WARNING, 0, "Could not check volume label: ERR=%s\n",
+             jcr->errmsg);
       } else {
         Dmsg1(200, "Msg suppressed by poll: %s\n", jcr->errmsg);
       }

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -131,6 +131,7 @@ fi
 export PYTHONPATH=@pythonpath@
 
 gfapi_fd_host=@gfapi_fd_host@
+gfapi_fd_testvolume=@gfapi_fd_testvolume@
 
 dbHost="@dbHost@"
 test_db_port=@test_db_port@

--- a/systemtests/tests/gfapi-fd/testrunner
+++ b/systemtests/tests/gfapi-fd/testrunner
@@ -52,9 +52,9 @@ BackupDirectory="${tmp}/data"
 
 
 [ -d "${tmp}/data" ] ||  mkdir -p "${tmp}/data"
-"${SUDO}" mount -t glusterfs ${gfapi_fd_host}:/testvol "${tmp}/data"
+"${SUDO}" mount -t glusterfs "${gfapi_fd_host}:/${gfapi_fd_testvolume}" "${tmp}/data"
 
-"${SUDO}" rm -Rvf "${tmp}/data/*"
+"${SUDO}" rm -Rvf "${tmp}/data"/*
 
 # Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
@@ -69,7 +69,7 @@ cat <<END_OF_DATA_BACKUP >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=100 storage=File
+setdebug level=150 storage=File client
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director

--- a/systemtests/tests/restore/CMakeLists.txt
+++ b/systemtests/tests/restore/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -21,8 +21,9 @@ get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
 create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
 
 set_tests_properties(
-  system:restore:create-backup PROPERTIES FIXTURES_SETUP
-                                          "system:restore:backup-job-fixture"
+  system:restore:create-backup
+  PROPERTIES FIXTURES_SETUP "system:restore:backup-job-fixture"
+             FIXTURES_REQUIRED "system:restore-fixture"
 )
 set_tests_properties(
   system:restore:archive-restore-file

--- a/systemtests/tests/restore/CMakeLists.txt
+++ b/systemtests/tests/restore/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/restore/testrunner-archive-restore-dir
+++ b/systemtests/tests/restore/testrunner-archive-restore-dir
@@ -1,10 +1,32 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # restore some a directory from archives
 #
+
+set -e
+set -o pipefail
+set -u
+
 TestName="$(basename "$(pwd)")"
 export TestName
 

--- a/systemtests/tests/restore/testrunner-check-hints
+++ b/systemtests/tests/restore/testrunner-check-hints
@@ -1,12 +1,33 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # Check wether hints are issued when trying to restore
 # backups, but none of the right type exist.
 # (i.e. an archive exists, but a non-archive is wanted.)
 #
+
+set -e
+set -o pipefail
+set -u
 
 TestName="$(basename "$(pwd)")"
 export TestName

--- a/systemtests/tests/restore/testrunner-create-backup
+++ b/systemtests/tests/restore/testrunner-create-backup
@@ -1,10 +1,32 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # Run a simple backup
 #
+
+set -e
+set -o pipefail
+set -u
+
 TestName="$(basename "$(pwd)")"
 export TestName
 

--- a/systemtests/tests/restore/testrunner-full-restore
+++ b/systemtests/tests/restore/testrunner-full-restore
@@ -1,10 +1,31 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # Do a full restore from an archive job.
 #
+
+set -e
+set -o pipefail
+set -u
 
 TestName="$(basename "$(pwd)")"
 export TestName

--- a/systemtests/tests/restore/testrunner-restore-dir
+++ b/systemtests/tests/restore/testrunner-restore-dir
@@ -1,10 +1,31 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # restore some a directory from archives
 #
+
+set -e
+set -o pipefail
+set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 

--- a/systemtests/tests/restore/testrunner-restore-file
+++ b/systemtests/tests/restore/testrunner-restore-file
@@ -1,10 +1,31 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # restore some single files from archives
 #
+
+set -e
+set -o pipefail
+set -u
 TestName="$(basename "$(pwd)")"
 export TestName
 

--- a/systemtests/tests/restore/testrunner-restore-old-archive
+++ b/systemtests/tests/restore/testrunner-restore-old-archive
@@ -1,11 +1,32 @@
 #!/bin/bash
-set -e
-set -o pipefail
-set -u
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
 #
 # check that bareos actually selects the archive
 #   to restore instead of just picking the newest one.
 #
+
+set -e
+set -o pipefail
+set -u
 
 TestName="$(basename "$(pwd)")"
 export TestName


### PR DESCRIPTION
**Backport of PR #1722 to bareos-22**

Does not contain the missing record detection nor the updated testrunner for always-incremental.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1722 is merged
- [X] All functional differences to the original PR are documented above
