### PR TITLE
VMware Plugin: Adapt to older urllib3 versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cats: fixes BigSqlQuery header fetching [PR #1746]
 - Fix issue #1780 libpng icc profil [PR #1788]
 - Fix missing DLL in windows packaging [PR #1807]
+- VMware Plugin: Adapt to older urllib3 versions [PR #1810]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -172,5 +173,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1805]: https://github.com/bareos/bareos/pull/1805
 [PR #1807]: https://github.com/bareos/bareos/pull/1807
 [PR #1808]: https://github.com/bareos/bareos/pull/1808
+[PR #1810]: https://github.com/bareos/bareos/pull/1810
 [PR #1821]: https://github.com/bareos/bareos/pull/1821
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -693,6 +693,22 @@ vadp_dumper_query_allocated_blocks_chunk_size (optional)
    any performance impact. However, with more data it might have an impact on
    the backup performance.
 
+fallback_to_full_cbt (optional)
+   In some situations requesting the CBT information for an incremental backup
+   can fail, for example when the CBT information had to be reset. In that
+   case, by default the plugin will fall back to request full level CBT
+   information, which leads to a successful incremental backup job, but it
+   will have the size of a full level backup job. As a consequence, restore
+   time would increase, so a warning will be emitted in the job log, recommending
+   a new full level backup.
+   By setting ``fallback_to_full_cbt=no``, the job will not request full level
+   CBT and terminate immediately with failure instead. This can be used if it
+   is desired to run a subsequent new full level backup. Note that this does not
+   happen automatically, a new full level job must be run manually afterwards,
+   but this can be automated by using a post backup script, for details see
+   https://github.com/bareos/bareos/tree/master/contrib/misc/reschedule_job_as_full
+
+   Since :sinceVersion:`23.0.3: VMware Plugin`
 
 uuid (deprecated)
    The uuid option could be used instead of *dc*, *folder* and *vmname* to uniquely address a VM for backup. As the plugin since :sinceVersion:`22.0.0: VMware Plugin` is able recreate VMs in a different datacenter, folder or datastore, this option has become useless. When using uuid, restoring is only possible to the same still existing VM. It is recommended to change the configuration, as the uuid option will be dropped in the next version.

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -62,6 +62,8 @@ Current limitations amongst others are:
 
    When a disk of a VM was removed and then added again on the same datastore with the same name, or when a CBT reset happened, then the plugin will detect this and request the full level CBT information, and all allocated blocks of that disk will be backed up in an incremental or differential job as if it were a full level job. The restore of such a job will work, but it will take longer than necessary. The backup will terminate with a warning and a recommendation to run a full level job to optimize restore time.
 
+   Since :sinceVersion:`23.0.3: VMware Plugin` the plugin option **fallback_to_full_cbt=no** (see below) can be used to disable this and terminate the job with failure instead. This can be useful if it is desired to run a new full level job anyway.
+
 Requirements
 ^^^^^^^^^^^^
 
@@ -70,6 +72,15 @@ As the Plugin is based on the |vsphere| Storage APIs for Data Protection, which 
 Since Bareos :sinceVersion:`22.0.0: VMware Plugin: VDDK 8.0.0` the plugin is using the Virtual Disk Development Kit (VDDK) 8.0.0, as of the VDDK 8.0 release notes, it should be compatible with vSphere 8 and the next major release (except new features) and backward compatible with vSphere 6.7 and 7, see VDDK release notes at https://developer.vmware.com/web/sdk/8.0/vddk for details.
 
 This plugin requires the pyVmomi module version 7.0.2 or greater. Since Bareos :sinceVersion:`21.0.0: VMware Plugin: pyVmomi` the package **bareos-vmware-plugin** no longer includes a dependency on a pyVmomi package, because some Linux distributions don't provide current versions. Consequently, pyVmomi must be either installed by using :command:`pip install pyvmomi` or by manually installing a distribution provided pyVmomi package.
+
+Since :sinceVersion:`23.0.3: VMware Plugin` the plugin requires the modules
+**requests** and **urllib3** for backup and restore of the NVRAM.
+There is no dependency in the package. In most Linux distributions,
+the packages providing these modules can be used. The minimum version of
+**requests** must be 2.20.0 and **urllib3** must be at least 1.24.1.
+On RHEL 7 or CentOS 7, the package
+https://forensics.cert.org/centos/cert/7/x86_64/python36-requests-2.27.1-1.el7.noarch.rpm
+can be used to fulfill this requirement.
 
 Installation
 ^^^^^^^^^^^^
@@ -294,6 +305,21 @@ And the config file as follows:
    Do not use quotes in the above config file, it is processed by the Python ConfigParser module and the quotes would not be stripped from the string.
 
 Since :sinceVersion:`20: VMware Plugin: quiesce` To allow backing up VMs which do not support quiesced snapshots, it is now possible to use the plugin option **quiesce**. By default quiescing when not explicitly using this option, quiescing is enabled to create backups that are as consistent as possible. When setting **quiesce=no** it is more likely to backup an inconsistent state. In this case, the backup job log will contain an appropriate warning and the the job termination will be **Backup OK -- with warnings**.
+
+Quiescing on Windows VMs also triggers VSS snapshot when VMware Tools are
+installed.
+If that fails for example on MS SQL Server, it can help to disable VSS
+application quiescing using the VMware Tools configuration by adding
+this to the VMware Tools config:
+
+.. code-block:: bareosconfig
+
+   [vmbackup]
+   vss.disableAppQuiescing = true
+
+For details see https://kb.vmware.com/s/article/2146204
+
+For consistent backups of MS SQL server, please use the Bareos **MSSQL Plugin**.
 
 Backup
 ^^^^^^


### PR DESCRIPTION
In urllib3 version 1.26 the parameter method_whitelist was replaced by allowed_methods. The Plugin now detects which parameter to use so that it also works with older versions.
    
Also the new plugin option fallback_to_full_cbt was added, which can be used when it is desired to run a new full level job anyway when incremental CBT is not possible.

Fix #1760 
Fix #1791 

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
