### PR TITLE
Build ULC and EL_9 for aarch64

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -13,15 +13,19 @@ OS:
       IMAGE: "ubuntu20.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
+      CUSTOM_TEST_IMAGES: [ "Ubuntu-20.04", "Debian-10", "Debian-11" ]
       ARCH:
         - x86_64
+        - aarch64
     "OpenSSL_3.0":
       TYPE: scripted
       IMAGE: "ubuntu22.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
+      CUSTOM_TEST_IMAGES: [ "Ubuntu-22.04", "Ubuntu-24.04", "Debian-12" ]
       ARCH:
         - x86_64
+        - aarch64
   xUbuntu:
     "22.04":
       TYPE: deb
@@ -80,19 +84,19 @@ OS:
       IMAGE: rhel9
       CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream, RHEL ]
       ARCH:
-      - x86_64
+        - x86_64
     "8":
       TYPE: rpm
       IMAGE: rhel8
       CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream, RHEL ]
       ARCH:
-      - x86_64
+        - x86_64
     "7":
       TYPE: rpm
       IMAGE: rhel7
       CUSTOM_TEST_IMAGES: [ CentOS, RHEL ]
       ARCH:
-      - x86_64
+        - x86_64
   FreeBSD:
     "14.0":
       TYPE: freebsd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Allow cross-building for Windows on newer compiler [PR #1776]
 - replace https://bugs.bareos.org by  https://github.com/bareos/bareos/issues/ [PR #1813]
 - tools: remove perl in mtx changer [PR #1816]
+- Build ULC and EL_9 for aarch64 [PR #1827]
 
 ### Documentation
 - docs: fix Pool explanation for migration jobs [PR #1735]
@@ -466,4 +467,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1813]: https://github.com/bareos/bareos/pull/1813
 [PR #1816]: https://github.com/bareos/bareos/pull/1816
 [PR #1817]: https://github.com/bareos/bareos/pull/1817
+[PR #1827]: https://github.com/bareos/bareos/pull/1827
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/pkglists/ULC_deb_OpenSSL_1.1.aarch64
+++ b/docs/pkglists/ULC_deb_OpenSSL_1.1.aarch64
@@ -1,0 +1,2 @@
+arm64/bareos-universal-client
+arm64/bareos-universal-client-dbg

--- a/docs/pkglists/ULC_deb_OpenSSL_3.0.aarch64
+++ b/docs/pkglists/ULC_deb_OpenSSL_3.0.aarch64
@@ -1,0 +1,2 @@
+arm64/bareos-universal-client
+arm64/bareos-universal-client-dbg


### PR DESCRIPTION
**Backport of PR #1821 to bareos-23**

This is a partial backport, that does not enable building on EL 9 like it was done for the master branch.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

#### Backport quality
- [x] Original PR #1821 is merged
