### PR TITLE
python-bareos: fix description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - tools: add dedup estimation tool `bdedupestimate` [PR #1654]
 - Build ULC and EL_9 for aarch64 [PR #1821]
 - webui: fix and improve update check [PR #1809]
+- python-bareos: fix description [PR #1840]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -181,4 +182,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1810]: https://github.com/bareos/bareos/pull/1810
 [PR #1821]: https://github.com/bareos/bareos/pull/1821
 [PR #1829]: https://github.com/bareos/bareos/pull/1829
+[PR #1840]: https://github.com/bareos/bareos/pull/1840
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/setup.py
+++ b/python-bareos/setup.py
@@ -55,7 +55,9 @@ def get_long_description():
         bsock_content = bsock_file.read().strip()
     # bsock_description = re.sub(r'.*"""(.*?)""".*', r'\1', bsock_content, flags=re.DOTALL)
     bsock_description = re.sub(
-        r'.*(\.\. note::.*?)""".*', r"\n\n\1", bsock_content, flags=re.DOTALL
+        ":py:class:",
+        "",
+        re.sub(r'.*(\.\. note::.*?)""".*', r"\n\n\1", bsock_content, flags=re.DOTALL),
     )
     return description + bsock_description
 


### PR DESCRIPTION
The package long description is based on python-bareos/bareos/bsock/__init__.py However, the formatting :py:class: must be removed, as PyPI does not allows it.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR