### PR TITLE
stored: fix reordering bsr entries during restore

### DIFF
--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -598,6 +598,8 @@ void DoRestore(JobControlRecord* jcr)
         }
 
         if (status == CF_CORE) {
+          Jmsg(jcr, M_INFO, 0, "Create File (%lu): %s\n", jcr->JobFiles,
+               attr->ofname);
           status = CreateFile(jcr, attr, &rctx.bfd, jcr->fd_impl->replace);
         }
 

--- a/core/src/stored/bsr.cc
+++ b/core/src/stored/bsr.cc
@@ -741,11 +741,16 @@ void CreateRestoreVolumeList(JobControlRecord* jcr)
     }
   } else {
     /* This is the old way -- deprecated */
-    for (p = jcr->sd_impl->dcr->VolumeName; p && *p;) {
-      n = strchr(p, '|'); /* volume name separator */
-      if (n) { *n++ = 0; /* Terminate name */ }
+    for (const char* p = jcr->sd_impl->dcr->VolumeName; p && *p;) {
+      const char* n = strchr(p, '|'); /* volume name separator */
       vol = new_restore_volume();
-      bstrncpy(vol->VolumeName, p, sizeof(vol->VolumeName));
+      if (n) {
+        bstrncpy(vol->VolumeName, p,
+                 MIN((size_t)(n - p), sizeof(vol->VolumeName)));
+        n += 1;
+      } else {
+        bstrncpy(vol->VolumeName, p, sizeof(vol->VolumeName));
+      }
       bstrncpy(vol->MediaType, jcr->sd_impl->dcr->media_type,
                sizeof(vol->MediaType));
       if (AddRestoreVolume(jcr, vol)) {

--- a/core/src/stored/bsr.cc
+++ b/core/src/stored/bsr.cc
@@ -108,8 +108,6 @@ static int MatchBlockSesstime(BootStrapRecord* bsr,
 static int MatchBlockSessid(BootStrapRecord* bsr,
                             BsrSessionId* sessid,
                             DeviceBlock* block);
-static BootStrapRecord* find_smallest_volfile(BootStrapRecord* fbsr,
-                                              BootStrapRecord* bsr);
 
 /**
  *
@@ -129,12 +127,9 @@ int MatchBsrBlock(BootStrapRecord* bsr, DeviceBlock* block)
     return 1; /* cannot fast reject */
   }
 
-  for (; bsr; bsr = bsr->next) {
-    if (!MatchBlockSesstime(bsr, bsr->sesstime, block)) { continue; }
-    if (!MatchBlockSessid(bsr, bsr->sessid, block)) { continue; }
-    return 1;
-  }
-  return 0;
+  if (!MatchBlockSesstime(bsr, bsr->sesstime, block)) { return 0; }
+  if (!MatchBlockSessid(bsr, bsr->sessid, block)) { return 0; }
+  return 1;
 }
 
 static int MatchBlockSesstime(BootStrapRecord* bsr,
@@ -224,16 +219,18 @@ int MatchBsr(BootStrapRecord* bsr,
  * Find the next bsr that applies to the current tape.
  *   It is the one with the smallest VolFile position.
  */
-BootStrapRecord* find_next_bsr(BootStrapRecord* root_bsr, Device* dev)
+BootStrapRecord* find_next_bsr(BootStrapRecord* root_bsr,
+                               BootStrapRecord* bsr,
+                               Device* dev)
 {
-  BootStrapRecord* bsr;
-  BootStrapRecord* found_bsr = NULL;
-
   /* Do tape/disk seeking only if CAP_POSITIONBLOCKS is on */
-  if (!root_bsr) {
+  if (!root_bsr || !bsr) {
     Dmsg0(dbglevel, "NULL root bsr pointer passed to find_next_bsr.\n");
     return NULL;
   }
+
+  ASSERT(root_bsr == bsr->root);
+
   if (!root_bsr->use_positioning || !root_bsr->Reposition
       || !dev->HasCap(CAP_POSITIONBLOCKS)) {
     Dmsg2(dbglevel, "No nxt_bsr use_pos=%d repos=%d\n",
@@ -243,114 +240,23 @@ BootStrapRecord* find_next_bsr(BootStrapRecord* root_bsr, Device* dev)
   Dmsg2(dbglevel, "use_pos=%d repos=%d\n", root_bsr->use_positioning,
         root_bsr->Reposition);
   root_bsr->mount_next_volume = false;
-  /* Walk through all bsrs to find the next one to use => smallest file,block */
-  for (bsr = root_bsr; bsr; bsr = bsr->next) {
-    if (bsr->done || !MatchVolume(bsr, bsr->volume, &dev->VolHdr, 1)) {
-      continue;
-    }
-    if (found_bsr == NULL) {
-      found_bsr = bsr;
+
+  if (!bsr->done && MatchVolume(bsr, bsr->volume, &dev->VolHdr, 1)) {
+    return bsr;
+  }
+
+  /* check if next bsr has the same volume */
+  if (auto* next = bsr->next) {
+    if (MatchVolume(next, next->volume, &dev->VolHdr, 1)) {
+      return next;
     } else {
-      found_bsr = find_smallest_volfile(found_bsr, bsr);
-    }
-  }
-  /* If we get to this point and found no bsr, it means
-   *  that any additional bsr's must apply to the next
-   *  tape, so set a flag. */
-  if (found_bsr == NULL) { root_bsr->mount_next_volume = true; }
-  return found_bsr;
-}
-
-/**
- * Get the smallest address from this voladdr part
- * Don't use "done" elements
- */
-static bool GetSmallestVoladdr(BsrVolumeAddress* va, uint64_t* ret)
-{
-  bool ok = false;
-  uint64_t min_val = 0;
-
-  for (; va; va = va->next) {
-    if (!va->done) {
-      if (ok) {
-        min_val = MIN(min_val, va->saddr);
-      } else {
-        min_val = va->saddr;
-        ok = true;
-      }
-    }
-  }
-  *ret = min_val;
-  return ok;
-}
-
-/* FIXME
- * This routine needs to be fixed to only look at items that
- *   are not marked as done.  Otherwise, it can find a bsr
- *   that has already been consumed, and this will cause the
- *   bsr to be used, thus we may seek back and re-read the
- *   same records, causing an error.  This deficiency must
- *   be fixed.  For the moment, it has been kludged in
- *   read_record.c to avoid seeking back if find_next_bsr
- *   returns a bsr pointing to a smaller address (file/block).
- *
- */
-static BootStrapRecord* find_smallest_volfile(BootStrapRecord* found_bsr,
-                                              BootStrapRecord* bsr)
-{
-  BootStrapRecord* return_bsr = found_bsr;
-  BsrVolumeFile* vf;
-  BsrVolumeBlock* vb;
-  uint32_t found_bsr_sfile, bsr_sfile;
-  uint32_t found_bsr_sblock, bsr_sblock;
-  uint64_t found_bsr_saddr, bsr_saddr;
-
-  /* if we have VolAddr, use it, else try with File and Block */
-  if (GetSmallestVoladdr(found_bsr->voladdr, &found_bsr_saddr)) {
-    if (GetSmallestVoladdr(bsr->voladdr, &bsr_saddr)) {
-      if (found_bsr_saddr > bsr_saddr) {
-        return bsr;
-      } else {
-        return found_bsr;
-      }
+      // if it exists, but has a different volume, then notify the caller
+      root_bsr->mount_next_volume = true;
     }
   }
 
-  /* Find the smallest file in the found_bsr */
-  vf = found_bsr->volfile;
-  found_bsr_sfile = vf->sfile;
-  while ((vf = vf->next)) {
-    if (vf->sfile < found_bsr_sfile) { found_bsr_sfile = vf->sfile; }
-  }
-
-  /* Find the smallest file in the bsr */
-  vf = bsr->volfile;
-  bsr_sfile = vf->sfile;
-  while ((vf = vf->next)) {
-    if (vf->sfile < bsr_sfile) { bsr_sfile = vf->sfile; }
-  }
-
-  /* if the bsr file is less than the found_bsr file, return bsr */
-  if (found_bsr_sfile > bsr_sfile) {
-    return_bsr = bsr;
-  } else if (found_bsr_sfile == bsr_sfile) {
-    /* Files are equal */
-    /* find smallest block in found_bsr */
-    vb = found_bsr->volblock;
-    found_bsr_sblock = vb->sblock;
-    while ((vb = vb->next)) {
-      if (vb->sblock < found_bsr_sblock) { found_bsr_sblock = vb->sblock; }
-    }
-    /* Find smallest block in bsr */
-    vb = bsr->volblock;
-    bsr_sblock = vb->sblock;
-    while ((vb = vb->next)) {
-      if (vb->sblock < bsr_sblock) { bsr_sblock = vb->sblock; }
-    }
-    /* Compare and return the smallest */
-    if (found_bsr_sblock > bsr_sblock) { return_bsr = bsr; }
-  }
-  return return_bsr;
+  // next bsr not on this volume (or does not exist)
+  return NULL;
 }
 
 /**
@@ -504,9 +410,7 @@ static int MatchAll(BootStrapRecord* bsr,
   return 1;
 
 no_match:
-  if (bsr->next) {
-    return MatchAll(bsr->next, rec, volrec, sessrec, bsr->done && done, jcr);
-  }
+  if (bsr->next) { return 0; }
   if (bsr->done && done) {
     Dmsg0(dbglevel, "Leave match all -1\n");
     return -1;
@@ -780,26 +684,16 @@ static bool AddRestoreVolume(JobControlRecord* jcr, VolumeList* vol)
 
   if (!next) {                   /* list empty ? */
     jcr->sd_impl->VolList = vol; /* yes, add volume */
-  } else {
-    /* Loop through all but last */
-    for (; next->next; next = next->next) {
-      if (bstrcmp(vol->VolumeName, next->VolumeName)) {
-        /* Save smallest start file */
-        if (vol->start_file < next->start_file) {
-          next->start_file = vol->start_file;
-        }
-        return false; /* already in list */
-      }
-    }
-    /* Check last volume in list */
-    if (bstrcmp(vol->VolumeName, next->VolumeName)) {
-      if (vol->start_file < next->start_file) {
-        next->start_file = vol->start_file;
-      }
-      return false; /* already in list */
-    }
-    next->next = vol; /* add volume */
+    return true;
   }
+
+  /* Loop through all but last */
+  while (next->next) { next = next->next; }
+  if (bstrcmp(vol->VolumeName, next->VolumeName)) {
+    return false; /* already in list */
+  }
+
+  next->next = vol;
   return true;
 }
 
@@ -809,7 +703,6 @@ static bool AddRestoreVolume(JobControlRecord* jcr, VolumeList* vol)
  */
 void CreateRestoreVolumeList(JobControlRecord* jcr)
 {
-  char *p, *n;
   VolumeList* vol;
 
   // Build a list of volumes to be processed

--- a/core/src/stored/device.h
+++ b/core/src/stored/device.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2018 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -30,8 +30,10 @@ void SetStartVolPosition(DeviceControlRecord* dcr);
 void SetNewVolumeParameters(DeviceControlRecord* dcr);
 void SetNewFileParameters(DeviceControlRecord* dcr);
 BootStrapRecord* PositionDeviceToFirstFile(JobControlRecord* jcr,
+                                           BootStrapRecord** current,
                                            DeviceControlRecord* dcr);
 bool TryDeviceRepositioning(JobControlRecord* jcr,
+                            BootStrapRecord** current,
                             DeviceRecord* rec,
                             DeviceControlRecord* dcr);
 

--- a/core/src/stored/match_bsr.h
+++ b/core/src/stored/match_bsr.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -29,7 +29,9 @@ int MatchBsr(BootStrapRecord* bsr,
              Session_Label* sesrec,
              JobControlRecord* jcr);
 int MatchBsrBlock(BootStrapRecord* bsr, DeviceBlock* block);
-BootStrapRecord* find_next_bsr(BootStrapRecord* root_bsr, Device* dev);
+BootStrapRecord* find_next_bsr(BootStrapRecord* root_bsr,
+                               BootStrapRecord* bsr,
+                               Device* dev);
 bool IsThisBsrDone(BootStrapRecord* bsr, DeviceRecord* rec);
 uint64_t GetBsrStartAddr(BootStrapRecord* bsr,
                          uint32_t* file = NULL,

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -358,7 +358,7 @@ static inline bool bndmp_read_data_from_block(JobControlRecord* jcr,
       }
     } else {
       // Read the next block into our buffers.
-      if (!ReadNextBlockFromDevice(dcr, &rctx->sessrec, NULL,
+      if (!ReadNextBlockFromDevice(dcr, rctx, &rctx->sessrec, NULL,
                                    MountNextReadVolume, NULL, &ok)) {
         return false;
       }
@@ -678,15 +678,16 @@ extern "C" ndmp9_error bndmp_tape_open(struct ndm_session* sess,
 
       Dmsg1(50, "Begin reading device=%s\n", dcr->dev->print_name());
 
-      PositionDeviceToFirstFile(jcr, dcr);
-      jcr->sd_impl->read_session.mount_next_volume = false;
-
       // Allocate a new read context for this Job.
       rctx = new_read_context();
       jcr->sd_impl->read_session.rctx = rctx;
 
+      PositionDeviceToFirstFile(jcr, &rctx->current, dcr);
+      jcr->sd_impl->read_session.mount_next_volume = false;
+
+
       // Read the first block and setup record processing.
-      if (!ReadNextBlockFromDevice(dcr, &rctx->sessrec, NULL,
+      if (!ReadNextBlockFromDevice(dcr, rctx, &rctx->sessrec, NULL,
                                    MountNextReadVolume, NULL, &ok)) {
         Jmsg1(jcr, M_FATAL, 0, T_("Read session label failed. ERR=%s\n"),
               dcr->dev->bstrerror());

--- a/core/src/stored/read_ctx.h
+++ b/core/src/stored/read_ctx.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -37,6 +37,8 @@ struct Read_Context {
   Session_Label sessrec;          /**< Start Of Session record info */
   uint32_t records_processed = 0; /**< Number of records processed from this block */
   int32_t lastFileIndex = 0;      /**< Last File Index processed */
+
+  BootStrapRecord* current = nullptr;
 };
 /* clang-format on */
 

--- a/core/src/stored/read_record.h
+++ b/core/src/stored/read_record.h
@@ -29,6 +29,7 @@ READ_CTX* new_read_context(void);
 void FreeReadContext(READ_CTX* rctx);
 void ReadContextSetRecord(DeviceControlRecord* dcr, READ_CTX* rctx);
 bool ReadNextBlockFromDevice(DeviceControlRecord* dcr,
+                             READ_CTX* ctx,
                              Session_Label* sessrec,
                              bool RecordCb(DeviceControlRecord* dcr,
                                            DeviceRecord* rec,


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The way it worked was the following:
1) Go through all bsr, and note which volumes are used (basically in a
set)
2) For each listed volume: open it, position it to the first position
mentioned in any bsr entry, and read from it until _no_ bsr entry
wants to read from it anymore
3) send all records that match _any_ bsr entry to the callback

The Problem with this approach is that we do not guarantee that the
order of records send to to e.g. the fd stays the same.  In some
situations we could even interleave records from two different files!
Think of a volume separated into blocks like so:

| job 1 | job 2 | job 1 | job 2 | job 1 | job 2 |

where job 1 and job 2 are jobs that backed up to the
same device at the same time.  If you now try to restore both of them,
the records will arrive interleaved!  Cleary we should first send all
of job 1 blocks and only then start sending all of job 2 blocks.

This is fixed in the following way:

1) We know create an ordered list of volumes by either appending the
bsrs volume to the end of the list or merging it into the last entry of
the list in case they refer to the same volume. E.g. the bsrs

| Vol 1 | Vol 2 | Vol 1 | Vol 1 |

will result in the list Vol 1 -> Vol 2 -> Vol 1.

2) We go through the list of volumes, keeping track of the current bsr
entry.  We only accept records of the _current_ bsr entry.  If we
finished the current bsr entry, and the next bsr entry uses the same
volume, we set the current bsr to the next bsr (This causes the core
to reposition the current volume to the start of that bsr).  Otherwise
we mount the next volume and then switch bsrs.

3) We only send records to the callback that match the current bsr.

This should hopefully prevent any interleaving.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
