### PR TITLE
VMware Plugin: Adapt to Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - pull-request-template: add milestone check to reviewers list [PR #1868]
 - contrib: add pure python statefile parser [PR #1789]
 - Use only MinGW VSS [PR #1847]
+- VMware Plugin: Adapt to Python 3.12 [PR #1850]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -195,6 +196,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1829]: https://github.com/bareos/bareos/pull/1829
 [PR #1840]: https://github.com/bareos/bareos/pull/1840
 [PR #1847]: https://github.com/bareos/bareos/pull/1847
+[PR #1850]: https://github.com/bareos/bareos/pull/1850
 [PR #1853]: https://github.com/bareos/bareos/pull/1853
 [PR #1865]: https://github.com/bareos/bareos/pull/1865
 [PR #1868]: https://github.com/bareos/bareos/pull/1868

--- a/core/cmake/get_python_compile_settings.py
+++ b/core/cmake/get_python_compile_settings.py
@@ -34,7 +34,7 @@ except:
 for var in ("CC", "BLDSHARED"):
     value = sysconfig.get_config_var(var)
     print(
-        'message(STATUS "Python{0}_{1}\ is\  {2}")'.format(
+        'message(STATUS "Python{0}_{1} is  {2}")'.format(
             sys.version_info[0], var, value
         )
     )
@@ -47,7 +47,7 @@ for var in ("CC", "BLDSHARED"):
         value = ""
     # as these vars contain the compiler itself, we remove the first word and return it as _FLAGS
     print(
-        'message(STATUS "Python{0}_{1}_FLAGS\ is\  {2}")'.format(
+        'message(STATUS "Python{0}_{1}_FLAGS is  {2}")'.format(
             sys.version_info[0], var, value
         )
     )
@@ -56,7 +56,7 @@ for var in ("CC", "BLDSHARED"):
 for var in ("CFLAGS", "CCSHARED", "INCLUDEPY", "LDFLAGS"):
     value = sysconfig.get_config_var(var)
     print(
-        'message(STATUS "Python{0}_{1}\ is\  {2}")'.format(
+        'message(STATUS "Python{0}_{1} is  {2}")'.format(
             sys.version_info[0], var, value
         )
     )
@@ -67,7 +67,7 @@ for var in ("EXT_SUFFIX",):
     if value is None:
         value = ""
     print(
-        'message(STATUS "Python{0}_{1}\ is\  {2}")'.format(
+        'message(STATUS "Python{0}_{1} is  {2}")'.format(
             sys.version_info[0], var, value
         )
     )

--- a/core/cmake/get_python_compile_settings.py
+++ b/core/cmake/get_python_compile_settings.py
@@ -3,7 +3,7 @@
 
 #   BAREOS(R) - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public


### PR DESCRIPTION
The changed configparser and ssl modules in Python 3.12 required adaptions of the plugin code so that it now works with the Python versions 3.6, 3.9, 3.10 and 3.12

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
