### PR TITLE
dird: disallow running always incremental virtual full jobs with empty jobid list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - Use only MinGW VSS [PR #1896]
 - filed: fix python plugin crash on python <3.10 [PR #1913]
 - vadp-dumper: fix out of bounds read [PR #1918]
+- dird: disallow running always incremental virtual full jobs with empty jobid list [PR #1901]
 
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
@@ -513,6 +514,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1890]: https://github.com/bareos/bareos/pull/1890
 [PR #1894]: https://github.com/bareos/bareos/pull/1894
 [PR #1896]: https://github.com/bareos/bareos/pull/1896
+[PR #1901]: https://github.com/bareos/bareos/pull/1901
 [PR #1905]: https://github.com/bareos/bareos/pull/1905
 [PR #1906]: https://github.com/bareos/bareos/pull/1906
 [PR #1913]: https://github.com/bareos/bareos/pull/1913

--- a/core/src/dird/vbackup.cc
+++ b/core/src/dird/vbackup.cc
@@ -105,6 +105,12 @@ std::string GetVfJobids(JobControlRecord& jcr)
   if (jcr.dir_impl->vf_jobids) {
     Dmsg1(10, "jobids=%s\n", jcr.dir_impl->vf_jobids);
     return jcr.dir_impl->vf_jobids;
+  } else if (jcr.dir_impl->res.job->AlwaysIncremental) {
+    // jcr.dir_impl->vf_jobids is NULL here
+    Jmsg(&jcr, M_ERROR, 0,
+         "Cannot run always incremental job at level VirtualFull with no jobid "
+         "list.\n");
+    return std::string{};
   } else {
     db_list_ctx jobids_ctx;
     jcr.db->AccurateGetJobids(&jcr, &jcr.dir_impl->jr, &jobids_ctx);

--- a/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
@@ -54,9 +54,17 @@ END_OF_DATA
 run_bconsole
 
 cat <<END_OF_DATA >${tmp}/bconcmds
-@$out ${tmp}/consolidatevfs_canceled.out
+.api 2
+@$out ${tmp}/consolidatevfs_consolidate.out
 run job=Consolidate yes
-@sleep 2
+END_OF_DATA
+run_bconsole
+
+consolidate_jobid=$(grep "jobid" ${tmp}/consolidatevfs_consolidate.out | tail -n1 | sed 's/.*"jobid": "\(.*\)"/\1/')
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/consolidatevfs_canceled.out
+wait jobid=${consolidate_jobid}
 cancel all yes
 wait
 messages

--- a/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-06-rerun-ai-vf
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+#
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=ai-backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+# Check consolidate ai virtual full can't be rerun manually (without a jobid list).
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/ai2backups.out
+messages
+label volume=TestVolume002 storage=File pool=Full
+run job=$JobName level=Full yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-19'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-20'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/file-21'"
+run job=$JobName level=Incremental yes
+wait
+messages
+END_OF_DATA
+run_bconsole
+
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/consolidatevfs_canceled.out
+run job=Consolidate yes
+@sleep 2
+cancel all yes
+wait
+messages
+@$out ${tmp}/consolidatevfs_canceled_listjobs.out
+list jobs jobtype=B jobstatus=A,C
+quit
+END_OF_DATA
+run_bconsole
+
+last_jobid=$(awk '/^\| [ 0-9]/{a=$2}END{print a}' ${tmp}/consolidatevfs_canceled_listjobs.out)
+cat <<END_OF_DATA >${tmp}/bconcmds
+@$out ${tmp}/consolidatevfs_rerun_canceled.out
+rerun jobid=${last_jobid} yes
+wait
+messages
+END_OF_DATA
+run_bconsole
+
+expect_grep "Cannot run always incremental job at level VirtualFull with no jobid" \
+            "${tmp}/consolidatevfs_rerun_canceled.out" \
+            "Aborting rerun without jobis not found"
+
+end_test


### PR DESCRIPTION
**Backport of PR #1738 to bareos-23**

This backport does _not_ contain the removal of the unused `fdcalled` feature.
Nor the fixes in ua_ouput changing core behavior.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1738 is merged
- [x] All functional differences to the original PR are documented above
