### PR TITLE
contrib: fix reschedule_job_as_full.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build ULC and EL_9 for aarch64 [PR #1821]
 - webui: fix and improve update check [PR #1809]
 - python-bareos: fix description [PR #1840]
+- contrib: fix reschedule_job_as_full.sh [PR #1853]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -185,4 +186,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1821]: https://github.com/bareos/bareos/pull/1821
 [PR #1829]: https://github.com/bareos/bareos/pull/1829
 [PR #1840]: https://github.com/bareos/bareos/pull/1840
+[PR #1853]: https://github.com/bareos/bareos/pull/1853
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/contrib/misc/reschedule_job_as_full/README.md
+++ b/contrib/misc/reschedule_job_as_full/README.md
@@ -1,6 +1,6 @@
 # helper script to reschedule a failed job
 
-This helper script can be used to reschedule a failed job 
+This helper script can be used to reschedule a failed job
 to level=Full.
 
 This kind of situation is encountered often by plugin job
@@ -8,9 +8,13 @@ running an incremental and not suitable full is detected.
 The job will fail on each run until a valid full is done.
 
 So when the plugin detects such a state, it must emit a
-job message that contains the string "A new full level
-backup of this job is required." and it must ensure to
-terminate the job with failure.
+job message that contains the string
+
+```
+new full level backup of this job is required
+```
+
+and it must ensure to terminate the job with failure.
 
 You can add this runscript resource in your job or jobdefs like this:
 

--- a/contrib/misc/reschedule_job_as_full/reschedule_job_as_full.sh
+++ b/contrib/misc/reschedule_job_as_full/reschedule_job_as_full.sh
@@ -46,7 +46,7 @@ debug_log_file=${6:-/dev/null}
 } >> "${debug_log_file}"
 
 if [ "${JobExitStatus}" == "Fatal Error" ] && [ "${JobLevel}" == "Incremental" ] && [ "${JobType}" == "Backup" ]; then
-  if (bconsole <<< "list joblog jobid=${JobId}" | tee -a "${debug_log_file}" | grep -q -F "A new full level backup of this job is required."); then
+  if (bconsole <<< "list joblog jobid=${JobId}" | tee -a "${debug_log_file}" | grep -q -F "new full level backup of this job is required"); then
     echo "Required new full level run will be started in 1 minute."
     if ! bconsole <<< "run job=${JobName} level=Full when=\"$(date -d "now 1min" +"%Y-%m-%d %H:%M:%S")\" yes"; then
       echo "Error while rescheduling ${JobName}"


### PR DESCRIPTION
Removed the article "A" from the matching string to make it a bit more flexible for the job message.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

