### PR TITLE
Fix mistake in VolumeManagement.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Documentation
+- Fix mistake in VolumeManagement.rst [PR #1834]
+
 ## [23.0.3] - 2024-06-04
 
 ### Added
@@ -475,4 +478,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1827]: https://github.com/bareos/bareos/pull/1827
 [PR #1831]: https://github.com/bareos/bareos/pull/1831
 [PR #1833]: https://github.com/bareos/bareos/pull/1833
+[PR #1834]: https://github.com/bareos/bareos/pull/1834
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/VolumeManagement.rst
+++ b/docs/manuals/source/TasksAndConcepts/VolumeManagement.rst
@@ -273,7 +273,7 @@ The |dir| configuration is as follows:
      Address = bareos-sd.example.com
      Password = local_storage_password
      Device = RecycleDir2
-     Media Type = File1
+     Media Type = File2
    }
 
    Catalog {


### PR DESCRIPTION
**Backport of PR #1829 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1829 is merged
- [X] All functional differences to the original PR are documented above
