### PR TITLE
stored: fix some sd error messages; add additional check during restore; split up always-incremental-consolidate test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - systemtests: backport `wait for jobs to terminate` function [PR #1747]
+- stored: fix some sd error messages; add additional check during restore; split up always-incremental-consolidate test [PR #1771]
 
 ## [21.1.9] - 2024-02-28
 
@@ -735,4 +736,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1742]: https://github.com/bareos/bareos/pull/1742
 [PR #1747]: https://github.com/bareos/bareos/pull/1747
 [PR #1751]: https://github.com/bareos/bareos/pull/1751
+[PR #1771]: https://github.com/bareos/bareos/pull/1771
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/ansi_label.cc
+++ b/core/src/stored/ansi_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2005-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -64,10 +64,8 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
   char* VolName = dcr->VolumeName;
   bool ok = false;
 
-  /*
-   * Read VOL1, HDR1, HDR2 labels, but ignore the data
-   * If tape read the following EOF mark, on disk do not read.
-   */
+  /* Read VOL1, HDR1, HDR2 labels, but ignore the data
+   * If tape read the following EOF mark, on disk do not read. */
   Dmsg0(100, "Read ansi label.\n");
   if (!dev->IsTape()) { return VOL_OK; }
 
@@ -85,7 +83,7 @@ int ReadAnsiIbmLabel(DeviceControlRecord* dcr)
       Dmsg1(100, "Read device got: ERR=%s\n", be.bstrerror());
       Mmsg2(jcr->errmsg, _("Read error on device %s in ANSI label. ERR=%s\n"),
             dev->archive_device_string, be.bstrerror());
-      Jmsg(jcr, M_ERROR, 0, "%s", dev->errmsg);
+      Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
       dev->VolCatInfo.VolCatErrors++;
       return VOL_IO_ERROR;
     }
@@ -300,10 +298,8 @@ bool WriteAnsiIbmLabels(DeviceControlRecord* dcr, int type, const char* VolName)
   time_t now;
   int len, status, label_type;
 
-  /*
-   * If the Device requires a specific label type use it,
-   * otherwise, use the type requested by the Director
-   */
+  /* If the Device requires a specific label type use it,
+   * otherwise, use the type requested by the Director */
   if (dcr->device_resource->label_type != B_BAREOS_LABEL) {
     label_type = dcr->device_resource->label_type; /* force label type */
   } else {
@@ -325,10 +321,8 @@ bool WriteAnsiIbmLabels(DeviceControlRecord* dcr, int type, const char* VolName)
         return false;
       }
 
-      /*
-       * ANSI labels have 6 characters, and are padded with spaces 'vol1\0' =>
-       * 'vol1   \0'
-       */
+      /* ANSI labels have 6 characters, and are padded with spaces 'vol1\0' =>
+       * 'vol1   \0' */
       strcpy(ansi_volname, VolName);
       for (int i = len; i < 6; i++) { ansi_volname[i] = ' '; }
       ansi_volname[6] = '\0'; /* only for debug */

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -86,11 +86,9 @@ bool DeviceControlRecord::MountNextWriteVolume()
 
   P(mount_mutex);
 
-  /*
-   * Attempt to mount the next volume. If something non-fatal goes
+  /* Attempt to mount the next volume. If something non-fatal goes
    *  wrong, we come back here to re-try (new op messages, re-read
-   *  Volume, ...)
-   */
+   *  Volume, ...) */
 
 mount_next_vol:
   Dmsg1(150, "mount_next_vol retry=%d\n", retry);
@@ -128,24 +126,20 @@ mount_next_vol:
   Dmsg2(150, "After find_next_append. Vol=%s Slot=%d\n", getVolCatName(),
         VolCatInfo.Slot);
 
-  /*
-   * Get next volume and ready it for append
+  /* Get next volume and ready it for append
    * This code ensures that the device is ready for
    * writing. We start from the assumption that there
    * may not be a tape mounted.
    *
    * If the device is a file, we create the output
    * file. If it is a tape, we check the volume name
-   * and move the tape to the end of data.
-   */
+   * and move the tape to the end of data. */
   dcr->setVolCatInfo(false); /* out of date when Vols unlocked */
 
-  /*
-   * See if this is a retry of the mounting of the next volume.
+  /* See if this is a retry of the mounting of the next volume.
    * If the device is already open close it first as otherwise we could
    * potentially write to an already open device a new volume label.
-   * This is only interesting for non tape devices.
-   */
+   * This is only interesting for non tape devices. */
   if (!dev->IsTape()) {
     if (retry && dev->IsOpen()) { dev->close(dcr); }
   }
@@ -173,11 +167,9 @@ mount_next_vol:
       autochanger = false;
       VolCatInfo.Slot = 0;
 
-      /*
-       * If the VolCatInfo.InChanger flag is not set we are trying to use a
+      /* If the VolCatInfo.InChanger flag is not set we are trying to use a
        * volume that is not in the autochanger so that means we need to ask the
-       * operator to mount it.
-       */
+       * operator to mount it. */
       if (dev->AttachedToAutochanger() && !VolCatInfo.InChanger) {
         ask = true;
       } else {
@@ -192,12 +184,10 @@ mount_next_vol:
   }
   Dmsg1(150, "autoLoadDev returns %d\n", autochanger);
 
-  /*
-   * If we autochanged to correct Volume or (we have not just
+  /* If we autochanged to correct Volume or (we have not just
    * released the Volume AND we can automount) we go ahead
    * and read the label. If there is no tape in the drive,
-   * we will fail, recurse and ask the operator the next time.
-   */
+   * we will fail, recurse and ask the operator the next time. */
   if (!dev->MustUnload() && dev->IsTape() && dev->HasCap(CAP_AUTOMOUNT)) {
     Dmsg0(250, "(1)Ask=0\n");
     ask = false; /* don't ask SYSOP this time */
@@ -297,8 +287,7 @@ read_volume:
     dev->SetBlocksizes(dcr);
   }
 
-  /*
-   * See if we have a fresh tape or a tape with data.
+  /* See if we have a fresh tape or a tape with data.
    *
    * Note, if the LabelType is PRE_LABEL, it was labeled
    *  but never written. If so, rewrite the label but set as
@@ -308,8 +297,7 @@ read_volume:
    *  a second volume, the calling routine will write the label
    *  before writing the overflow block.
    *
-   *  If the tape is marked as Recycle, we rewrite the label.
-   */
+   *  If the tape is marked as Recycle, we rewrite the label. */
   recycle = bstrcmp(dev->VolCatInfo.VolCatStatus, "Recycle");
   if (dev->VolHdr.LabelType == PRE_LABEL || recycle) {
     if (!dcr->RewriteVolumeLabel(recycle)) {
@@ -317,11 +305,9 @@ read_volume:
       goto mount_next_vol;
     }
   } else {
-    /*
-     * OK, at this point, we have a valid Bareos label, but
+    /* OK, at this point, we have a valid Bareos label, but
      * we need to position to the end of the volume, since we are
-     * just now putting it into append mode.
-     */
+     * just now putting it into append mode. */
     Dmsg1(
         100,
         "Device previously written, moving to end of data. Expect %lld bytes\n",
@@ -386,10 +372,8 @@ bool DeviceControlRecord::find_a_volume()
       have_vol = dcr->DirGetVolumeInfo(GET_VOL_INFO_FOR_WRITE);
     }
 
-    /*
-     * Get Director's idea of what tape we should have mounted, in
-     * dcr->VolCatInfo
-     */
+    /* Get Director's idea of what tape we should have mounted, in
+     * dcr->VolCatInfo */
     if (!have_vol) {
       Dmsg0(200, "Before DirFindNextAppendableVolume.\n");
       while (!dcr->DirFindNextAppendableVolume()) {
@@ -417,10 +401,8 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
   DeviceControlRecord* dcr = this;
   int vol_label_status;
 
-  /*
-   * If we are writing to a stream device, ASSUME the volume label
-   *  is correct.
-   */
+  /* If we are writing to a stream device, ASSUME the volume label
+   *  is correct. */
   if (dev->HasCap(CAP_STREAM)) {
     vol_label_status = VOL_OK;
     CreateVolumeLabel(dev, VolumeName, "Default");
@@ -433,10 +415,8 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
   Dmsg2(150, "Want dirVol=%s dirStat=%s\n", VolumeName,
         VolCatInfo.VolCatStatus);
 
-  /*
-   * At this point, dev->VolCatInfo has what is in the drive, if anything,
-   *          and   dcr->VolCatInfo has what the Director wants.
-   */
+  /* At this point, dev->VolCatInfo has what is in the drive, if anything,
+   *          and   dcr->VolCatInfo has what the Director wants. */
   switch (vol_label_status) {
     case VOL_OK:
       Dmsg1(150, "Vol OK name=%s\n", dev->VolHdr.VolumeName);
@@ -461,12 +441,10 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
         goto check_next_volume;
       }
 
-      /*
-       * OK, we got a different volume mounted. First save the
+      /* OK, we got a different volume mounted. First save the
        *  requested Volume info (dcr) structure, then query if
        *  this volume is really OK. If not, put back the desired
-       *  volume name, mark it not in changer and continue.
-       */
+       *  volume name, mark it not in changer and continue. */
       dcrVolCatInfo = VolCatInfo;      /* structure assignment */
       devVolCatInfo = dev->VolCatInfo; /* structure assignment */
       /* Check if this is a valid Volume in the pool */
@@ -479,11 +457,9 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
         /* This gets the info regardless of the Pool */
         bstrncpy(VolumeName, dev->VolHdr.VolumeName, sizeof(VolumeName));
         if (autochanger && !dcr->DirGetVolumeInfo(GET_VOL_INFO_FOR_READ)) {
-          /*
-           * If we get here, we know we cannot write on the Volume,
+          /* If we get here, we know we cannot write on the Volume,
            *  and we know that we cannot read it either, so it
-           *  is not in the autochanger.
-           */
+           *  is not in the autochanger. */
           mark_volume_not_inchanger();
         }
         dev->VolCatInfo = devVolCatInfo; /* structure assignment */
@@ -500,10 +476,8 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
         VolCatInfo = dcrVolCatInfo; /* structure assignment */
         goto check_next_volume;
       }
-      /*
-       * This was not the volume we expected, but it is OK with
-       * the Director, so use it.
-       */
+      /* This was not the volume we expected, but it is OK with
+       * the Director, so use it. */
       Dmsg1(150, "Got new Volume name=%s\n", VolumeName);
       dev->VolCatInfo = VolCatInfo; /* structure assignment */
       Dmsg1(100, "Call reserve_volume=%s\n", dev->VolHdr.VolumeName);
@@ -537,6 +511,8 @@ int DeviceControlRecord::CheckVolumeLabel(bool& ask, bool& autochanger)
       Dmsg0(200, "VOL_NO_MEDIA or default.\n");
       /* Send error message */
       if (!dev->poll) {
+        Jmsg(jcr, M_WARNING, 0, "Could not check volume label: ERR=%s\n",
+             jcr->errmsg);
       } else {
         Dmsg1(200, "Msg suppressed by poll: %s\n", jcr->errmsg);
       }
@@ -613,11 +589,9 @@ void DeviceControlRecord::DoSwapping(bool IsWriting)
 {
   DeviceControlRecord* dcr = this;
 
-  /*
-   * See if we are asked to swap the Volume from another device
+  /* See if we are asked to swap the Volume from another device
    *  if so, unload the other device here, and attach the
-   *  volume to our drive.
-   */
+   *  volume to our drive. */
   if (dev->swap_dev) {
     if (dev->swap_dev->MustUnload()) {
       if (dev->vol) { dev->swap_dev->SetSlotNumber(dev->vol->GetSlot()); }
@@ -654,10 +628,8 @@ bool DeviceControlRecord::is_eod_valid()
   DeviceControlRecord* dcr = this;
 
   if (dev->IsTape()) {
-    /*
-     * Check if we are positioned on the tape at the same place
-     * that the database says we should be.
-     */
+    /* Check if we are positioned on the tape at the same place
+     * that the database says we should be. */
     if (dev->VolCatInfo.VolCatFiles == dev->GetFile()) {
       Jmsg(jcr, M_INFO, 0,
            _("Ready to append to end of Volume \"%s\" at file=%d.\n"),
@@ -894,12 +866,10 @@ bool DeviceControlRecord::IsTapePositionOk()
            _("Invalid tape position on volume \"%s\""
              " on device %s. Expected %d, got %d\n"),
            dev->VolHdr.VolumeName, dev->print_name(), dev->GetFile(), file);
-      /*
-       * If the current file is greater than zero, it means we probably
+      /* If the current file is greater than zero, it means we probably
        *  have some bad count of EOF marks, so mark tape in error.  Otherwise
        *  the operator might have moved the tape, so we just release it
-       *  and try again.
-       */
+       *  and try again. */
       if (file > 0) { MarkVolumeInError(); }
       ReleaseVolume();
       return false;

--- a/systemtests/environment.in
+++ b/systemtests/environment.in
@@ -127,6 +127,7 @@ fi
 export PYTHONPATH=@pythonpath@
 
 gfapi_fd_host=@gfapi_fd_host@
+gfapi_fd_testvolume=@gfapi_fd_testvolume@
 
 dbHost="@dbHost@"
 test_db_port=@test_db_port@

--- a/systemtests/tests/gfapi-fd/testrunner
+++ b/systemtests/tests/gfapi-fd/testrunner
@@ -52,9 +52,9 @@ BackupDirectory="${tmp}/data"
 
 
 [ -d "${tmp}/data" ] ||  mkdir -p "${tmp}/data"
-"${SUDO}" mount -t glusterfs ${gfapi_fd_host}:/testvol "${tmp}/data"
+"${SUDO}" mount -t glusterfs "${gfapi_fd_host}:/${gfapi_fd_testvolume}" "${tmp}/data"
 
-"${SUDO}" rm -Rvf "${tmp}/data/*"
+"${SUDO}" rm -Rvf "${tmp}/data"/*
 
 # Use a tgz to setup data to be backed up.
 # Data will be placed at "${tmp}/data/".
@@ -69,7 +69,7 @@ cat <<END_OF_DATA_BACKUP >"$tmp/bconcmds"
 @$out /dev/null
 messages
 @$out $tmp/log1.out
-setdebug level=100 storage=File
+setdebug level=150 storage=File client
 label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director

--- a/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-percona-xtrabackup/testrunner
@@ -30,6 +30,7 @@ JobName=backup-bareos-fd
 XTRABACKUP="${XTRABACKUP_BINARY} --defaults-file=mysqldefaults"
 
 shutdown_mysql_server(){
+[ -f "mysql/mysqld.pid" ] && kill "$(cat mysql/mysqld.pid)" || :
 [ -f "mysql/data/${HOSTNAME}.pid" ] && kill "$(cat mysql/data/${HOSTNAME}.pid)" || :
 }
 


### PR DESCRIPTION
**Backport of PR #1722 to bareos-21**
Differences to main pr:
Removals:
- Removed missing record detection in restore
- Removed new always-incremental-consolidate test
- Removed changes to restore tests (since it does not exist in 21)

Additions:
- fixed percona systemtest not stopping the right mysql instance

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1722 is merged
- [X] All functional differences to the original PR are documented above
