### PR TITLE
freebsd: fix build issues with ports tree 2024Q3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - python-bareos: fix description [PR #1841]
 - VMware Plugin: Adapt to Python 3.12 [PR #1879]
+- freebsd: fix build issues with ports tree 2024Q3 [PR #1884]
 
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
@@ -493,4 +494,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1842]: https://github.com/bareos/bareos/pull/1842
 [PR #1860]: https://github.com/bareos/bareos/pull/1860
 [PR #1879]: https://github.com/bareos/bareos/pull/1879
+[PR #1884]: https://github.com/bareos/bareos/pull/1884
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/BareosCommonMakefile
@@ -71,7 +71,7 @@ CMAKE_SOURCE_PATH=   ${WRKSRC}
 CMAKE_ARGS+= -DCMAKE_VERBOSE_MAKEFILE=ON \
       -DCMAKE_INSTALL_PREFIX:PATH=/usr/local \
       -DCMAKE_INSTALL_LIBDIR:PATH=/usr/local/lib \
-      -DCMAKE_INSTALL_MANDIR:PATH=/usr/local/man \
+      -DCMAKE_INSTALL_MANDIR:PATH=/usr/local/share/man \
       -DINCLUDE_INSTALL_DIR:PATH=/usr/include \
       -DLIB_INSTALL_DIR:PATH=/usr/local/lib \
       -DSYSCONF_INSTALL_DIR:PATH=/etc \

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.common
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.common
@@ -47,5 +47,5 @@ bin/bsmtp
 sbin/bsmtp
 sbin/btraceback
 sbin/bareos
-man/man1/bsmtp.1.gz
-man/man8/btraceback.8.gz
+share/man/man1/bsmtp.1.gz
+share/man/man8/btraceback.8.gz

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.database-tools
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.database-tools
@@ -1,5 +1,5 @@
 
 sbin/bareos-dbcheck
 sbin/bscan
-man/man8/bareos-dbcheck.8.gz
-man/man8/bscan.8.gz
+share/man/man8/bareos-dbcheck.8.gz
+share/man/man8/bscan.8.gz

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.director
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.director
@@ -23,6 +23,6 @@
 lib/bareos/scripts/delete_catalog_backup
 lib/bareos/scripts/make_catalog_backup
 sbin/bareos-dir
-man/man8/bareos-dir.8.gz
-man/man8/bareos.8.gz
+share/man/man8/bareos-dir.8.gz
+share/man/man8/bareos.8.gz
 etc/rc.d/bareos-dir

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.filedaemon
@@ -9,5 +9,5 @@
 @sample(bareos,root,0640) %%ETCDIR%%/bareos-fd.d/messages/Standard.conf.sample
 sbin/bareos-fd
 lib/bareos/plugins/bpipe-fd.so
-man/man8/bareos-fd.8.gz
+share/man/man8/bareos-fd.8.gz
 etc/rc.d/bareos-fd

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage
@@ -14,6 +14,6 @@ sbin/bareos-sd
 lib/bareos/scripts/disk-changer
 lib/bareos/plugins/autoxflate-sd.so
 lib/libbareossd-file.so
-man/man8/bareos-sd.8.gz
+share/man/man8/bareos-sd.8.gz
 @dir(bareos,bareos,0775) /var/lib/bareos/storage
 etc/rc.d/bareos-sd

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage-tape
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.storage-tape
@@ -2,8 +2,8 @@
 lib/libbareossd-tape.so
 lib/bareos/scripts/mtx-changer
 @sample  %%ETCDIR%%/mtx-changer.conf.sample
-man/man8/bscrypto.8.gz
-man/man8/btape.8.gz
+share/man/man8/bscrypto.8.gz
+share/man/man8/btape.8.gz
 sbin/bscrypto
 sbin/btape
 @(bareos,bareos,0640)  %%ETCDIR%%/bareos-dir.d/storage/Tape.conf.example

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.tools
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-common/pkg-plist.tools
@@ -8,9 +8,9 @@ sbin/bls
 sbin/bregex
 sbin/bwild
 sbin/bpluginfo
-man/man1/bwild.1.gz
-man/man1/bregex.1.gz
-man/man8/bcopy.8.gz
-man/man8/bextract.8.gz
-man/man8/bls.8.gz
-man/man8/bpluginfo.8.gz
+share/man/man1/bwild.1.gz
+share/man/man1/bregex.1.gz
+share/man/man8/bcopy.8.gz
+share/man/man8/bextract.8.gz
+share/man/man8/bls.8.gz
+share/man/man8/bpluginfo.8.gz


### PR DESCRIPTION
**Backport of PR #1883 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1883 is merged
- [x] All functional differences to the original PR are documented above
