### PR TITLE
VMware Plugin: Add option restore_allow_disks_mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - VMware Plugin: Adapt to Python 3.12 [PR #1879]
 - freebsd: fix build issues with ports tree 2024Q3 [PR #1884]
 - matrix remove obsolete SUSE [PR #1906]
+- VMware Plugin: Add option restore_allow_disks_mismatch [PR #1905]
 
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
@@ -508,5 +509,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1886]: https://github.com/bareos/bareos/pull/1886
 [PR #1890]: https://github.com/bareos/bareos/pull/1890
 [PR #1894]: https://github.com/bareos/bareos/pull/1894
+[PR #1905]: https://github.com/bareos/bareos/pull/1905
 [PR #1906]: https://github.com/bareos/bareos/pull/1906
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -710,11 +710,12 @@ fallback_to_full_cbt (optional)
 
    Since :sinceVersion:`23.0.3: VMware Plugin`
 
-restore_ignore_disks_mismatch (optional)
+restore_allow_disks_mismatch (optional)
    When using VSAN, restoring with recreating the VM can fail because the plugin
    detects a disk mismatch, as when using VSAN obviously recreated disks get a
    generated backing disk path. When passing the plugin option
-   ``restore_ignore_disks_mismatch=yes``, this disk match check will be skipped.
+   ``restore_allow_disks_mismatch=yes``, this disk match check will allow a
+   mismatch and continue the restore.
    This option will only be used when recreating the VM to be restored.
 
    Since :sinceVersion:`23.0.4: VMware Plugin`

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -710,5 +710,14 @@ fallback_to_full_cbt (optional)
 
    Since :sinceVersion:`23.0.3: VMware Plugin`
 
+restore_ignore_disks_mismatch (optional)
+   When using VSAN, restoring with recreating the VM can fail because the plugin
+   detects a disk mismatch, as when using VSAN obviously recreated disks get a
+   generated backing disk path. When passing the plugin option
+   ``restore_ignore_disks_mismatch=yes``, this disk match check will be skipped.
+   This option will only be used when recreating the VM to be restored.
+
+   Since :sinceVersion:`23.0.4: VMware Plugin`
+
 uuid (deprecated)
    The uuid option could be used instead of *dc*, *folder* and *vmname* to uniquely address a VM for backup. As the plugin since :sinceVersion:`22.0.0: VMware Plugin` is able recreate VMs in a different datacenter, folder or datastore, this option has become useless. When using uuid, restoring is only possible to the same still existing VM. It is recommended to change the configuration, as the uuid option will be dropped in the next version.


### PR DESCRIPTION
**Backport of PR #1876 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1876 is merged
- [x] All functional differences to the original PR are documented above
