### PR TITLE
create_bareos_database: fix `db_name` not being double quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
 - windows: fix some crashes, change handling of invalid paths; lex: add better error detection; accurate: fix out of bounds writes [PR #1860]
+- create_bareos_database: fix `db_name` not being double quoted [PR #1869]
 
 ## [23.0.3] - 2024-06-04
 
@@ -493,6 +494,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1841]: https://github.com/bareos/bareos/pull/1841
 [PR #1842]: https://github.com/bareos/bareos/pull/1842
 [PR #1860]: https://github.com/bareos/bareos/pull/1860
+[PR #1869]: https://github.com/bareos/bareos/pull/1869
 [PR #1879]: https://github.com/bareos/bareos/pull/1879
 [PR #1884]: https://github.com/bareos/bareos/pull/1884
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -47,8 +47,8 @@ info "Creating database '${db_name}'"
 retval=0
 psql -f - -d template1 << END-OF-DATA || retval=$?
 \set ON_ERROR_STOP on
-CREATE DATABASE ${db_name} ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
-ALTER DATABASE ${db_name} SET datestyle TO 'ISO, YMD';
+CREATE DATABASE "${db_name}" ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
+ALTER DATABASE "${db_name}" SET datestyle TO 'ISO, YMD';
 END-OF-DATA
 
 QUERY="SELECT pg_catalog.pg_encoding_to_char(d.encoding) as encoding \

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public


### PR DESCRIPTION
**Backport of PR #1865 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

#### Backport quality
- [x] Original PR #1865 is merged
- [X] All functional differences to the original PR are documented above
