### PR TITLE
Fix missing DLL in windows packaging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stored: fix not counting files correctly in mac jobs when autoxflate is enabled [PR #1745]
 - cats: fixes BigSqlQuery header fetching [PR #1746]
 - Fix issue #1780 libpng icc profil [PR #1788]
+- Fix missing DLL in windows packaging [PR #1807]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -162,5 +163,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1786]: https://github.com/bareos/bareos/pull/1786
 [PR #1788]: https://github.com/bareos/bareos/pull/1788
 [PR #1805]: https://github.com/bareos/bareos/pull/1805
+[PR #1807]: https://github.com/bareos/bareos/pull/1807
 [PR #1808]: https://github.com/bareos/bareos/pull/1808
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1851,14 +1851,13 @@ Function getDatabaseParametersLeave
   ReadINIStr  $DbPassword             "$PLUGINSDIR\databasedialog.ini" "Field 6" "state"
   ReadINIStr  $DbName                 "$PLUGINSDIR\databasedialog.ini" "Field 7" "state"
   ReadINIStr  $DbPort                 "$PLUGINSDIR\databasedialog.ini" "Field 8" "state"
-dbcheckend:
 
-   StrCmp $InstallDirector "no" SkipDbCheck # skip DbConnection if not instaling director
+  StrCmp $InstallDirector "no" SkipDbCheck # skip DbConnection if not installing director
 
-   ${If} ${SectionIsSelected} ${SEC_DIR_POSTGRES}
-     !insertmacro CheckDbAdminConnection
-     MessageBox MB_OK|MB_ICONINFORMATION "Connection to db server with DbAdmin credentials was successful."
-   ${EndIF}
+  ${If} ${SectionIsSelected} ${SEC_DIR_POSTGRES}
+    !insertmacro CheckDbAdminConnection
+    MessageBox MB_OK|MB_ICONINFORMATION "Connection to db server with DbAdmin credentials was successful."
+  ${EndIF}
 SkipDbCheck:
 
 FunctionEnd

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1,7 +1,7 @@
 ;
 ;   BAREOS - Backup Archiving REcovery Open Sourced
 ;
-;   Copyright (C) 2012-2023 Bareos GmbH & Co. KG
+;   Copyright (C) 2012-2024 Bareos GmbH & Co. KG
 ;
 ;   This program is Free Software; you can redistribute it and/or
 ;   modify it under the terms of version three of the GNU Affero General Public
@@ -871,6 +871,7 @@ SectionIn 1 2 3
   File "libglib-2.0-0.dll"
   File "libintl-8.dll"
   File "libharfbuzz-0.dll"
+  File "libpcre2-8-0.dll"
   File "libpcre2-16-0.dll"
 
   SetOutPath "$INSTDIR\platforms"
@@ -2046,6 +2047,7 @@ ConfDeleteSkip:
   Delete "$INSTDIR\libglib-2.0-0.dll"
   Delete "$INSTDIR\libintl-8.dll"
   Delete "$INSTDIR\libharfbuzz-0.dll"
+  Delete "$INSTDIR\libpcre2-8-0.dll"
   Delete "$INSTDIR\libpcre2-16-0.dll"
   Delete "$INSTDIR\iconv.dll"
   Delete "$INSTDIR\libxml2-2.dll"

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1497,15 +1497,19 @@ done:
   File "/oname=$PLUGINSDIR\libintl-8.dll" "libintl-8.dll"
   File "/oname=$PLUGINSDIR\libwinpthread-1.dll" "libwinpthread-1.dll"
 
-  # one of the two files  have to be available depending onwhat openssl Version we sue
-  File /nonfatal "/oname=$PLUGINSDIR\libcrypto-1_1.dll" "libcrypto-1_1.dll"
-  File /nonfatal "/oname=$PLUGINSDIR\libcrypto-1_1-x64.dll" "libcrypto-1_1-x64.dll"
-  # Either one of this two files will be available depending on 32/64 bits.
-  File /nonfatal "/oname=$PLUGINSDIR\libgcc_s_sjlj-1.dll" "libgcc_s_sjlj-1.dll"
-  File /nonfatal "/oname=$PLUGINSDIR\libgcc_s_seh-1.dll" "libgcc_s_seh-1.dll"
+  # Either one of these files will be available depending on 32/64 bits.
+!if ${BIT_WIDTH} == '64'
+    File "/oname=$PLUGINSDIR\libcrypto-3-x64.dll" "libcrypto-3-x64.dll"
+    File "/oname=$PLUGINSDIR\libssl-3-x64.dll" "libssl-3-x64.dll"
+    File "/oname=$PLUGINSDIR\libgcc_s_seh-1.dll" "libgcc_s_seh-1.dll"
+!else if ${BIT_WIDTH} == '32'
+    File "/oname=$PLUGINSDIR\libcrypto-3.dll" "libcrypto-3.dll"
+    File "/oname=$PLUGINSDIR\libssl-3.dll" "libssl-3.dll"
+    File "/oname=$PLUGINSDIR\libgcc_s_dw2-1.dll" "libgcc_s_dw2-1.dll"
+!else
+    !error "BIT_WIDTH neither 32 nor 64!"
+!endif
 
-  File /nonfatal "/oname=$PLUGINSDIR\libssl-1_1.dll" "libssl-1_1.dll"
-  File /nonfatal "/oname=$PLUGINSDIR\libssl-1_1-x64.dll" "libssl-1_1-x64.dll"
 
   File "/oname=$PLUGINSDIR\libstdc++-6.dll" "libstdc++-6.dll"
   File "/oname=$PLUGINSDIR\zlib1.dll" "zlib1.dll"


### PR DESCRIPTION
After switching to a newer crossbuild-image a DLL for bareos-tray-monitor.exe is missing from packaging. This PR adds that DLL and fixes some minor issues with the NSI script.

This will resolve #1801 

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR