### PR TITLE
freebsd: fix build issues with ports tree 2024Q3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - contrib: add pure python statefile parser [PR #1789]
 - Use only MinGW VSS [PR #1847]
 - VMware Plugin: Adapt to Python 3.12 [PR #1850]
+- freebsd: fix build issues with ports tree 2024Q3 [PR #1883]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -201,4 +202,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1865]: https://github.com/bareos/bareos/pull/1865
 [PR #1868]: https://github.com/bareos/bareos/pull/1868
 [PR #1881]: https://github.com/bareos/bareos/pull/1881
+[PR #1883]: https://github.com/bareos/bareos/pull/1883
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -71,7 +71,7 @@ CMAKE_SOURCE_PATH=   ${WRKSRC}
 CMAKE_ARGS+= -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
       -DCMAKE_INSTALL_LIBDIR:PATH=/usr/local/lib \
-      -DCMAKE_INSTALL_MANDIR:PATH=/usr/local/man \
+      -DCMAKE_INSTALL_MANDIR:PATH=/usr/local/share/man \
       -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
       -DLIB_INSTALL_DIR:PATH=/usr/local/lib \
       -DSYSCONF_INSTALL_DIR:PATH=/etc \

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.common
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.common
@@ -47,5 +47,5 @@ bin/bsmtp
 sbin/bsmtp
 sbin/btraceback
 sbin/bareos
-man/man1/bsmtp.1.gz
-man/man8/btraceback.8.gz
+share/man/man1/bsmtp.1.gz
+share/man/man8/btraceback.8.gz

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.database-tools
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.database-tools
@@ -1,5 +1,5 @@
 
 sbin/bareos-dbcheck
 sbin/bscan
-man/man8/bareos-dbcheck.8.gz
-man/man8/bscan.8.gz
+share/man/man8/bareos-dbcheck.8.gz
+share/man/man8/bscan.8.gz

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.director
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.director
@@ -23,6 +23,6 @@
 lib/bareos/scripts/delete_catalog_backup
 lib/bareos/scripts/make_catalog_backup
 sbin/bareos-dir
-man/man8/bareos-dir.8.gz
-man/man8/bareos.8.gz
+share/man/man8/bareos-dir.8.gz
+share/man/man8/bareos.8.gz
 etc/rc.d/bareos-dir

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon
@@ -9,5 +9,5 @@
 @sample(bareos,root,0640) %%ETCDIR%%/bareos-fd.d/messages/Standard.conf.sample
 sbin/bareos-fd
 lib/bareos/plugins/bpipe-fd.so
-man/man8/bareos-fd.8.gz
+share/man/man8/bareos-fd.8.gz
 etc/rc.d/bareos-fd

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
@@ -14,6 +14,6 @@ sbin/bareos-sd
 lib/bareos/scripts/disk-changer
 lib/bareos/plugins/autoxflate-sd.so
 lib/libbareossd-file.so
-man/man8/bareos-sd.8.gz
+share/man/man8/bareos-sd.8.gz
 @dir(bareos,bareos,0775) /var/lib/bareos/storage
 etc/rc.d/bareos-sd

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage-tape
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage-tape
@@ -2,8 +2,8 @@
 lib/libbareossd-tape.so
 lib/bareos/scripts/mtx-changer
 @sample  %%ETCDIR%%/mtx-changer.conf.sample
-man/man8/bscrypto.8.gz
-man/man8/btape.8.gz
+share/man/man8/bscrypto.8.gz
+share/man/man8/btape.8.gz
 sbin/bscrypto
 sbin/btape
 @(bareos,bareos,0640)  %%ETCDIR%%/bareos-dir.d/storage/Tape.conf.example

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.tools
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.tools
@@ -8,9 +8,9 @@ sbin/bls
 sbin/bregex
 sbin/bwild
 sbin/bpluginfo
-man/man1/bwild.1.gz
-man/man1/bregex.1.gz
-man/man8/bcopy.8.gz
-man/man8/bextract.8.gz
-man/man8/bls.8.gz
-man/man8/bpluginfo.8.gz
+share/man/man1/bwild.1.gz
+share/man/man1/bregex.1.gz
+share/man/man8/bcopy.8.gz
+share/man/man8/bextract.8.gz
+share/man/man8/bls.8.gz
+share/man/man8/bpluginfo.8.gz


### PR DESCRIPTION
The new FreeBSD ports tree 2024Q3 introduced a few incompatibilities. This PR adapts the Bareos build to work with the new ports tree.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set
