### PR TITLE
filed: fix python plugin crash on python <3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VMware Plugin: Add option restore_allow_disks_mismatch [PR #1876]
 - matrix remove obsolete SUSE [PR #1888]
 - cats: scripts add option --no-psqlrc to psql [PR #1900]
+- filed: fix python plugin crash on python <3.10 [PR #1889]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -236,5 +237,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1881]: https://github.com/bareos/bareos/pull/1881
 [PR #1883]: https://github.com/bareos/bareos/pull/1883
 [PR #1888]: https://github.com/bareos/bareos/pull/1888
+[PR #1889]: https://github.com/bareos/bareos/pull/1889
 [PR #1900]: https://github.com/bareos/bareos/pull/1900
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -275,6 +275,7 @@ bRC freePlugin(PluginContext* plugin_ctx)
 
   // Stop any sub interpreter started per plugin instance.
   auto* ts = PopThreadStateForInterp(plugin_priv_ctx->interp);
+  ASSERT(ts);
   PyEval_AcquireThread(ts);
 
   if (plugin_priv_ctx->pModule) { Py_DECREF(plugin_priv_ctx->pModule); }
@@ -283,6 +284,9 @@ bRC freePlugin(PluginContext* plugin_ctx)
   if (PyVersion() < VERSION_HEX(3, 12, 0)) {
     // release gil a different way
     PyThreadState_Swap(mainThreadState);
+    // while we still have the gil, we need to make sure we clear the type cache
+    // so that it does not contain outdated references
+    if (PyVersion() < VERSION_HEX(3, 10, 0)) { PyType_ClearCache(); }
     PyEval_ReleaseThread(mainThreadState);
   } else {
     // endinterpreter releases the gil for us since 3.12


### PR DESCRIPTION
Pythons internal cache may contain dangling pointers to objects of already destroyed interpreters.  This is thankfully very unlikely but it does still happen.  As such we need to make sure to clear the cache whenever we destroy a subinterpreter.

For more details see the commit messages.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
