### PR TITLE
cats: scripts add option --no-psqlrc to psql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - msgchan: fix deadlock [PR #1858]
 - VMware Plugin: Add option restore_allow_disks_mismatch [PR #1876]
 - matrix remove obsolete SUSE [PR #1888]
+- cats: scripts add option --no-psqlrc to psql [PR #1900]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -235,4 +236,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1881]: https://github.com/bareos/bareos/pull/1881
 [PR #1883]: https://github.com/bareos/bareos/pull/1883
 [PR #1888]: https://github.com/bareos/bareos/pull/1888
+[PR #1900]: https://github.com/bareos/bareos/pull/1900
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -45,7 +45,7 @@ info "Creating database '${db_name}'"
 # use SQL_ASCII to be able to put any filename into
 # the database even those created with unusual character sets
 retval=0
-psql -f - -d template1 << END-OF-DATA || retval=$?
+psql --no-psqlrc -f - -d template1 << END-OF-DATA || retval=$?
 \set ON_ERROR_STOP on
 CREATE DATABASE "${db_name}" ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 ALTER DATABASE "${db_name}" SET datestyle TO 'ISO, YMD';
@@ -54,7 +54,7 @@ END-OF-DATA
 QUERY="SELECT pg_catalog.pg_encoding_to_char(d.encoding) as encoding \
  FROM pg_catalog.pg_database d WHERE d.datname='${db_name}';"
 
-if [ "$(psql --tuples-only --no-align --command="${QUERY}" | tr -d '\r')" = "SQL_ASCII" ]
+if [ "$(psql --no-psqlrc --tuples-only --no-align --command="${QUERY}" | tr -d '\r')" = "SQL_ASCII" ]
 then
     info "Database encoding OK"
 else

--- a/core/src/cats/drop_bareos_database.in
+++ b/core/src/cats/drop_bareos_database.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/cats/drop_bareos_database.in
+++ b/core/src/cats/drop_bareos_database.in
@@ -42,7 +42,7 @@ fi
 info "Dropping of ${db_name} database"
 
 retval=0
-dropdb "${db_name}" || retval=$?
+dropdb --if-exists "${db_name}" || retval=$?
 if [ ${retval} -eq 0 ]; then
    info "Drop of ${db_name} database succeeded."
 else

--- a/core/src/cats/drop_bareos_tables.in
+++ b/core/src/cats/drop_bareos_tables.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -59,7 +59,7 @@ if [ -n "${sql_definitions}" ]; then
 fi
 
 retval=0
-PGOPTIONS='--client-min-messages=warning' psql -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
 if [ $retval -eq 0 ]; then
     info "Dropping ${db_name} tables succeeded."
 else

--- a/core/src/cats/grant_bareos_privileges.in
+++ b/core/src/cats/grant_bareos_privileges.in
@@ -53,9 +53,9 @@ fi
 
 retval=0
 if [[ "$(uname -s)" =~ _NT ]]; then
-  PGOPTIONS='--client-min-messages=warning' psql -f "$(cygpath -w ${temp_sql_grants})" -d "${db_name}" || retval=$?
+  PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "$(cygpath -w ${temp_sql_grants})" -d "${db_name}" || retval=$?
 else
-  PGOPTIONS='--client-min-messages=warning' psql -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
+  PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
 fi
 if [ ${retval} -eq 0 ]; then
    info "Privileges for user ${db_user} granted ON database ${db_name}."

--- a/core/src/cats/update_bareos_tables.in
+++ b/core/src/cats/update_bareos_tables.in
@@ -49,7 +49,7 @@ info "Updating ${db_name} tables"
 
 while true
 do
-    DBVERSION=$(PGOPTIONS='--client-min-messages=warning' psql -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
+    DBVERSION=$(PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
     if [ -z "${DBVERSION}" ]; then
         error "Unable to determine version of Bareos database"
         exit 1
@@ -108,9 +108,9 @@ do
    info "Upgrading database schema from version ${start_version} to ${end_version}"
    retval=0
    if [[ "$(uname -s)" =~ _NT ]]; then
-     PAGER="" PGOPTIONS="--client-min-messages=warning" psql -f "$(cygpath -w ${temp_sql_schema})" -d "${db_name}" || retval=$?
+     PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "$(cygpath -w ${temp_sql_schema})" -d "${db_name}" || retval=$?
    else
-     PAGER="" PGOPTIONS="--client-min-messages=warning" psql -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+     PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
    fi
 
    rm -f "${temp_sql_schema}"
@@ -123,7 +123,7 @@ do
    # return value of psql is does says OK when transaction was rolled back.
    # So we verify that the version was set to what we expect.
    #
-   DBVERSION_AFTER=$(PGOPTIONS='--client-min-messages=warning' psql -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
+   DBVERSION_AFTER=$(PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
    if [ "${DBVERSION_AFTER}" -ne "${end_version}" ]; then
       error "Failed to upgrade database schema from version ${DBVERSION} to ${end_version}, is still on ${DBVERSION_AFTER}"
       exit 1


### PR DESCRIPTION
- **script: add --if-exists to dropdb**

    This commit will turn the error into a warning when we try to dropdb
    non existing database.

- **cats: add option --no-psqlrc to psql command in scripts**

    While it is rare to have .psqlrc configuration file setup for user
    like `bareos` or `postgres`, it may contains configuration that
    may defeat our expectation in terms of return.
    `--no-psqlrc` is now added to all catalog scripts.


### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
