### PR TITLE
create_bareos_database: fix `db_name` not being double quoted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - python-bareos: add missing `dirname` variable [PR #1848]
 
+### Fixed
+- create_bareos_database: fix `db_name` not being double quoted [PR #1870]
+
 ## [22.1.5] - 2024-06-04
 
 ### Changed
@@ -680,4 +683,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1814]: https://github.com/bareos/bareos/pull/1814
 [PR #1818]: https://github.com/bareos/bareos/pull/1818
 [PR #1848]: https://github.com/bareos/bareos/pull/1848
+[PR #1870]: https://github.com/bareos/bareos/pull/1870
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -46,8 +46,8 @@ info "Creating database '${db_name}'"
 retval=0
 PGOPTIONS='--client-min-messages=warning' psql -f - -d template1 << END-OF-DATA || retval=$?
 \set ON_ERROR_STOP on
-CREATE DATABASE ${db_name} ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
-ALTER DATABASE ${db_name} SET datestyle TO 'ISO, YMD';
+CREATE DATABASE "${db_name}" ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
+ALTER DATABASE "${db_name}" SET datestyle TO 'ISO, YMD';
 END-OF-DATA
 
 if PGOPTIONS='--client-min-messages=warning' psql --list --tuples-only --no-align | grep "^${db_name}|.*|SQL_ASCII|C|C" >/dev/null


### PR DESCRIPTION
**Backport of PR #1865 to bareos-22**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

#### Backport quality
- [x] Original PR #1865 is merged
- [X] All functional differences to the original PR are documented above
