### PR TITLE
dir: fix crash on purge with job without client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - windows: fix some crashes, change handling of invalid paths; lex: add better error detection; accurate: fix out of bounds writes [PR #1793]
 - create_bareos_database: fix `db_name` not being double quoted [PR #1865]
 - fix warnings on FreeBSD 13.3 compiler [PR #1881]
+- dir: fix crash on purge with job without client [PR #1857]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -198,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1847]: https://github.com/bareos/bareos/pull/1847
 [PR #1850]: https://github.com/bareos/bareos/pull/1850
 [PR #1853]: https://github.com/bareos/bareos/pull/1853
+[PR #1857]: https://github.com/bareos/bareos/pull/1857
 [PR #1865]: https://github.com/bareos/bareos/pull/1865
 [PR #1868]: https://github.com/bareos/bareos/pull/1868
 [PR #1881]: https://github.com/bareos/bareos/pull/1881

--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -301,14 +301,12 @@ static bool PurgeJobsFromPool(UaContext* ua, PoolDbRecord* pool_record)
   ua->db->SqlQuery(select_jobs_from_pool.c_str(), JobDeleteHandler,
                    &delete_list);
 
-  ClientResource* client = ua->jcr->dir_impl->res.client;
   if (delete_list.empty()) {
-    ua->WarningMsg(T_("No Jobs found for pool %s to purge from %s catalog.\n"),
-                   pool_record->Name, client->catalog->resource_name_);
+    ua->WarningMsg(T_("No Jobs found for pool %s to purge from catalog.\n"),
+                   pool_record->Name);
   } else {
-    ua->InfoMsg(T_("Found %d Jobs for pool \"%s\" in catalog \"%s\".\n"),
-                delete_list.size(), pool_record->Name,
-                client->catalog->resource_name_);
+    ua->InfoMsg(T_("Found %d Jobs for pool \"%s\" in catalog.\n"),
+                delete_list.size(), pool_record->Name);
     if (!GetConfirmation(ua, "Purge (yes/no)? ")) {
       ua->InfoMsg(T_("Purge canceled.\n"));
     } else {
@@ -321,8 +319,7 @@ static bool PurgeJobsFromPool(UaContext* ua, PoolDbRecord* pool_record)
 
   std::vector<DBId_t> media_ids_in_pool;
   if (ua->db->GetMediaIdsInPool(pool_record, &media_ids_in_pool)) {
-    ua->WarningMsg(T_("No Medias found for pool %s.\n"), pool_record->Name,
-                   client->catalog->resource_name_);
+    ua->WarningMsg(T_("No Media found for pool %s.\n"), pool_record->Name);
   }
   for (auto mediaid : media_ids_in_pool) {
     MediaDbRecord mr;
@@ -531,13 +528,12 @@ bool PurgeJobsFromVolume(UaContext* ua, MediaDbRecord* mr, bool force)
     jobids = lst.GetAsString();
   }
 
-  ClientResource* client = ua->jcr->dir_impl->res.client;
   if (lst.empty()) {
-    ua->WarningMsg(T_("No Jobs found for media %s to purge from %s catalog.\n"),
-                   mr->VolumeName, client->catalog->resource_name_);
+    ua->WarningMsg(T_("No Jobs found for media %s to purge from catalog.\n"),
+                   mr->VolumeName);
   } else {
-    ua->InfoMsg(T_("Found %d Jobs for media \"%s\" in catalog \"%s\".\n"),
-                lst.size(), mr->VolumeName, client->catalog->resource_name_);
+    ua->InfoMsg(T_("Found %d Jobs for media \"%s\" in catalog.\n"), lst.size(),
+                mr->VolumeName);
     if (!GetConfirmation(ua, "Purge (yes/no)? ", true)) {
       ua->InfoMsg(T_("Purge canceled.\n"));
     } else {


### PR DESCRIPTION
purge volume would crash if the first job declared in your configuration has no client defined, because the code uses the default-client taken from there to fill information in the log messages.
That not really required information has been removed from the log messages which will also fix the crash.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR