### PR TITLE
fix warnings on FreeBSD 13.3 compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1725]
 - windows: fix some crashes, change handling of invalid paths; lex: add better error detection; accurate: fix out of bounds writes [PR #1793]
 - create_bareos_database: fix `db_name` not being double quoted [PR #1865]
+- fix warnings on FreeBSD 13.3 compiler [PR #1881]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -197,4 +198,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1853]: https://github.com/bareos/bareos/pull/1853
 [PR #1865]: https://github.com/bareos/bareos/pull/1865
 [PR #1868]: https://github.com/bareos/bareos/pull/1868
+[PR #1881]: https://github.com/bareos/bareos/pull/1881
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/channel.h
+++ b/core/src/lib/channel.h
@@ -138,8 +138,8 @@ template <typename T> class queue {
   result_type input_lock()
   {
     auto locked = shared.lock();
-    locked.wait(out_update, [max_size = max_size](const auto& t_queue) {
-      return t_queue.data.size() < max_size || t_queue.out_dead;
+    locked.wait(out_update, [msz = max_size](const auto& t_queue) {
+      return t_queue.data.size() < msz || t_queue.out_dead;
     });
     ASSERT(!locked->in_dead);
 


### PR DESCRIPTION
This PR fixes build warnings on FreeBSD 13.3

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
