### PR TITLE
Refactor some Xattr and Acl internals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Inherit RunScript elements between JobDef resources [PR #2097]
 - python-bareos: Add missing dh-python build dep [PR #2130]
 - stored: list all devices if device is invalid/missing [PR #2122]
+- Refactor some Xattr and Acl internals [PR #1893]
 
+[PR #1893]: https://github.com/bareos/bareos/pull/1893
 [PR #2039]: https://github.com/bareos/bareos/pull/2039
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
 [PR #2056]: https://github.com/bareos/bareos/pull/2056

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -196,8 +196,9 @@ if(BUILD_BAREOS_BINARIES)
     set(CMAKE_BUILD_TYPE "RelWithDebInfo")
   endif()
   include(BareosCpmPackages)
-  include(BareosCcache)
+  # include PrefixMap before BareosCcache so hash_dir is set correctly
   include(PrefixMap)
+  include(BareosCcache)
   add_subdirectory(core)
   if(ENABLE_WEBUI)
     add_subdirectory(webui)

--- a/cmake/BareosCcache.cmake
+++ b/cmake/BareosCcache.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -21,7 +21,11 @@ find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
   set(CCACHE_CMDLINE "${CCACHE_PROGRAM}")
   list(APPEND CCACHE_CMDLINE "base_dir=${CMAKE_SOURCE_DIR}")
-  list(APPEND CCACHE_CMDLINE "hash_dir=true")
+  if(CCACHE_MAY_HASHDIR)
+    list(APPEND CCACHE_CMDLINE "hash_dir=true")
+  else()
+    list(APPEND CCACHE_CMDLINE "hash_dir=false")
+  endif()
   list(APPEND CCACHE_CMDLINE "namespace=bareos")
   set(CMAKE_C_COMPILER_LAUNCHER "${CCACHE_CMDLINE}")
   set(CMAKE_CXX_COMPILER_LAUNCHER "${CCACHE_CMDLINE}")

--- a/cmake/BareosGenerateDebianInfo.cmake
+++ b/cmake/BareosGenerateDebianInfo.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -16,6 +16,10 @@
 #   along with this program; if not, write to the Free Software
 #   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 #   02110-1301, USA.
+
+if(MSVC)
+  return()
+endif()
 
 # always add "src" package snippet
 set(DEBIAN_CONTROL_SNIPPETS "src")

--- a/cmake/PrefixMap.cmake
+++ b/cmake/PrefixMap.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -33,6 +33,7 @@ if(c_compiler_debug_prefix_map AND cxx_compiler_debug_prefix_map)
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} -fdebug-prefix-map=${BAREOS_PREFIX_MAP}"
   )
+  set(CCACHE_MAY_HASHDIR ON)
 endif()
 
 check_c_compiler_flag(

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -172,10 +172,10 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
     jcr->setJobStatusWithPriorityCheck(JS_ErrorTerminated);
   }
 
-  if (have_acl && jcr->fd_impl->acl_data->u.build->nr_errors > 0) {
+  if (have_acl && jcr->fd_impl->acl_data->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
          T_("Encountered %ld acl errors while doing backup\n"),
-         jcr->fd_impl->acl_data->u.build->nr_errors);
+         jcr->fd_impl->acl_data->nr_errors);
   }
   if (have_xattr && jcr->fd_impl->xattr_data->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
@@ -456,7 +456,7 @@ static inline bool DoBackupAcl(JobControlRecord* jcr, FindFilesPacket* ff_pkt)
       return false;
     case bacl_exit_error:
       Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
-      jcr->fd_impl->acl_data->u.build->nr_errors++;
+      jcr->fd_impl->acl_data->nr_errors++;
       break;
     case bacl_exit_ok:
       break;

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -155,10 +155,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
 
   if (have_acl) {
     jcr->fd_impl->acl_data = std::make_unique<AclData>();
-    jcr->fd_impl->acl_data->u.build
-        = (acl_build_data_t*)malloc(sizeof(acl_build_data_t));
-    memset(jcr->fd_impl->acl_data->u.build, 0, sizeof(acl_build_data_t));
-    jcr->fd_impl->acl_data->u.build->content = GetPoolMemory(PM_MESSAGE);
+    jcr->fd_impl->acl_data->u.build = new acl_build_data_t();
   }
 
   if (have_xattr) {
@@ -194,8 +191,7 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
   sd->signal(BNET_EOD); /* end of sending data */
 
   if (have_acl && jcr->fd_impl->acl_data) {
-    FreePoolMemory(jcr->fd_impl->acl_data->u.build->content);
-    free(jcr->fd_impl->acl_data->u.build);
+    delete jcr->fd_impl->acl_data->u.build;
   }
 
   if (jcr->fd_impl->big_buf) {

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -181,10 +181,10 @@ bool BlastDataToStorageDaemon(JobControlRecord* jcr, crypto_cipher_t cipher)
          T_("Encountered %ld acl errors while doing backup\n"),
          jcr->fd_impl->acl_data->u.build->nr_errors);
   }
-  if (have_xattr && jcr->fd_impl->xattr_data->u.build->nr_errors > 0) {
+  if (have_xattr && jcr->fd_impl->xattr_data->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
          T_("Encountered %ld xattr errors while doing backup\n"),
-         jcr->fd_impl->xattr_data->u.build->nr_errors);
+         jcr->fd_impl->xattr_data->nr_errors);
   }
 
 #if defined(WIN32_VSS)
@@ -495,7 +495,7 @@ static inline bool DoBackupXattr(JobControlRecord* jcr, FindFilesPacket* ff_pkt)
       break;
     case BxattrExitCode::kError:
       Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
-      jcr->fd_impl->xattr_data->u.build->nr_errors++;
+      jcr->fd_impl->xattr_data->nr_errors++;
       break;
     case BxattrExitCode::kSuccess:
       break;

--- a/core/src/filed/backup.cc
+++ b/core/src/filed/backup.cc
@@ -435,7 +435,7 @@ static inline bool DoBackupAcl(JobControlRecord* jcr, FindFilesPacket* ff_pkt)
   jcr->fd_impl->acl_data->last_fname = jcr->fd_impl->last_fname;
 
   auto* acl_build_data
-      = static_cast<AclBuildData*>(jcr->fd_impl->acl_data.get());
+      = dynamic_cast<AclBuildData*>(jcr->fd_impl->acl_data.get());
   if (jcr->IsPlugin()) {
     retval = PluginBuildAclStreams(jcr, acl_build_data, ff_pkt);
   } else {
@@ -464,11 +464,11 @@ static inline bool DoBackupXattr(JobControlRecord* jcr, FindFilesPacket* ff_pkt)
 
   if (jcr->IsPlugin()) {
     retval = PluginBuildXattrStreams(
-        jcr, static_cast<XattrBuildData*>(jcr->fd_impl->xattr_data.get()),
+        jcr, dynamic_cast<XattrBuildData*>(jcr->fd_impl->xattr_data.get()),
         ff_pkt);
   } else {
     retval = BuildXattrStreams(
-        jcr, static_cast<XattrBuildData*>(jcr->fd_impl->xattr_data.get()),
+        jcr, dynamic_cast<XattrBuildData*>(jcr->fd_impl->xattr_data.get()),
         ff_pkt);
   }
 

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1506,20 +1506,9 @@ BxattrExitCode PluginBuildXattrStreams(
 
     // If we found any xattr send them to the SD.
     if (xattr_count > 0) {
-      // Serialize the datastream.
-      if (SerializeXattrStream(jcr, xattr_data, expected_serialize_len,
-                               xattr_value_list)
-          < expected_serialize_len) {
-        Mmsg1(jcr->errmsg,
-              T_("Failed to Serialize extended attributes on file \"%s\"\n"),
-              xattr_data->last_fname);
-        Dmsg1(100, "Failed to Serialize extended attributes on file \"%s\"\n",
-              xattr_data->last_fname);
-        goto bail_out;
-      }
-
-      // Send the datastream to the SD.
-      retval = SendXattrStream(jcr, xattr_data, STREAM_XATTR_PLUGIN);
+      retval
+          = SerializeAndSendXattrStream(jcr, xattr_data, expected_serialize_len,
+                                        xattr_value_list, STREAM_XATTR_PLUGIN);
     } else {
       retval = BxattrExitCode::kSuccess;
     }

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1364,12 +1364,12 @@ bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
     switch (PlugFunc(plugin)->getAcl(jcr->plugin_ctx, &ap)) {
       case bRC_OK:
         if (ap.content_length && ap.content) {
-          acl_data->u.build->content = CheckPoolMemorySize(
-              acl_data->u.build->content, ap.content_length + 1);
-          memcpy(acl_data->u.build->content, ap.content, ap.content_length);
+          acl_data->u.build->content.check_size(ap.content_length + 1);
+          PmMemcpy(acl_data->u.build->content, ap.content, ap.content_length);
           acl_data->u.build->content_length = ap.content_length;
           free(ap.content);
-          acl_data->u.build->content[acl_data->u.build->content_length] = '\0';
+          acl_data->u.build->content.c_str()[acl_data->u.build->content_length]
+              = '\0';
           retval = SendAclStream(jcr, acl_data, STREAM_ACL_PLUGIN);
         } else {
           retval = bacl_exit_ok;

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -1343,7 +1343,7 @@ bool PluginSetAttributes(JobControlRecord* jcr,
 
 // Plugin specific callback for getting ACL information.
 bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
-                                     [[maybe_unused]] AclData* acl_data,
+                                     [[maybe_unused]] AclBuildData* acl_data,
                                      FindFilesPacket*)
 {
   Plugin* plugin;
@@ -1364,12 +1364,11 @@ bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
     switch (PlugFunc(plugin)->getAcl(jcr->plugin_ctx, &ap)) {
       case bRC_OK:
         if (ap.content_length && ap.content) {
-          acl_data->u.build->content.check_size(ap.content_length + 1);
-          PmMemcpy(acl_data->u.build->content, ap.content, ap.content_length);
-          acl_data->u.build->content_length = ap.content_length;
+          acl_data->content.check_size(ap.content_length + 1);
+          PmMemcpy(acl_data->content, ap.content, ap.content_length);
+          acl_data->content_length = ap.content_length;
           free(ap.content);
-          acl_data->u.build->content.c_str()[acl_data->u.build->content_length]
-              = '\0';
+          acl_data->content.c_str()[acl_data->content_length] = '\0';
           retval = SendAclStream(jcr, acl_data, STREAM_ACL_PLUGIN);
         } else {
           retval = bacl_exit_ok;

--- a/core/src/filed/fd_plugins.cc
+++ b/core/src/filed/fd_plugins.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1425,7 +1425,7 @@ bacl_exit_code plugin_parse_acl_streams(
 // Plugin specific callback for getting XATTR information.
 BxattrExitCode PluginBuildXattrStreams(
     JobControlRecord* jcr,
-    [[maybe_unused]] struct XattrData* xattr_data,
+    [[maybe_unused]] XattrBuildData* xattr_data,
     FindFilesPacket*)
 {
   Plugin* plugin;
@@ -1535,12 +1535,11 @@ bail_out:
 }
 
 // Plugin specific callback for setting XATTR information.
-BxattrExitCode PluginParseXattrStreams(
-    JobControlRecord* jcr,
-    [[maybe_unused]] struct XattrData* xattr_data,
-    int,
-    [[maybe_unused]] char* content,
-    [[maybe_unused]] uint32_t content_length)
+BxattrExitCode PluginParseXattrStreams(JobControlRecord* jcr,
+                                       [[maybe_unused]] XattrData* xattr_data,
+                                       int,
+                                       [[maybe_unused]] char* content,
+                                       [[maybe_unused]] uint32_t content_length)
 {
 #if defined(HAVE_XATTR)
   Plugin* plugin;

--- a/core/src/filed/fd_plugins.h
+++ b/core/src/filed/fd_plugins.h
@@ -283,7 +283,7 @@ bool PluginSetAttributes(JobControlRecord* jcr,
                          Attributes* attr,
                          BareosFilePacket* ofd);
 bacl_exit_code PluginBuildAclStreams(JobControlRecord* jcr,
-                                     AclData* acl_data,
+                                     AclBuildData* acl_data,
                                      FindFilesPacket* ff_pkt);
 bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
                                         AclData* acl_data,

--- a/core/src/filed/fd_plugins.h
+++ b/core/src/filed/fd_plugins.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -291,10 +291,10 @@ bacl_exit_code plugin_parse_acl_streams(JobControlRecord* jcr,
                                         char* content,
                                         uint32_t content_length);
 BxattrExitCode PluginBuildXattrStreams(JobControlRecord* jcr,
-                                       struct XattrData* xattr_data,
+                                       XattrBuildData* xattr_data,
                                        FindFilesPacket* ff_pkt);
 BxattrExitCode PluginParseXattrStreams(JobControlRecord* jcr,
-                                       struct XattrData* xattr_data,
+                                       XattrData* xattr_data,
                                        int stream,
                                        char* content,
                                        uint32_t content_length);

--- a/core/src/filed/filed_jcr_impl.h
+++ b/core/src/filed/filed_jcr_impl.h
@@ -30,12 +30,16 @@
 
 #include <atomic>
 
-struct AclData;
+struct FindFilesPacket;
+class AclData;
 class XattrData;
+class RunScript;
 
 namespace filedaemon {
 class BareosAccurateFilelist;
-}
+class DirectorResource;
+struct save_pkt;
+}  // namespace filedaemon
 
 /* clang-format off */
 struct CryptoContext {

--- a/core/src/filed/filed_jcr_impl.h
+++ b/core/src/filed/filed_jcr_impl.h
@@ -31,8 +31,8 @@
 #include <atomic>
 
 struct FindFilesPacket;
-class AclData;
-class XattrData;
+struct AclData;
+struct XattrData;
 class RunScript;
 
 namespace filedaemon {

--- a/core/src/filed/filed_jcr_impl.h
+++ b/core/src/filed/filed_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,7 +31,7 @@
 #include <atomic>
 
 struct AclData;
-struct XattrData;
+class XattrData;
 
 namespace filedaemon {
 class BareosAccurateFilelist;

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -283,7 +283,7 @@ static inline bool do_restore_xattr(JobControlRecord* jcr,
       break;
     case BxattrExitCode::kError:
       Jmsg(jcr, M_ERROR, 0, "%s", jcr->errmsg);
-      jcr->fd_impl->xattr_data->u.parse->nr_errors++;
+      jcr->fd_impl->xattr_data->nr_errors++;
       break;
     case BxattrExitCode::kSuccess:
       break;
@@ -479,12 +479,7 @@ void DoRestore(JobControlRecord* jcr)
         = (acl_parse_data_t*)malloc(sizeof(acl_parse_data_t));
     memset(jcr->fd_impl->acl_data->u.parse, 0, sizeof(acl_parse_data_t));
   }
-  if (have_xattr) {
-    jcr->fd_impl->xattr_data = std::make_unique<XattrData>();
-    jcr->fd_impl->xattr_data->u.parse
-        = (xattr_parse_data_t*)malloc(sizeof(xattr_parse_data_t));
-    memset(jcr->fd_impl->xattr_data->u.parse, 0, sizeof(xattr_parse_data_t));
-  }
+  if (have_xattr) { jcr->fd_impl->xattr_data = std::make_unique<XattrData>(); }
 
   while (BgetMsg(sd) >= 0 && !jcr->IsJobCanceled()) {
     // Remember previous stream type
@@ -1033,7 +1028,7 @@ void DoRestore(JobControlRecord* jcr)
         Dmsg2(0, "Unknown stream=%d data=%s\n", rctx.stream, sd->msg);
         break;
     } /* end switch(stream) */
-  }   /* end while get_msg() */
+  } /* end while get_msg() */
 
   /* If output file is still open, it was the last one in the
    * archive since we just hit an end of file, so close the file. */
@@ -1062,10 +1057,10 @@ ok_out:
          T_("Encountered %ld acl errors while doing restore\n"),
          jcr->fd_impl->acl_data->u.parse->nr_errors);
   }
-  if (have_xattr && jcr->fd_impl->xattr_data->u.parse->nr_errors > 0) {
+  if (have_xattr && jcr->fd_impl->xattr_data->nr_errors > 0) {
     Jmsg(jcr, M_WARNING, 0,
          T_("Encountered %ld xattr errors while doing restore\n"),
-         jcr->fd_impl->xattr_data->u.parse->nr_errors);
+         jcr->fd_impl->xattr_data->nr_errors);
   }
   if (non_support_data > 1 || non_support_attr > 1) {
     Jmsg(jcr, M_WARNING, 0,
@@ -1126,10 +1121,6 @@ ok_out:
 
   if (have_acl && jcr->fd_impl->acl_data) {
     free(jcr->fd_impl->acl_data->u.parse);
-  }
-
-  if (have_xattr && jcr->fd_impl->xattr_data) {
-    free(jcr->fd_impl->xattr_data->u.parse);
   }
 
   // Free the delayed stream stack list.

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -110,9 +110,9 @@ bacl_exit_code SendAclStream(JobControlRecord* jcr,
   }
 
   // Send the buffer to the storage daemon
-  Dmsg1(400, "Backing up ACL <%s>\n", acl_data->u.build->content);
+  Dmsg1(400, "Backing up ACL <%s>\n", acl_data->u.build->content.c_str());
   msgsave = sd->msg;
-  sd->msg = acl_data->u.build->content;
+  sd->msg = acl_data->u.build->content.c_str();
   sd->message_length = acl_data->u.build->content_length + 1;
   if (!sd->send()) {
     sd->msg = msgsave;

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -1840,7 +1840,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
       } else {
         /* Increment error count but don't log an error again for the same
          * filesystem. */
-        acl_data->u.parse->nr_errors++;
+        acl_data->nr_errors++;
         return bacl_exit_ok;
       }
       break;
@@ -1868,7 +1868,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
       } else {
         /* Increment error count but don't log an error again for the same
          * filesystem. */
-        acl_data->u.parse->nr_errors++;
+        acl_data->nr_errors++;
         return bacl_exit_ok;
       }
       break;

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -586,7 +586,7 @@ static acl_type_t BacToOsAcltype(bacl_type acltype)
     default:
       /* This should never happen, as the per OS version function only tries acl
        * types supported on a certain platform. */
-      ostype = (acl_type_t)ACL_TYPE_NONE;
+      ostype = ACL_TYPE_NONE;
       break;
   }
   return ostype;

--- a/core/src/findlib/acl.cc
+++ b/core/src/findlib/acl.cc
@@ -207,10 +207,10 @@ static bacl_exit_code aix_build_acl_streams(JobControlRecord* jcr,
         goto bail_out;
       case ENOSYS:
         /* If the filesystem reports it doesn't support ACLs we clear the
-         * BACL_FLAG_SAVE_NATIVE flag so we skip ACL saves on all other files
-         * on the same filesystem. The BACL_FLAG_SAVE_NATIVE flag gets set again
-         * when we change from one filesystem to another. */
-        acl_data->flags &= ~BACL_FLAG_SAVE_NATIVE;
+         * SaveNative flag so we skip ACL saves on all other files on the same
+         * filesystem. The SaveNative flag gets set again when we change from
+         * one filesystem to another. */
+        acl_data->flags.SaveNative = false;
         retval = bacl_exit_ok;
         goto bail_out;
       default:
@@ -443,10 +443,10 @@ static bacl_exit_code aix_parse_acl_streams(JobControlRecord* jcr,
         goto bail_out;
       case ENOSYS:
         /* If the filesystem reports it doesn't support ACLs we clear the
-         * BACL_FLAG_RESTORE_NATIVE flag so we skip ACL restores on all other
-         * files on the same filesystem. The BACL_FLAG_RESTORE_NATIVE flag gets
-         * set again when we change from one filesystem to another. */
-        acl_data->flags &= ~BACL_FLAG_RESTORE_NATIVE;
+         * RestoreNative flag so we skip ACL restores on all other files on the
+         * same filesystem. The RestoreNative flag gets set again when we change
+         * from one filesystem to another. */
+        acl_data->flags.RestoreNative = false;
         retval = bacl_exit_ok;
         goto bail_out;
       default:
@@ -717,10 +717,10 @@ static bacl_exit_code generic_get_acl_from_os(JobControlRecord* jcr,
 #      if defined(BACL_ENOTSUP)
       case BACL_ENOTSUP:
         /* If the filesystem reports it doesn't support ACLs we clear the
-         * BACL_FLAG_SAVE_NATIVE flag so we skip ACL saves on all other files
-         * on the same filesystem. The BACL_FLAG_SAVE_NATIVE flag gets set again
+         * SaveNative flag so we skip ACL saves on all other files
+         * on the same filesystem. The SaveNative flag gets set again
          * when we change from one filesystem to another. */
-        acl_data->flags &= ~BACL_FLAG_SAVE_NATIVE;
+        acl_data->flags.SaveNative = false;
         goto bail_out;
 #      endif
       case ENOENT:
@@ -766,10 +766,10 @@ static bacl_exit_code generic_set_acl_on_os(JobControlRecord* jcr,
 #      if defined(BACL_ENOTSUP)
       case BACL_ENOTSUP:
         /* If the filesystem reports it doesn't support ACLs we clear the
-         * BACL_FLAG_RESTORE_NATIVE flag so we skip ACL restores on all other
-         * files on the same filesystem. The BACL_FLAG_RESTORE_NATIVE flag gets
+         * RestoreNative flag so we skip ACL restores on all other
+         * files on the same filesystem. The RestoreNative flag gets
          * set again when we change from one filesystem to another. */
-        acl_data->flags &= ~BACL_FLAG_RESTORE_NATIVE;
+        acl_data->flags.RestoreNative = false;
         Mmsg1(jcr->errmsg,
               T_("acl_delete_def_file error on file \"%s\": filesystem doesn't "
                  "support ACLs\n"),
@@ -830,10 +830,10 @@ static bacl_exit_code generic_set_acl_on_os(JobControlRecord* jcr,
 #      if defined(BACL_ENOTSUP)
       case BACL_ENOTSUP:
         /* If the filesystem reports it doesn't support ACLs we clear the
-         * BACL_FLAG_RESTORE_NATIVE flag so we skip ACL restores on all other
-         * files on the same filesystem. The BACL_FLAG_RESTORE_NATIVE flag gets
+         * RestoreNative flag so we skip ACL restores on all other
+         * files on the same filesystem. The RestoreNative flag gets
          * set again when we change from one filesystem to another. */
-        acl_data->flags &= ~BACL_FLAG_RESTORE_NATIVE;
+        acl_data->flags.RestoreNative = false;
         Mmsg1(
             jcr->errmsg,
             T_("acl_set_file error on file \"%s\": filesystem doesn't support "
@@ -989,11 +989,11 @@ static bacl_exit_code freebsd_build_acl_streams(JobControlRecord* jcr,
   }
 
   /* If the filesystem reports it doesn't support ACLs we clear the
-   * BACL_FLAG_SAVE_NATIVE flag so we skip ACL saves on all other files
-   * on the same filesystem. The BACL_FLAG_SAVE_NATIVE flag gets set again
+   * SaveNative flag so we skip ACL saves on all other files
+   * on the same filesystem. The SaveNative flag gets set again
    * when we change from one filesystem to another. */
   if (acl_enabled == 0) {
-    acl_data->flags &= ~BACL_FLAG_SAVE_NATIVE;
+    acl_data->flags.SaveNative = false;
     PmStrcpy(acl_data->content, "");
     acl_data->content_length = 0;
     return bacl_exit_ok;
@@ -1090,10 +1090,10 @@ static bacl_exit_code freebsd_parse_acl_streams(JobControlRecord* jcr,
     }
     case 0:
       /* If the filesystem reports it doesn't support ACLs we clear the
-       * BACL_FLAG_RESTORE_NATIVE flag so we skip ACL restores on all other
-       * files on the same filesystem. The BACL_FLAG_RESTORE_NATIVE flag gets
+       * RestoreNative flag so we skip ACL restores on all other
+       * files on the same filesystem. The RestoreNative flag gets
        * set again when we change from one filesystem to another. */
-      acl_data->flags &= ~BACL_FLAG_SAVE_NATIVE;
+      acl_data->flags.SaveNative = false;
       Mmsg2(jcr->errmsg,
             T_("Trying to restore acl on file \"%s\" on filesystem without %s "
                "acl support\n"),
@@ -1285,10 +1285,10 @@ static bacl_exit_code solaris_build_acl_streams(JobControlRecord* jcr,
   switch (acl_enabled) {
     case 0:
       /* If the filesystem reports it doesn't support ACLs we clear the
-       * BACL_FLAG_SAVE_NATIVE flag so we skip ACL saves on all other files
-       * on the same filesystem. The BACL_FLAG_SAVE_NATIVE flag gets set again
+       * SaveNative flag so we skip ACL saves on all other files
+       * on the same filesystem. The SaveNative flag gets set again
        * when we change from one filesystem to another. */
-      acl_data->flags &= ~BACL_FLAG_SAVE_NATIVE;
+      acl_data->flags.SaveNative = false;
       PmStrcpy(acl_data->content, "");
       acl_data->content_length = 0;
       return bacl_exit_ok;
@@ -1379,10 +1379,10 @@ static bacl_exit_code solaris_parse_acl_streams(JobControlRecord* jcr,
       switch (acl_enabled) {
         case 0:
           /* If the filesystem reports it doesn't support ACLs we clear the
-           * BACL_FLAG_RESTORE_NATIVE flag so we skip ACL restores on all other
-           * files on the same filesystem. The BACL_FLAG_RESTORE_NATIVE flag
+           * RestoreNative flag so we skip ACL restores on all other
+           * files on the same filesystem. The RestoreNative flag
            * gets set again when we change from one filesystem to another. */
-          acl_data->flags &= ~BACL_FLAG_RESTORE_NATIVE;
+          acl_data->flags.RestoreNative = false;
           Mmsg1(jcr->errmsg,
                 T_("Trying to restore acl on file \"%s\" on filesystem without "
                    "acl support\n"),
@@ -1716,20 +1716,20 @@ bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
    * it with the current st_dev in the last stat performed on
    * the file we are currently storing. */
   if (acl_data->first_dev || acl_data->current_dev != ff_pkt->statp.st_dev) {
-    acl_data->flags = 0;
+    acl_data->flags = {};
     acl_data->first_dev = false;
 
 #  if defined(HAVE_AFS_ACL)
     /* AFS is a non OS specific filesystem so see if this path is on an AFS
-     * filesystem Set the BACL_FLAG_SAVE_AFS flag if it is. If not set the
-     * BACL_FLAG_SAVE_NATIVE flag. */
+     * filesystem Set the SaveAfs flag if it is. If not set the
+     * SaveNative flag. */
     if (FstypeEquals(acl_data->last_fname, "afs")) {
-      acl_data->flags |= BACL_FLAG_SAVE_AFS;
+      acl_data->flags.SaveAfs = true;
     } else {
-      acl_data->flags |= BACL_FLAG_SAVE_NATIVE;
+      acl_data->flags.SaveNative = true;
     }
 #  else
-    acl_data->flags |= BACL_FLAG_SAVE_NATIVE;
+    acl_data->flags.SaveNative = true;
 #  endif
 
     // Save that we started scanning a new filesystem.
@@ -1737,16 +1737,16 @@ bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
   }
 
 #  if defined(HAVE_AFS_ACL)
-  /* See if the BACL_FLAG_SAVE_AFS flag is set which lets us know if we should
+  /* See if the SaveAfs flag is set which lets us know if we should
    * save AFS ACLs. */
-  if (acl_data->flags & BACL_FLAG_SAVE_AFS) {
+  if (acl_data->flags.SaveAfs) {
     return afs_build_acl_streams(jcr, acl_data, ff_pkt);
   }
 #  endif
 #  if defined(HAVE_ACL)
-  /* See if the BACL_FLAG_SAVE_NATIVE flag is set which lets us know if we
+  /* See if the SaveNative flag is set which lets us know if we
    * should save native ACLs. */
-  if (acl_data->flags & BACL_FLAG_SAVE_NATIVE) {
+  if (acl_data->flags.SaveNative) {
     // Call the appropriate function.
     if (os_build_acl_streams) {
       return os_build_acl_streams(jcr, acl_data, ff_pkt);
@@ -1793,20 +1793,20 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
       break;
   }
   if (acl_data->first_dev || acl_data->current_dev != st.st_dev) {
-    acl_data->flags = 0;
+    acl_data->flags = {};
     acl_data->first_dev = false;
 
 #  if defined(HAVE_AFS_ACL)
     /* AFS is a non OS specific filesystem so see if this path is on an AFS
-     * filesystem Set the BACL_FLAG_RESTORE_AFS flag if it is. If not set the
-     * BACL_FLAG_RETORE_NATIVE flag. */
+     * filesystem Set the RestoreAfs flag if it is. If not set the
+     * RestoreNative flag. */
     if (FstypeEquals(acl_data->last_fname, "afs")) {
-      acl_data->flags |= BACL_FLAG_RESTORE_AFS;
+      acl_data->flags.RestoreAfs = true;
     } else {
-      acl_data->flags |= BACL_FLAG_RESTORE_NATIVE;
+      acl_data->flags.RestoreNative = true;
     }
 #  else
-    acl_data->flags |= BACL_FLAG_RESTORE_NATIVE;
+    acl_data->flags.RestoreNative = true;
 #  endif
 
     // Save that we started restoring to a new filesystem.
@@ -1816,7 +1816,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
   switch (stream) {
 #  if defined(HAVE_AFS_ACL)
     case STREAM_ACL_AFS_TEXT:
-      if (acl_data->flags & BACL_FLAG_RESTORE_AFS) {
+      if (acl_data->flags.RestoreAfs) {
         return afs_parse_acl_stream(jcr, acl_data, stream, content,
                                     content_length);
       } else {
@@ -1830,8 +1830,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
     case STREAM_UNIX_ACCESS_ACL:
     case STREAM_UNIX_DEFAULT_ACL:
       // Handle legacy ACL streams.
-      if ((acl_data->flags & BACL_FLAG_RESTORE_NATIVE)
-          && os_parse_acl_streams) {
+      if (acl_data->flags.RestoreNative && os_parse_acl_streams) {
         return os_parse_acl_streams(jcr, acl_data, stream, content,
                                     content_length);
       } else {
@@ -1842,8 +1841,7 @@ bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
       }
       break;
     default:
-      if ((acl_data->flags & BACL_FLAG_RESTORE_NATIVE)
-          && os_parse_acl_streams) {
+      if (acl_data->flags.RestoreNative && os_parse_acl_streams) {
         /* Walk the os_access_acl_streams array with the supported Access ACL
          * streams for this OS. */
         for (cnt = 0; cnt < sizeof(os_access_acl_streams) / sizeof(int);

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -88,8 +88,7 @@ struct bacl_flags {
 };
 
 // Internal tracking data.
-class AclData {
- public:
+struct AclData {
   int filetype;
   POOLMEM* last_fname;
   bacl_flags flags{};
@@ -99,8 +98,7 @@ class AclData {
   virtual ~AclData() noexcept = default;
 };
 
-class AclBuildData : public AclData {
- public:
+struct AclBuildData : public AclData {
   uint32_t content_length;
   PoolMem content{PM_MESSAGE};
 };

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -28,13 +28,26 @@
 #ifndef BAREOS_FINDLIB_ACL_H_
 #define BAREOS_FINDLIB_ACL_H_
 
-// Number of acl errors to report per job.
+#include "include/config.h"
 #include <cstdint>
 #include "include/bc_types.h"
+#include "lib/mem_pool.h"
+
+#ifdef HAVE_SYS_ACL_H
+#  include <sys/acl.h>
+/**
+ * This value is used as ostype when we encounter an invalid acl type.
+ * The way the code is build this should never happen.
+ */
+static inline constexpr acl_type_t ACL_TYPE_NONE = static_cast<acl_type_t>(0);
+#endif
+
 class JobControlRecord;
 struct FindFilesPacket;
 
-#define ACL_REPORT_ERR_MAX_PER_JOB 25
+// Number of acl errors to report per job.
+static inline constexpr uint32_t ACL_REPORT_ERR_MAX_PER_JOB = 25;
+
 
 // Return codes from acl subroutines.
 typedef enum
@@ -61,23 +74,16 @@ typedef enum
   BACL_TYPE_NFS4 = 5
 } bacl_type;
 
-/**
- * This value is used as ostype when we encounter an invalid acl type.
- * The way the code is build this should never happen.
- */
-#if !defined(ACL_TYPE_NONE)
-#  define ACL_TYPE_NONE 0x0
-#endif
 
 #if defined(HAVE_FREEBSD_OS) || defined(HAVE_DARWIN_OS) \
     || defined(HAVE_LINUX_OS)
 #  define BACL_ENOTSUP EOPNOTSUPP
 #endif
 
-#define BACL_FLAG_SAVE_NATIVE 0x01
-#define BACL_FLAG_SAVE_AFS 0x02
-#define BACL_FLAG_RESTORE_NATIVE 0x04
-#define BACL_FLAG_RESTORE_AFS 0x08
+static inline constexpr uint32_t BACL_FLAG_SAVE_NATIVE = 0x01;
+static inline constexpr uint32_t BACL_FLAG_SAVE_AFS = 0x02;
+static inline constexpr uint32_t BACL_FLAG_RESTORE_NATIVE = 0x04;
+static inline constexpr uint32_t BACL_FLAG_RESTORE_AFS = 0x08;
 
 struct acl_build_data_t {
   uint32_t nr_errors;

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -87,7 +87,7 @@ static inline constexpr uint32_t BACL_FLAG_RESTORE_AFS = 0x08;
 
 struct acl_build_data_t {
   uint32_t content_length;
-  POOLMEM* content;
+  PoolMem content{PM_MESSAGE};
 };
 
 // Internal tracking data.

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -85,29 +85,29 @@ static inline constexpr uint32_t BACL_FLAG_SAVE_AFS = 0x02;
 static inline constexpr uint32_t BACL_FLAG_RESTORE_NATIVE = 0x04;
 static inline constexpr uint32_t BACL_FLAG_RESTORE_AFS = 0x08;
 
-struct acl_build_data_t {
-  uint32_t content_length;
-  PoolMem content{PM_MESSAGE};
-};
-
 // Internal tracking data.
-struct AclData {
+class AclData {
+ public:
   int filetype;
   POOLMEM* last_fname;
   uint32_t flags{}; /* See BACL_FLAG_* */
   uint32_t current_dev{0};
   bool first_dev{true};
   uint32_t nr_errors;
-  union {
-    struct acl_build_data_t* build;
-  } u;
+  virtual ~AclData() noexcept = default;
+};
+
+class AclBuildData : public AclData {
+ public:
+  uint32_t content_length;
+  PoolMem content{PM_MESSAGE};
 };
 
 bacl_exit_code SendAclStream(JobControlRecord* jcr,
-                             AclData* acl_data,
+                             AclBuildData* acl_data,
                              int stream);
 bacl_exit_code BuildAclStreams(JobControlRecord* jcr,
-                               AclData* acl_data,
+                               AclBuildData* acl_data,
                                FindFilesPacket* ff_pkt);
 bacl_exit_code parse_acl_streams(JobControlRecord* jcr,
                                  AclData* acl_data,

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -86,13 +86,8 @@ static inline constexpr uint32_t BACL_FLAG_RESTORE_NATIVE = 0x04;
 static inline constexpr uint32_t BACL_FLAG_RESTORE_AFS = 0x08;
 
 struct acl_build_data_t {
-  uint32_t nr_errors;
   uint32_t content_length;
   POOLMEM* content;
-};
-
-struct acl_parse_data_t {
-  uint32_t nr_errors;
 };
 
 // Internal tracking data.
@@ -102,9 +97,9 @@ struct AclData {
   uint32_t flags{}; /* See BACL_FLAG_* */
   uint32_t current_dev{0};
   bool first_dev{true};
+  uint32_t nr_errors;
   union {
     struct acl_build_data_t* build;
-    struct acl_parse_data_t* parse;
   } u;
 };
 

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -29,6 +29,11 @@
 #define BAREOS_FINDLIB_ACL_H_
 
 // Number of acl errors to report per job.
+#include <cstdint>
+#include "include/bc_types.h"
+class JobControlRecord;
+struct FindFilesPacket;
+
 #define ACL_REPORT_ERR_MAX_PER_JOB 25
 
 // Return codes from acl subroutines.

--- a/core/src/findlib/acl.h
+++ b/core/src/findlib/acl.h
@@ -80,17 +80,19 @@ typedef enum
 #  define BACL_ENOTSUP EOPNOTSUPP
 #endif
 
-static inline constexpr uint32_t BACL_FLAG_SAVE_NATIVE = 0x01;
-static inline constexpr uint32_t BACL_FLAG_SAVE_AFS = 0x02;
-static inline constexpr uint32_t BACL_FLAG_RESTORE_NATIVE = 0x04;
-static inline constexpr uint32_t BACL_FLAG_RESTORE_AFS = 0x08;
+struct bacl_flags {
+  bool SaveNative{false};
+  bool SaveAfs{false};
+  bool RestoreNative{false};
+  bool RestoreAfs{false};
+};
 
 // Internal tracking data.
 class AclData {
  public:
   int filetype;
   POOLMEM* last_fname;
-  uint32_t flags{}; /* See BACL_FLAG_* */
+  bacl_flags flags{};
   uint32_t current_dev{0};
   bool first_dev{true};
   uint32_t nr_errors;

--- a/core/src/findlib/bfile.h
+++ b/core/src/findlib/bfile.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,7 +35,6 @@
  * from winbase.h on Win32. We didn't inlcude cStreamName
  * as we don't use it and don't need it for a correct struct size.
  */
-
 #define WIN32_BACKUP_DATA 1
 
 typedef struct _BWIN32_STREAM_ID {

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2008-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -2812,7 +2812,7 @@ BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
   } else {
     /* Increment error count but don't log an error again for the same
      * filesystem. */
-    if (xattr_data->u.parse) xattr_data->u.parse->nr_errors++;
+    xattr_data->nr_errors++;
     retval = BxattrExitCode::kSuccess;
     goto bail_out;
   }

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -175,10 +175,10 @@ void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list)
  * This is repeated 1 or more times.
  *
  */
-uint32_t SerializeXattrStream(JobControlRecord*,
-                              XattrBuildData* xattr_data,
-                              uint32_t expected_serialize_len,
-                              alist<xattr_t*>* xattr_value_list)
+static bool SerializeXattrStream(JobControlRecord*,
+                                 XattrBuildData* xattr_data,
+                                 uint32_t expected_serialize_len,
+                                 alist<xattr_t*>* xattr_value_list)
 {
   ser_declare;
 
@@ -212,7 +212,7 @@ uint32_t SerializeXattrStream(JobControlRecord*,
   SerEnd(xattr_data->content.c_str(), expected_serialize_len + 10);
   xattr_data->content_length = SerLength(xattr_data->content.c_str());
 
-  return xattr_data->content_length;
+  return xattr_data->content_length == expected_serialize_len;
 }
 
 BxattrExitCode UnSerializeXattrStream(JobControlRecord* jcr,
@@ -296,14 +296,18 @@ BxattrExitCode SerializeAndSendXattrStream(JobControlRecord* jcr,
                                            int stream_type)
 {
   // Serialize the datastream.
-  const uint32_t serialize_len = SerializeXattrStream(
-      jcr, xattr_data, expected_serialize_len, xattr_value_list);
-  if (serialize_len < expected_serialize_len) {
+  if (!SerializeXattrStream(jcr, xattr_data, expected_serialize_len,
+                            xattr_value_list)) {
     Mmsg1(jcr->errmsg,
-          T_("Failed to Serialize extended attributes on file \"%s\"\n"),
-          xattr_data->last_fname);
-    Dmsg1(100, "Failed to Serialize extended attributes on file \"%s\"\n",
-          xattr_data->last_fname);
+          T_("Failed to Serialize extended attributes on file \"%s\" (expected "
+             "len %lu != actual len %lu)\n"),
+          xattr_data->last_fname, expected_serialize_len,
+          xattr_data->content_length);
+    Dmsg1(100,
+          T_("Failed to Serialize extended attributes on file \"%s\" (expected "
+             "len %lu != actual len %lu)\n"),
+          xattr_data->last_fname, expected_serialize_len,
+          xattr_data->content_length);
     return BxattrExitCode::kError;
   }
   return SendXattrStream(jcr, xattr_data, stream_type);

--- a/core/src/findlib/xattr.h
+++ b/core/src/findlib/xattr.h
@@ -78,18 +78,15 @@ class XattrData {
   uint32_t current_dev{0};
   bool first_dev{true};
   uint32_t nr_errors{0};
-  virtual ~XattrData() noexcept {}
+  virtual ~XattrData() noexcept = default;
 };
 
 class XattrBuildData : public XattrData {
  public:
   uint32_t nr_saved{0};
-  POOLMEM* content{nullptr};
+  PoolMem content{PM_MESSAGE};
   uint32_t content_length{0};
   alist<xattr_link_cache_entry_t*>* link_cache{nullptr};
-
-  XattrBuildData() noexcept : content(GetPoolMemory(PM_MESSAGE)) {}
-  ~XattrBuildData() noexcept override { FreePoolMemory(content); }
 };
 
 // Maximum size of the XATTR stream this prevents us from blowing up the filed.
@@ -98,6 +95,11 @@ class XattrBuildData : public XattrData {
 // Upperlimit on a xattr internal buffer
 #define XATTR_BUFSIZ 1024
 
+BxattrExitCode SerializeAndSendXattrStream(JobControlRecord* jcr,
+                                           XattrBuildData* xattr_data,
+                                           uint32_t expected_serialize_len,
+                                           alist<xattr_t*>* xattr_value_list,
+                                           int stream_type);
 BxattrExitCode SendXattrStream(JobControlRecord* jcr,
                                XattrBuildData* xattr_data,
                                int stream);

--- a/core/src/findlib/xattr.h
+++ b/core/src/findlib/xattr.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -23,6 +23,12 @@
 
 #ifndef BAREOS_FINDLIB_XATTR_H_
 #define BAREOS_FINDLIB_XATTR_H_
+
+#include <cstdint>
+#include "include/bc_types.h"
+template <typename T> class alist;
+class JobControlRecord;
+struct FindFilesPacket;
 
 // Return codes from xattr subroutines.
 enum class BxattrExitCode
@@ -64,15 +70,10 @@ struct xattr_link_cache_entry_t {
 #define BXATTR_FLAG_RESTORE_NATIVE 0x02
 
 struct xattr_build_data_t {
-  uint32_t nr_errors;
   uint32_t nr_saved;
   POOLMEM* content;
   uint32_t content_length;
   alist<xattr_link_cache_entry_t*>* link_cache;
-};
-
-struct xattr_parse_data_t {
-  uint32_t nr_errors;
 };
 
 // Internal tracking data.
@@ -81,9 +82,9 @@ struct XattrData {
   uint32_t flags{0}; /* See BXATTR_FLAG_* */
   uint32_t current_dev{0};
   bool first_dev{true};
+  uint32_t nr_errors{0};
   union {
     struct xattr_build_data_t* build;
-    struct xattr_parse_data_t* parse;
   } u;
 };
 

--- a/core/src/findlib/xattr.h
+++ b/core/src/findlib/xattr.h
@@ -71,8 +71,7 @@ struct xattr_link_cache_entry_t {
 #define BXATTR_FLAG_RESTORE_NATIVE 0x02
 
 // Internal tracking data.
-class XattrData {
- public:
+struct XattrData {
   POOLMEM* last_fname{nullptr};
   uint32_t flags{0}; /* See BXATTR_FLAG_* */
   uint32_t current_dev{0};
@@ -81,8 +80,7 @@ class XattrData {
   virtual ~XattrData() noexcept = default;
 };
 
-class XattrBuildData : public XattrData {
- public:
+struct XattrBuildData : public XattrData {
   uint32_t nr_saved{0};
   PoolMem content{PM_MESSAGE};
   uint32_t content_length{0};
@@ -104,10 +102,6 @@ BxattrExitCode SendXattrStream(JobControlRecord* jcr,
                                XattrBuildData* xattr_data,
                                int stream);
 void XattrDropInternalTable(alist<xattr_t*>* xattr_value_list);
-uint32_t SerializeXattrStream(JobControlRecord* jcr,
-                              XattrBuildData* xattr_data,
-                              uint32_t expected_serialize_len,
-                              alist<xattr_t*>* xattr_value_list);
 BxattrExitCode UnSerializeXattrStream(JobControlRecord* jcr,
                                       XattrData* xattr_data,
                                       char* content,


### PR DESCRIPTION
This is my approach to use proper C++ types instead of pointer-connected C structs for XattrData (and maybe AclData).
This will also fix a crash when running bextract to extract a job with xattr onto a filesystem without xattr support (and presumably the same for acl data).

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
