### PR TITLE
Libcloud Accurate File Backup

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,6 +36,7 @@ Bernd Frick
 Bernhard M. Wiedemann
 Bill Moran
 Braian Bressan
+Brian Sperduto
 Bruno Friedmann
 Camilo Viecco
 Carlos A. Molina G

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: fixing selenium tests [PR #1885]
 - plugins: adjust plugin info formatting [PR #1919]
 - python-bareos: fix backslash usage in regex [PR #1917]
+- Libcloud Accurate File Backup [PR #1903]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -244,6 +245,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1888]: https://github.com/bareos/bareos/pull/1888
 [PR #1889]: https://github.com/bareos/bareos/pull/1889
 [PR #1900]: https://github.com/bareos/bareos/pull/1900
+[PR #1903]: https://github.com/bareos/bareos/pull/1903
 [PR #1908]: https://github.com/bareos/bareos/pull/1908
 [PR #1917]: https://github.com/bareos/bareos/pull/1917
 [PR #1919]: https://github.com/bareos/bareos/pull/1919

--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
+++ b/core/src/plugins/filed/python/libcloud/BareosFdPluginLibcloud.py
@@ -392,7 +392,8 @@ class BareosFdPluginLibcloud(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                     )
                     self.current_backup_task["skip_file"] = True
                     return bRC_OK
-
+        elif self.current_backup_task["type"] == TASK_TYPE.ACCURATE:
+            self.FILE = None
         else:
             raise Exception(value='Wrong argument for current_backup_task["type"]')
 

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
@@ -27,6 +27,7 @@ class TASK_TYPE(object):
     DOWNLOADED = 1
     TEMP_FILE = 2
     STREAM = 3
+    ACCURATE = 4
 
     def __setattr__(self, *_):
         raise Exception("class TASK_TYPE is read only")
@@ -139,6 +140,7 @@ class BucketExplorer(ProcessBase):
                 # again but remembered as "still here" (for accurate mode)
                 # If accurate mode is off, we can simply skip that object
                 if self.options["accurate"] is True:
+                    task["type"] = TASK_TYPE.ACCURATE
                     self.queue_try_put(self.discovered_objects_queue, task)
 
                 continue

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/worker.py
@@ -121,7 +121,9 @@ class Worker(ProcessBase):
 
         action = CONTINUE
 
-        if task["size"] < 1024 * 10:
+        if task["type"] == TASK_TYPE.ACCURATE:
+            action = self._put_accurate_object_into_queue(task, obj)
+        elif task["size"] < 1024 * 10:
             action = self._download_object_into_queue(task, obj)
         elif task["size"] < self.options["prefetch_size"]:
             action = self._download_object_into_tempfile(task, obj)
@@ -234,6 +236,32 @@ class Worker(ProcessBase):
         except Exception as e:
             self.error_message(
                 "Error preparing stream object, skipping: %s"
+                % (task_object_full_name(task)),
+                e,
+            )
+            return self._fail_job_or_continue_running()
+
+    def _put_accurate_object_into_queue(self, task, obj):
+        try:
+            self.debug_message(
+                110,
+                "Prepare object as accurate for download %s"
+                % (task_object_full_name(task)),
+            )
+            task["data"] = obj
+            task["type"] = TASK_TYPE.ACCURATE
+            self.queue_try_put(self.output_queue, task)
+            return CONTINUE
+        except LibcloudError as e:
+            self.error_message(
+                "Libcloud error preparing accurate object, skipping: %s"
+                % (task_object_full_name(task)),
+                e,
+            )
+            return self._fail_job_or_continue_running()
+        except Exception as e:
+            self.error_message(
+                "Error preparing accurate object, skipping: %s"
                 % (task_object_full_name(task)),
                 e,
             )


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!
Currently with libcloud with accurate backup mode on all files are added to the backup queue including unchanged files. This causes the unchanged files to be downloaded or a stream resource to be created prior to the start_backup_file method being called. It appears in an accurate only situation the resources are available but never used as no IO is ever called when there's no changes. This change creates a 4th file type called "ACCURATE" which is effectively a dummy record with no backing stream or temp file. It simply passes through the accurate information and is removed from the queue. This fixes issues where in an accurate incremental backup the temp space is filled with accurate only files which are never cleaned up due to the file never being opened for IO.

Open to other suggestions or solutions
#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
