### PR TITLE
msgchan: fix deadlock

### DIFF
--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -642,14 +642,19 @@ static void* job_thread(void* arg)
   return NULL;
 }
 
-void SdMsgThreadSendSignal(JobControlRecord* jcr, int sig)
+void SdMsgThreadSendSignal_Locked(JobControlRecord* jcr, int sig)
 {
-  std::unique_lock l(jcr->mutex_guard());
   if (!jcr->dir_impl->sd_msg_thread_done && jcr->dir_impl->SD_msg_chan_started
       && !pthread_equal(jcr->dir_impl->SD_msg_chan, pthread_self())) {
     Dmsg1(800, "Send kill to SD msg chan jid=%d\n", jcr->JobId);
     pthread_kill(jcr->dir_impl->SD_msg_chan, sig);
   }
+}
+
+void SdMsgThreadSendSignal(JobControlRecord* jcr, int sig)
+{
+  std::unique_lock l(jcr->mutex_guard());
+  SdMsgThreadSendSignal_Locked(jcr, sig);
 }
 
 /**

--- a/core/src/dird/job.h
+++ b/core/src/dird/job.h
@@ -58,6 +58,7 @@ void DirdFreeJcrPointers(JobControlRecord* jcr);
 void CancelStorageDaemonJob(JobControlRecord* jcr);
 bool RunConsoleCommand(JobControlRecord* jcr, const char* cmd);
 void SdMsgThreadSendSignal(JobControlRecord* jcr, int sig);
+void SdMsgThreadSendSignal_Locked(JobControlRecord* jcr, int sig);
 void InitJobServer(int max_workers);
 void TermJobServer();
 

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -529,7 +529,7 @@ static void WaitForCanceledStorageDaemonTermination(
     if (jcr->dir_impl->SD_msg_chan_started) {
       jcr->store_bsock->SetTimedOut();
       jcr->store_bsock->SetTerminated();
-      SdMsgThreadSendSignal(jcr, TIMEOUT_SIGNAL);
+      SdMsgThreadSendSignal_Locked(jcr, TIMEOUT_SIGNAL);
     }
 
     if (jcr->dir_impl->term_wait.wait_until(l, timeout)


### PR DESCRIPTION
We called a function that locks the jcr while we a already held the lock, which causes a deadlock.  This commit fixes this by offering an alternative function which does no locking.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
