### PR TITLE
alist: fix race condition while iterating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - freebsd: fix build issues with ports tree 2024Q3 [PR #1883]
 - Improve PythonFdWrapper class [PR #1846]
 - windows: build natively with msvc compiler [PR #1744]
+- alist: fix race condition while iterating [PR #1859]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -211,6 +212,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1850]: https://github.com/bareos/bareos/pull/1850
 [PR #1853]: https://github.com/bareos/bareos/pull/1853
 [PR #1857]: https://github.com/bareos/bareos/pull/1857
+[PR #1859]: https://github.com/bareos/bareos/pull/1859
 [PR #1865]: https://github.com/bareos/bareos/pull/1865
 [PR #1868]: https://github.com/bareos/bareos/pull/1868
 [PR #1871]: https://github.com/bareos/bareos/pull/1871

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -132,8 +132,6 @@ char* StorageAddressToContact(StorageResource* read_storage,
 
 static inline bool ValidateStorage(JobControlRecord* jcr)
 {
-  StorageResource* store = nullptr;
-
   foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
     switch (store->Protocol) {
       case APT_NATIVE:
@@ -180,7 +178,6 @@ bool DoNativeBackupInit(JobControlRecord* jcr)
 static bool GetBaseJobids(JobControlRecord* jcr, db_list_ctx* jobids)
 {
   JobDbRecord jr;
-  JobResource* job = nullptr;
   JobId_t id;
 
   if (!jcr->dir_impl->res.job->base) {

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -132,17 +132,19 @@ char* StorageAddressToContact(StorageResource* read_storage,
 
 static inline bool ValidateStorage(JobControlRecord* jcr)
 {
-  for (auto* store : *jcr->dir_impl->res.write_storage_list) {
-    switch (store->Protocol) {
-      case APT_NATIVE:
-        continue;
-      default:
-        Jmsg(
-            jcr, M_FATAL, 0,
-            T_("Storage %s has illegal backup protocol %s for Native backup\n"),
-            store->resource_name_,
-            AuthenticationProtocolTypeToString(store->Protocol));
-        return false;
+  if (jcr->dir_impl->res.write_storage_list) {
+    for (auto* store : *jcr->dir_impl->res.write_storage_list) {
+      switch (store->Protocol) {
+        case APT_NATIVE:
+          continue;
+        default:
+          Jmsg(jcr, M_FATAL, 0,
+               T_("Storage %s has illegal backup protocol %s for Native "
+                  "backup\n"),
+               store->resource_name_,
+               AuthenticationProtocolTypeToString(store->Protocol));
+          return false;
+      }
     }
   }
 

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -132,19 +132,17 @@ char* StorageAddressToContact(StorageResource* read_storage,
 
 static inline bool ValidateStorage(JobControlRecord* jcr)
 {
-  if (jcr->dir_impl->res.write_storage_list) {
-    for (auto* store : *jcr->dir_impl->res.write_storage_list) {
-      switch (store->Protocol) {
-        case APT_NATIVE:
-          continue;
-        default:
-          Jmsg(jcr, M_FATAL, 0,
-               T_("Storage %s has illegal backup protocol %s for Native "
-                  "backup\n"),
-               store->resource_name_,
-               AuthenticationProtocolTypeToString(store->Protocol));
-          return false;
-      }
+  for (auto* store : jcr->dir_impl->res.write_storage_list) {
+    switch (store->Protocol) {
+      case APT_NATIVE:
+        continue;
+      default:
+        Jmsg(jcr, M_FATAL, 0,
+             T_("Storage %s has illegal backup protocol %s for Native "
+                "backup\n"),
+             store->resource_name_,
+             AuthenticationProtocolTypeToString(store->Protocol));
+        return false;
     }
   }
 
@@ -188,7 +186,7 @@ static bool GetBaseJobids(JobControlRecord* jcr, db_list_ctx* jobids)
 
   jr.StartTime = jcr->dir_impl->jr.StartTime;
 
-  for (auto* job : *jcr->dir_impl->res.job->base) {
+  for (auto* job : jcr->dir_impl->res.job->base) {
     bstrncpy(jr.Name, job->resource_name_, sizeof(jr.Name));
     jcr->db->GetBaseJobid(jcr, &jr, &id);
 

--- a/core/src/dird/backup.cc
+++ b/core/src/dird/backup.cc
@@ -132,7 +132,7 @@ char* StorageAddressToContact(StorageResource* read_storage,
 
 static inline bool ValidateStorage(JobControlRecord* jcr)
 {
-  foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
+  for (auto* store : *jcr->dir_impl->res.write_storage_list) {
     switch (store->Protocol) {
       case APT_NATIVE:
         continue;
@@ -186,7 +186,7 @@ static bool GetBaseJobids(JobControlRecord* jcr, db_list_ctx* jobids)
 
   jr.StartTime = jcr->dir_impl->jr.StartTime;
 
-  foreach_alist (job, jcr->dir_impl->res.job->base) {
+  for (auto* job : *jcr->dir_impl->res.job->base) {
     bstrncpy(jr.Name, job->resource_name_, sizeof(jr.Name));
     jcr->db->GetBaseJobid(jcr, &jr, &id);
 

--- a/core/src/dird/dir_plugins.cc
+++ b/core/src/dird/dir_plugins.cc
@@ -446,7 +446,7 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
        * instance. */
       if (jcr->plugin_ctx_list) {
         PluginContext* found_ctx = nullptr;
-        foreach_alist (ctx, jcr->plugin_ctx_list) {
+        for (auto* ctx : *jcr->plugin_ctx_list) {
           if (ctx->instance == instance && ctx->plugin->file_len == len
               && bstrncasecmp(ctx->plugin->file, plugin_name, len)) {
             found_ctx = ctx;
@@ -505,7 +505,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance dir-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  foreach_alist (ctx, jcr->plugin_ctx_list) {
+  for (auto* ctx : *jcr->plugin_ctx_list) {
     // Free the plugin instance
     DirplugFunc(ctx->plugin)->freePlugin(ctx);
     free(ctx->core_private_context); /* Free BAREOS private context */
@@ -787,7 +787,7 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
   cnt = 0;
   foreach_jcr (njcr) {
     if (jcr->plugin_ctx_list) {
-      foreach_alist (nctx, jcr->plugin_ctx_list) {
+      for (auto* nctx : *jcr->plugin_ctx_list) {
         if (nctx->plugin == bctx->plugin) { cnt++; }
       }
     }

--- a/core/src/dird/dir_plugins.cc
+++ b/core/src/dird/dir_plugins.cc
@@ -446,7 +446,7 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
        * instance. */
       if (jcr->plugin_ctx_list) {
         PluginContext* found_ctx = nullptr;
-        for (auto* ctx : *jcr->plugin_ctx_list) {
+        for (auto* ctx : jcr->plugin_ctx_list) {
           if (ctx->instance == instance && ctx->plugin->file_len == len
               && bstrncasecmp(ctx->plugin->file, plugin_name, len)) {
             found_ctx = ctx;
@@ -505,7 +505,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance dir-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  for (auto* ctx : *jcr->plugin_ctx_list) {
+  for (auto* ctx : jcr->plugin_ctx_list) {
     // Free the plugin instance
     DirplugFunc(ctx->plugin)->freePlugin(ctx);
     free(ctx->core_private_context); /* Free BAREOS private context */
@@ -786,10 +786,8 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
 
   cnt = 0;
   foreach_jcr (njcr) {
-    if (jcr->plugin_ctx_list) {
-      for (auto* nctx : *jcr->plugin_ctx_list) {
-        if (nctx->plugin == bctx->plugin) { cnt++; }
-      }
+    for (auto* nctx : jcr->plugin_ctx_list) {
+      if (nctx->plugin == bctx->plugin) { cnt++; }
     }
   }
   endeach_jcr(njcr);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1064,7 +1064,6 @@ static void PropagateResource(ResourceItem* items,
           break;
         }
         case CFG_TYPE_ALIST_STR: {
-          const char* str = nullptr;
           alist<const char*>*orig_list, **new_list;
 
           // Handle alist strings
@@ -1086,7 +1085,6 @@ static void PropagateResource(ResourceItem* items,
           break;
         }
         case CFG_TYPE_ALIST_RES: {
-          BareosResource* res = nullptr;
           alist<BareosResource*>*orig_list, **new_list;
 
           // Handle alist resources
@@ -1108,7 +1106,6 @@ static void PropagateResource(ResourceItem* items,
           break;
         }
         case CFG_TYPE_ACL: {
-          const char* str = nullptr;
           alist<const char*>*orig_list, **new_list;
 
           // Handle ACL lists.
@@ -1303,7 +1300,6 @@ static void PrintConfigRunscript(OutputFormatterResource& send,
 
   send.ArrayStart(item.name, inherited, "");
 
-  RunScript* runscript = nullptr;
   foreach_alist (runscript, list) {
     std::string esc = EscapeString(runscript->command.c_str());
 
@@ -2412,7 +2408,6 @@ bool PropagateJobdefs(int res_type, JobResource* res)
         res->RunScripts = new alist<RunScript*>(10, not_owned_by_alist);
       }
 
-      RunScript* rs = nullptr;
       foreach_alist (rs, jobdefs->RunScripts) {
         RunScript* r = DuplicateRunscript(rs);
         r->from_jobdef = true;

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1077,7 +1077,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
+            for (auto* str : *orig_list) { (*new_list)->append(strdup(str)); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1098,7 +1098,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<BareosResource*>(10, not_owned_by_alist);
             }
 
-            foreach_alist (res, orig_list) { (*new_list)->append(res); }
+            for (auto* res : *orig_list) { (*new_list)->append(res); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1121,7 +1121,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            foreach_alist (str, orig_list) { (*new_list)->append(strdup(str)); }
+            for (auto* str : *orig_list) { (*new_list)->append(strdup(str)); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1300,7 +1300,7 @@ static void PrintConfigRunscript(OutputFormatterResource& send,
 
   send.ArrayStart(item.name, inherited, "");
 
-  foreach_alist (runscript, list) {
+  for (auto* runscript : *list) {
     std::string esc = EscapeString(runscript->command.c_str());
 
     bool print_as_comment = inherited;
@@ -2408,7 +2408,7 @@ bool PropagateJobdefs(int res_type, JobResource* res)
         res->RunScripts = new alist<RunScript*>(10, not_owned_by_alist);
       }
 
-      foreach_alist (rs, jobdefs->RunScripts) {
+      for (auto* rs : *jobdefs->RunScripts) {
         RunScript* r = DuplicateRunscript(rs);
         r->from_jobdef = true;
         res->RunScripts->append(r); /* free it at FreeResource */

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1077,7 +1077,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            for (auto* str : *orig_list) { (*new_list)->append(strdup(str)); }
+            for (auto* str : orig_list) { (*new_list)->append(strdup(str)); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1098,7 +1098,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<BareosResource*>(10, not_owned_by_alist);
             }
 
-            for (auto* res : *orig_list) { (*new_list)->append(res); }
+            for (auto* res : orig_list) { (*new_list)->append(res); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1121,7 +1121,7 @@ static void PropagateResource(ResourceItem* items,
               *new_list = new alist<const char*>(10, owned_by_alist);
             }
 
-            for (auto* str : *orig_list) { (*new_list)->append(strdup(str)); }
+            for (auto* str : orig_list) { (*new_list)->append(strdup(str)); }
 
             dest->SetMemberPresent(items[i].name);
             SetBit(i, dest->inherit_content_);
@@ -1300,7 +1300,7 @@ static void PrintConfigRunscript(OutputFormatterResource& send,
 
   send.ArrayStart(item.name, inherited, "");
 
-  for (auto* runscript : *list) {
+  for (auto* runscript : list) {
     std::string esc = EscapeString(runscript->command.c_str());
 
     bool print_as_comment = inherited;
@@ -2408,7 +2408,7 @@ bool PropagateJobdefs(int res_type, JobResource* res)
         res->RunScripts = new alist<RunScript*>(10, not_owned_by_alist);
       }
 
-      for (auto* rs : *jobdefs->RunScripts) {
+      for (auto* rs : jobdefs->RunScripts) {
         RunScript* r = DuplicateRunscript(rs);
         r->from_jobdef = true;
         res->RunScripts->append(r); /* free it at FreeResource */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -580,6 +580,8 @@ static bool HaveClientRunscripts(alist<RunScript*>* RunScripts)
 {
   bool retval = false;
 
+  if (!RunScripts) { return false; }
+
   if (RunScripts->empty()) { return false; }
 
   for (auto* cmd : *RunScripts) {

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -582,7 +582,7 @@ static bool HaveClientRunscripts(alist<RunScript*>* RunScripts)
 
   if (RunScripts->empty()) { return false; }
 
-  foreach_alist (cmd, RunScripts) {
+  for (auto* cmd : *RunScripts) {
     if (!cmd->IsLocal()) { retval = true; }
   }
 
@@ -609,7 +609,7 @@ int SendRunscriptsCommands(JobControlRecord* jcr)
 
   msg = GetPoolMemory(PM_FNAME);
   ehost = GetPoolMemory(PM_FNAME);
-  foreach_alist (cmd, jcr->dir_impl->res.job->RunScripts) {
+  for (auto* cmd : *jcr->dir_impl->res.job->RunScripts) {
     if (!cmd->target.empty()) {
       ehost = edit_job_codes(jcr, ehost, cmd->target.c_str(), "");
       Dmsg2(200, "dird: runscript %s -> %s\n", cmd->target.c_str(), ehost);

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -578,7 +578,6 @@ bool SendIncludeExcludeLists(JobControlRecord* jcr)
 // This checks to see if there are any non local runscripts for this job.
 static bool HaveClientRunscripts(alist<RunScript*>* RunScripts)
 {
-  RunScript* cmd = nullptr;
   bool retval = false;
 
   if (RunScripts->empty()) { return false; }
@@ -599,7 +598,6 @@ static bool HaveClientRunscripts(alist<RunScript*>* RunScripts)
 int SendRunscriptsCommands(JobControlRecord* jcr)
 {
   int result;
-  RunScript* cmd = nullptr;
   POOLMEM *msg, *ehost;
   BareosSocket* fd = jcr->file_bsock;
   bool has_before_jobs = false;

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -584,7 +584,7 @@ static bool HaveClientRunscripts(alist<RunScript*>* RunScripts)
 
   if (RunScripts->empty()) { return false; }
 
-  for (auto* cmd : *RunScripts) {
+  for (auto* cmd : RunScripts) {
     if (!cmd->IsLocal()) { retval = true; }
   }
 
@@ -611,7 +611,7 @@ int SendRunscriptsCommands(JobControlRecord* jcr)
 
   msg = GetPoolMemory(PM_FNAME);
   ehost = GetPoolMemory(PM_FNAME);
-  for (auto* cmd : *jcr->dir_impl->res.job->RunScripts) {
+  for (auto* cmd : jcr->dir_impl->res.job->RunScripts) {
     if (!cmd->target.empty()) {
       ehost = edit_job_codes(jcr, ehost, cmd->target.c_str(), "");
       Dmsg2(200, "dird: runscript %s -> %s\n", cmd->target.c_str(), ehost);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1744,7 +1744,7 @@ void CreateClones(JobControlRecord* jcr)
 
     UaContext* ua = new_ua_context(jcr);
     ua->batch = true;
-    for (auto* runcmd : *job->run_cmds) {
+    for (auto* runcmd : job->run_cmds) {
       cmd = edit_job_codes(jcr, cmd, runcmd, "", job_code_callback_director);
       Mmsg(ua->cmd, "run %s cloned=yes", cmd);
       Dmsg1(900, "=============== Clone cmd=%s\n", ua->cmd);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1738,7 +1738,6 @@ void CreateClones(JobControlRecord* jcr)
   Dmsg2(900, "cloned=%d run_cmds=%p\n", jcr->dir_impl->cloned,
         jcr->dir_impl->res.job->run_cmds);
   if (!jcr->dir_impl->cloned && jcr->dir_impl->res.job->run_cmds) {
-    const char* runcmd = nullptr;
     JobId_t jobid;
     JobResource* job = jcr->dir_impl->res.job;
     POOLMEM* cmd = GetPoolMemory(PM_FNAME);

--- a/core/src/dird/job.cc
+++ b/core/src/dird/job.cc
@@ -1744,7 +1744,7 @@ void CreateClones(JobControlRecord* jcr)
 
     UaContext* ua = new_ua_context(jcr);
     ua->batch = true;
-    foreach_alist (runcmd, job->run_cmds) {
+    for (auto* runcmd : *job->run_cmds) {
       cmd = edit_job_codes(jcr, cmd, runcmd, "", job_code_callback_director);
       Mmsg(ua->cmd, "run %s cloned=yes", cmd);
       Dmsg1(900, "=============== Clone cmd=%s\n", ua->cmd);

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -147,7 +147,7 @@ bool ReserveReadDevice(JobControlRecord* jcr,
     }
     BashSpaces(pool_type);
     BashSpaces(pool_name);
-    foreach_alist (storage, read_storage) {
+    for (auto* storage : *read_storage) {
       Dmsg1(100, "Rstore=%s\n", storage->resource_name_);
       StoreName = storage->resource_name_;
       BashSpaces(StoreName);
@@ -157,7 +157,7 @@ bool ReserveReadDevice(JobControlRecord* jcr,
                        pool_name.c_str(), pool_type.c_str(), 0, copy, stripe);
       Dmsg1(100, "read_storage >stored: %s", sd_socket->msg);
       /* Loop over alternative storage Devices until one is OK */
-      foreach_alist (dev, storage->device) {
+      for (auto* dev : *storage->device) {
         PmStrcpy(device_name, dev->resource_name_);
         BashSpaces(device_name);
         sd_socket->fsend(use_device, device_name.c_str());
@@ -221,7 +221,7 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
     pool_name = jcr->dir_impl->res.pool->resource_name_;
     BashSpaces(pool_type);
     BashSpaces(pool_name);
-    foreach_alist (storage, write_storage) {
+    for (auto* storage : *write_storage) {
       StoreName = storage->resource_name_;
       BashSpaces(StoreName);
       media_type = storage->media_type;
@@ -232,7 +232,7 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
 
       Dmsg1(100, "write_storage >stored: %s", jcr->store_bsock->msg);
       // Loop over alternative storage Devices until one is OK
-      foreach_alist (dev, storage->device) {
+      for (auto* dev : *storage->device) {
         PmStrcpy(device_name, dev->resource_name_);
         BashSpaces(device_name);
         jcr->store_bsock->fsend(use_device, device_name.c_str());

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -119,7 +119,6 @@ bool ReserveReadDevice(JobControlRecord* jcr,
                        alist<StorageResource*>* read_storage)
 {
   BareosSocket* sd_socket = jcr->store_bsock;
-  StorageResource* storage = nullptr;
   PoolMem device_name;
   std::string StoreName{};
   std::string pool_name{};
@@ -157,7 +156,6 @@ bool ReserveReadDevice(JobControlRecord* jcr,
       sd_socket->fsend(use_storage, StoreName.c_str(), media_type.c_str(),
                        pool_name.c_str(), pool_type.c_str(), 0, copy, stripe);
       Dmsg1(100, "read_storage >stored: %s", sd_socket->msg);
-      DeviceResource* dev = nullptr;
       /* Loop over alternative storage Devices until one is OK */
       foreach_alist (dev, storage->device) {
         PmStrcpy(device_name, dev->resource_name_);
@@ -223,7 +221,6 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
     pool_name = jcr->dir_impl->res.pool->resource_name_;
     BashSpaces(pool_type);
     BashSpaces(pool_name);
-    StorageResource* storage = nullptr;
     foreach_alist (storage, write_storage) {
       StoreName = storage->resource_name_;
       BashSpaces(StoreName);
@@ -234,7 +231,6 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
                               pool_type.c_str(), 1, copy, stripe);
 
       Dmsg1(100, "write_storage >stored: %s", jcr->store_bsock->msg);
-      DeviceResource* dev = nullptr;
       // Loop over alternative storage Devices until one is OK
       foreach_alist (dev, storage->device) {
         PmStrcpy(device_name, dev->resource_name_);

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -147,7 +147,7 @@ bool ReserveReadDevice(JobControlRecord* jcr,
     }
     BashSpaces(pool_type);
     BashSpaces(pool_name);
-    for (auto* storage : *read_storage) {
+    for (auto* storage : read_storage) {
       Dmsg1(100, "Rstore=%s\n", storage->resource_name_);
       StoreName = storage->resource_name_;
       BashSpaces(StoreName);
@@ -157,13 +157,11 @@ bool ReserveReadDevice(JobControlRecord* jcr,
                        pool_name.c_str(), pool_type.c_str(), 0, copy, stripe);
       Dmsg1(100, "read_storage >stored: %s", sd_socket->msg);
       /* Loop over alternative storage Devices until one is OK */
-      if (storage->device) {
-        for (auto* dev : *storage->device) {
-          PmStrcpy(device_name, dev->resource_name_);
-          BashSpaces(device_name);
-          sd_socket->fsend(use_device, device_name.c_str());
-          Dmsg1(100, ">stored: %s", sd_socket->msg);
-        }
+      for (auto* dev : storage->device) {
+        PmStrcpy(device_name, dev->resource_name_);
+        BashSpaces(device_name);
+        sd_socket->fsend(use_device, device_name.c_str());
+        Dmsg1(100, ">stored: %s", sd_socket->msg);
       }
       sd_socket->signal(BNET_EOD);  // end of Device
     }
@@ -223,7 +221,7 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
     pool_name = jcr->dir_impl->res.pool->resource_name_;
     BashSpaces(pool_type);
     BashSpaces(pool_name);
-    for (auto* storage : *write_storage) {
+    for (auto* storage : write_storage) {
       StoreName = storage->resource_name_;
       BashSpaces(StoreName);
       media_type = storage->media_type;
@@ -234,13 +232,11 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
 
       Dmsg1(100, "write_storage >stored: %s", jcr->store_bsock->msg);
       // Loop over alternative storage Devices until one is OK
-      if (storage->device) {
-        for (auto* dev : *storage->device) {
-          PmStrcpy(device_name, dev->resource_name_);
-          BashSpaces(device_name);
-          jcr->store_bsock->fsend(use_device, device_name.c_str());
-          Dmsg1(100, ">stored: %s", jcr->store_bsock->msg);
-        }
+      for (auto* dev : storage->device) {
+        PmStrcpy(device_name, dev->resource_name_);
+        BashSpaces(device_name);
+        jcr->store_bsock->fsend(use_device, device_name.c_str());
+        Dmsg1(100, ">stored: %s", jcr->store_bsock->msg);
       }
       jcr->store_bsock->signal(BNET_EOD);  // end of Devices
     }

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -157,11 +157,13 @@ bool ReserveReadDevice(JobControlRecord* jcr,
                        pool_name.c_str(), pool_type.c_str(), 0, copy, stripe);
       Dmsg1(100, "read_storage >stored: %s", sd_socket->msg);
       /* Loop over alternative storage Devices until one is OK */
-      for (auto* dev : *storage->device) {
-        PmStrcpy(device_name, dev->resource_name_);
-        BashSpaces(device_name);
-        sd_socket->fsend(use_device, device_name.c_str());
-        Dmsg1(100, ">stored: %s", sd_socket->msg);
+      if (storage->device) {
+        for (auto* dev : *storage->device) {
+          PmStrcpy(device_name, dev->resource_name_);
+          BashSpaces(device_name);
+          sd_socket->fsend(use_device, device_name.c_str());
+          Dmsg1(100, ">stored: %s", sd_socket->msg);
+        }
       }
       sd_socket->signal(BNET_EOD);  // end of Device
     }
@@ -232,11 +234,13 @@ bool ReserveWriteDevice(JobControlRecord* jcr,
 
       Dmsg1(100, "write_storage >stored: %s", jcr->store_bsock->msg);
       // Loop over alternative storage Devices until one is OK
-      for (auto* dev : *storage->device) {
-        PmStrcpy(device_name, dev->resource_name_);
-        BashSpaces(device_name);
-        jcr->store_bsock->fsend(use_device, device_name.c_str());
-        Dmsg1(100, ">stored: %s", jcr->store_bsock->msg);
+      if (storage->device) {
+        for (auto* dev : *storage->device) {
+          PmStrcpy(device_name, dev->resource_name_);
+          BashSpaces(device_name);
+          jcr->store_bsock->fsend(use_device, device_name.c_str());
+          Dmsg1(100, ">stored: %s", jcr->store_bsock->msg);
+        }
       }
       jcr->store_bsock->signal(BNET_EOD);  // end of Devices
     }

--- a/core/src/dird/ndmp_dma_generic.cc
+++ b/core/src/dird/ndmp_dma_generic.cc
@@ -142,11 +142,11 @@ static inline bool NdmpValidateStorage(JobControlRecord* jcr,
 bool NdmpValidateStorage(JobControlRecord* jcr)
 {
   if (jcr->dir_impl->res.write_storage_list) {
-    foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
+    for (auto* store : *jcr->dir_impl->res.write_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }
   } else {
-    foreach_alist (store, jcr->dir_impl->res.read_storage_list) {
+    for (auto* store : *jcr->dir_impl->res.read_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }
   }

--- a/core/src/dird/ndmp_dma_generic.cc
+++ b/core/src/dird/ndmp_dma_generic.cc
@@ -145,7 +145,8 @@ bool NdmpValidateStorage(JobControlRecord* jcr)
     for (auto* store : *jcr->dir_impl->res.write_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }
-  } else {
+
+  } else if (jcr->dir_impl->res.read_storage_list) {
     for (auto* store : *jcr->dir_impl->res.read_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }

--- a/core/src/dird/ndmp_dma_generic.cc
+++ b/core/src/dird/ndmp_dma_generic.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2015 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -141,8 +141,6 @@ static inline bool NdmpValidateStorage(JobControlRecord* jcr,
 
 bool NdmpValidateStorage(JobControlRecord* jcr)
 {
-  StorageResource* store = nullptr;
-
   if (jcr->dir_impl->res.write_storage_list) {
     foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }

--- a/core/src/dird/ndmp_dma_generic.cc
+++ b/core/src/dird/ndmp_dma_generic.cc
@@ -142,12 +142,12 @@ static inline bool NdmpValidateStorage(JobControlRecord* jcr,
 bool NdmpValidateStorage(JobControlRecord* jcr)
 {
   if (jcr->dir_impl->res.write_storage_list) {
-    for (auto* store : *jcr->dir_impl->res.write_storage_list) {
+    for (auto* store : jcr->dir_impl->res.write_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }
 
   } else if (jcr->dir_impl->res.read_storage_list) {
-    for (auto* store : *jcr->dir_impl->res.read_storage_list) {
+    for (auto* store : jcr->dir_impl->res.read_storage_list) {
       if (!NdmpValidateStorage(jcr, store)) { return false; }
     }
   }

--- a/core/src/dird/ndmp_dma_storage.cc
+++ b/core/src/dird/ndmp_dma_storage.cc
@@ -783,7 +783,7 @@ char* lookup_ndmp_drive(StorageResource* store, drive_number_t drivenumber)
   int cnt = 0;
   char* tapedevice;
   if (store->device) {
-    foreach_alist (tapedeviceres, store->device) {
+    for (auto* tapedeviceres : *store->device) {
       if (cnt == drivenumber) {
         tapedevice = tapedeviceres->resource_name_;
         return tapedevice;

--- a/core/src/dird/ndmp_dma_storage.cc
+++ b/core/src/dird/ndmp_dma_storage.cc
@@ -782,8 +782,6 @@ char* lookup_ndmp_drive(StorageResource* store, drive_number_t drivenumber)
 {
   int cnt = 0;
   char* tapedevice;
-  BareosResource* tapedeviceres = nullptr;
-
   if (store->device) {
     foreach_alist (tapedeviceres, store->device) {
       if (cnt == drivenumber) {

--- a/core/src/dird/ndmp_dma_storage.cc
+++ b/core/src/dird/ndmp_dma_storage.cc
@@ -782,14 +782,12 @@ char* lookup_ndmp_drive(StorageResource* store, drive_number_t drivenumber)
 {
   int cnt = 0;
   char* tapedevice;
-  if (store->device) {
-    for (auto* tapedeviceres : *store->device) {
-      if (cnt == drivenumber) {
-        tapedevice = tapedeviceres->resource_name_;
-        return tapedevice;
-      }
-      cnt++;
+  for (auto* tapedeviceres : store->device) {
+    if (cnt == drivenumber) {
+      tapedevice = tapedeviceres->resource_name_;
+      return tapedevice;
     }
+    cnt++;
   }
 
   return NULL;

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -717,7 +717,7 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
     PoolMem devicenames;
 
     // Build a list of devicenames that belong to this storage defintion.
-    foreach_alist (device_resource, store->device) {
+    for (auto* device_resource : *store->device) {
       if (cnt == 0) {
         PmStrcpy(devicenames, device_resource->resource_name_);
       } else {

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -716,15 +716,17 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
     int cnt = 0;
     PoolMem devicenames;
 
-    // Build a list of devicenames that belong to this storage defintion.
-    for (auto* device_resource : *store->device) {
-      if (cnt == 0) {
-        PmStrcpy(devicenames, device_resource->resource_name_);
-      } else {
-        PmStrcat(devicenames, ",");
-        PmStrcat(devicenames, device_resource->resource_name_);
+    if (store->device) {
+      // Build a list of devicenames that belong to this storage defintion.
+      for (auto* device_resource : *store->device) {
+        if (cnt == 0) {
+          PmStrcpy(devicenames, device_resource->resource_name_);
+        } else {
+          PmStrcat(devicenames, ",");
+          PmStrcat(devicenames, device_resource->resource_name_);
+        }
+        cnt++;
       }
-      cnt++;
     }
 
     BashSpaces(devicenames);

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -716,17 +716,15 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
     int cnt = 0;
     PoolMem devicenames;
 
-    if (store->device) {
-      // Build a list of devicenames that belong to this storage defintion.
-      for (auto* device_resource : *store->device) {
-        if (cnt == 0) {
-          PmStrcpy(devicenames, device_resource->resource_name_);
-        } else {
-          PmStrcat(devicenames, ",");
-          PmStrcat(devicenames, device_resource->resource_name_);
-        }
-        cnt++;
+    // Build a list of devicenames that belong to this storage defintion.
+    for (auto* device_resource : store->device) {
+      if (cnt == 0) {
+        PmStrcpy(devicenames, device_resource->resource_name_);
+      } else {
+        PmStrcat(devicenames, ",");
+        PmStrcat(devicenames, device_resource->resource_name_);
       }
+      cnt++;
     }
 
     BashSpaces(devicenames);

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -714,7 +714,6 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
 
   } else {
     int cnt = 0;
-    DeviceResource* device_resource = nullptr;
     PoolMem devicenames;
 
     // Build a list of devicenames that belong to this storage defintion.

--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -237,12 +237,15 @@ void SetPairedStorage(JobControlRecord* jcr)
             = jcr->dir_impl->res.write_storage_list;
         jcr->dir_impl->res.write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        for (auto* store : *jcr->dir_impl->res.paired_read_write_storage_list) {
-          if (store->paired_storage) {
-            Dmsg1(100, "write_storage_list=%s\n",
-                  store->paired_storage->resource_name_);
-            jcr->dir_impl->res.write_storage_list->append(
-                store->paired_storage);
+        if (jcr->dir_impl->res.paired_read_write_storage_list) {
+          for (auto* store :
+               *jcr->dir_impl->res.paired_read_write_storage_list) {
+            if (store->paired_storage) {
+              Dmsg1(100, "write_storage_list=%s\n",
+                    store->paired_storage->resource_name_);
+              jcr->dir_impl->res.write_storage_list->append(
+                  store->paired_storage);
+            }
           }
         }
 
@@ -309,11 +312,15 @@ void SetPairedStorage(JobControlRecord* jcr)
             = jcr->dir_impl->res.read_storage_list;
         jcr->dir_impl->res.read_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        for (auto* store : *jcr->dir_impl->res.paired_read_write_storage_list) {
-          if (store->paired_storage) {
-            Dmsg1(100, "read_storage_list=%s\n",
-                  store->paired_storage->resource_name_);
-            jcr->dir_impl->res.read_storage_list->append(store->paired_storage);
+        if (jcr->dir_impl->res.paired_read_write_storage_list) {
+          for (auto* store :
+               *jcr->dir_impl->res.paired_read_write_storage_list) {
+            if (store->paired_storage) {
+              Dmsg1(100, "read_storage_list=%s\n",
+                    store->paired_storage->resource_name_);
+              jcr->dir_impl->res.read_storage_list->append(
+                  store->paired_storage);
+            }
           }
         }
 

--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -104,7 +104,7 @@ void CopyRstorage(JobControlRecord* jcr,
     }
     jcr->dir_impl->res.read_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
-    foreach_alist (store, storage) {
+    for (auto* store : *storage) {
       jcr->dir_impl->res.read_storage_list->append(store);
     }
     if (!jcr->dir_impl->res.rstore_source) {
@@ -135,7 +135,7 @@ void SetRstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
     jcr->dir_impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
   }
   PmStrcpy(jcr->dir_impl->res.rstore_source, store->store_source);
-  foreach_alist (storage, jcr->dir_impl->res.read_storage_list) {
+  for (auto* storage : *jcr->dir_impl->res.read_storage_list) {
     if (store->store == storage) { return; }
   }
   /* Store not in list, so add it */
@@ -162,7 +162,7 @@ void CopyWstorage(JobControlRecord* jcr,
     }
     jcr->dir_impl->res.write_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
-    foreach_alist (st, storage) {
+    for (auto* st : *storage) {
       Dmsg1(100, "write_storage_list=%s\n", st->resource_name_);
       jcr->dir_impl->res.write_storage_list->append(st);
     }
@@ -200,7 +200,7 @@ void SetWstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
   Dmsg2(50, "write_storage=%s where=%s\n",
         jcr->dir_impl->res.write_storage->resource_name_,
         jcr->dir_impl->res.wstore_source);
-  foreach_alist (storage, jcr->dir_impl->res.write_storage_list) {
+  for (auto* storage : *jcr->dir_impl->res.write_storage_list) {
     if (store->store == storage) { return; }
   }
 
@@ -237,8 +237,7 @@ void SetPairedStorage(JobControlRecord* jcr)
             = jcr->dir_impl->res.write_storage_list;
         jcr->dir_impl->res.write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        foreach_alist (store,
-                       jcr->dir_impl->res.paired_read_write_storage_list) {
+        for (auto* store : *jcr->dir_impl->res.paired_read_write_storage_list) {
           if (store->paired_storage) {
             Dmsg1(100, "write_storage_list=%s\n",
                   store->paired_storage->resource_name_);
@@ -269,8 +268,8 @@ void SetPairedStorage(JobControlRecord* jcr)
          * jcr->dir_impl_->res.read_storage_list. */
         jcr->dir_impl->res.paired_read_write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        foreach_alist (paired_read_write_storage,
-                       jcr->dir_impl->res.read_storage_list) {
+        for (auto* paired_read_write_storage :
+             *jcr->dir_impl->res.read_storage_list) {
           auto* store
               = (StorageResource*)my_config->GetNextRes(R_STORAGE, NULL);
           while (store) {
@@ -310,8 +309,7 @@ void SetPairedStorage(JobControlRecord* jcr)
             = jcr->dir_impl->res.read_storage_list;
         jcr->dir_impl->res.read_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
-        foreach_alist (store,
-                       jcr->dir_impl->res.paired_read_write_storage_list) {
+        for (auto* store : *jcr->dir_impl->res.paired_read_write_storage_list) {
           if (store->paired_storage) {
             Dmsg1(100, "read_storage_list=%s\n",
                   store->paired_storage->resource_name_);
@@ -405,7 +403,7 @@ bool HasPairedStorage(JobControlRecord* jcr)
     case JT_BACKUP:
       // For a backup we look at the write storage.
       if (jcr->dir_impl->res.write_storage_list) {
-        foreach_alist (store, jcr->dir_impl->res.write_storage_list) {
+        for (auto* store : *jcr->dir_impl->res.write_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {
@@ -419,7 +417,7 @@ bool HasPairedStorage(JobControlRecord* jcr)
     case JT_MIGRATE:
     case JT_COPY:
       if (jcr->dir_impl->res.read_storage_list) {
-        foreach_alist (store, jcr->dir_impl->res.read_storage_list) {
+        for (auto* store : *jcr->dir_impl->res.read_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {

--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -99,7 +99,6 @@ void CopyRstorage(JobControlRecord* jcr,
                   const char* where)
 {
   if (storage) {
-    StorageResource* store = nullptr;
     if (jcr->dir_impl->res.read_storage_list) {
       delete jcr->dir_impl->res.read_storage_list;
     }
@@ -125,8 +124,6 @@ void CopyRstorage(JobControlRecord* jcr,
  */
 void SetRstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
 {
-  StorageResource* storage = nullptr;
-
   if (!store->store) { return; }
   if (jcr->dir_impl->res.read_storage_list) { FreeRstorage(jcr); }
   if (!jcr->dir_impl->res.read_storage_list) {
@@ -160,7 +157,6 @@ void CopyWstorage(JobControlRecord* jcr,
                   const char* where)
 {
   if (storage) {
-    StorageResource* st = nullptr;
     if (jcr->dir_impl->res.write_storage_list) {
       delete jcr->dir_impl->res.write_storage_list;
     }
@@ -190,8 +186,6 @@ void CopyWstorage(JobControlRecord* jcr,
  */
 void SetWstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
 {
-  StorageResource* storage = nullptr;
-
   if (!store->store) { return; }
   if (jcr->dir_impl->res.write_storage_list) { FreeWstorage(jcr); }
   if (!jcr->dir_impl->res.write_storage_list) {
@@ -231,8 +225,6 @@ void FreeWstorage(JobControlRecord* jcr)
  */
 void SetPairedStorage(JobControlRecord* jcr)
 {
-  StorageResource *store = nullptr, *paired_read_write_storage = nullptr;
-
   switch (jcr->getJobType()) {
     case JT_BACKUP:
       // For a backup we look at the write storage.
@@ -259,7 +251,7 @@ void SetPairedStorage(JobControlRecord* jcr)
          * paired storage entry. We save the actual storage entry in
          * paired_read_write_storage which is for restore in the
          * FreePairedStorage() function. */
-        store = jcr->dir_impl->res.write_storage;
+        auto* store = jcr->dir_impl->res.write_storage;
         if (store->paired_storage) {
           jcr->dir_impl->res.write_storage = store->paired_storage;
           jcr->dir_impl->res.paired_read_write_storage = store;
@@ -279,7 +271,8 @@ void SetPairedStorage(JobControlRecord* jcr)
             = new alist<StorageResource*>(10, not_owned_by_alist);
         foreach_alist (paired_read_write_storage,
                        jcr->dir_impl->res.read_storage_list) {
-          store = (StorageResource*)my_config->GetNextRes(R_STORAGE, NULL);
+          auto* store
+              = (StorageResource*)my_config->GetNextRes(R_STORAGE, NULL);
           while (store) {
             if (store->paired_storage == paired_read_write_storage) { break; }
 
@@ -330,7 +323,7 @@ void SetPairedStorage(JobControlRecord* jcr)
          * paired storage entry. We save the actual storage entry in
          * paired_read_write_storage which is for restore in the
          * FreePairedStorage() function. */
-        store = jcr->dir_impl->res.read_storage;
+        auto* store = jcr->dir_impl->res.read_storage;
         if (store->paired_storage) {
           jcr->dir_impl->res.read_storage = store->paired_storage;
           jcr->dir_impl->res.paired_read_write_storage = store;
@@ -408,8 +401,6 @@ void FreePairedStorage(JobControlRecord* jcr)
 // Check if every possible storage has paired storage associated.
 bool HasPairedStorage(JobControlRecord* jcr)
 {
-  StorageResource* store = nullptr;
-
   switch (jcr->getJobType()) {
     case JT_BACKUP:
       // For a backup we look at the write storage.

--- a/core/src/dird/storage.cc
+++ b/core/src/dird/storage.cc
@@ -104,7 +104,7 @@ void CopyRstorage(JobControlRecord* jcr,
     }
     jcr->dir_impl->res.read_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
-    for (auto* store : *storage) {
+    for (auto* store : storage) {
       jcr->dir_impl->res.read_storage_list->append(store);
     }
     if (!jcr->dir_impl->res.rstore_source) {
@@ -135,7 +135,7 @@ void SetRstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
     jcr->dir_impl->res.rstore_source = GetPoolMemory(PM_MESSAGE);
   }
   PmStrcpy(jcr->dir_impl->res.rstore_source, store->store_source);
-  for (auto* storage : *jcr->dir_impl->res.read_storage_list) {
+  for (auto* storage : jcr->dir_impl->res.read_storage_list) {
     if (store->store == storage) { return; }
   }
   /* Store not in list, so add it */
@@ -162,7 +162,7 @@ void CopyWstorage(JobControlRecord* jcr,
     }
     jcr->dir_impl->res.write_storage_list
         = new alist<StorageResource*>(10, not_owned_by_alist);
-    for (auto* st : *storage) {
+    for (auto* st : storage) {
       Dmsg1(100, "write_storage_list=%s\n", st->resource_name_);
       jcr->dir_impl->res.write_storage_list->append(st);
     }
@@ -200,7 +200,7 @@ void SetWstorage(JobControlRecord* jcr, UnifiedStorageResource* store)
   Dmsg2(50, "write_storage=%s where=%s\n",
         jcr->dir_impl->res.write_storage->resource_name_,
         jcr->dir_impl->res.wstore_source);
-  for (auto* storage : *jcr->dir_impl->res.write_storage_list) {
+  for (auto* storage : jcr->dir_impl->res.write_storage_list) {
     if (store->store == storage) { return; }
   }
 
@@ -239,7 +239,7 @@ void SetPairedStorage(JobControlRecord* jcr)
             = new alist<StorageResource*>(10, not_owned_by_alist);
         if (jcr->dir_impl->res.paired_read_write_storage_list) {
           for (auto* store :
-               *jcr->dir_impl->res.paired_read_write_storage_list) {
+               jcr->dir_impl->res.paired_read_write_storage_list) {
             if (store->paired_storage) {
               Dmsg1(100, "write_storage_list=%s\n",
                     store->paired_storage->resource_name_);
@@ -272,7 +272,7 @@ void SetPairedStorage(JobControlRecord* jcr)
         jcr->dir_impl->res.paired_read_write_storage_list
             = new alist<StorageResource*>(10, not_owned_by_alist);
         for (auto* paired_read_write_storage :
-             *jcr->dir_impl->res.read_storage_list) {
+             jcr->dir_impl->res.read_storage_list) {
           auto* store
               = (StorageResource*)my_config->GetNextRes(R_STORAGE, NULL);
           while (store) {
@@ -314,7 +314,7 @@ void SetPairedStorage(JobControlRecord* jcr)
             = new alist<StorageResource*>(10, not_owned_by_alist);
         if (jcr->dir_impl->res.paired_read_write_storage_list) {
           for (auto* store :
-               *jcr->dir_impl->res.paired_read_write_storage_list) {
+               jcr->dir_impl->res.paired_read_write_storage_list) {
             if (store->paired_storage) {
               Dmsg1(100, "read_storage_list=%s\n",
                     store->paired_storage->resource_name_);
@@ -410,7 +410,7 @@ bool HasPairedStorage(JobControlRecord* jcr)
     case JT_BACKUP:
       // For a backup we look at the write storage.
       if (jcr->dir_impl->res.write_storage_list) {
-        for (auto* store : *jcr->dir_impl->res.write_storage_list) {
+        for (auto* store : jcr->dir_impl->res.write_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {
@@ -424,7 +424,7 @@ bool HasPairedStorage(JobControlRecord* jcr)
     case JT_MIGRATE:
     case JT_COPY:
       if (jcr->dir_impl->res.read_storage_list) {
-        for (auto* store : *jcr->dir_impl->res.read_storage_list) {
+        for (auto* store : jcr->dir_impl->res.read_storage_list) {
           if (!store->paired_storage) { return false; }
         }
       } else {

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -167,13 +167,11 @@ bool UaContext::AclAccessOk(int acl,
   /* If we didn't find a matching ACL try to use the profiles this console is
    * connected to. */
   if (!retval.has_value()) {
-    if (user_acl->profiles && user_acl->profiles->size()) {
-      for (auto* profile : *user_acl->profiles) {
-        retval = FindInAclList(profile->ACL_lists[acl], acl, item, item_length);
+    for (auto* profile : user_acl->profiles) {
+      retval = FindInAclList(profile->ACL_lists[acl], acl, item, item_length);
 
-        // If we found a match break the loop.
-        if (retval.has_value()) { break; }
-      }
+      // If we found a match break the loop.
+      if (retval.has_value()) { break; }
     }
   }
 
@@ -206,20 +204,18 @@ bool UaContext::AclNoRestrictions(int acl)
     }
   }
 
-  if (user_acl->profiles) {
-    for (auto* profile : *user_acl->profiles) {
-      if (profile) {
-        if (profile->ACL_lists[acl]) {
-          for (int i = 0; i < profile->ACL_lists[acl]->size(); i++) {
-            list_value = (char*)profile->ACL_lists[acl]->get(i);
+  for (auto* profile : user_acl->profiles) {
+    if (profile) {
+      if (profile->ACL_lists[acl]) {
+        for (int i = 0; i < profile->ACL_lists[acl]->size(); i++) {
+          list_value = (char*)profile->ACL_lists[acl]->get(i);
 
-            if (*list_value == '!') { return false; }
+          if (*list_value == '!') { return false; }
 
-            if (Bstrcasecmp("*all*", list_value)) { return true; }
-          } /* for (int i = 0; */
-        }   /* if (profile->ACL_lists[acl]) */
-      }     /* if (profile) */
-    }
+          if (Bstrcasecmp("*all*", list_value)) { return true; }
+        } /* for (int i = 0; */
+      }   /* if (profile->ACL_lists[acl]) */
+    }     /* if (profile) */
   }
 
   return false;

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -119,7 +119,6 @@ static inline std::optional<bool> FindInAclList(alist<const char*>* list,
   if (!list || list->empty()) { return std::nullopt; }
 
   // Search list for item
-  const char* list_value = nullptr;
   foreach_alist (list_value, list) {
     // See if this is a deny acl.
     if (*list_value == '!') {
@@ -198,7 +197,6 @@ bail_out:
 bool UaContext::AclNoRestrictions(int acl)
 {
   const char* list_value;
-  ProfileResource* profile = nullptr;
 
   // If no console resource => default console and all is permitted
   if (!user_acl) { return true; }

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -206,18 +206,20 @@ bool UaContext::AclNoRestrictions(int acl)
     }
   }
 
-  for (auto* profile : *user_acl->profiles) {
-    if (profile) {
-      if (profile->ACL_lists[acl]) {
-        for (int i = 0; i < profile->ACL_lists[acl]->size(); i++) {
-          list_value = (char*)profile->ACL_lists[acl]->get(i);
+  if (user_acl->profiles) {
+    for (auto* profile : *user_acl->profiles) {
+      if (profile) {
+        if (profile->ACL_lists[acl]) {
+          for (int i = 0; i < profile->ACL_lists[acl]->size(); i++) {
+            list_value = (char*)profile->ACL_lists[acl]->get(i);
 
-          if (*list_value == '!') { return false; }
+            if (*list_value == '!') { return false; }
 
-          if (Bstrcasecmp("*all*", list_value)) { return true; }
-        } /* for (int i = 0; */
-      }   /* if (profile->ACL_lists[acl]) */
-    }     /* if (profile) */
+            if (Bstrcasecmp("*all*", list_value)) { return true; }
+          } /* for (int i = 0; */
+        }   /* if (profile->ACL_lists[acl]) */
+      }     /* if (profile) */
+    }
   }
 
   return false;

--- a/core/src/dird/ua_acl.cc
+++ b/core/src/dird/ua_acl.cc
@@ -115,11 +115,8 @@ static inline std::optional<bool> FindInAclList(alist<const char*>* list,
                                                 const char* item,
                                                 int item_length)
 {
-  // See if we have an empty list.
-  if (!list || list->empty()) { return std::nullopt; }
-
   // Search list for item
-  foreach_alist (list_value, list) {
+  for (auto* list_value : list) {
     // See if this is a deny acl.
     if (*list_value == '!') {
       if (CompareAclListValueWithItem(acl, list_value, list_value + 1, item,
@@ -171,9 +168,7 @@ bool UaContext::AclAccessOk(int acl,
    * connected to. */
   if (!retval.has_value()) {
     if (user_acl->profiles && user_acl->profiles->size()) {
-      ProfileResource* profile = nullptr;
-
-      foreach_alist (profile, user_acl->profiles) {
+      for (auto* profile : *user_acl->profiles) {
         retval = FindInAclList(profile->ACL_lists[acl], acl, item, item_length);
 
         // If we found a match break the loop.
@@ -211,7 +206,7 @@ bool UaContext::AclNoRestrictions(int acl)
     }
   }
 
-  foreach_alist (profile, user_acl->profiles) {
+  for (auto* profile : *user_acl->profiles) {
     if (profile) {
       if (profile->ACL_lists[acl]) {
         for (int i = 0; i < profile->ACL_lists[acl]->size(); i++) {

--- a/core/src/dird/ua_audit.cc
+++ b/core/src/dird/ua_audit.cc
@@ -38,7 +38,7 @@ bool UaContext::AuditEventWanted(bool audit_event_enabled)
   if (!me->audit_events) { return audit_event_enabled; }
 
   if (audit_event_enabled) {
-    foreach_alist (event, me->audit_events) {
+    for (auto* event : *me->audit_events) {
       if (Bstrcasecmp(event, argk[0])) { return true; }
     }
   }

--- a/core/src/dird/ua_audit.cc
+++ b/core/src/dird/ua_audit.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2014-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -38,8 +38,6 @@ bool UaContext::AuditEventWanted(bool audit_event_enabled)
   if (!me->audit_events) { return audit_event_enabled; }
 
   if (audit_event_enabled) {
-    const char* event = nullptr;
-
     foreach_alist (event, me->audit_events) {
       if (Bstrcasecmp(event, argk[0])) { return true; }
     }

--- a/core/src/dird/ua_audit.cc
+++ b/core/src/dird/ua_audit.cc
@@ -38,7 +38,7 @@ bool UaContext::AuditEventWanted(bool audit_event_enabled)
   if (!me->audit_events) { return audit_event_enabled; }
 
   if (audit_event_enabled) {
-    for (auto* event : *me->audit_events) {
+    for (auto* event : me->audit_events) {
       if (Bstrcasecmp(event, argk[0])) { return true; }
     }
   }

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -803,7 +803,6 @@ static inline bool CancelStorageDaemonJob(UaContext* ua, const char*)
 static inline bool CancelJobs(UaContext* ua, const char*)
 {
   JobControlRecord* jcr;
-  JobId_t* JobId = nullptr;
   alist<JobId_t*>* selection;
 
   selection = select_jobs(ua, "cancel");
@@ -971,7 +970,6 @@ static bool SetbwlimitCmd(UaContext* ua, const char*)
 
   if (FindArgKeyword(ua, lst) > 0) {
     JobControlRecord* jcr;
-    JobId_t* JobId = nullptr;
     alist<JobId_t*>* selection;
 
     selection = select_jobs(ua, "limit");

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -809,7 +809,7 @@ static inline bool CancelJobs(UaContext* ua, const char*)
   if (!selection) { return true; }
 
   // Loop over the different JobIds selected.
-  for (auto* JobId : *selection) {
+  for (auto* JobId : selection) {
     if (!(jcr = get_jcr_by_id(*JobId))) { continue; }
 
     CancelJob(ua, jcr);
@@ -976,7 +976,7 @@ static bool SetbwlimitCmd(UaContext* ua, const char*)
     if (!selection) { return true; }
 
     // Loop over the different JobIds selected.
-    for (auto* JobId : *selection) {
+    for (auto* JobId : selection) {
       if (!(jcr = get_jcr_by_id(*JobId))) { continue; }
 
       jcr->max_bandwidth = limit;

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -809,7 +809,7 @@ static inline bool CancelJobs(UaContext* ua, const char*)
   if (!selection) { return true; }
 
   // Loop over the different JobIds selected.
-  foreach_alist (JobId, selection) {
+  for (auto* JobId : *selection) {
     if (!(jcr = get_jcr_by_id(*JobId))) { continue; }
 
     CancelJob(ua, jcr);
@@ -976,7 +976,7 @@ static bool SetbwlimitCmd(UaContext* ua, const char*)
     if (!selection) { return true; }
 
     // Loop over the different JobIds selected.
-    foreach_alist (JobId, selection) {
+    for (auto* JobId : *selection) {
       if (!(jcr = get_jcr_by_id(*JobId))) { continue; }
 
       jcr->max_bandwidth = limit;

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -1306,7 +1306,7 @@ bool DotDefaultsCmd(UaContext* ua, const char*)
                                "%s\n");
 
       std::string devices;
-      for (auto* device_resource : *storage->device) {
+      for (auto* device_resource : storage->device) {
         if (device_resource) {
           // if the string is nonempty, then there are already devices in the
           // "list", so seperate the new entry with a comma.

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1509,7 +1509,7 @@ static inline bool InsertSelectedJobid(alist<JobId_t*>* selected_jobids,
 {
   if (!selected_jobids) { return false; }
 
-  for (auto* jobid : *selected_jobids) {
+  for (auto* jobid : selected_jobids) {
     if (*jobid == JobId) { return false; }
   }
 

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1507,6 +1507,8 @@ bool GetLevelFromName(JobControlRecord* jcr, const char* level_name)
 static inline bool InsertSelectedJobid(alist<JobId_t*>* selected_jobids,
                                        JobId_t JobId)
 {
+  if (!selected_jobids) { return false; }
+
   for (auto* jobid : *selected_jobids) {
     if (*jobid == JobId) { return false; }
   }

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1507,25 +1507,14 @@ bool GetLevelFromName(JobControlRecord* jcr, const char* level_name)
 static inline bool InsertSelectedJobid(alist<JobId_t*>* selected_jobids,
                                        JobId_t JobId)
 {
-  bool found;
-  JobId_t* selected_jobid = nullptr;
-
-  found = false;
-  foreach_alist (selected_jobid, selected_jobids) {
-    if (*selected_jobid == JobId) {
-      found = true;
-      break;
-    }
+  foreach_alist (jobid, selected_jobids) {
+    if (*jobid == JobId) { return false; }
   }
 
-  if (!found) {
-    selected_jobid = (JobId_t*)malloc(sizeof(JobId_t));
-    *selected_jobid = JobId;
-    selected_jobids->append(selected_jobid);
-    return true;
-  }
-
-  return false;
+  auto* selected_jobid = (JobId_t*)malloc(sizeof(JobId_t));
+  *selected_jobid = JobId;
+  selected_jobids->append(selected_jobid);
+  return true;
 }
 
 /**

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1507,7 +1507,7 @@ bool GetLevelFromName(JobControlRecord* jcr, const char* level_name)
 static inline bool InsertSelectedJobid(alist<JobId_t*>* selected_jobids,
                                        JobId_t JobId)
 {
-  foreach_alist (jobid, selected_jobids) {
+  for (auto* jobid : *selected_jobids) {
     if (*jobid == JobId) { return false; }
   }
 

--- a/core/src/filed/crypto.cc
+++ b/core/src/filed/crypto.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -152,7 +152,6 @@ bool CryptoSessionSend(JobControlRecord* jcr, BareosSocket* sd)
  */
 bool VerifySignature(JobControlRecord* jcr, r_ctx& rctx)
 {
-  X509_KEYPAIR* keypair = nullptr;
   DIGEST* digest = NULL;
   crypto_error_t err;
   uint64_t saved_bytes;

--- a/core/src/filed/crypto.cc
+++ b/core/src/filed/crypto.cc
@@ -174,7 +174,7 @@ bool VerifySignature(JobControlRecord* jcr, r_ctx& rctx)
   }
 
   // Iterate through the trusted signers
-  foreach_alist (keypair, jcr->fd_impl->crypto.pki_signers) {
+  for (auto* keypair : *jcr->fd_impl->crypto.pki_signers) {
     err = CryptoSignGetDigest(sig, jcr->fd_impl->crypto.pki_keypair, algorithm,
                               &digest);
     switch (err) {

--- a/core/src/filed/crypto.cc
+++ b/core/src/filed/crypto.cc
@@ -174,83 +174,81 @@ bool VerifySignature(JobControlRecord* jcr, r_ctx& rctx)
   }
 
   // Iterate through the trusted signers
-  if (jcr->fd_impl->crypto.pki_signers) {
-    for (auto* keypair : *jcr->fd_impl->crypto.pki_signers) {
-      err = CryptoSignGetDigest(sig, jcr->fd_impl->crypto.pki_keypair,
-                                algorithm, &digest);
-      switch (err) {
-        case CRYPTO_ERROR_NONE:
-          Dmsg0(50, "== Got digest\n");
-          /* We computed jcr->fd_impl_->crypto.digest using signing_algorithm
-           * while writing the file. If it is not the same as the algorithm used
-           * for this file, punt by releasing the computed algorithm and
-           * computing by re-reading the file. */
-          if (algorithm != signing_algorithm) {
-            if (jcr->fd_impl->crypto.digest) {
-              CryptoDigestFree(jcr->fd_impl->crypto.digest);
-              jcr->fd_impl->crypto.digest = NULL;
-            }
-          }
+  for (auto* keypair : jcr->fd_impl->crypto.pki_signers) {
+    err = CryptoSignGetDigest(sig, jcr->fd_impl->crypto.pki_keypair, algorithm,
+                              &digest);
+    switch (err) {
+      case CRYPTO_ERROR_NONE:
+        Dmsg0(50, "== Got digest\n");
+        /* We computed jcr->fd_impl_->crypto.digest using signing_algorithm
+         * while writing the file. If it is not the same as the algorithm used
+         * for this file, punt by releasing the computed algorithm and
+         * computing by re-reading the file. */
+        if (algorithm != signing_algorithm) {
           if (jcr->fd_impl->crypto.digest) {
-            // Use digest computed while writing the file to verify the
-            // signature
-            if ((err
-                 = CryptoSignVerify(sig, keypair, jcr->fd_impl->crypto.digest))
-                != CRYPTO_ERROR_NONE) {
-              Dmsg1(50, "Bad signature on %s\n", jcr->fd_impl->last_fname);
-              Jmsg2(jcr, M_ERROR, 0,
-                    T_("Signature validation failed for file %s: ERR=%s\n"),
-                    jcr->fd_impl->last_fname, crypto_strerror(err));
-              goto bail_out;
-            }
-          } else {
-            /* Signature found, digest allocated.  Old method,
-             * re-read the file and compute the digest */
-            jcr->fd_impl->crypto.digest = digest;
-
-            /* Checksum the entire file
-             * Make sure we don't modify JobBytes by saving and restoring it */
-            saved_bytes = jcr->JobBytes;
-            if (FindOneFile(jcr, jcr->fd_impl->ff, DoFileDigest,
-                            jcr->fd_impl->last_fname, (dev_t)-1, 1)
-                != 0) {
-              Jmsg(jcr, M_ERROR, 0, T_("Digest one file failed for file: %s\n"),
-                   jcr->fd_impl->last_fname);
-              jcr->JobBytes = saved_bytes;
-              goto bail_out;
-            }
-            jcr->JobBytes = saved_bytes;
-
-            // Verify the signature
-            if ((err = CryptoSignVerify(sig, keypair, digest))
-                != CRYPTO_ERROR_NONE) {
-              Dmsg1(50, "Bad signature on %s\n", jcr->fd_impl->last_fname);
-              Jmsg2(jcr, M_ERROR, 0,
-                    T_("Signature validation failed for file %s: ERR=%s\n"),
-                    jcr->fd_impl->last_fname, crypto_strerror(err));
-              goto bail_out;
-            }
+            CryptoDigestFree(jcr->fd_impl->crypto.digest);
             jcr->fd_impl->crypto.digest = NULL;
           }
-
-          // Valid signature
-          Dmsg1(50, "Signature good on %s\n", jcr->fd_impl->last_fname);
-          CryptoDigestFree(digest);
-          return true;
-
-        case CRYPTO_ERROR_NOSIGNER:
-          // Signature not found, try again
-          if (digest) {
-            CryptoDigestFree(digest);
-            digest = NULL;
+        }
+        if (jcr->fd_impl->crypto.digest) {
+          // Use digest computed while writing the file to verify the
+          // signature
+          if ((err
+               = CryptoSignVerify(sig, keypair, jcr->fd_impl->crypto.digest))
+              != CRYPTO_ERROR_NONE) {
+            Dmsg1(50, "Bad signature on %s\n", jcr->fd_impl->last_fname);
+            Jmsg2(jcr, M_ERROR, 0,
+                  T_("Signature validation failed for file %s: ERR=%s\n"),
+                  jcr->fd_impl->last_fname, crypto_strerror(err));
+            goto bail_out;
           }
-          continue;
-        default:
-          // Something strange happened (that shouldn't happen!)...
-          Qmsg2(jcr, M_ERROR, 0, T_("Signature validation failed for %s: %s\n"),
-                jcr->fd_impl->last_fname, crypto_strerror(err));
-          goto bail_out;
-      }
+        } else {
+          /* Signature found, digest allocated.  Old method,
+           * re-read the file and compute the digest */
+          jcr->fd_impl->crypto.digest = digest;
+
+          /* Checksum the entire file
+           * Make sure we don't modify JobBytes by saving and restoring it */
+          saved_bytes = jcr->JobBytes;
+          if (FindOneFile(jcr, jcr->fd_impl->ff, DoFileDigest,
+                          jcr->fd_impl->last_fname, (dev_t)-1, 1)
+              != 0) {
+            Jmsg(jcr, M_ERROR, 0, T_("Digest one file failed for file: %s\n"),
+                 jcr->fd_impl->last_fname);
+            jcr->JobBytes = saved_bytes;
+            goto bail_out;
+          }
+          jcr->JobBytes = saved_bytes;
+
+          // Verify the signature
+          if ((err = CryptoSignVerify(sig, keypair, digest))
+              != CRYPTO_ERROR_NONE) {
+            Dmsg1(50, "Bad signature on %s\n", jcr->fd_impl->last_fname);
+            Jmsg2(jcr, M_ERROR, 0,
+                  T_("Signature validation failed for file %s: ERR=%s\n"),
+                  jcr->fd_impl->last_fname, crypto_strerror(err));
+            goto bail_out;
+          }
+          jcr->fd_impl->crypto.digest = NULL;
+        }
+
+        // Valid signature
+        Dmsg1(50, "Signature good on %s\n", jcr->fd_impl->last_fname);
+        CryptoDigestFree(digest);
+        return true;
+
+      case CRYPTO_ERROR_NOSIGNER:
+        // Signature not found, try again
+        if (digest) {
+          CryptoDigestFree(digest);
+          digest = NULL;
+        }
+        continue;
+      default:
+        // Something strange happened (that shouldn't happen!)...
+        Qmsg2(jcr, M_ERROR, 0, T_("Signature validation failed for %s: %s\n"),
+              jcr->fd_impl->last_fname, crypto_strerror(err));
+        goto bail_out;
     }
   }
 

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -264,7 +264,7 @@ static bool ValidateCommand(JobControlRecord* jcr,
   // If there is no explicit list of allowed cmds allow all cmds.
   if (!allowed_job_cmds) { return true; }
 
-  foreach_alist (allowed_job_cmd, allowed_job_cmds) {
+  for (auto* allowed_job_cmd : *allowed_job_cmds) {
     if (Bstrcasecmp(cmd, allowed_job_cmd)) {
       allowed = true;
       break;

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -259,7 +259,6 @@ static bool ValidateCommand(JobControlRecord* jcr,
                             const char* cmd,
                             alist<const char*>* allowed_job_cmds)
 {
-  const char* allowed_job_cmd = nullptr;
   bool allowed = false;
 
   // If there is no explicit list of allowed cmds allow all cmds.

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -264,7 +264,7 @@ static bool ValidateCommand(JobControlRecord* jcr,
   // If there is no explicit list of allowed cmds allow all cmds.
   if (!allowed_job_cmds) { return true; }
 
-  for (auto* allowed_job_cmd : *allowed_job_cmds) {
+  for (auto* allowed_job_cmd : allowed_job_cmds) {
     if (Bstrcasecmp(cmd, allowed_job_cmd)) {
       allowed = true;
       break;

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -398,13 +398,11 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
       call_if_canceled = true; /* plugin *must* see this call */
       break;
     case bEventStartRestoreJob:
-      if (plugin_ctx_list) {
-        for (auto* ctx : *plugin_ctx_list) {
-          ((FiledPluginContext*)ctx->core_private_context)->restoreFileStarted
-              = false;
-          ((FiledPluginContext*)ctx->core_private_context)->createFileCalled
-              = false;
-        }
+      for (auto* ctx : plugin_ctx_list) {
+        ((FiledPluginContext*)ctx->core_private_context)->restoreFileStarted
+            = false;
+        ((FiledPluginContext*)ctx->core_private_context)->createFileCalled
+            = false;
       }
       break;
     case bEventEndRestoreJob:
@@ -482,7 +480,7 @@ bool PluginCheckFile(JobControlRecord* jcr, char* fname)
         jcr->JobId);
 
   // Pass event to every plugin
-  for (auto* ctx : *plugin_ctx_list) {
+  for (auto* ctx : plugin_ctx_list) {
     if (IsPluginDisabled(ctx)) { continue; }
 
     jcr->plugin_ctx = ctx;
@@ -613,7 +611,7 @@ bRC PluginOptionHandleFile(JobControlRecord* jcr,
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  for (auto* ctx : *plugin_ctx_list) {
+  for (auto* ctx : plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -689,7 +687,7 @@ int PluginSave(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  for (auto* ctx : *plugin_ctx_list) {
+  for (auto* ctx : plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -926,7 +924,7 @@ int PluginEstimate(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  for (auto* ctx : *plugin_ctx_list) {
+  for (auto* ctx : plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -1138,7 +1136,7 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Search for correct plugin as specified on the command
-  for (auto* ctx : *plugin_ctx_list) {
+  for (auto* ctx : plugin_ctx_list) {
     bEvent event;
     bEventType eventType;
     FiledPluginContext* b_ctx;
@@ -1568,7 +1566,7 @@ BxattrExitCode PluginParseXattrStreams(
     xattr_pkt xp;
     xp.fname = xattr_data->last_fname;
 
-    for (auto* current_xattr : *xattr_value_list) {
+    for (auto* current_xattr : xattr_value_list) {
       xp.name = current_xattr->name;
       xp.name_length = current_xattr->name_length;
       xp.value = current_xattr->value;
@@ -1775,7 +1773,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance fd-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  for (auto* ctx : *jcr->plugin_ctx_list) {
+  for (auto* ctx : jcr->plugin_ctx_list) {
     // Free the plugin instance
     PlugFunc(ctx->plugin)->freePlugin(ctx);
     delete static_cast<FiledPluginContext*>(ctx->core_private_context);
@@ -2182,10 +2180,8 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
 
   cnt = 0;
   foreach_jcr (njcr) {
-    if (jcr->plugin_ctx_list) {
-      for (auto* nctx : *jcr->plugin_ctx_list) {
-        if (nctx->plugin == bctx->plugin) { cnt++; }
-      }
+    for (auto* nctx : jcr->plugin_ctx_list) {
+      if (nctx->plugin == bctx->plugin) { cnt++; }
     }
   }
   endeach_jcr(njcr);

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -398,11 +398,13 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
       call_if_canceled = true; /* plugin *must* see this call */
       break;
     case bEventStartRestoreJob:
-      for (auto* ctx : *plugin_ctx_list) {
-        ((FiledPluginContext*)ctx->core_private_context)->restoreFileStarted
-            = false;
-        ((FiledPluginContext*)ctx->core_private_context)->createFileCalled
-            = false;
+      if (plugin_ctx_list) {
+        for (auto* ctx : *plugin_ctx_list) {
+          ((FiledPluginContext*)ctx->core_private_context)->restoreFileStarted
+              = false;
+          ((FiledPluginContext*)ctx->core_private_context)->createFileCalled
+              = false;
+        }
       }
       break;
     case bEventEndRestoreJob:

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -354,7 +354,6 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
   int len = 0;
   bool call_if_canceled = false;
   restore_object_pkt* rop;
-  PluginContext* ctx = nullptr;
   alist<PluginContext*>* plugin_ctx_list;
   bRC rc = bRC_OK;
 
@@ -425,6 +424,7 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
    *
    * See if we need to trigger the loaded plugins in reverse order. */
   if (reverse) {
+    PluginContext* ctx;
     int i{};
     foreach_alist_rindex (i, ctx, plugin_ctx_list) {
       if (!IsEventForThisPlugin(ctx->plugin, name, len)) {
@@ -439,6 +439,7 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
       }
     }
   } else {
+    PluginContext* ctx;
     int i{};
     foreach_alist_index (i, ctx, plugin_ctx_list) {
       if (!IsEventForThisPlugin(ctx->plugin, name, len)) {
@@ -466,7 +467,6 @@ bail_out:
 // Check if file was seen for accurate
 bool PluginCheckFile(JobControlRecord* jcr, char* fname)
 {
-  PluginContext* ctx = nullptr;
   alist<PluginContext*>* plugin_ctx_list;
   int retval = bRC_OK;
 
@@ -574,7 +574,6 @@ bRC PluginOptionHandleFile(JobControlRecord* jcr,
   bRC retval = bRC_Core;
   bEvent event;
   bEventType eventType;
-  PluginContext* ctx = nullptr;
   alist<PluginContext*>* plugin_ctx_list;
 
   cmd = ff_pkt->plugin;
@@ -655,7 +654,6 @@ int PluginSave(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   int len;
   char* cmd;
   bEvent event;
-  PluginContext* ctx = nullptr;
   bEventType eventType;
   PoolMem fname(PM_FNAME);
   PoolMem link(PM_FNAME);
@@ -909,7 +907,6 @@ int PluginEstimate(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   bEventType eventType;
   PoolMem fname(PM_FNAME);
   PoolMem link(PM_FNAME);
-  PluginContext* ctx = nullptr;
   alist<PluginContext*>* plugin_ctx_list;
   Attributes attr;
 
@@ -1092,7 +1089,6 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
   char* p = name;
   bool start;
   bool retval = true;
-  PluginContext* ctx = nullptr;
   alist<PluginContext*>* plugin_ctx_list;
 
   Dmsg1(debuglevel, "Read plugin stream string=%s\n", name);
@@ -1559,8 +1555,6 @@ BxattrExitCode PluginParseXattrStreams(
 #if defined(HAVE_XATTR)
   plugin = (Plugin*)jcr->plugin_ctx->plugin;
   if (PlugFunc(plugin)->setXattr != NULL) {
-    xattr_t* current_xattr = nullptr;
-
     xattr_value_list = new alist<xattr_t*>(10, not_owned_by_alist);
 
     if (UnSerializeXattrStream(jcr, xattr_data, content, content_length,
@@ -1775,8 +1769,6 @@ void NewPlugins(JobControlRecord* jcr)
 // Free the plugin instances for this Job
 void FreePlugins(JobControlRecord* jcr)
 {
-  PluginContext* ctx = nullptr;
-
   if (!fd_plugin_list || !jcr->plugin_ctx_list) { return; }
 
   Dmsg2(debuglevel, "Free instance fd-plugin_ctx_list=%p JobId=%d\n",
@@ -2179,7 +2171,6 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
 {
   int cnt;
   JobControlRecord *jcr, *njcr;
-  PluginContext* nctx;
   FiledPluginContext* bctx;
   bRC retval = bRC_Error;
 

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -398,7 +398,7 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
       call_if_canceled = true; /* plugin *must* see this call */
       break;
     case bEventStartRestoreJob:
-      foreach_alist (ctx, plugin_ctx_list) {
+      for (auto* ctx : *plugin_ctx_list) {
         ((FiledPluginContext*)ctx->core_private_context)->restoreFileStarted
             = false;
         ((FiledPluginContext*)ctx->core_private_context)->createFileCalled
@@ -480,7 +480,7 @@ bool PluginCheckFile(JobControlRecord* jcr, char* fname)
         jcr->JobId);
 
   // Pass event to every plugin
-  foreach_alist (ctx, plugin_ctx_list) {
+  for (auto* ctx : *plugin_ctx_list) {
     if (IsPluginDisabled(ctx)) { continue; }
 
     jcr->plugin_ctx = ctx;
@@ -611,7 +611,7 @@ bRC PluginOptionHandleFile(JobControlRecord* jcr,
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  foreach_alist (ctx, plugin_ctx_list) {
+  for (auto* ctx : *plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -687,7 +687,7 @@ int PluginSave(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  foreach_alist (ctx, plugin_ctx_list) {
+  for (auto* ctx : *plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -924,7 +924,7 @@ int PluginEstimate(JobControlRecord* jcr, FindFilesPacket* ff_pkt, bool)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Note, we stop the loop on the first plugin that matches the name
-  foreach_alist (ctx, plugin_ctx_list) {
+  for (auto* ctx : *plugin_ctx_list) {
     Dmsg4(debuglevel, "plugin=%s plen=%d cmd=%s len=%d\n", ctx->plugin->file,
           ctx->plugin->file_len, cmd, len);
     if (!IsEventForThisPlugin(ctx->plugin, cmd, len)) { continue; }
@@ -1136,7 +1136,7 @@ bool PluginNameStream(JobControlRecord* jcr, char* name)
   if (!GetPluginName(jcr, cmd, &len)) { goto bail_out; }
 
   // Search for correct plugin as specified on the command
-  foreach_alist (ctx, plugin_ctx_list) {
+  for (auto* ctx : *plugin_ctx_list) {
     bEvent event;
     bEventType eventType;
     FiledPluginContext* b_ctx;
@@ -1566,7 +1566,7 @@ BxattrExitCode PluginParseXattrStreams(
     xattr_pkt xp;
     xp.fname = xattr_data->last_fname;
 
-    foreach_alist (current_xattr, xattr_value_list) {
+    for (auto* current_xattr : *xattr_value_list) {
       xp.name = current_xattr->name;
       xp.name_length = current_xattr->name_length;
       xp.value = current_xattr->value;
@@ -1773,7 +1773,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance fd-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  foreach_alist (ctx, jcr->plugin_ctx_list) {
+  for (auto* ctx : *jcr->plugin_ctx_list) {
     // Free the plugin instance
     PlugFunc(ctx->plugin)->freePlugin(ctx);
     delete static_cast<FiledPluginContext*>(ctx->core_private_context);
@@ -2181,7 +2181,7 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
   cnt = 0;
   foreach_jcr (njcr) {
     if (jcr->plugin_ctx_list) {
-      foreach_alist (nctx, jcr->plugin_ctx_list) {
+      for (auto* nctx : *jcr->plugin_ctx_list) {
         if (nctx->plugin == bctx->plugin) { cnt++; }
       }
     }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -382,14 +382,12 @@ static void FreeResource(BareosResource* res, int type)
       if (p->pki_keypair) { CryptoKeypairFree(p->pki_keypair); }
       if (p->pki_signing_key_files) { delete p->pki_signing_key_files; }
       if (p->pki_signers) {
-        foreach_alist (keypair, p->pki_signers) { CryptoKeypairFree(keypair); }
+        for (auto* keypair : *p->pki_signers) { CryptoKeypairFree(keypair); }
         delete p->pki_signers;
       }
       if (p->pki_master_key_files) { delete p->pki_master_key_files; }
       if (p->pki_recipients) {
-        foreach_alist (keypair, p->pki_recipients) {
-          CryptoKeypairFree(keypair);
-        }
+        for (auto* keypair : *p->pki_recipients) { CryptoKeypairFree(keypair); }
         delete p->pki_recipients;
       }
       if (p->verid) { free(p->verid); }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -382,12 +382,12 @@ static void FreeResource(BareosResource* res, int type)
       if (p->pki_keypair) { CryptoKeypairFree(p->pki_keypair); }
       if (p->pki_signing_key_files) { delete p->pki_signing_key_files; }
       if (p->pki_signers) {
-        for (auto* keypair : *p->pki_signers) { CryptoKeypairFree(keypair); }
+        for (auto* keypair : p->pki_signers) { CryptoKeypairFree(keypair); }
         delete p->pki_signers;
       }
       if (p->pki_master_key_files) { delete p->pki_master_key_files; }
       if (p->pki_recipients) {
-        for (auto* keypair : *p->pki_recipients) { CryptoKeypairFree(keypair); }
+        for (auto* keypair : p->pki_recipients) { CryptoKeypairFree(keypair); }
         delete p->pki_recipients;
       }
       if (p->verid) { free(p->verid); }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -382,13 +382,11 @@ static void FreeResource(BareosResource* res, int type)
       if (p->pki_keypair) { CryptoKeypairFree(p->pki_keypair); }
       if (p->pki_signing_key_files) { delete p->pki_signing_key_files; }
       if (p->pki_signers) {
-        X509_KEYPAIR* keypair = nullptr;
         foreach_alist (keypair, p->pki_signers) { CryptoKeypairFree(keypair); }
         delete p->pki_signers;
       }
       if (p->pki_master_key_files) { delete p->pki_master_key_files; }
       if (p->pki_recipients) {
-        X509_KEYPAIR* keypair = nullptr;
         foreach_alist (keypair, p->pki_recipients) {
           CryptoKeypairFree(keypair);
         }

--- a/core/src/filed/filed_utils.cc
+++ b/core/src/filed/filed_utils.cc
@@ -29,7 +29,6 @@ namespace filedaemon {
 static bool InitPublicPrivateKeys(const char* configfile)
 {
   bool OK = true;
-  const char* filepath = nullptr;
   /* Load our keypair */
   me->pki_keypair = crypto_keypair_new();
   if (!me->pki_keypair) {

--- a/core/src/filed/filed_utils.cc
+++ b/core/src/filed/filed_utils.cc
@@ -61,7 +61,7 @@ static bool InitPublicPrivateKeys(const char* configfile)
 
   /* If additional signing public keys have been specified, load them up */
   if (me->pki_signing_key_files) {
-    foreach_alist (filepath, me->pki_signing_key_files) {
+    for (auto* filepath : *me->pki_signing_key_files) {
       X509_KEYPAIR* keypair;
 
       keypair = crypto_keypair_new();
@@ -104,7 +104,7 @@ static bool InitPublicPrivateKeys(const char* configfile)
 
   /* If additional keys have been specified, load them up */
   if (me->pki_master_key_files) {
-    foreach_alist (filepath, me->pki_master_key_files) {
+    for (auto* filepath : *me->pki_master_key_files) {
       X509_KEYPAIR* keypair;
 
       keypair = crypto_keypair_new();

--- a/core/src/filed/filed_utils.cc
+++ b/core/src/filed/filed_utils.cc
@@ -60,36 +60,34 @@ static bool InitPublicPrivateKeys(const char* configfile)
   }
 
   /* If additional signing public keys have been specified, load them up */
-  if (me->pki_signing_key_files) {
-    for (auto* filepath : *me->pki_signing_key_files) {
-      X509_KEYPAIR* keypair;
+  for (auto* filepath : me->pki_signing_key_files) {
+    X509_KEYPAIR* keypair;
 
-      keypair = crypto_keypair_new();
-      if (!keypair) {
-        Emsg0(M_FATAL, 0, T_("Failed to allocate a new keypair object.\n"));
-        OK = false;
-      } else {
-        if (CryptoKeypairLoadCert(keypair, filepath)) {
-          me->pki_signers->append(keypair);
+    keypair = crypto_keypair_new();
+    if (!keypair) {
+      Emsg0(M_FATAL, 0, T_("Failed to allocate a new keypair object.\n"));
+      OK = false;
+    } else {
+      if (CryptoKeypairLoadCert(keypair, filepath)) {
+        me->pki_signers->append(keypair);
 
-          /* Attempt to load a private key, if available */
-          if (CryptoKeypairHasKey(filepath)) {
-            if (!CryptoKeypairLoadKey(keypair, filepath, nullptr, nullptr)) {
-              Emsg3(M_FATAL, 0,
-                    T_("Failed to load private key from file %s for File"
-                       " daemon \"%s\" in %s.\n"),
-                    filepath, me->resource_name_, configfile);
-              OK = false;
-            }
+        /* Attempt to load a private key, if available */
+        if (CryptoKeypairHasKey(filepath)) {
+          if (!CryptoKeypairLoadKey(keypair, filepath, nullptr, nullptr)) {
+            Emsg3(M_FATAL, 0,
+                  T_("Failed to load private key from file %s for File"
+                     " daemon \"%s\" in %s.\n"),
+                  filepath, me->resource_name_, configfile);
+            OK = false;
           }
-
-        } else {
-          Emsg3(M_FATAL, 0,
-                T_("Failed to load trusted signer certificate"
-                   " from file %s for File daemon \"%s\" in %s.\n"),
-                filepath, me->resource_name_, configfile);
-          OK = false;
         }
+
+      } else {
+        Emsg3(M_FATAL, 0,
+              T_("Failed to load trusted signer certificate"
+                 " from file %s for File daemon \"%s\" in %s.\n"),
+              filepath, me->resource_name_, configfile);
+        OK = false;
       }
     }
   }
@@ -103,24 +101,22 @@ static bool InitPublicPrivateKeys(const char* configfile)
 
 
   /* If additional keys have been specified, load them up */
-  if (me->pki_master_key_files) {
-    for (auto* filepath : *me->pki_master_key_files) {
-      X509_KEYPAIR* keypair;
+  for (auto* filepath : me->pki_master_key_files) {
+    X509_KEYPAIR* keypair;
 
-      keypair = crypto_keypair_new();
-      if (!keypair) {
-        Emsg0(M_FATAL, 0, T_("Failed to allocate a new keypair object.\n"));
-        OK = false;
+    keypair = crypto_keypair_new();
+    if (!keypair) {
+      Emsg0(M_FATAL, 0, T_("Failed to allocate a new keypair object.\n"));
+      OK = false;
+    } else {
+      if (CryptoKeypairLoadCert(keypair, filepath)) {
+        me->pki_recipients->append(keypair);
       } else {
-        if (CryptoKeypairLoadCert(keypair, filepath)) {
-          me->pki_recipients->append(keypair);
-        } else {
-          Emsg3(M_FATAL, 0,
-                T_("Failed to load master key certificate"
-                   " from file %s for File daemon \"%s\" in %s.\n"),
-                filepath, me->resource_name_, configfile);
-          OK = false;
-        }
+        Emsg3(M_FATAL, 0,
+              T_("Failed to load master key certificate"
+                 " from file %s for File daemon \"%s\" in %s.\n"),
+              filepath, me->resource_name_, configfile);
+        OK = false;
       }
     }
   }

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -184,7 +184,7 @@ static inline void DropDelayedDataStreams(r_ctx& rctx, bool reuse)
 {
   if (!rctx.delayed_streams || rctx.delayed_streams->empty()) { return; }
 
-  foreach_alist (dds, rctx.delayed_streams) { free(dds->content); }
+  for (auto* dds : *rctx.delayed_streams) { free(dds->content); }
 
   rctx.delayed_streams->destroy();
   if (reuse) { rctx.delayed_streams->init(10, owned_by_alist); }
@@ -313,7 +313,7 @@ static inline bool PopDelayedDataStreams(JobControlRecord* jcr, r_ctx& rctx)
    * processing for the following type of streams:
    * - *_ACL_*
    * - *_XATTR_* */
-  foreach_alist (dds, rctx.delayed_streams) {
+  for (auto* dds : *rctx.delayed_streams) {
     switch (dds->stream) {
       case STREAM_UNIX_ACCESS_ACL:
       case STREAM_UNIX_DEFAULT_ACL:

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -182,8 +182,6 @@ static inline bool RestoreFinderinfo(JobControlRecord*, POOLMEM*, int32_t)
 // Cleanup of delayed restore stack with streams for later processing.
 static inline void DropDelayedDataStreams(r_ctx& rctx, bool reuse)
 {
-  DelayedDataStream* dds = nullptr;
-
   if (!rctx.delayed_streams || rctx.delayed_streams->empty()) { return; }
 
   foreach_alist (dds, rctx.delayed_streams) { free(dds->content); }
@@ -303,8 +301,6 @@ static inline bool do_restore_xattr(JobControlRecord* jcr,
  */
 static inline bool PopDelayedDataStreams(JobControlRecord* jcr, r_ctx& rctx)
 {
-  DelayedDataStream* dds = nullptr;
-
   // See if there is anything todo.
   if (!rctx.delayed_streams || rctx.delayed_streams->empty()) { return true; }
 

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -184,7 +184,7 @@ static inline void DropDelayedDataStreams(r_ctx& rctx, bool reuse)
 {
   if (!rctx.delayed_streams || rctx.delayed_streams->empty()) { return; }
 
-  for (auto* dds : *rctx.delayed_streams) { free(dds->content); }
+  for (auto* dds : rctx.delayed_streams) { free(dds->content); }
 
   rctx.delayed_streams->destroy();
   if (reuse) { rctx.delayed_streams->init(10, owned_by_alist); }
@@ -313,7 +313,7 @@ static inline bool PopDelayedDataStreams(JobControlRecord* jcr, r_ctx& rctx)
    * processing for the following type of streams:
    * - *_ACL_*
    * - *_XATTR_* */
-  for (auto* dds : *rctx.delayed_streams) {
+  for (auto* dds : rctx.delayed_streams) {
     switch (dds->stream) {
       case STREAM_UNIX_ACCESS_ACL:
       case STREAM_UNIX_DEFAULT_ACL:

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -1317,7 +1317,6 @@ static BxattrExitCode bsd_parse_xattr_streams(JobControlRecord* jcr,
                                               char* content,
                                               uint32_t content_length)
 {
-  xattr_t* current_xattr = nullptr;
   alist<xattr_t*>* xattr_value_list;
   int current_attrnamespace, cnt;
   char *attrnamespace, *attrname;

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -143,6 +143,7 @@ BxattrExitCode SendXattrStream(JobControlRecord* jcr,
  */
 void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list)
 {
+  if (!xattr_value_list) { return; }
   // Walk the list of xattrs and free allocated memory on traversing.
   for (auto* current_xattr : *xattr_value_list) {
     // See if we can shortcut.
@@ -1519,8 +1520,7 @@ static inline xattr_link_cache_entry_t* find_xattr_link_cache_entry(
     XattrData* xattr_data,
     ino_t inum)
 {
-  xattr_link_cache_entry_t* ptr;
-
+  if (xattr_data->u.build->link_cache) { return nullptr; }
   for (auto* ptr : *xattr_data->u.build->link_cache) {
     if (ptr && ptr->inum == inum) { return ptr; }
   }
@@ -1547,10 +1547,9 @@ static inline void add_xattr_link_cache_entry(XattrData* xattr_data,
 
 static inline void DropXattrLinkCache(XattrData* xattr_data)
 {
-  xattr_link_cache_entry_t* ptr;
-
   /* Walk the list of xattr link cache entries and free allocated memory on
    * traversing. */
+  if (xattr_data) { return; }
   for (auto* ptr : *xattr_data->u.build->link_cache) {
     free(ptr->target);
     free(ptr);

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -145,7 +145,7 @@ void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list)
 {
   if (!xattr_value_list) { return; }
   // Walk the list of xattrs and free allocated memory on traversing.
-  for (auto* current_xattr : *xattr_value_list) {
+  for (auto* current_xattr : xattr_value_list) {
     // See if we can shortcut.
     if (current_xattr == NULL || current_xattr->magic != XATTR_MAGIC) break;
 
@@ -186,7 +186,7 @@ uint32_t SerializeXattrStream(JobControlRecord*,
   SerBegin(xattr_data->u.build->content, expected_serialize_len + 10);
 
   // Walk the list of xattrs and Serialize the data.
-  for (auto* current_xattr : *xattr_value_list) {
+  for (auto* current_xattr : xattr_value_list) {
     // See if we can shortcut.
     if (current_xattr == NULL || current_xattr->magic != XATTR_MAGIC) break;
 
@@ -559,7 +559,7 @@ static BxattrExitCode aix_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  for (auto* current_xattr : *xattr_value_list) {
+  for (auto* current_xattr : xattr_value_list) {
     if (lsetea(xattr_data->last_fname, current_xattr->name,
                current_xattr->value, current_xattr->value_length, 0)
         != 0) {
@@ -928,7 +928,7 @@ static BxattrExitCode generic_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  for (auto* current_xattr : *xattr_value_list) {
+  for (auto* current_xattr : xattr_value_list) {
     if (lsetxattr(xattr_data->last_fname, current_xattr->name,
                   current_xattr->value, current_xattr->value_length, 0)
         != 0) {
@@ -1330,7 +1330,7 @@ static BxattrExitCode bsd_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  for (auto* current_xattr : *xattr_value_list) {
+  for (auto* current_xattr : xattr_value_list) {
     /* Try splitting the xattr_name into a namespace and name part.
      * The splitting character is a . */
     attrnamespace = current_xattr->name;
@@ -1520,7 +1520,7 @@ static inline xattr_link_cache_entry_t* find_xattr_link_cache_entry(
     ino_t inum)
 {
   if (xattr_data->u.build->link_cache) { return nullptr; }
-  for (auto* ptr : *xattr_data->u.build->link_cache) {
+  for (auto* ptr : xattr_data->u.build->link_cache) {
     if (ptr && ptr->inum == inum) { return ptr; }
   }
   return NULL;
@@ -1549,7 +1549,7 @@ static inline void DropXattrLinkCache(XattrData* xattr_data)
   /* Walk the list of xattr link cache entries and free allocated memory on
    * traversing. */
   if (xattr_data) { return; }
-  for (auto* ptr : *xattr_data->u.build->link_cache) {
+  for (auto* ptr : xattr_data->u.build->link_cache) {
     free(ptr->target);
     free(ptr);
   }

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2008-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -143,8 +143,6 @@ BxattrExitCode SendXattrStream(JobControlRecord* jcr,
  */
 void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list)
 {
-  xattr_t* current_xattr = nullptr;
-
   // Walk the list of xattrs and free allocated memory on traversing.
   foreach_alist (current_xattr, xattr_value_list) {
     // See if we can shortcut.
@@ -178,7 +176,6 @@ uint32_t SerializeXattrStream(JobControlRecord*,
                               uint32_t expected_serialize_len,
                               alist<xattr_t*>* xattr_value_list)
 {
-  xattr_t* current_xattr = nullptr;
   ser_declare;
 
   /* Make sure the serialized stream fits in the poolmem buffer.
@@ -919,7 +916,6 @@ static BxattrExitCode generic_parse_xattr_streams(JobControlRecord* jcr,
                                                   char* content,
                                                   uint32_t content_length)
 {
-  xattr_t* current_xattr = nullptr;
   alist<xattr_t*>* xattr_value_list;
   BxattrExitCode retval = BxattrExitCode::kError;
 

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -144,7 +144,7 @@ BxattrExitCode SendXattrStream(JobControlRecord* jcr,
 void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list)
 {
   // Walk the list of xattrs and free allocated memory on traversing.
-  foreach_alist (current_xattr, xattr_value_list) {
+  for (auto* current_xattr : *xattr_value_list) {
     // See if we can shortcut.
     if (current_xattr == NULL || current_xattr->magic != XATTR_MAGIC) break;
 
@@ -185,7 +185,7 @@ uint32_t SerializeXattrStream(JobControlRecord*,
   SerBegin(xattr_data->u.build->content, expected_serialize_len + 10);
 
   // Walk the list of xattrs and Serialize the data.
-  foreach_alist (current_xattr, xattr_value_list) {
+  for (auto* current_xattr : *xattr_value_list) {
     // See if we can shortcut.
     if (current_xattr == NULL || current_xattr->magic != XATTR_MAGIC) break;
 
@@ -558,7 +558,7 @@ static BxattrExitCode aix_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  foreach_alist (current_xattr, xattr_value_list) {
+  for (auto* current_xattr : *xattr_value_list) {
     if (lsetea(xattr_data->last_fname, current_xattr->name,
                current_xattr->value, current_xattr->value_length, 0)
         != 0) {
@@ -927,7 +927,7 @@ static BxattrExitCode generic_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  foreach_alist (current_xattr, xattr_value_list) {
+  for (auto* current_xattr : *xattr_value_list) {
     if (lsetxattr(xattr_data->last_fname, current_xattr->name,
                   current_xattr->value, current_xattr->value_length, 0)
         != 0) {
@@ -1330,7 +1330,7 @@ static BxattrExitCode bsd_parse_xattr_streams(JobControlRecord* jcr,
     goto bail_out;
   }
 
-  foreach_alist (current_xattr, xattr_value_list) {
+  for (auto* current_xattr : *xattr_value_list) {
     /* Try splitting the xattr_name into a namespace and name part.
      * The splitting character is a . */
     attrnamespace = current_xattr->name;
@@ -1521,7 +1521,7 @@ static inline xattr_link_cache_entry_t* find_xattr_link_cache_entry(
 {
   xattr_link_cache_entry_t* ptr;
 
-  foreach_alist (ptr, xattr_data->u.build->link_cache) {
+  for (auto* ptr : *xattr_data->u.build->link_cache) {
     if (ptr && ptr->inum == inum) { return ptr; }
   }
   return NULL;
@@ -1551,7 +1551,7 @@ static inline void DropXattrLinkCache(XattrData* xattr_data)
 
   /* Walk the list of xattr link cache entries and free allocated memory on
    * traversing. */
-  foreach_alist (ptr, xattr_data->u.build->link_cache) {
+  for (auto* ptr : *xattr_data->u.build->link_cache) {
     free(ptr->target);
     free(ptr);
   }

--- a/core/src/lib/alist.h
+++ b/core/src/lib/alist.h
@@ -55,7 +55,6 @@ enum
  *               array of pointers to inserted items
  */
 
-
 template <typename T> class alist {
  public:
   T* begin() { return &items[0]; }
@@ -175,5 +174,29 @@ template <typename T> class alist {
   int num_grow = 0;
   bool own_items = false;
 };
+
+template <typename T> const T* begin(const alist<T>* alist)
+{
+  if (!alist) { return nullptr; }
+  return alist->begin();
+}
+
+template <typename T> const T* end(const alist<T>* alist)
+{
+  if (!alist) { return nullptr; }
+  return alist->end();
+}
+
+template <typename T> T* begin(alist<T>* alist)
+{
+  if (!alist) { return nullptr; }
+  return alist->begin();
+}
+
+template <typename T> T* end(alist<T>* alist)
+{
+  if (!alist) { return nullptr; }
+  return alist->end();
+}
 
 #endif  // BAREOS_LIB_ALIST_H_

--- a/core/src/lib/alist.h
+++ b/core/src/lib/alist.h
@@ -27,19 +27,13 @@
 #define BAREOS_LIB_ALIST_H_
 
 
-/* There is a lot of extra casting here to work around the fact
- * that some compilers (Sun and Visual C++) do not accept
- * (void *) as an lvalue on the left side of an equal.
- *
- * Loop var through each member of list
- * Loop var through each member of list using an increasing index.
- * Loop var through each member of list using an decreasing index.
- */
-#define foreach_alist(var, list) for (auto var : *list)
+/* Loop var through each member of list using an increasing index.
+ * Loop var through each member of list using an decreasing index. */
 
-#define foreach_alist_null(var, list) \
-  for ((var) = list ? (list)->first() : nullptr; (var); (var) = (list)->next())
 
+/* These should also get removed.  Currently there are some situations where
+ * items are removed from the list during traversal (see UnloadPlugin).
+ * Since this is thread safe it can stay for now. */
 #define foreach_alist_index(inx, var, list) \
   for ((inx) = 0; (list != nullptr) ? ((var) = (list)->get((inx))) : 0; (inx)++)
 
@@ -50,7 +44,6 @@
 
 #include <string>
 #include <list>
-
 
 // Second arg of init
 enum

--- a/core/src/lib/alist.h
+++ b/core/src/lib/alist.h
@@ -56,6 +56,7 @@ enum
  *               array of pointers to inserted items
  */
 
+
 template <typename T> class alist {
  public:
   template <typename Mem> struct enumerated_span {

--- a/core/src/lib/breg.cc
+++ b/core/src/lib/breg.cc
@@ -67,9 +67,7 @@ void FreeBregexps(alist<BareosRegex*>* bregexps)
 {
   Dmsg0(500, "bregexp: freeing all BareosRegex object\n");
 
-  if (bregexps) {
-    for (auto* elt : *bregexps) { FreeBregexp(elt); }
-  }
+  for (auto* elt : bregexps) { FreeBregexp(elt); }
 }
 
 /* Apply all regexps to fname
@@ -81,11 +79,9 @@ bool ApplyBregexps(const char* fname,
   bool ok = false;
 
   char* ret = (char*)fname;
-  if (bregexps) {
-    for (auto* elt : *bregexps) {
-      ret = elt->replace(ret);
-      ok = ok || elt->success;
-    }
+  for (auto* elt : bregexps) {
+    ret = elt->replace(ret);
+    ok = ok || elt->success;
   }
   Dmsg2(500, "bregexp: fname=%s ret=%s\n", fname, ret);
 

--- a/core/src/lib/breg.cc
+++ b/core/src/lib/breg.cc
@@ -67,7 +67,9 @@ void FreeBregexps(alist<BareosRegex*>* bregexps)
 {
   Dmsg0(500, "bregexp: freeing all BareosRegex object\n");
 
-  for (auto* elt : *bregexps) { FreeBregexp(elt); }
+  if (bregexps) {
+    for (auto* elt : *bregexps) { FreeBregexp(elt); }
+  }
 }
 
 /* Apply all regexps to fname
@@ -79,9 +81,11 @@ bool ApplyBregexps(const char* fname,
   bool ok = false;
 
   char* ret = (char*)fname;
-  for (auto* elt : *bregexps) {
-    ret = elt->replace(ret);
-    ok = ok || elt->success;
+  if (bregexps) {
+    for (auto* elt : *bregexps) {
+      ret = elt->replace(ret);
+      ok = ok || elt->success;
+    }
   }
   Dmsg2(500, "bregexp: fname=%s ret=%s\n", fname, ret);
 

--- a/core/src/lib/breg.cc
+++ b/core/src/lib/breg.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2006-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -67,7 +67,6 @@ void FreeBregexps(alist<BareosRegex*>* bregexps)
 {
   Dmsg0(500, "bregexp: freeing all BareosRegex object\n");
 
-  BareosRegex* elt = nullptr;
   foreach_alist (elt, bregexps) { FreeBregexp(elt); }
 }
 
@@ -77,7 +76,6 @@ bool ApplyBregexps(const char* fname,
                    alist<BareosRegex*>* bregexps,
                    char** result)
 {
-  BareosRegex* elt = nullptr;
   bool ok = false;
 
   char* ret = (char*)fname;

--- a/core/src/lib/breg.cc
+++ b/core/src/lib/breg.cc
@@ -67,7 +67,7 @@ void FreeBregexps(alist<BareosRegex*>* bregexps)
 {
   Dmsg0(500, "bregexp: freeing all BareosRegex object\n");
 
-  foreach_alist (elt, bregexps) { FreeBregexp(elt); }
+  for (auto* elt : *bregexps) { FreeBregexp(elt); }
 }
 
 /* Apply all regexps to fname
@@ -79,7 +79,7 @@ bool ApplyBregexps(const char* fname,
   bool ok = false;
 
   char* ret = (char*)fname;
-  foreach_alist (elt, bregexps) {
+  for (auto* elt : *bregexps) {
     ret = elt->replace(ret);
     ok = ok || elt->success;
   }

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1154,62 +1154,59 @@ CRYPTO_SESSION* crypto_session_new(crypto_cipher_t cipher,
 
   /* Create RecipientInfo structures for supplied
    * public keys. */
-  if (pubkeys) {
-    for (auto* keypair : *pubkeys) {
-      RecipientInfo* ri;
-      unsigned char* ekey;
-      int ekey_len;
+  for (auto* keypair : pubkeys) {
+    RecipientInfo* ri;
+    unsigned char* ekey;
+    int ekey_len;
 
-      ri = RecipientInfo_new();
-      if (!ri) {
-        /* Allocation failed in OpenSSL */
-        CryptoSessionFree(cs);
-        return NULL;
-      }
-
-      /* Set the ASN.1 structure version number */
-      ASN1_INTEGER_set(ri->version, BAREOS_ASN1_VERSION);
-
-      /* Drop the string allocated by OpenSSL, and add our subjectKeyIdentifier
-       */
-      M_ASN1_OCTET_STRING_free(ri->subjectKeyIdentifier);
-      ri->subjectKeyIdentifier = M_ASN1_OCTET_STRING_dup(keypair->keyid);
-
-      /* Set our key encryption algorithm. We currently require RSA */
-      assert(keypair->pubkey
-             && EVP_PKEY_type(EVP_PKEY_id(keypair->pubkey)) == EVP_PKEY_RSA);
-      ri->keyEncryptionAlgorithm = OBJ_nid2obj(NID_rsaEncryption);
-
-      /* Encrypt the session key */
-      ekey = (unsigned char*)malloc(EVP_PKEY_size(keypair->pubkey));
-
-      IGNORE_DEPRECATED_ON;
-      if ((ekey_len = EVP_PKEY_encrypt(ekey, cs->session_key,
-                                       cs->session_key_len, keypair->pubkey))
-          <= 0) {
-        /* OpenSSL failure */
-        RecipientInfo_free(ri);
-        CryptoSessionFree(cs);
-        free(ekey);
-        return NULL;
-      }
-      IGNORE_DEPRECATED_OFF;
-
-      /* Store it in our ASN.1 structure */
-      if (!M_ASN1_OCTET_STRING_set(ri->encryptedKey, ekey, ekey_len)) {
-        /* Allocation failed in OpenSSL */
-        RecipientInfo_free(ri);
-        CryptoSessionFree(cs);
-        free(ekey);
-        return NULL;
-      }
-
-      /* Free the encrypted key buffer */
-      free(ekey);
-
-      /* Push the new RecipientInfo structure onto the stack */
-      sk_RecipientInfo_push(cs->cryptoData->recipientInfo, ri);
+    ri = RecipientInfo_new();
+    if (!ri) {
+      /* Allocation failed in OpenSSL */
+      CryptoSessionFree(cs);
+      return NULL;
     }
+
+    /* Set the ASN.1 structure version number */
+    ASN1_INTEGER_set(ri->version, BAREOS_ASN1_VERSION);
+
+    /* Drop the string allocated by OpenSSL, and add our subjectKeyIdentifier
+     */
+    M_ASN1_OCTET_STRING_free(ri->subjectKeyIdentifier);
+    ri->subjectKeyIdentifier = M_ASN1_OCTET_STRING_dup(keypair->keyid);
+
+    /* Set our key encryption algorithm. We currently require RSA */
+    assert(keypair->pubkey
+           && EVP_PKEY_type(EVP_PKEY_id(keypair->pubkey)) == EVP_PKEY_RSA);
+    ri->keyEncryptionAlgorithm = OBJ_nid2obj(NID_rsaEncryption);
+
+    /* Encrypt the session key */
+    ekey = (unsigned char*)malloc(EVP_PKEY_size(keypair->pubkey));
+
+    IGNORE_DEPRECATED_ON;
+    if ((ekey_len = EVP_PKEY_encrypt(ekey, cs->session_key, cs->session_key_len,
+                                     keypair->pubkey))
+        <= 0) {
+      /* OpenSSL failure */
+      RecipientInfo_free(ri);
+      CryptoSessionFree(cs);
+      free(ekey);
+      return NULL;
+    }
+    IGNORE_DEPRECATED_OFF;
+    /* Store it in our ASN.1 structure */
+    if (!M_ASN1_OCTET_STRING_set(ri->encryptedKey, ekey, ekey_len)) {
+      /* Allocation failed in OpenSSL */
+      RecipientInfo_free(ri);
+      CryptoSessionFree(cs);
+      free(ekey);
+      return NULL;
+    }
+
+    /* Free the encrypted key buffer */
+    free(ekey);
+
+    /* Push the new RecipientInfo structure onto the stack */
+    sk_RecipientInfo_push(cs->cryptoData->recipientInfo, ri);
   }
 
   return cs;
@@ -1280,54 +1277,51 @@ crypto_error_t CryptoSessionDecode(const uint8_t* data,
 
   /* Find a matching RecipientInfo structure for a supplied
    * public key */
-  if (keypairs) {
-    for (auto* keypair : *keypairs) {
-      RecipientInfo* ri;
-      int i;
+  for (auto* keypair : keypairs) {
+    RecipientInfo* ri;
+    int i;
 
-      /* Private key available? */
-      if (keypair->privkey == NULL) { continue; }
+    /* Private key available? */
+    if (keypair->privkey == NULL) { continue; }
 
-      for (i = 0; i < sk_RecipientInfo_num(recipients); i++) {
-        ri = sk_RecipientInfo_value(recipients, i);
+    for (i = 0; i < sk_RecipientInfo_num(recipients); i++) {
+      ri = sk_RecipientInfo_value(recipients, i);
 
-        /* Match against the subjectKeyIdentifier */
-        if (M_ASN1_OCTET_STRING_cmp(keypair->keyid, ri->subjectKeyIdentifier)
-            == 0) {
-          /* Match found, extract symmetric encryption session data */
+      /* Match against the subjectKeyIdentifier */
+      if (M_ASN1_OCTET_STRING_cmp(keypair->keyid, ri->subjectKeyIdentifier)
+          == 0) {
+        /* Match found, extract symmetric encryption session data */
 
-          /* RSA is required. */
-          assert(EVP_PKEY_type(EVP_PKEY_id(keypair->privkey)) == EVP_PKEY_RSA);
+        /* RSA is required. */
+        assert(EVP_PKEY_type(EVP_PKEY_id(keypair->privkey)) == EVP_PKEY_RSA);
 
-          /* If we recieve a RecipientInfo structure that does not use
-           * RSA, return an error */
-          if (OBJ_obj2nid(ri->keyEncryptionAlgorithm) != NID_rsaEncryption) {
-            retval = CRYPTO_ERROR_INVALID_CRYPTO;
-            goto err;
-          }
-
-          /* Decrypt the session key */
-          /* Allocate sufficient space for the largest possible decrypted data
-           */
-          cs->session_key
-              = (unsigned char*)malloc(EVP_PKEY_size(keypair->privkey));
-          IGNORE_DEPRECATED_ON;
-          cs->session_key_len = EVP_PKEY_decrypt(
-              cs->session_key, M_ASN1_STRING_data(ri->encryptedKey),
-              M_ASN1_STRING_length(ri->encryptedKey), keypair->privkey);
-          IGNORE_DEPRECATED_OFF;
-          if (cs->session_key_len <= 0) {
-            OpensslPostErrors(M_ERROR,
-                              T_("Failure decrypting the session key"));
-            retval = CRYPTO_ERROR_DECRYPTION;
-            goto err;
-          }
-
-          /* Session key successfully extracted, return the CRYPTO_SESSION
-           * structure */
-          *session = cs;
-          return CRYPTO_ERROR_NONE;
+        /* If we recieve a RecipientInfo structure that does not use
+         * RSA, return an error */
+        if (OBJ_obj2nid(ri->keyEncryptionAlgorithm) != NID_rsaEncryption) {
+          retval = CRYPTO_ERROR_INVALID_CRYPTO;
+          goto err;
         }
+
+        /* Decrypt the session key */
+        /* Allocate sufficient space for the largest possible decrypted data
+         */
+        cs->session_key
+            = (unsigned char*)malloc(EVP_PKEY_size(keypair->privkey));
+        IGNORE_DEPRECATED_ON;
+        cs->session_key_len = EVP_PKEY_decrypt(
+            cs->session_key, M_ASN1_STRING_data(ri->encryptedKey),
+            M_ASN1_STRING_length(ri->encryptedKey), keypair->privkey);
+        IGNORE_DEPRECATED_OFF;
+        if (cs->session_key_len <= 0) {
+          OpensslPostErrors(M_ERROR, T_("Failure decrypting the session key"));
+          retval = CRYPTO_ERROR_DECRYPTION;
+          goto err;
+        }
+
+        /* Session key successfully extracted, return the CRYPTO_SESSION
+         * structure */
+        *session = cs;
+        return CRYPTO_ERROR_NONE;
       }
     }
   }

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1154,7 +1154,7 @@ CRYPTO_SESSION* crypto_session_new(crypto_cipher_t cipher,
 
   /* Create RecipientInfo structures for supplied
    * public keys. */
-  foreach_alist (keypair, pubkeys) {
+  for (auto* keypair : *pubkeys) {
     RecipientInfo* ri;
     unsigned char* ekey;
     int ekey_len;
@@ -1277,7 +1277,7 @@ crypto_error_t CryptoSessionDecode(const uint8_t* data,
 
   /* Find a matching RecipientInfo structure for a supplied
    * public key */
-  foreach_alist (keypair, keypairs) {
+  for (auto* keypair : *keypairs) {
     RecipientInfo* ri;
     int i;
 

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1154,59 +1154,62 @@ CRYPTO_SESSION* crypto_session_new(crypto_cipher_t cipher,
 
   /* Create RecipientInfo structures for supplied
    * public keys. */
-  for (auto* keypair : *pubkeys) {
-    RecipientInfo* ri;
-    unsigned char* ekey;
-    int ekey_len;
+  if (pubkeys) {
+    for (auto* keypair : *pubkeys) {
+      RecipientInfo* ri;
+      unsigned char* ekey;
+      int ekey_len;
 
-    ri = RecipientInfo_new();
-    if (!ri) {
-      /* Allocation failed in OpenSSL */
-      CryptoSessionFree(cs);
-      return NULL;
-    }
+      ri = RecipientInfo_new();
+      if (!ri) {
+        /* Allocation failed in OpenSSL */
+        CryptoSessionFree(cs);
+        return NULL;
+      }
 
-    /* Set the ASN.1 structure version number */
-    ASN1_INTEGER_set(ri->version, BAREOS_ASN1_VERSION);
+      /* Set the ASN.1 structure version number */
+      ASN1_INTEGER_set(ri->version, BAREOS_ASN1_VERSION);
 
-    /* Drop the string allocated by OpenSSL, and add our subjectKeyIdentifier */
-    M_ASN1_OCTET_STRING_free(ri->subjectKeyIdentifier);
-    ri->subjectKeyIdentifier = M_ASN1_OCTET_STRING_dup(keypair->keyid);
+      /* Drop the string allocated by OpenSSL, and add our subjectKeyIdentifier
+       */
+      M_ASN1_OCTET_STRING_free(ri->subjectKeyIdentifier);
+      ri->subjectKeyIdentifier = M_ASN1_OCTET_STRING_dup(keypair->keyid);
 
-    /* Set our key encryption algorithm. We currently require RSA */
-    assert(keypair->pubkey
-           && EVP_PKEY_type(EVP_PKEY_id(keypair->pubkey)) == EVP_PKEY_RSA);
-    ri->keyEncryptionAlgorithm = OBJ_nid2obj(NID_rsaEncryption);
+      /* Set our key encryption algorithm. We currently require RSA */
+      assert(keypair->pubkey
+             && EVP_PKEY_type(EVP_PKEY_id(keypair->pubkey)) == EVP_PKEY_RSA);
+      ri->keyEncryptionAlgorithm = OBJ_nid2obj(NID_rsaEncryption);
 
-    /* Encrypt the session key */
-    ekey = (unsigned char*)malloc(EVP_PKEY_size(keypair->pubkey));
+      /* Encrypt the session key */
+      ekey = (unsigned char*)malloc(EVP_PKEY_size(keypair->pubkey));
 
-    IGNORE_DEPRECATED_ON;
-    if ((ekey_len = EVP_PKEY_encrypt(ekey, cs->session_key, cs->session_key_len,
-                                     keypair->pubkey))
-        <= 0) {
-      /* OpenSSL failure */
-      RecipientInfo_free(ri);
-      CryptoSessionFree(cs);
+      IGNORE_DEPRECATED_ON;
+      if ((ekey_len = EVP_PKEY_encrypt(ekey, cs->session_key,
+                                       cs->session_key_len, keypair->pubkey))
+          <= 0) {
+        /* OpenSSL failure */
+        RecipientInfo_free(ri);
+        CryptoSessionFree(cs);
+        free(ekey);
+        return NULL;
+      }
+      IGNORE_DEPRECATED_OFF;
+
+      /* Store it in our ASN.1 structure */
+      if (!M_ASN1_OCTET_STRING_set(ri->encryptedKey, ekey, ekey_len)) {
+        /* Allocation failed in OpenSSL */
+        RecipientInfo_free(ri);
+        CryptoSessionFree(cs);
+        free(ekey);
+        return NULL;
+      }
+
+      /* Free the encrypted key buffer */
       free(ekey);
-      return NULL;
+
+      /* Push the new RecipientInfo structure onto the stack */
+      sk_RecipientInfo_push(cs->cryptoData->recipientInfo, ri);
     }
-    IGNORE_DEPRECATED_OFF;
-
-    /* Store it in our ASN.1 structure */
-    if (!M_ASN1_OCTET_STRING_set(ri->encryptedKey, ekey, ekey_len)) {
-      /* Allocation failed in OpenSSL */
-      RecipientInfo_free(ri);
-      CryptoSessionFree(cs);
-      free(ekey);
-      return NULL;
-    }
-
-    /* Free the encrypted key buffer */
-    free(ekey);
-
-    /* Push the new RecipientInfo structure onto the stack */
-    sk_RecipientInfo_push(cs->cryptoData->recipientInfo, ri);
   }
 
   return cs;
@@ -1277,50 +1280,54 @@ crypto_error_t CryptoSessionDecode(const uint8_t* data,
 
   /* Find a matching RecipientInfo structure for a supplied
    * public key */
-  for (auto* keypair : *keypairs) {
-    RecipientInfo* ri;
-    int i;
+  if (keypairs) {
+    for (auto* keypair : *keypairs) {
+      RecipientInfo* ri;
+      int i;
 
-    /* Private key available? */
-    if (keypair->privkey == NULL) { continue; }
+      /* Private key available? */
+      if (keypair->privkey == NULL) { continue; }
 
-    for (i = 0; i < sk_RecipientInfo_num(recipients); i++) {
-      ri = sk_RecipientInfo_value(recipients, i);
+      for (i = 0; i < sk_RecipientInfo_num(recipients); i++) {
+        ri = sk_RecipientInfo_value(recipients, i);
 
-      /* Match against the subjectKeyIdentifier */
-      if (M_ASN1_OCTET_STRING_cmp(keypair->keyid, ri->subjectKeyIdentifier)
-          == 0) {
-        /* Match found, extract symmetric encryption session data */
+        /* Match against the subjectKeyIdentifier */
+        if (M_ASN1_OCTET_STRING_cmp(keypair->keyid, ri->subjectKeyIdentifier)
+            == 0) {
+          /* Match found, extract symmetric encryption session data */
 
-        /* RSA is required. */
-        assert(EVP_PKEY_type(EVP_PKEY_id(keypair->privkey)) == EVP_PKEY_RSA);
+          /* RSA is required. */
+          assert(EVP_PKEY_type(EVP_PKEY_id(keypair->privkey)) == EVP_PKEY_RSA);
 
-        /* If we recieve a RecipientInfo structure that does not use
-         * RSA, return an error */
-        if (OBJ_obj2nid(ri->keyEncryptionAlgorithm) != NID_rsaEncryption) {
-          retval = CRYPTO_ERROR_INVALID_CRYPTO;
-          goto err;
+          /* If we recieve a RecipientInfo structure that does not use
+           * RSA, return an error */
+          if (OBJ_obj2nid(ri->keyEncryptionAlgorithm) != NID_rsaEncryption) {
+            retval = CRYPTO_ERROR_INVALID_CRYPTO;
+            goto err;
+          }
+
+          /* Decrypt the session key */
+          /* Allocate sufficient space for the largest possible decrypted data
+           */
+          cs->session_key
+              = (unsigned char*)malloc(EVP_PKEY_size(keypair->privkey));
+          IGNORE_DEPRECATED_ON;
+          cs->session_key_len = EVP_PKEY_decrypt(
+              cs->session_key, M_ASN1_STRING_data(ri->encryptedKey),
+              M_ASN1_STRING_length(ri->encryptedKey), keypair->privkey);
+          IGNORE_DEPRECATED_OFF;
+          if (cs->session_key_len <= 0) {
+            OpensslPostErrors(M_ERROR,
+                              T_("Failure decrypting the session key"));
+            retval = CRYPTO_ERROR_DECRYPTION;
+            goto err;
+          }
+
+          /* Session key successfully extracted, return the CRYPTO_SESSION
+           * structure */
+          *session = cs;
+          return CRYPTO_ERROR_NONE;
         }
-
-        /* Decrypt the session key */
-        /* Allocate sufficient space for the largest possible decrypted data */
-        cs->session_key
-            = (unsigned char*)malloc(EVP_PKEY_size(keypair->privkey));
-        IGNORE_DEPRECATED_ON;
-        cs->session_key_len = EVP_PKEY_decrypt(
-            cs->session_key, M_ASN1_STRING_data(ri->encryptedKey),
-            M_ASN1_STRING_length(ri->encryptedKey), keypair->privkey);
-        IGNORE_DEPRECATED_OFF;
-        if (cs->session_key_len <= 0) {
-          OpensslPostErrors(M_ERROR, T_("Failure decrypting the session key"));
-          retval = CRYPTO_ERROR_DECRYPTION;
-          goto err;
-        }
-
-        /* Session key successfully extracted, return the CRYPTO_SESSION
-         * structure */
-        *session = cs;
-        return CRYPTO_ERROR_NONE;
       }
     }
   }

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1013,7 +1013,6 @@ CRYPTO_SESSION* crypto_session_new(crypto_cipher_t cipher,
                                    alist<X509_KEYPAIR*>* pubkeys)
 {
   CRYPTO_SESSION* cs;
-  X509_KEYPAIR* keypair = nullptr;
   const EVP_CIPHER* ec;
   unsigned char* iv;
   int iv_len;
@@ -1248,7 +1247,6 @@ crypto_error_t CryptoSessionDecode(const uint8_t* data,
                                    CRYPTO_SESSION** session)
 {
   CRYPTO_SESSION* cs;
-  X509_KEYPAIR* keypair = nullptr;
   STACK_OF(RecipientInfo) * recipients;
   crypto_error_t retval = CRYPTO_ERROR_NONE;
 #    if (OPENSSL_VERSION_NUMBER >= 0x0090800FL)

--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -661,10 +661,8 @@ void OutputFormatter::ClearFilters()
 
 bool OutputFormatter::has_acl_filters()
 {
-  if (filters) {
-    for (of_filter_tuple* tuple : *filters) {
-      if (tuple->type == OF_FILTER_ACL) { return true; }
-    }
+  for (of_filter_tuple* tuple : filters) {
+    if (tuple->type == OF_FILTER_ACL) { return true; }
   }
 
   return false;
@@ -677,8 +675,8 @@ bool OutputFormatter::FilterData(void* data)
 
   /* See if a filtering function is registered.
    * See if there are any filters. */
-  if (filter_func && filters && !filters->empty()) {
-    for (of_filter_tuple* tuple : *filters) {
+  if (filter_func) {
+    for (of_filter_tuple* tuple : filters) {
       state = filter_func(filter_ctx, data, tuple);
 
       Dmsg1(800, "filter_state %d\n", state);
@@ -977,7 +975,7 @@ void OutputFormatter::JsonFinalizeResult(bool result)
 
       range_obj = json_object();
 
-      for (of_filter_tuple* tuple : *filters) {
+      for (of_filter_tuple* tuple : filters) {
         if (tuple->type == OF_FILTER_LIMIT) {
           json_object_set_new(range_obj, "limit",
                               json_integer(tuple->u.limit_filter.limit));

--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -661,10 +661,8 @@ void OutputFormatter::ClearFilters()
 
 bool OutputFormatter::has_acl_filters()
 {
-  of_filter_tuple* tuple = nullptr;
-
   if (filters) {
-    foreach_alist (tuple, filters) {
+    for (of_filter_tuple* tuple : *filters) {
       if (tuple->type == OF_FILTER_ACL) { return true; }
     }
   }
@@ -675,13 +673,12 @@ bool OutputFormatter::has_acl_filters()
 bool OutputFormatter::FilterData(void* data)
 {
   of_filter_state state;
-  of_filter_tuple* tuple = nullptr;
   int acl_filter_show = 0, acl_filter_unknown = 0;
 
   /* See if a filtering function is registered.
    * See if there are any filters. */
   if (filter_func && filters && !filters->empty()) {
-    foreach_alist (tuple, filters) {
+    for (of_filter_tuple* tuple : *filters) {
       state = filter_func(filter_ctx, data, tuple);
 
       Dmsg1(800, "filter_state %d\n", state);
@@ -980,8 +977,7 @@ void OutputFormatter::JsonFinalizeResult(bool result)
 
       range_obj = json_object();
 
-      of_filter_tuple* tuple = nullptr;
-      foreach_alist (tuple, filters) {
+      for (of_filter_tuple* tuple : *filters) {
         if (tuple->type == OF_FILTER_LIMIT) {
           json_object_set_new(range_obj, "limit",
                               json_integer(tuple->u.limit_filter.limit));

--- a/core/src/lib/output_formatter_resource.cc
+++ b/core/src/lib/output_formatter_resource.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -86,10 +86,8 @@ void OutputFormatterResource::ResourceStart(const char* resource_type_groupname,
                                             bool as_comment)
 {
   const bool case_sensitive_name = true;
-  /*
-   * Use resource_type_groupname as structure key (JSON),
-   * but use resource_type_name when writing config resources.
-   */
+  /* Use resource_type_groupname as structure key (JSON),
+   * but use resource_type_name when writing config resources. */
   std::string format = std::string(resource_type_name) + std::string(" {\n");
   send_->ObjectStart(resource_type_groupname,
                      GetKeyFormatString(as_comment, format).c_str());
@@ -205,7 +203,6 @@ void OutputFormatterResource::KeyMultipleStringsInOneLine(
 {
   // Each member of the list is comma-separated
   int cnt = 0;
-  const char* item = nullptr;
   std::string format = "%s";
   if (quoted_strings) { format = "\"%s\""; }
 
@@ -261,7 +258,6 @@ void OutputFormatterResource::KeyMultipleStringsOnePerLine(
     bool escape_strings)
 {
   // One line for each member of the list
-  const char* item = nullptr;
 
   if ((list == NULL) or (list->empty())) {
     if (as_comment) {

--- a/core/src/lib/output_formatter_resource.cc
+++ b/core/src/lib/output_formatter_resource.cc
@@ -208,7 +208,7 @@ void OutputFormatterResource::KeyMultipleStringsInOneLine(
 
   send_->ArrayStart(key, GetKeyFormatString(as_comment).c_str());
   if (list != NULL) {
-    foreach_alist (item, list) {
+    for (auto* item : *list) {
       send_->ArrayItem(GetValue(item), format.c_str());
       if (cnt == 0) { format.insert(0, ", "); }
       cnt++;
@@ -267,7 +267,7 @@ void OutputFormatterResource::KeyMultipleStringsOnePerLine(
     }
   } else {
     send_->ArrayStart(key);
-    foreach_alist (item, list) {
+    for (auto* item : *list) {
       KeyMultipleStringsOnePerLineAddItem(key, GetValue(item), as_comment,
                                           quoted_strings, escape_strings);
     }

--- a/core/src/lib/output_formatter_resource.cc
+++ b/core/src/lib/output_formatter_resource.cc
@@ -207,12 +207,10 @@ void OutputFormatterResource::KeyMultipleStringsInOneLine(
   if (quoted_strings) { format = "\"%s\""; }
 
   send_->ArrayStart(key, GetKeyFormatString(as_comment).c_str());
-  if (list != NULL) {
-    for (auto* item : *list) {
-      send_->ArrayItem(GetValue(item), format.c_str());
-      if (cnt == 0) { format.insert(0, ", "); }
-      cnt++;
-    }
+  for (auto* item : list) {
+    send_->ArrayItem(GetValue(item), format.c_str());
+    if (cnt == 0) { format.insert(0, ", "); }
+    cnt++;
   }
   send_->ArrayEnd(key, "\n");
 }
@@ -267,7 +265,7 @@ void OutputFormatterResource::KeyMultipleStringsOnePerLine(
     }
   } else {
     send_->ArrayStart(key);
-    for (auto* item : *list) {
+    for (auto* item : list) {
       KeyMultipleStringsOnePerLineAddItem(key, GetValue(item), as_comment,
                                           quoted_strings, escape_strings);
     }

--- a/core/src/lib/plugins.cc
+++ b/core/src/lib/plugins.cc
@@ -216,10 +216,9 @@ bool LoadPlugins(void* bareos_plugin_interface_version,
   /* See if we are loading certain plugins only or all plugins of a certain
    * type. */
   if (plugin_names && plugin_names->size()) {
-    const char* name = nullptr;
     PoolMem plugin_name(PM_FNAME);
 
-    foreach_alist (name, plugin_names) {
+    for (const char* name : *plugin_names) {
       // Generate the plugin name e.g. <name>-<daemon>.so
       Mmsg(plugin_name, "%s%s", name, type);
 
@@ -414,12 +413,11 @@ void DbgPrintPluginAddHook(dbg_print_plugin_hook_t* fct)
 
 void DumpPlugins(alist<Plugin*>* plugin_list, FILE* fp)
 {
-  Plugin* plugin{};
   fprintf(fp, "Attempt to dump plugins. Hook count=%d\n",
           dbg_plugin_hook_count);
 
   if (!plugin_list) { return; }
-  foreach_alist (plugin, plugin_list) {
+  for (auto* plugin : *plugin_list) {
     for (int i = 0; i < dbg_plugin_hook_count; i++) {
       fprintf(fp, "Plugin %p name=\"%s\"\n", plugin, plugin->file);
     }

--- a/core/src/lib/plugins.cc
+++ b/core/src/lib/plugins.cc
@@ -218,7 +218,7 @@ bool LoadPlugins(void* bareos_plugin_interface_version,
   if (plugin_names && plugin_names->size()) {
     PoolMem plugin_name(PM_FNAME);
 
-    for (const char* name : *plugin_names) {
+    for (const char* name : plugin_names) {
       // Generate the plugin name e.g. <name>-<daemon>.so
       Mmsg(plugin_name, "%s%s", name, type);
 
@@ -416,8 +416,7 @@ void DumpPlugins(alist<Plugin*>* plugin_list, FILE* fp)
   fprintf(fp, "Attempt to dump plugins. Hook count=%d\n",
           dbg_plugin_hook_count);
 
-  if (!plugin_list) { return; }
-  for (auto* plugin : *plugin_list) {
+  for (auto* plugin : plugin_list) {
     for (int i = 0; i < dbg_plugin_hook_count; i++) {
       fprintf(fp, "Plugin %p name=\"%s\"\n", plugin, plugin->file);
     }

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -62,7 +62,6 @@ static bool ScriptDirAllowed(JobControlRecord*,
                              RunScript* script,
                              alist<const char*>* allowed_script_dirs)
 {
-  const char* allowed_script_dir = nullptr;
   bool allowed = false;
   PoolMem script_dir(PM_FNAME);
 
@@ -105,7 +104,11 @@ int RunScripts(JobControlRecord* jcr,
                const char* label,
                alist<const char*>* allowed_script_dirs)
 {
-  RunScript* script = nullptr;
+  std::vector<std::string> names;
+
+  foreach_alist (script, runscripts) { names.push_back(script->command); }
+
+
   bool runit;
   int when;
 
@@ -284,7 +287,6 @@ void FreeRunscripts(alist<RunScript*>* runscripts)
 {
   Dmsg0(500, "runscript: freeing all RUNSCRIPTS object\n");
 
-  RunScript* r = nullptr;
   foreach_alist (r, runscripts) { FreeRunscript(r); }
 }
 

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -85,7 +85,7 @@ static bool ScriptDirAllowed(JobControlRecord*,
 
   /* Match the path the script is in against the list of allowed script
    * directories. */
-  foreach_alist (allowed_script_dir, allowed_script_dirs) {
+  for (auto* allowed_script_dir : *allowed_script_dirs) {
     if (Bstrcasecmp(script_dir.c_str(), allowed_script_dir)) {
       allowed = true;
       break;
@@ -106,7 +106,7 @@ int RunScripts(JobControlRecord* jcr,
 {
   std::vector<std::string> names;
 
-  foreach_alist (script, runscripts) { names.push_back(script->command); }
+  for (auto* script : *runscripts) { names.push_back(script->command); }
 
 
   bool runit;
@@ -128,7 +128,7 @@ int RunScripts(JobControlRecord* jcr,
     return 0;
   }
 
-  foreach_alist (script, runscripts) {
+  for (auto* script : *runscripts) {
     Dmsg5(200,
           "runscript: try to run (Target=%s, OnSuccess=%i, OnFailure=%i, "
           "CurrentJobStatus=%c, command=%s)\n",
@@ -287,7 +287,7 @@ void FreeRunscripts(alist<RunScript*>* runscripts)
 {
   Dmsg0(500, "runscript: freeing all RUNSCRIPTS object\n");
 
-  foreach_alist (r, runscripts) { FreeRunscript(r); }
+  for (auto* r : *runscripts) { FreeRunscript(r); }
 }
 
 void RunScript::Debug() const

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -104,11 +104,6 @@ int RunScripts(JobControlRecord* jcr,
                const char* label,
                alist<const char*>* allowed_script_dirs)
 {
-  std::vector<std::string> names;
-
-  for (auto* script : *runscripts) { names.push_back(script->command); }
-
-
   bool runit;
   int when;
 
@@ -123,7 +118,7 @@ int RunScripts(JobControlRecord* jcr,
     when = SCRIPT_After;
   }
 
-  if (runscripts == NULL) {
+  if (!runscripts) {
     Dmsg0(100, "runscript: WARNING RUNSCRIPTS list is NULL\n");
     return 0;
   }
@@ -287,7 +282,9 @@ void FreeRunscripts(alist<RunScript*>* runscripts)
 {
   Dmsg0(500, "runscript: freeing all RUNSCRIPTS object\n");
 
-  for (auto* r : *runscripts) { FreeRunscript(r); }
+  if (runscripts) {
+    for (auto* r : *runscripts) { FreeRunscript(r); }
+  }
 }
 
 void RunScript::Debug() const

--- a/core/src/lib/runscript.cc
+++ b/core/src/lib/runscript.cc
@@ -85,7 +85,7 @@ static bool ScriptDirAllowed(JobControlRecord*,
 
   /* Match the path the script is in against the list of allowed script
    * directories. */
-  for (auto* allowed_script_dir : *allowed_script_dirs) {
+  for (auto* allowed_script_dir : allowed_script_dirs) {
     if (Bstrcasecmp(script_dir.c_str(), allowed_script_dir)) {
       allowed = true;
       break;
@@ -123,7 +123,7 @@ int RunScripts(JobControlRecord* jcr,
     return 0;
   }
 
-  for (auto* script : *runscripts) {
+  for (auto* script : runscripts) {
     Dmsg5(200,
           "runscript: try to run (Target=%s, OnSuccess=%i, OnFailure=%i, "
           "CurrentJobStatus=%c, command=%s)\n",
@@ -282,9 +282,7 @@ void FreeRunscripts(alist<RunScript*>* runscripts)
 {
   Dmsg0(500, "runscript: freeing all RUNSCRIPTS object\n");
 
-  if (runscripts) {
-    for (auto* r : *runscripts) { FreeRunscript(r); }
-  }
+  for (auto* r : runscripts) { FreeRunscript(r); }
 }
 
 void RunScript::Debug() const

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -65,8 +65,6 @@ bool InitAutochangers()
 
   // Ensure that the media_type for each device is the same
   foreach_res (changer, R_AUTOCHANGER) {
-    DeviceResource* device_resource = nullptr;
-
     logical_drive_number = 0;
     foreach_alist (device_resource, changer->device_resources) {
       /* If the device does not have a changer name or changer command
@@ -504,7 +502,6 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
   Device* dev_save;
   bool found = false;
   AutochangerResource* changer = dcr->dev->device_resource->changer_res;
-  DeviceResource* device_resource = nullptr;
   int retries = 0; /* wait for device retries */
 
   if (!changer) { return false; }

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -66,33 +66,35 @@ bool InitAutochangers()
   // Ensure that the media_type for each device is the same
   foreach_res (changer, R_AUTOCHANGER) {
     logical_drive_number = 0;
-    for (auto* device_resource : *changer->device_resources) {
-      /* If the device does not have a changer name or changer command
-       * defined, used the one from the Autochanger resource */
-      if (!device_resource->changer_name && changer->changer_name) {
-        device_resource->changer_name = strdup(changer->changer_name);
-      }
+    if (changer->device_resources) {
+      for (auto* device_resource : *changer->device_resources) {
+        /* If the device does not have a changer name or changer command
+         * defined, used the one from the Autochanger resource */
+        if (!device_resource->changer_name && changer->changer_name) {
+          device_resource->changer_name = strdup(changer->changer_name);
+        }
 
-      if (!device_resource->changer_command && changer->changer_command) {
-        device_resource->changer_command = strdup(changer->changer_command);
-      }
+        if (!device_resource->changer_command && changer->changer_command) {
+          device_resource->changer_command = strdup(changer->changer_command);
+        }
 
-      if (!device_resource->changer_name) {
-        Jmsg(NULL, M_ERROR, 0,
-             T_("No Changer Name given for device %s. Cannot continue.\n"),
-             device_resource->resource_name_);
-        OK = false;
-      }
+        if (!device_resource->changer_name) {
+          Jmsg(NULL, M_ERROR, 0,
+               T_("No Changer Name given for device %s. Cannot continue.\n"),
+               device_resource->resource_name_);
+          OK = false;
+        }
 
-      if (!device_resource->changer_command) {
-        Jmsg(NULL, M_ERROR, 0,
-             T_("No Changer Command given for device %s. Cannot continue.\n"),
-             device_resource->resource_name_);
-        OK = false;
-      }
+        if (!device_resource->changer_command) {
+          Jmsg(NULL, M_ERROR, 0,
+               T_("No Changer Command given for device %s. Cannot continue.\n"),
+               device_resource->resource_name_);
+          OK = false;
+        }
 
-      // Give the drive in the autochanger a logical drive number.
-      device_resource->drive = logical_drive_number++;
+        // Give the drive in the autochanger a logical drive number.
+        device_resource->drive = logical_drive_number++;
+      }
     }
   }
 

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -66,35 +66,33 @@ bool InitAutochangers()
   // Ensure that the media_type for each device is the same
   foreach_res (changer, R_AUTOCHANGER) {
     logical_drive_number = 0;
-    if (changer->device_resources) {
-      for (auto* device_resource : *changer->device_resources) {
-        /* If the device does not have a changer name or changer command
-         * defined, used the one from the Autochanger resource */
-        if (!device_resource->changer_name && changer->changer_name) {
-          device_resource->changer_name = strdup(changer->changer_name);
-        }
-
-        if (!device_resource->changer_command && changer->changer_command) {
-          device_resource->changer_command = strdup(changer->changer_command);
-        }
-
-        if (!device_resource->changer_name) {
-          Jmsg(NULL, M_ERROR, 0,
-               T_("No Changer Name given for device %s. Cannot continue.\n"),
-               device_resource->resource_name_);
-          OK = false;
-        }
-
-        if (!device_resource->changer_command) {
-          Jmsg(NULL, M_ERROR, 0,
-               T_("No Changer Command given for device %s. Cannot continue.\n"),
-               device_resource->resource_name_);
-          OK = false;
-        }
-
-        // Give the drive in the autochanger a logical drive number.
-        device_resource->drive = logical_drive_number++;
+    for (auto* device_resource : changer->device_resources) {
+      /* If the device does not have a changer name or changer command
+       * defined, used the one from the Autochanger resource */
+      if (!device_resource->changer_name && changer->changer_name) {
+        device_resource->changer_name = strdup(changer->changer_name);
       }
+
+      if (!device_resource->changer_command && changer->changer_command) {
+        device_resource->changer_command = strdup(changer->changer_command);
+      }
+
+      if (!device_resource->changer_name) {
+        Jmsg(NULL, M_ERROR, 0,
+             T_("No Changer Name given for device %s. Cannot continue.\n"),
+             device_resource->resource_name_);
+        OK = false;
+      }
+
+      if (!device_resource->changer_command) {
+        Jmsg(NULL, M_ERROR, 0,
+             T_("No Changer Command given for device %s. Cannot continue.\n"),
+             device_resource->resource_name_);
+        OK = false;
+      }
+
+      // Give the drive in the autochanger a logical drive number.
+      device_resource->drive = logical_drive_number++;
     }
   }
 
@@ -512,7 +510,7 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
   /* We look for the slot number corresponding to the tape
    * we want in other drives, and if possible, unload it. */
   Dmsg0(100, "Wiffle through devices looking for slot\n");
-  for (auto* device_resource : *changer->device_resources) {
+  for (auto* device_resource : changer->device_resources) {
     dev = device_resource->dev;
     if (!dev) { continue; }
     dev_save = dcr->dev;

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -66,7 +66,7 @@ bool InitAutochangers()
   // Ensure that the media_type for each device is the same
   foreach_res (changer, R_AUTOCHANGER) {
     logical_drive_number = 0;
-    foreach_alist (device_resource, changer->device_resources) {
+    for (auto* device_resource : *changer->device_resources) {
       /* If the device does not have a changer name or changer command
        * defined, used the one from the Autochanger resource */
       if (!device_resource->changer_name && changer->changer_name) {
@@ -510,7 +510,7 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
   /* We look for the slot number corresponding to the tape
    * we want in other drives, and if possible, unload it. */
   Dmsg0(100, "Wiffle through devices looking for slot\n");
-  foreach_alist (device_resource, changer->device_resources) {
+  for (auto* device_resource : *changer->device_resources) {
     dev = device_resource->dev;
     if (!dev) { continue; }
     dev_save = dcr->dev;

--- a/core/src/stored/autochanger_resource.cc
+++ b/core/src/stored/autochanger_resource.cc
@@ -56,7 +56,7 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   alist<DeviceResource*>* original_alist = device_resources;
   alist<DeviceResource*>* temp_alist
       = new alist<DeviceResource*>(original_alist->size(), not_owned_by_alist);
-  foreach_alist (device_resource, original_alist) {
+  for (auto* device_resource : *original_alist) {
     if (device_resource->multiplied_device_resource) {
       if (device_resource->multiplied_device_resource == device_resource) {
         DeviceResource* d = new DeviceResource(*device_resource);
@@ -71,7 +71,7 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   device_resources = temp_alist;
   BareosResource::PrintConfig(send, *my_config, hide_sensitive_data, verbose);
   device_resources = original_alist;
-  foreach_alist (device_resource, temp_alist) { delete device_resource; }
+  for (auto* device_resource : *temp_alist) { delete device_resource; }
   delete temp_alist;
   return true;
 }

--- a/core/src/stored/autochanger_resource.cc
+++ b/core/src/stored/autochanger_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -56,7 +56,6 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   alist<DeviceResource*>* original_alist = device_resources;
   alist<DeviceResource*>* temp_alist
       = new alist<DeviceResource*>(original_alist->size(), not_owned_by_alist);
-  DeviceResource* device_resource = nullptr;
   foreach_alist (device_resource, original_alist) {
     if (device_resource->multiplied_device_resource) {
       if (device_resource->multiplied_device_resource == device_resource) {
@@ -72,9 +71,7 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   device_resources = temp_alist;
   BareosResource::PrintConfig(send, *my_config, hide_sensitive_data, verbose);
   device_resources = original_alist;
-  foreach_alist (device_resource, temp_alist) {
-    delete device_resource;
-  }
+  foreach_alist (device_resource, temp_alist) { delete device_resource; }
   delete temp_alist;
   return true;
 }

--- a/core/src/stored/autochanger_resource.cc
+++ b/core/src/stored/autochanger_resource.cc
@@ -56,7 +56,7 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   alist<DeviceResource*>* original_alist = device_resources;
   alist<DeviceResource*>* temp_alist
       = new alist<DeviceResource*>(original_alist->size(), not_owned_by_alist);
-  for (auto* device_resource : *original_alist) {
+  for (auto* device_resource : original_alist) {
     if (device_resource->multiplied_device_resource) {
       if (device_resource->multiplied_device_resource == device_resource) {
         DeviceResource* d = new DeviceResource(*device_resource);
@@ -71,7 +71,7 @@ bool AutochangerResource::PrintConfig(OutputFormatterResource& send,
   device_resources = temp_alist;
   BareosResource::PrintConfig(send, *my_config, hide_sensitive_data, verbose);
   device_resources = original_alist;
-  for (auto* device_resource : *temp_alist) { delete device_resource; }
+  for (auto* device_resource : temp_alist) { delete device_resource; }
   delete temp_alist;
   return true;
 }

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -181,7 +181,7 @@ void ChunkedDevice::StopThreads()
 
   // Wait for all threads to exit.
   if (thread_ids_) {
-    foreach_alist (handle, thread_ids_) {
+    for (auto* handle : *thread_ids_) {
       switch (handle->type) {
         case WAIT_CANCEL_THREAD:
           Dmsg1(100, "Canceling thread with threadid=%s\n",

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -181,7 +181,7 @@ void ChunkedDevice::StopThreads()
 
   // Wait for all threads to exit.
   if (thread_ids_) {
-    for (auto* handle : *thread_ids_) {
+    for (auto* handle : thread_ids_) {
       switch (handle->type) {
         case WAIT_CANCEL_THREAD:
           Dmsg1(100, "Canceling thread with threadid=%s\n",

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -174,7 +174,6 @@ bool ChunkedDevice::StartIoThreads()
 void ChunkedDevice::StopThreads()
 {
   char ed1[50];
-  thread_handle* handle = nullptr;
 
   /* Tell all IO threads that we flush the circular buffer.
    * As such they will get a NULL chunk_io_request back and exit. */

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -273,8 +273,6 @@ int main(int argc, char* argv[])
 // Cleanup of delayed restore stack with streams for later processing.
 static inline void DropDelayedDataStreams()
 {
-  DelayedDataStream* dds = nullptr;
-
   if (!delayed_streams || delayed_streams->empty()) { return; }
 
   foreach_alist (dds, delayed_streams) { free(dds->content); }
@@ -311,8 +309,6 @@ static inline void PushDelayedDataStream(int stream,
  */
 static inline void PopDelayedDataStreams()
 {
-  DelayedDataStream* dds = nullptr;
-
   // See if there is anything todo.
   if (!delayed_streams || delayed_streams->empty()) { return; }
 

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -275,7 +275,7 @@ static inline void DropDelayedDataStreams()
 {
   if (!delayed_streams || delayed_streams->empty()) { return; }
 
-  foreach_alist (dds, delayed_streams) { free(dds->content); }
+  for (auto* dds : *delayed_streams) { free(dds->content); }
 
   delayed_streams->destroy();
 }
@@ -321,7 +321,7 @@ static inline void PopDelayedDataStreams()
    * processing for the following type of streams:
    * - *_ACL_*
    * - *_XATTR_* */
-  foreach_alist (dds, delayed_streams) {
+  for (auto* dds : *delayed_streams) {
     switch (dds->stream) {
       case STREAM_UNIX_ACCESS_ACL:
       case STREAM_UNIX_DEFAULT_ACL:

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -275,7 +275,7 @@ static inline void DropDelayedDataStreams()
 {
   if (!delayed_streams || delayed_streams->empty()) { return; }
 
-  for (auto* dds : *delayed_streams) { free(dds->content); }
+  for (auto* dds : delayed_streams) { free(dds->content); }
 
   delayed_streams->destroy();
 }
@@ -321,7 +321,7 @@ static inline void PopDelayedDataStreams()
    * processing for the following type of streams:
    * - *_ACL_*
    * - *_XATTR_* */
-  for (auto* dds : *delayed_streams) {
+  for (auto* dds : delayed_streams) {
     switch (dds->stream) {
       case STREAM_UNIX_ACCESS_ACL:
       case STREAM_UNIX_DEFAULT_ACL:

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -866,7 +866,7 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
       if (bstrcmp(devname.c_str(), changer->resource_name_)) {
         // Try each device in this AutoChanger
         if (changer->device_resources) {
-          for (auto* device_resource : *changer->device_resources) {
+          for (auto* device_resource : changer->device_resources) {
             Dmsg1(100, "Try changer device %s\n",
                   device_resource->resource_name_);
             if (!device_resource->dev) {

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -865,7 +865,7 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
       // Find resource, and make sure we were able to open it
       if (bstrcmp(devname.c_str(), changer->resource_name_)) {
         // Try each device in this AutoChanger
-        foreach_alist (device_resource, changer->device_resources) {
+        for (auto* device_resource : *changer->device_resources) {
           Dmsg1(100, "Try changer device %s\n",
                 device_resource->resource_name_);
           if (!device_resource->dev) {

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -892,13 +892,11 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
             }
             Dmsg3(100, "Device %s drive wrong: want=%hd got=%hd skipping\n",
                   devname.c_str(), drive, device_resource->dev->drive);
-
-            if (changer->device_resources->current()
-                == changer->device_resources->size()) {
-              Jmsg(jcr, M_ERROR, 0,
-                   T_("Drive number \"%d\" for device \"%s\" not found.\n"),
-                   drive, devname.c_str());
-            }
+          }
+          if (!target_device) {
+            Jmsg(jcr, M_ERROR, 0,
+                 T_("Drive number \"%d\" for device \"%s\" not found.\n"),
+                 drive, devname.c_str());
           }
         }
         break; /* we found it but could not open a device */

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -865,37 +865,40 @@ static DeviceControlRecord* FindDevice(JobControlRecord* jcr,
       // Find resource, and make sure we were able to open it
       if (bstrcmp(devname.c_str(), changer->resource_name_)) {
         // Try each device in this AutoChanger
-        for (auto* device_resource : *changer->device_resources) {
-          Dmsg1(100, "Try changer device %s\n",
-                device_resource->resource_name_);
-          if (!device_resource->dev) {
-            device_resource->dev = FactoryCreateDevice(jcr, device_resource);
-          }
-          if (!device_resource->dev) {
-            Dmsg1(100, "Device %s could not be opened. Skipped\n",
-                  devname.c_str());
-            Jmsg(jcr, M_WARNING, 0,
-                 T_("\n"
-                    "     Device \"%s\" in changer \"%s\" requested by DIR "
-                    "could not be opened or does not exist.\n"),
-                 device_resource->resource_name_, devname.c_str());
-            continue;
-          }
-          if ((drive == kInvalidDriveNumber && device_resource->dev->autoselect)
-              || drive == device_resource->dev->drive) {
-            Dmsg1(20, "Found changer device %s\n",
+        if (changer->device_resources) {
+          for (auto* device_resource : *changer->device_resources) {
+            Dmsg1(100, "Try changer device %s\n",
                   device_resource->resource_name_);
-            target_device = device_resource;
-            break;
-          }
-          Dmsg3(100, "Device %s drive wrong: want=%hd got=%hd skipping\n",
-                devname.c_str(), drive, device_resource->dev->drive);
+            if (!device_resource->dev) {
+              device_resource->dev = FactoryCreateDevice(jcr, device_resource);
+            }
+            if (!device_resource->dev) {
+              Dmsg1(100, "Device %s could not be opened. Skipped\n",
+                    devname.c_str());
+              Jmsg(jcr, M_WARNING, 0,
+                   T_("\n"
+                      "     Device \"%s\" in changer \"%s\" requested by DIR "
+                      "could not be opened or does not exist.\n"),
+                   device_resource->resource_name_, devname.c_str());
+              continue;
+            }
+            if ((drive == kInvalidDriveNumber
+                 && device_resource->dev->autoselect)
+                || drive == device_resource->dev->drive) {
+              Dmsg1(20, "Found changer device %s\n",
+                    device_resource->resource_name_);
+              target_device = device_resource;
+              break;
+            }
+            Dmsg3(100, "Device %s drive wrong: want=%hd got=%hd skipping\n",
+                  devname.c_str(), drive, device_resource->dev->drive);
 
-          if (changer->device_resources->current()
-              == changer->device_resources->size()) {
-            Jmsg(jcr, M_ERROR, 0,
-                 T_("Drive number \"%d\" for device \"%s\" not found.\n"),
-                 drive, devname.c_str());
+            if (changer->device_resources->current()
+                == changer->device_resources->size()) {
+              Jmsg(jcr, M_ERROR, 0,
+                   T_("Drive number \"%d\" for device \"%s\" not found.\n"),
+                   drive, devname.c_str());
+            }
           }
         }
         break; /* we found it but could not open a device */

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -440,7 +440,6 @@ void StoredFreeJcr(JobControlRecord* jcr)
   if (jcr->sd_impl->plugin_options) { delete jcr->sd_impl->plugin_options; }
 
   if (jcr->sd_impl->read_store) {
-    DirectorStorage* store = nullptr;
     foreach_alist (store, jcr->sd_impl->read_store) {
       delete store->device;
       delete store;
@@ -450,7 +449,6 @@ void StoredFreeJcr(JobControlRecord* jcr)
   }
 
   if (jcr->sd_impl->write_store) {
-    DirectorStorage* store = nullptr;
     foreach_alist (store, jcr->sd_impl->write_store) {
       delete store->device;
       delete store;

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -440,7 +440,7 @@ void StoredFreeJcr(JobControlRecord* jcr)
   if (jcr->sd_impl->plugin_options) { delete jcr->sd_impl->plugin_options; }
 
   if (jcr->sd_impl->read_store) {
-    foreach_alist (store, jcr->sd_impl->read_store) {
+    for (auto* store : *jcr->sd_impl->read_store) {
       delete store->device;
       delete store;
     }
@@ -449,7 +449,7 @@ void StoredFreeJcr(JobControlRecord* jcr)
   }
 
   if (jcr->sd_impl->write_store) {
-    foreach_alist (store, jcr->sd_impl->write_store) {
+    for (auto* store : *jcr->sd_impl->write_store) {
       delete store->device;
       delete store;
     }

--- a/core/src/stored/job.cc
+++ b/core/src/stored/job.cc
@@ -440,7 +440,7 @@ void StoredFreeJcr(JobControlRecord* jcr)
   if (jcr->sd_impl->plugin_options) { delete jcr->sd_impl->plugin_options; }
 
   if (jcr->sd_impl->read_store) {
-    for (auto* store : *jcr->sd_impl->read_store) {
+    for (auto* store : jcr->sd_impl->read_store) {
       delete store->device;
       delete store;
     }
@@ -449,7 +449,7 @@ void StoredFreeJcr(JobControlRecord* jcr)
   }
 
   if (jcr->sd_impl->write_store) {
-    for (auto* store : *jcr->sd_impl->write_store) {
+    for (auto* store : jcr->sd_impl->write_store) {
       delete store->device;
       delete store;
     }

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -427,47 +427,51 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
       if (!dcr->DirGetVolumeInfo(GET_VOL_INFO_FOR_WRITE)) { continue; }
 
       Dmsg1(debuglevel, "vol=%s OK for this job\n", vol->vol_name);
-      for (auto* store : *dirstore) {
-        int status;
-        rctx.store = store;
-        for (auto* device_name : *store->device) {
-          // Found a device, try to use it
-          rctx.device_name = device_name;
-          rctx.device_resource = vol->dev->device_resource;
+      if (dirstore) {
+        for (auto* store : *dirstore) {
+          int status;
+          rctx.store = store;
+          if (store->device) {
+            for (auto* device_name : *store->device) {
+              // Found a device, try to use it
+              rctx.device_name = device_name;
+              rctx.device_resource = vol->dev->device_resource;
 
-          if (vol->dev->AttachedToAutochanger()) {
-            Dmsg1(debuglevel, "vol=%s is in changer\n", vol->vol_name);
-            if (!IsVolInAutochanger(rctx, vol) || !vol->dev->autoselect) {
-              continue;
+              if (vol->dev->AttachedToAutochanger()) {
+                Dmsg1(debuglevel, "vol=%s is in changer\n", vol->vol_name);
+                if (!IsVolInAutochanger(rctx, vol) || !vol->dev->autoselect) {
+                  continue;
+                }
+              } else if (!bstrcmp(device_name,
+                                  vol->dev->device_resource->resource_name_)) {
+                Dmsg2(debuglevel, "device=%s not suitable want %s\n",
+                      vol->dev->device_resource->resource_name_, device_name);
+                continue;
+              }
+
+              bstrncpy(rctx.VolumeName, vol->vol_name, sizeof(rctx.VolumeName));
+              rctx.have_volume = true;
+
+              // Try reserving this device and volume
+              Dmsg2(debuglevel, "try vol=%s on device=%s\n", rctx.VolumeName,
+                    device_name);
+              status = ReserveDevice(rctx);
+              if (status == 1) { /* found available device */
+                Dmsg1(debuglevel, "Suitable device found=%s\n", device_name);
+                ok = true;
+                break;
+              } else if (status == 0) { /* device busy */
+                Dmsg1(debuglevel, "Suitable device=%s, busy: not use\n",
+                      device_name);
+              } else {
+                Dmsg0(debuglevel, "No suitable device found.\n");
+              }
+              rctx.have_volume = false;
+              rctx.VolumeName[0] = 0;
             }
-          } else if (!bstrcmp(device_name,
-                              vol->dev->device_resource->resource_name_)) {
-            Dmsg2(debuglevel, "device=%s not suitable want %s\n",
-                  vol->dev->device_resource->resource_name_, device_name);
-            continue;
           }
-
-          bstrncpy(rctx.VolumeName, vol->vol_name, sizeof(rctx.VolumeName));
-          rctx.have_volume = true;
-
-          // Try reserving this device and volume
-          Dmsg2(debuglevel, "try vol=%s on device=%s\n", rctx.VolumeName,
-                device_name);
-          status = ReserveDevice(rctx);
-          if (status == 1) { /* found available device */
-            Dmsg1(debuglevel, "Suitable device found=%s\n", device_name);
-            ok = true;
-            break;
-          } else if (status == 0) { /* device busy */
-            Dmsg1(debuglevel, "Suitable device=%s, busy: not use\n",
-                  device_name);
-          } else {
-            Dmsg0(debuglevel, "No suitable device found.\n");
-          }
-          rctx.have_volume = false;
-          rctx.VolumeName[0] = 0;
+          if (ok) { break; }
         }
-        if (ok) { break; }
       }
       if (ok) { break; }
     } /* end for loop over reserved volumes */
@@ -490,23 +494,28 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
    *
    * For each storage device that the user specified, we
    * search and see if there is a resource for that device. */
-  for (auto* store : *dirstore) {
-    rctx.store = store;
-    for (auto* device_name : *store->device) {
-      int status;
-      rctx.device_name = device_name;
-      status = SearchResForDevice(rctx);
-      if (status == 1) { /* found available device */
-        Dmsg1(debuglevel, "available device found=%s\n", device_name);
-        ok = true;
-        break;
-      } else if (status == 0) { /* device busy */
-        Dmsg1(debuglevel, "No usable device=%s, busy: not use\n", device_name);
-      } else {
-        Dmsg0(debuglevel, "No usable device found.\n");
+  if (dirstore) {
+    for (auto* store : *dirstore) {
+      rctx.store = store;
+      if (store->device) {
+        for (auto* device_name : *store->device) {
+          int status;
+          rctx.device_name = device_name;
+          status = SearchResForDevice(rctx);
+          if (status == 1) { /* found available device */
+            Dmsg1(debuglevel, "available device found=%s\n", device_name);
+            ok = true;
+            break;
+          } else if (status == 0) { /* device busy */
+            Dmsg1(debuglevel, "No usable device=%s, busy: not use\n",
+                  device_name);
+          } else {
+            Dmsg0(debuglevel, "No usable device found.\n");
+          }
+        }
       }
+      if (ok) { break; }
     }
-    if (ok) { break; }
   }
   if (ok) {
     Dmsg1(debuglevel, "OK dev found. Vol=%s\n", rctx.VolumeName);
@@ -532,32 +541,34 @@ int SearchResForDevice(ReserveContext& rctx)
     // Find resource, and make sure we were able to open it
     if (bstrcmp(rctx.device_name, changer->resource_name_)) {
       // Try each device_resource in this AutoChanger
-      for (auto* device_resource : *changer->device_resources) {
-        Dmsg1(debuglevel, "Try changer device %s\n",
-              device_resource->resource_name_);
-        if (!device_resource->autoselect) {
-          Dmsg1(100, "Device %s not autoselect skipped.\n",
+      if (changer->device_resources) {
+        for (auto* device_resource : *changer->device_resources) {
+          rctx.device_resource = device_resource;
+          Dmsg1(debuglevel, "Try changer device %s\n",
                 device_resource->resource_name_);
-          continue; /* Device is not available */
-        }
-        status = ReserveDevice(rctx);
-        if (status != 1) { /* Try another device */
-          continue;
-        }
+          if (!device_resource->autoselect) {
+            Dmsg1(100, "Device %s not autoselect skipped.\n",
+                  device_resource->resource_name_);
+            continue; /* Device is not available */
+          }
+          status = ReserveDevice(rctx);
+          if (status != 1) { /* Try another device */
+            continue;
+          }
 
-        // Debug code
-        if (rctx.store->append == SD_APPEND) {
-          Dmsg2(debuglevel, "Device %s reserved=%d for append.\n",
-                device_resource->resource_name_,
-                rctx.jcr->sd_impl->dcr->dev->NumReserved());
-        } else {
-          Dmsg2(debuglevel, "Device %s reserved=%d for read.\n",
-                device_resource->resource_name_,
-                rctx.jcr->sd_impl->read_dcr->dev->NumReserved());
-        }
+          // Debug code
+          if (rctx.store->append == SD_APPEND) {
+            Dmsg2(debuglevel, "Device %s reserved=%d for append.\n",
+                  device_resource->resource_name_,
+                  rctx.jcr->sd_impl->dcr->dev->NumReserved());
+          } else {
+            Dmsg2(debuglevel, "Device %s reserved=%d for read.\n",
+                  device_resource->resource_name_,
+                  rctx.jcr->sd_impl->read_dcr->dev->NumReserved());
+          }
 
-        rctx.device_resource = device_resource;
-        return status;
+          return status;
+        }
       }
     }
   }

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -391,8 +391,6 @@ static bool IsVolInAutochanger(ReserveContext& rctx, VolumeReservationItem* vol)
 bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
 {
   bool ok = false;
-  DirectorStorage* store = nullptr;
-  const char* device_name = nullptr;
   alist<DirectorStorage*>* dirstore;
   DeviceControlRecord* dcr = jcr->sd_impl->dcr;
 
@@ -534,12 +532,12 @@ int SearchResForDevice(ReserveContext& rctx)
     // Find resource, and make sure we were able to open it
     if (bstrcmp(rctx.device_name, changer->resource_name_)) {
       // Try each device_resource in this AutoChanger
-      foreach_alist (rctx.device_resource, changer->device_resources) {
+      foreach_alist (device_resource, changer->device_resources) {
         Dmsg1(debuglevel, "Try changer device %s\n",
-              rctx.device_resource->resource_name_);
-        if (!rctx.device_resource->autoselect) {
+              device_resource->resource_name_);
+        if (!device_resource->autoselect) {
           Dmsg1(100, "Device %s not autoselect skipped.\n",
-                rctx.device_resource->resource_name_);
+                device_resource->resource_name_);
           continue; /* Device is not available */
         }
         status = ReserveDevice(rctx);
@@ -550,13 +548,15 @@ int SearchResForDevice(ReserveContext& rctx)
         // Debug code
         if (rctx.store->append == SD_APPEND) {
           Dmsg2(debuglevel, "Device %s reserved=%d for append.\n",
-                rctx.device_resource->resource_name_,
+                device_resource->resource_name_,
                 rctx.jcr->sd_impl->dcr->dev->NumReserved());
         } else {
           Dmsg2(debuglevel, "Device %s reserved=%d for read.\n",
-                rctx.device_resource->resource_name_,
+                device_resource->resource_name_,
                 rctx.jcr->sd_impl->read_dcr->dev->NumReserved());
         }
+
+        rctx.device_resource = device_resource;
         return status;
       }
     }

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -427,10 +427,10 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
       if (!dcr->DirGetVolumeInfo(GET_VOL_INFO_FOR_WRITE)) { continue; }
 
       Dmsg1(debuglevel, "vol=%s OK for this job\n", vol->vol_name);
-      foreach_alist (store, dirstore) {
+      for (auto* store : *dirstore) {
         int status;
         rctx.store = store;
-        foreach_alist (device_name, store->device) {
+        for (auto* device_name : *store->device) {
           // Found a device, try to use it
           rctx.device_name = device_name;
           rctx.device_resource = vol->dev->device_resource;
@@ -490,9 +490,9 @@ bool FindSuitableDeviceForJob(JobControlRecord* jcr, ReserveContext& rctx)
    *
    * For each storage device that the user specified, we
    * search and see if there is a resource for that device. */
-  foreach_alist (store, dirstore) {
+  for (auto* store : *dirstore) {
     rctx.store = store;
-    foreach_alist (device_name, store->device) {
+    for (auto* device_name : *store->device) {
       int status;
       rctx.device_name = device_name;
       status = SearchResForDevice(rctx);
@@ -532,7 +532,7 @@ int SearchResForDevice(ReserveContext& rctx)
     // Find resource, and make sure we were able to open it
     if (bstrcmp(rctx.device_name, changer->resource_name_)) {
       // Try each device_resource in this AutoChanger
-      foreach_alist (device_resource, changer->device_resources) {
+      for (auto* device_resource : *changer->device_resources) {
         Dmsg1(debuglevel, "Try changer device %s\n",
               device_resource->resource_name_);
         if (!device_resource->autoselect) {

--- a/core/src/stored/sd_plugins.cc
+++ b/core/src/stored/sd_plugins.cc
@@ -560,7 +560,7 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
        * instance. */
       if (jcr->plugin_ctx_list) {
         PluginContext* found_ctx = nullptr;
-        foreach_alist (ctx, jcr->plugin_ctx_list) {
+        for (auto* ctx : *jcr->plugin_ctx_list) {
           if (ctx->instance == instance && ctx->plugin->file_len == len
               && bstrncasecmp(ctx->plugin->file, plugin_name, len)) {
             found_ctx = ctx;
@@ -621,7 +621,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance dir-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  foreach_alist (ctx, jcr->plugin_ctx_list) {
+  for (auto* ctx : *jcr->plugin_ctx_list) {
     // Free the plugin instance
     SdplugFunc(ctx->plugin)->freePlugin(ctx);
     free(ctx->core_private_context); /* Free BAREOS private context */
@@ -842,7 +842,7 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
   cnt = 0;
   foreach_jcr (njcr) {
     if (jcr->plugin_ctx_list) {
-      foreach_alist (nctx, jcr->plugin_ctx_list) {
+      for (auto* nctx : *jcr->plugin_ctx_list) {
         if (nctx->plugin == bctx->plugin) { cnt++; }
       }
     }

--- a/core/src/stored/sd_plugins.cc
+++ b/core/src/stored/sd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -505,7 +505,6 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
 {
   int i, j, len;
   Plugin* plugin;
-  PluginContext* ctx = nullptr;
   uint32_t instance;
   bSdEvent event;
   bSdEventType eventType;
@@ -560,26 +559,28 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
       /* See if this plugin options are for an already instantiated plugin
        * instance. */
       if (jcr->plugin_ctx_list) {
+        PluginContext* found_ctx = nullptr;
         foreach_alist (ctx, jcr->plugin_ctx_list) {
           if (ctx->instance == instance && ctx->plugin->file_len == len
               && bstrncasecmp(ctx->plugin->file, plugin_name, len)) {
+            found_ctx = ctx;
             break;
           }
         }
 
         // Found a context in the previous loop ?
-        if (!ctx) {
+        if (!found_ctx) {
           foreach_alist_index (j, plugin, sd_plugin_list) {
             if (plugin->file_len == len
                 && bstrncasecmp(plugin->file, plugin_name, len)) {
-              ctx = instantiate_plugin(jcr, plugin, instance);
+              found_ctx = instantiate_plugin(jcr, plugin, instance);
               break;
             }
           }
         }
 
-        if (ctx) {
-          trigger_plugin_event(jcr, eventType, &event, ctx,
+        if (found_ctx) {
+          trigger_plugin_event(jcr, eventType, &event, found_ctx,
                                (void*)plugin_options, NULL, NULL, NULL);
         }
       }
@@ -616,8 +617,6 @@ void NewPlugins(JobControlRecord* jcr)
 // Free the plugin instances for this Job
 void FreePlugins(JobControlRecord* jcr)
 {
-  PluginContext* ctx = nullptr;
-
   if (!sd_plugin_list || !jcr->plugin_ctx_list) { return; }
 
   Dmsg2(debuglevel, "Free instance dir-plugin_ctx_list=%p JobId=%d\n",
@@ -833,7 +832,6 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
 {
   int cnt;
   JobControlRecord *jcr, *njcr;
-  PluginContext* nctx;
   b_plugin_ctx* bctx;
   bRC retval = bRC_Error;
 

--- a/core/src/stored/sd_plugins.cc
+++ b/core/src/stored/sd_plugins.cc
@@ -560,7 +560,7 @@ void DispatchNewPluginOptions(JobControlRecord* jcr)
        * instance. */
       if (jcr->plugin_ctx_list) {
         PluginContext* found_ctx = nullptr;
-        for (auto* ctx : *jcr->plugin_ctx_list) {
+        for (auto* ctx : jcr->plugin_ctx_list) {
           if (ctx->instance == instance && ctx->plugin->file_len == len
               && bstrncasecmp(ctx->plugin->file, plugin_name, len)) {
             found_ctx = ctx;
@@ -621,7 +621,7 @@ void FreePlugins(JobControlRecord* jcr)
 
   Dmsg2(debuglevel, "Free instance dir-plugin_ctx_list=%p JobId=%d\n",
         jcr->plugin_ctx_list, jcr->JobId);
-  for (auto* ctx : *jcr->plugin_ctx_list) {
+  for (auto* ctx : jcr->plugin_ctx_list) {
     // Free the plugin instance
     SdplugFunc(ctx->plugin)->freePlugin(ctx);
     free(ctx->core_private_context); /* Free BAREOS private context */
@@ -841,10 +841,8 @@ static bRC bareosGetInstanceCount(PluginContext* ctx, int* ret)
 
   cnt = 0;
   foreach_jcr (njcr) {
-    if (jcr->plugin_ctx_list) {
-      for (auto* nctx : *jcr->plugin_ctx_list) {
-        if (nctx->plugin == bctx->plugin) { cnt++; }
-      }
+    for (auto* nctx : jcr->plugin_ctx_list) {
+      if (nctx->plugin == bctx->plugin) { cnt++; }
     }
   }
   endeach_jcr(njcr);

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -220,15 +220,13 @@ static void ListDevices(JobControlRecord* jcr,
                changer->resource_name_);
     sp->send(msg, len);
 
-    if (changer->device_resources) {
-      for (auto* device_resource : *changer->device_resources) {
-        if (device_resource->dev) {
-          len = Mmsg(msg, "   %s\n", device_resource->dev->print_name());
-          sp->send(msg, len);
-        } else {
-          len = Mmsg(msg, "   %s\n", device_resource->resource_name_);
-          sp->send(msg, len);
-        }
+    for (auto* device_resource : changer->device_resources) {
+      if (device_resource->dev) {
+        len = Mmsg(msg, "   %s\n", device_resource->dev->print_name());
+        sp->send(msg, len);
+      } else {
+        len = Mmsg(msg, "   %s\n", device_resource->resource_name_);
+        sp->send(msg, len);
       }
     }
   }

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -220,13 +220,15 @@ static void ListDevices(JobControlRecord* jcr,
                changer->resource_name_);
     sp->send(msg, len);
 
-    for (auto* device_resource : *changer->device_resources) {
-      if (device_resource->dev) {
-        len = Mmsg(msg, "   %s\n", device_resource->dev->print_name());
-        sp->send(msg, len);
-      } else {
-        len = Mmsg(msg, "   %s\n", device_resource->resource_name_);
-        sp->send(msg, len);
+    if (changer->device_resources) {
+      for (auto* device_resource : *changer->device_resources) {
+        if (device_resource->dev) {
+          len = Mmsg(msg, "   %s\n", device_resource->dev->print_name());
+          sp->send(msg, len);
+        } else {
+          len = Mmsg(msg, "   %s\n", device_resource->resource_name_);
+          sp->send(msg, len);
+        }
       }
     }
   }

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -220,7 +220,7 @@ static void ListDevices(JobControlRecord* jcr,
                changer->resource_name_);
     sp->send(msg, len);
 
-    foreach_alist (device_resource, changer->device_resources) {
+    for (auto* device_resource : *changer->device_resources) {
       if (device_resource->dev) {
         len = Mmsg(msg, "   %s\n", device_resource->dev->print_name());
         sp->send(msg, len);

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -200,7 +200,6 @@ static void ListDevices(JobControlRecord* jcr,
   int len;
   int bpb;
   Device* dev;
-  DeviceResource* device_resource = nullptr;
   AutochangerResource* changer;
   PoolMem msg(PM_MESSAGE);
   char b1[35], b2[35], b3[35];
@@ -232,6 +231,7 @@ static void ListDevices(JobControlRecord* jcr,
     }
   }
 
+  DeviceResource* device_resource = nullptr;
   foreach_res (device_resource, R_DEVICE) {
     if (devicenames && !NeedToListDevice(devicenames, device_resource)) {
       continue;

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -799,7 +799,9 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
         } else {
           p->device_resources = res_changer->device_resources;
 
-          for (auto* q : *p->device_resources) { q->changer_res = p; }
+          if (p->device_resources) {
+            for (auto* q : *p->device_resources) { q->changer_res = p; }
+          }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -799,7 +799,6 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
         } else {
           p->device_resources = res_changer->device_resources;
 
-          DeviceResource* q = nullptr;
           foreach_alist (q, p->device_resources) { q->changer_res = p; }
 
           int errstat;

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -799,9 +799,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
         } else {
           p->device_resources = res_changer->device_resources;
 
-          if (p->device_resources) {
-            for (auto* q : *p->device_resources) { q->changer_res = p; }
-          }
+          for (auto* q : p->device_resources) { q->changer_res = p; }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -799,7 +799,7 @@ static bool SaveResource(int type, ResourceItem* items, int pass)
         } else {
           p->device_resources = res_changer->device_resources;
 
-          foreach_alist (q, p->device_resources) { q->changer_res = p; }
+          for (auto* q : *p->device_resources) { q->changer_res = p; }
 
           int errstat;
           if ((errstat = RwlInit(&p->changer_lock, PRIO_SD_ACH_ACCESS)) != 0) {

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -71,7 +71,7 @@ void TestForeachAlist(alist<const char*>* list)
 
   // test all available foreach loops
 
-  foreach_alist (str, list) {
+  for (auto* str : *list) {
     sprintf(buf, "%d", i);
     EXPECT_STREQ(str, buf);
     i++;

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -71,8 +71,6 @@ void TestForeachAlist(alist<const char*>* list)
 
   // test all available foreach loops
 
-  ASSERT_TRUE(list);
-
   for (auto* str : list) {
     sprintf(buf, "%d", i);
     EXPECT_STREQ(str, buf);
@@ -113,11 +111,8 @@ void test_alist_dynamic()
   alist<const char*>* list = nullptr;
   char* buf;
 
-  // NULL->size() will segfault
-  // EXPECT_EQ(list->size(), 0);
-
-  // does foreach work for NULL? -> not anymore (macro has been removed)
-  // TestForeachAlist(list);
+  // does foreach work for empty lists?
+  TestForeachAlist(list);
 
   // create empty list, which is prepared for a number of entires
   list = new alist<const char*>(10);

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -66,7 +66,6 @@ void AlistFill(alist<const char*>* list, int max)
 // we expect, that the list is filled with strings of numbers from 0 to n.
 void TestForeachAlist(alist<const char*>* list)
 {
-  const char* str = NULL;
   char buf[30];
   int i = 0;
 
@@ -78,6 +77,7 @@ void TestForeachAlist(alist<const char*>* list)
     i++;
   }
 
+  const char* str;
   foreach_alist_index (i, str, list) {
     sprintf(buf, "%d", i);
     EXPECT_STREQ(str, buf);

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -71,6 +71,8 @@ void TestForeachAlist(alist<const char*>* list)
 
   // test all available foreach loops
 
+  ASSERT_TRUE(list);
+
   for (auto* str : *list) {
     sprintf(buf, "%d", i);
     EXPECT_STREQ(str, buf);
@@ -114,8 +116,8 @@ void test_alist_dynamic()
   // NULL->size() will segfault
   // EXPECT_EQ(list->size(), 0);
 
-  // does foreach work for NULL?
-  TestForeachAlist(list);
+  // does foreach work for NULL? -> not anymore (macro has been removed)
+  // TestForeachAlist(list);
 
   // create empty list, which is prepared for a number of entires
   list = new alist<const char*>(10);

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -73,7 +73,7 @@ void TestForeachAlist(alist<const char*>* list)
 
   ASSERT_TRUE(list);
 
-  for (auto* str : *list) {
+  for (auto* str : list) {
     sprintf(buf, "%d", i);
     EXPECT_STREQ(str, buf);
     i++;

--- a/core/src/tests/multiplied_device_test.cc
+++ b/core/src/tests/multiplied_device_test.cc
@@ -275,7 +275,7 @@ static uint32_t CheckSomeDevicesInAutochanger(ConfigurationParser& config)
 
   while ((p = config.GetNextRes(R_AUTOCHANGER, p))) {
     AutochangerResource* autochanger = dynamic_cast<AutochangerResource*>(p);
-    if (autochanger) {
+    if (autochanger && autochanger->device_resources) {
       std::string autochanger_name(autochanger->resource_name_);
       std::string autochanger_name_test(
           "virtual-multiplied-device-autochanger");

--- a/core/src/tests/multiplied_device_test.cc
+++ b/core/src/tests/multiplied_device_test.cc
@@ -280,7 +280,6 @@ static uint32_t CheckSomeDevicesInAutochanger(ConfigurationParser& config)
       std::string autochanger_name_test(
           "virtual-multiplied-device-autochanger");
       if (autochanger_name == autochanger_name_test) {
-        DeviceResource* d = nullptr;
         foreach_alist (d, autochanger->device_resources) {
           std::string device_name(d->resource_name_);
           if (names.find(device_name) != names.end()) { ++count_str_ok; }

--- a/core/src/tests/multiplied_device_test.cc
+++ b/core/src/tests/multiplied_device_test.cc
@@ -280,7 +280,7 @@ static uint32_t CheckSomeDevicesInAutochanger(ConfigurationParser& config)
       std::string autochanger_name_test(
           "virtual-multiplied-device-autochanger");
       if (autochanger_name == autochanger_name_test) {
-        foreach_alist (d, autochanger->device_resources) {
+        for (auto* d : *autochanger->device_resources) {
           std::string device_name(d->resource_name_);
           if (names.find(device_name) != names.end()) { ++count_str_ok; }
         }

--- a/core/src/tests/multiplied_device_test.cc
+++ b/core/src/tests/multiplied_device_test.cc
@@ -280,7 +280,7 @@ static uint32_t CheckSomeDevicesInAutochanger(ConfigurationParser& config)
       std::string autochanger_name_test(
           "virtual-multiplied-device-autochanger");
       if (autochanger_name == autochanger_name_test) {
-        for (auto* d : *autochanger->device_resources) {
+        for (auto* d : autochanger->device_resources) {
           std::string device_name(d->resource_name_);
           if (names.find(device_name) != names.end()) { ++count_str_ok; }
         }

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -237,7 +237,7 @@ void test_config_directive_type(
 
 void test_CFG_TYPE_AUDIT(DirectorResource* res)
 {
-  foreach_alist (val, res->audit_events) { printf("AuditEvents = %s\n", val); }
+  for (auto* val : *res->audit_events) { printf("AuditEvents = %s\n", val); }
   EXPECT_EQ(res->audit_events->size(), 8);
 }
 
@@ -249,7 +249,7 @@ TEST_F(ConfigParser_Dir, CFG_TYPE_AUDIT)
 
 void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* res)
 {
-  foreach_alist (val, res->plugin_names) { printf("PluginNames = %s\n", val); }
+  for (auto* val : *res->plugin_names) { printf("PluginNames = %s\n", val); }
   EXPECT_EQ(res->plugin_names->size(), 16);
 }
 
@@ -328,7 +328,7 @@ void test_CFG_TYPE_FNAME(DirectorResource*)
 
   alist<const char*>* files
       = std::addressof(fileset1->include_items.at(0)->name_list);
-  foreach_alist (val, files) { printf("Files = %s\n", val); }
+  for (auto* val : *files) { printf("Files = %s\n", val); }
 }
 
 TEST_F(ConfigParser_Dir, CFG_TYPE_FNAME)

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -237,6 +237,7 @@ void test_config_directive_type(
 
 void test_CFG_TYPE_AUDIT(DirectorResource* res)
 {
+  ASSERT_TRUE(res->audit_events);
   for (auto* val : *res->audit_events) { printf("AuditEvents = %s\n", val); }
   EXPECT_EQ(res->audit_events->size(), 8);
 }
@@ -249,6 +250,7 @@ TEST_F(ConfigParser_Dir, CFG_TYPE_AUDIT)
 
 void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* res)
 {
+  ASSERT_TRUE(res->plugin_names);
   for (auto* val : *res->plugin_names) { printf("PluginNames = %s\n", val); }
   EXPECT_EQ(res->plugin_names->size(), 16);
 }
@@ -328,6 +330,7 @@ void test_CFG_TYPE_FNAME(DirectorResource*)
 
   alist<const char*>* files
       = std::addressof(fileset1->include_items.at(0)->name_list);
+  ASSERT_TRUE(files);
   for (auto* val : *files) { printf("Files = %s\n", val); }
 }
 

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -237,7 +237,6 @@ void test_config_directive_type(
 
 void test_CFG_TYPE_AUDIT(DirectorResource* res)
 {
-  const char* val = nullptr;
   foreach_alist (val, res->audit_events) { printf("AuditEvents = %s\n", val); }
   EXPECT_EQ(res->audit_events->size(), 8);
 }
@@ -250,7 +249,6 @@ TEST_F(ConfigParser_Dir, CFG_TYPE_AUDIT)
 
 void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* res)
 {
-  const char* val = nullptr;
   foreach_alist (val, res->plugin_names) { printf("PluginNames = %s\n", val); }
   EXPECT_EQ(res->plugin_names->size(), 16);
 }
@@ -330,7 +328,6 @@ void test_CFG_TYPE_FNAME(DirectorResource*)
 
   alist<const char*>* files
       = std::addressof(fileset1->include_items.at(0)->name_list);
-  const char* val = nullptr;
   foreach_alist (val, files) { printf("Files = %s\n", val); }
 }
 

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -238,7 +238,7 @@ void test_config_directive_type(
 void test_CFG_TYPE_AUDIT(DirectorResource* res)
 {
   ASSERT_TRUE(res->audit_events);
-  for (auto* val : *res->audit_events) { printf("AuditEvents = %s\n", val); }
+  for (auto* val : res->audit_events) { printf("AuditEvents = %s\n", val); }
   EXPECT_EQ(res->audit_events->size(), 8);
 }
 
@@ -251,7 +251,7 @@ TEST_F(ConfigParser_Dir, CFG_TYPE_AUDIT)
 void test_CFG_TYPE_PLUGIN_NAMES(DirectorResource* res)
 {
   ASSERT_TRUE(res->plugin_names);
-  for (auto* val : *res->plugin_names) { printf("PluginNames = %s\n", val); }
+  for (auto* val : res->plugin_names) { printf("PluginNames = %s\n", val); }
   EXPECT_EQ(res->plugin_names->size(), 16);
 }
 
@@ -331,7 +331,7 @@ void test_CFG_TYPE_FNAME(DirectorResource*)
   alist<const char*>* files
       = std::addressof(fileset1->include_items.at(0)->name_list);
   ASSERT_TRUE(files);
-  for (auto* val : *files) { printf("Files = %s\n", val); }
+  for (auto* val : files) { printf("Files = %s\n", val); }
 }
 
 TEST_F(ConfigParser_Dir, CFG_TYPE_FNAME)

--- a/core/src/tools/bdedup-estimate.cc
+++ b/core/src/tools/bdedup-estimate.cc
@@ -249,6 +249,7 @@ int main(int argc, const char* argv[])
   CLI::App app;
   std::string desc(1024, '\0');
   kBareosVersionStrings.FormatCopyright(desc.data(), desc.size(), 2023);
+  desc.resize(strlen(desc.c_str()));
   desc += "The Bareos Deduplication Estimation Tool";
   InitCLIApp(app, desc, 0);
   AddDebugOptions(app);


### PR DESCRIPTION
This pr fixes a race condition that happens when iterating over the same alist concurrently.  This is done by rippping out the internal iterator state and using extrernal ones.  Specifically we now use a simple pointer pair similar to std::vector.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR