### PR TITLE
VMware Plugin: Add option restore_allow_disks_mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - consolidate: disable vfull duplicate job check [PR #1739]
 - dird: disallow running always incremental virtual full jobs with empty jobid list [PR #1738]
 - msgchan: fix deadlock [PR #1858]
+- VMware Plugin: Add option restore_allow_disks_mismatch [PR #1876]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -228,6 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1871]: https://github.com/bareos/bareos/pull/1871
 [PR #1872]: https://github.com/bareos/bareos/pull/1872
 [PR #1875]: https://github.com/bareos/bareos/pull/1875
+[PR #1876]: https://github.com/bareos/bareos/pull/1876
 [PR #1878]: https://github.com/bareos/bareos/pull/1878
 [PR #1881]: https://github.com/bareos/bareos/pull/1881
 [PR #1883]: https://github.com/bareos/bareos/pull/1883

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -710,11 +710,12 @@ fallback_to_full_cbt (optional)
 
    Since :sinceVersion:`23.0.3: VMware Plugin`
 
-restore_ignore_disks_mismatch (optional)
+restore_allow_disks_mismatch (optional)
    When using VSAN, restoring with recreating the VM can fail because the plugin
    detects a disk mismatch, as when using VSAN obviously recreated disks get a
    generated backing disk path. When passing the plugin option
-   ``restore_ignore_disks_mismatch=yes``, this disk match check will be skipped.
+   ``restore_allow_disks_mismatch=yes``, this disk match check will allow a
+   mismatch and continue the restore.
    This option will only be used when recreating the VM to be restored.
 
    Since :sinceVersion:`23.0.4: VMware Plugin`

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -710,5 +710,14 @@ fallback_to_full_cbt (optional)
 
    Since :sinceVersion:`23.0.3: VMware Plugin`
 
+restore_ignore_disks_mismatch (optional)
+   When using VSAN, restoring with recreating the VM can fail because the plugin
+   detects a disk mismatch, as when using VSAN obviously recreated disks get a
+   generated backing disk path. When passing the plugin option
+   ``restore_ignore_disks_mismatch=yes``, this disk match check will be skipped.
+   This option will only be used when recreating the VM to be restored.
+
+   Since :sinceVersion:`23.0.4: VMware Plugin`
+
 uuid (deprecated)
    The uuid option could be used instead of *dc*, *folder* and *vmname* to uniquely address a VM for backup. As the plugin since :sinceVersion:`22.0.0: VMware Plugin` is able recreate VMs in a different datacenter, folder or datastore, this option has become useless. When using uuid, restoring is only possible to the same still existing VM. It is recommended to change the configuration, as the uuid option will be dropped in the next version.


### PR DESCRIPTION
Adds the option `restore_ignore_disks_mismatch` to the VMware Plugin.
This can be helpful when using VSAN and the restore fails due to disk check mismatch
when the VM is recreated by the plugin.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
