### PR TITLE
matrix remove obsolete SUSE

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -29,7 +29,7 @@ OS:
   SUSE:
     "15":
       TYPE: rpm
-      IMAGE: sle156
+      IMAGE: sle155
       CUSTOM_TEST_IMAGES: [ SLE-15_SP3, SLE-15_SP4, openSUSE-Leap_15.4, SLE-15_SP5, openSUSE-Leap_15.5, SLE-15_SP6, openSUSE-Leap_15.6 ]
       ARCH:
       - x86_64

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -29,8 +29,8 @@ OS:
   SUSE:
     "15":
       TYPE: rpm
-      IMAGE: sle154
-      CUSTOM_TEST_IMAGES: [ SLE-15_SP3, SLE-15_SP4, openSUSE-Leap_15.4, SLE-15_SP5, openSUSE-Leap_15.5 ]
+      IMAGE: sle156
+      CUSTOM_TEST_IMAGES: [ SLE-15_SP3, SLE-15_SP4, openSUSE-Leap_15.4, SLE-15_SP5, openSUSE-Leap_15.5, SLE-15_SP6, openSUSE-Leap_15.6 ]
       ARCH:
       - x86_64
   SLE:
@@ -77,7 +77,7 @@ OS:
     "8":
       TYPE: rpm
       IMAGE: rhel8
-      CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, Stream, RHEL ]
+      CUSTOM_TEST_IMAGES: [ Rocky, Alma, Oracle, RHEL ]
       ARCH:
       - x86_64
     "7":

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - python-bareos: add missing `dirname` variable [PR #1848]
+- matrix remove obsolete SUSE [PR #1907]
 
 ### Fixed
 - create_bareos_database: fix `db_name` not being double quoted [PR #1870]
@@ -690,4 +691,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1870]: https://github.com/bareos/bareos/pull/1870
 [PR #1891]: https://github.com/bareos/bareos/pull/1891
 [PR #1895]: https://github.com/bareos/bareos/pull/1895
+[PR #1907]: https://github.com/bareos/bareos/pull/1907
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -983,7 +983,7 @@ if(HAVE_WIN32)
 endif()
 # REPEAT_UNTIL requires cmake 3.17+
 if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
-  set(REPEAT_UNTIL "REPEAT UNTIL_PASS:2")
+  set(REPEAT_UNTIL "")
 endif()
 
 configure_file(

--- a/core/cmake/BareosFindPrograms.cmake
+++ b/core/cmake/BareosFindPrograms.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package bareos
 # Copyright (c) 2011-2012 Bruno Friedmann (Ioda-Net) and Philipp Storz (dass IT)
-#               2013-2023 Bareos GmbH & Co KG
+#               2013-2024 Bareos GmbH & Co KG
 #
 
 Name:       bareos
@@ -107,18 +107,13 @@ BuildRequires: devtoolset-8-gcc
 BuildRequires: devtoolset-8-gcc-c++
 %endif
 
-%if 0%{?sle_version} == 150400
-BuildRequires: gcc11
-BuildRequires: gcc11-c++
-%else
-  %if 0%{?sle_version} == 150300 || 0%{?suse_version} > 1500
-BuildRequires: gcc10
-BuildRequires: gcc10-c++
-  %else
-    %if 0%{?suse_version}
+%if 0%{?suse_version} < 1500 && 0%{?suse_version} >= 1210
 BuildRequires: gcc9
 BuildRequires: gcc9-c++
-    %endif
+%else
+  %if 0%{?suse_version}
+BuildRequires: gcc13
+BuildRequires: gcc13-c++
   %endif
 %endif
 
@@ -266,7 +261,7 @@ Bareos source code has been released under the AGPL version 3 license.
 %{dscr}
 
 
-%if 0%{?opensuse_version} || 0%{?sle_version}
+%if 0%{?suse_version}
 %debug_package
 %endif
 
@@ -719,7 +714,7 @@ Requires: httpd
 %define www_daemon_group apache
 %endif
 
-%if 0%{?suse_version} || 0%{?sle_version}
+%if 0%{?suse_version}
 Conflicts: mod_php_any
 %define _apache_conf_dir /etc/apache2/conf.d/
 %define www_daemon_user wwwrun
@@ -899,22 +894,15 @@ source /opt/rh/devtoolset-8/enable
 %endif
 
 # use modern compiler on suse
-%if 0%{?sle_version} == 150400
-CC=gcc-11  ; export CC
-CXX=g++-11 ; export CXX
-%else
-  %if 0%{?sle_version} == 150300 || 0%{?suse_version} > 1500
-CC=gcc-10  ; export CC
-CXX=g++-10 ; export CXX
-  %else
-    %if 0%{?suse_version}
+%if 0%{?suse_version} < 1500 && 0%{?suse_version} >= 1210
 CC=gcc-9  ; export CC
 CXX=g++-9 ; export CXX
-    %endif
+%else
+  %if 0%{?suse_version}
+CC=gcc-13  ; export CC
+CXX=g++-13 ; export CXX
   %endif
 %endif
-
-
 
 CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ;
 CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ;

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -34,6 +34,7 @@ cd /
 . "@scriptdir@"/bareos-config-lib.sh
 
 db_name="${db_name:-$(get_database_name @db_name@)}"
+export PGOPTIONS='--client-min-messages=warning' 
 
 if [ $# -gt 0 ]; then
   handle_database_scripts_command_line_parameter $*
@@ -44,13 +45,16 @@ info "Creating database '${db_name}'"
 # use SQL_ASCII to be able to put any filename into
 # the database even those created with unusual character sets
 retval=0
-PGOPTIONS='--client-min-messages=warning' psql -f - -d template1 << END-OF-DATA || retval=$?
+psql -f - -d template1 << END-OF-DATA || retval=$?
 \set ON_ERROR_STOP on
 CREATE DATABASE "${db_name}" ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 ALTER DATABASE "${db_name}" SET datestyle TO 'ISO, YMD';
 END-OF-DATA
 
-if PGOPTIONS='--client-min-messages=warning' psql --list --tuples-only --no-align | grep "^${db_name}|.*|SQL_ASCII|C|C" >/dev/null
+QUERY="SELECT pg_catalog.pg_encoding_to_char(d.encoding) as encoding \
+ FROM pg_catalog.pg_database d WHERE d.datname='${db_name}';"
+
+if [ "$(psql --tuples-only --no-align --command="${QUERY}")" = "SQL_ASCII" ]
 then
     info "Database encoding OK"
 else

--- a/core/src/lib/tls_openssl_private.cc
+++ b/core/src/lib/tls_openssl_private.cc
@@ -252,7 +252,7 @@ bool TlsOpenSslPrivate::init()
     return false;
   }
 
-  ASSERT(tcp_file_descriptor_);
+  ASSERT(tcp_file_descriptor_ >= 0);  // 0 is a good (socket-)fd
   BIO_set_fd(bio, tcp_file_descriptor_, BIO_NOCLOSE);
 
   SSL_set_bio(openssl_, bio, bio);

--- a/core/src/lib/tls_openssl_private.cc
+++ b/core/src/lib/tls_openssl_private.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/tls_openssl_private.h
+++ b/core/src/lib/tls_openssl_private.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -84,7 +84,7 @@ class TlsOpenSslPrivate {
   std::string protocol_;
 
   /* cert attributes */
-  int tcp_file_descriptor_{};
+  int tcp_file_descriptor_{kInvalidFiledescriptor};
   std::string ca_certfile_;
   std::string ca_certdir_;
   std::string crlfile_;

--- a/core/src/tests/bareos_test_sockets.cc
+++ b/core/src/tests/bareos_test_sockets.cc
@@ -195,7 +195,7 @@ std::unique_ptr<TestSockets> create_connected_server_and_client_bareos_socket()
 
   EXPECT_NE(portnumber_opt, std::nullopt) << "Could not find used port number";
   if (!portnumber_opt) {
-    socketClose(listen_fd);
+    close(listen_fd);
     return nullptr;
   }
 
@@ -208,18 +208,18 @@ std::unique_ptr<TestSockets> create_connected_server_and_client_bareos_socket()
                                           HOST, NULL, portnumber, false);
   EXPECT_EQ(ok, true) << "Could not connect client socket with server socket.";
   if (!ok) {
-    socketClose(listen_fd);
+    close(listen_fd);
     return nullptr;
   }
 
   auto server_fd = accept_server_socket(listen_fd);
   EXPECT_GE(server_fd, 0) << "Could not accept server socket.";
   if (server_fd <= 0) {
-    socketClose(listen_fd);
+    close(listen_fd);
     return nullptr;
   }
 
-  socketClose(listen_fd);
+  close(listen_fd);
 
   test_sockets->server.reset(create_new_bareos_socket(server_fd));
 
@@ -246,7 +246,7 @@ std::optional<listening_socket> create_listening_socket()
   auto port = port_number_of(sock_fd);
 
   if (!port) {
-    socketClose(sock_fd);
+    close(sock_fd);
     return std::nullopt;
   }
 
@@ -261,5 +261,5 @@ int accept_socket(const listening_socket& ls)
 
 listening_socket::~listening_socket()
 {
-  if (sockfd >= 0) { socketClose(sockfd); }
+  if (sockfd >= 0) { close(sockfd); }
 }

--- a/core/src/tests/bareos_test_sockets.cc
+++ b/core/src/tests/bareos_test_sockets.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -152,23 +152,54 @@ static int accept_server_socket(int listen_file_descriptor)
   return new_socket;
 }
 
-int create_accepted_server_socket(int port)
+static std::optional<uint16_t> port_number_of(int sockfd)
 {
-  int sock_fd = create_listening_server_socket(port);
-  if (sock_fd > 0) { sock_fd = accept_server_socket(sock_fd); }
-  return sock_fd;
+  union {
+    struct sockaddr addr;
+    struct sockaddr_in addr4;
+    struct sockaddr_in6 addr6;
+  } buf = {};
+
+  // the port gets chosen during StartSocketServer, so we need to query
+  // the port number afterwards.
+  socklen_t len = sizeof(buf);
+  auto error = getsockname(sockfd, &buf.addr, &len);
+  EXPECT_EQ(error, 0);
+  if (error != 0) {
+    perror("sock name error");
+    return false;
+  }
+
+  if (buf.addr.sa_family != AF_INET && buf.addr.sa_family != AF_INET6) {
+    return std::nullopt;
+  }
+
+  auto nport = (buf.addr.sa_family == AF_INET) ? buf.addr4.sin_port
+                                               : buf.addr6.sin6_port;
+
+  auto port = ntohs(nport);
+
+  return port;
 }
 
 std::unique_ptr<TestSockets> create_connected_server_and_client_bareos_socket()
 {
   std::unique_ptr<TestSockets> test_sockets(new TestSockets);
 
-  uint16_t portnumber = create_unique_socket_number();
+  int listen_fd = create_listening_server_socket(0);
 
-  int server_file_descriptor = create_listening_server_socket(portnumber);
+  EXPECT_GE(listen_fd, 0) << "Could not create listening socket";
+  if (listen_fd < 0) { return nullptr; }
 
-  EXPECT_GE(server_file_descriptor, 0) << "Could not create listening socket";
-  if (server_file_descriptor < 0) { return nullptr; }
+  auto portnumber_opt = port_number_of(listen_fd);
+
+  EXPECT_NE(portnumber_opt, std::nullopt) << "Could not find used port number";
+  if (!portnumber_opt) {
+    socketClose(listen_fd);
+    return nullptr;
+  }
+
+  auto portnumber = *portnumber_opt;
 
   test_sockets->client.reset(new BareosSocketTCP);
   test_sockets->client->sleep_time_after_authentication_error = 0;
@@ -176,13 +207,21 @@ std::unique_ptr<TestSockets> create_connected_server_and_client_bareos_socket()
   bool ok = test_sockets->client->connect(NULL, 1, 1, 0, "Director daemon",
                                           HOST, NULL, portnumber, false);
   EXPECT_EQ(ok, true) << "Could not connect client socket with server socket.";
-  if (!ok) { return nullptr; }
+  if (!ok) {
+    socketClose(listen_fd);
+    return nullptr;
+  }
 
-  server_file_descriptor = accept_server_socket(server_file_descriptor);
-  EXPECT_GE(server_file_descriptor, 0) << "Could not accept server socket.";
-  if (server_file_descriptor <= 0) { return nullptr; }
+  auto server_fd = accept_server_socket(listen_fd);
+  EXPECT_GE(server_fd, 0) << "Could not accept server socket.";
+  if (server_fd <= 0) {
+    socketClose(listen_fd);
+    return nullptr;
+  }
 
-  test_sockets->server.reset(create_new_bareos_socket(server_file_descriptor));
+  socketClose(listen_fd);
+
+  test_sockets->server.reset(create_new_bareos_socket(server_fd));
 
   return test_sockets;
 }
@@ -198,21 +237,29 @@ BareosSocket* create_new_bareos_socket(int fd)
   return bs;
 }
 
-
-#include <sys/types.h>
-#include <unistd.h>
-
-static uint16_t listening_server_port_number = 0;
-
-uint16_t create_unique_socket_number()
+std::optional<listening_socket> create_listening_socket()
 {
-  if (listening_server_port_number == 0) {
-    pid_t pid = getpid();
-    uint16_t port_number = 5 * (static_cast<uint32_t>(pid) % 10000) + 10000;
-    listening_server_port_number = port_number;
-  } else {
-    ++listening_server_port_number;
+  int sock_fd = create_listening_server_socket(0);
+
+  if (sock_fd < 0) { return std::nullopt; }
+
+  auto port = port_number_of(sock_fd);
+
+  if (!port) {
+    socketClose(sock_fd);
+    return std::nullopt;
   }
 
-  return listening_server_port_number;
+  return listening_socket{*port, sock_fd};
+}
+
+int accept_socket(const listening_socket& ls)
+{
+  auto fd = accept_server_socket(ls.sockfd);
+  return fd;
+}
+
+listening_socket::~listening_socket()
+{
+  if (sockfd >= 0) { socketClose(sockfd); }
 }

--- a/core/src/tests/bareos_test_sockets.h
+++ b/core/src/tests/bareos_test_sockets.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -24,6 +24,7 @@
 #define BAREOS_TESTS_BAREOS_TEST_SOCKETS_H_
 
 #include <memory>
+#include <optional>
 
 class BareosSocketTCP;
 class BareosSocket;
@@ -37,9 +38,30 @@ class TestSockets {
   TestSockets(const TestSockets&) = delete;
 };
 
-int create_accepted_server_socket(int port);
+struct listening_socket {
+  uint16_t port{};
+  int sockfd{};
+
+  listening_socket() = default;
+  listening_socket(uint16_t port_, int sockfd_) : port{port_}, sockfd{sockfd_}
+  {
+  }
+  listening_socket(const listening_socket&) = delete;
+  listening_socket& operator=(const listening_socket&) = delete;
+  listening_socket(listening_socket&& other) { *this = std::move(other); }
+  listening_socket& operator=(listening_socket&& other)
+  {
+    std::swap(port, other.port);
+    std::swap(sockfd, other.sockfd);
+    return *this;
+  }
+  ~listening_socket();
+};
+
+std::optional<listening_socket> create_listening_socket();
+int accept_socket(const listening_socket& ls);
+
 BareosSocket* create_new_bareos_socket(int fd);
 std::unique_ptr<TestSockets> create_connected_server_and_client_bareos_socket();
-uint16_t create_unique_socket_number();
 
 #endif  // BAREOS_TESTS_BAREOS_TEST_SOCKETS_H_

--- a/core/src/tests/create_resource.cc
+++ b/core/src/tests/create_resource.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -41,7 +41,7 @@ console::DirectorResource* CreateAndInitializeNewDirectorResource()
 {
   console::DirectorResource* dir = new (console::DirectorResource);
   dir->address = (char*)HOST;
-  dir->DIRport = htons(create_unique_socket_number());
+  dir->DIRport = 0;
   dir->tls_enable_ = false;
   dir->tls_require_ = false;
   dir->tls_cert_.certfile_ = CERTDIR "/bareos-dir.bareos.org-cert.pem";
@@ -91,7 +91,7 @@ directordaemon::StorageResource* CreateAndInitializeNewStorageResource()
   directordaemon::StorageResource* store
       = new (directordaemon::StorageResource);
   store->address = (char*)HOST;
-  store->SDport = htons(create_unique_socket_number());
+  store->SDport = 0;
   store->tls_enable_ = false;
   store->tls_require_ = false;
   store->tls_cert_.certfile_ = CERTDIR "/bareos-dir.bareos.org-cert.pem";

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -132,7 +132,7 @@ struct TestJob {
 void WaitThenUnreserve(std::unique_ptr<TestJob>&);
 void WaitThenUnreserve(std::unique_ptr<TestJob>& job)
 {
-  std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  std::this_thread::sleep_for(std::chrono::seconds(5));
   job->jcr->sd_impl->dcr->UnreserveDevice();
   ReleaseDeviceCond();
 }

--- a/core/src/tests/sd_reservation.cc
+++ b/core/src/tests/sd_reservation.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/tests/test_bsock.cc
+++ b/core/src/tests/test_bsock.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -1141,8 +1141,8 @@ fi
 # Used by mysqltest 
 skip_if_root()
 {
-USER=$(whoami)
-if [ "$USER" == "root"  ]; then
+USER="$(whoami)"
+if [ "${USER}" == "root"  ]; then
  echo "${TestName} test skipped: test cannot be run as user root."
  exit 77;
 fi

--- a/systemtests/scripts/mysql.sh
+++ b/systemtests/scripts/mysql.sh
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -86,7 +86,7 @@ mysql_server_start()
         [ $((tries-=1)) -eq 0 ] && {
             echo "Could not start MySQL server"
             cat mysql/mysql.log
-            shutdown_mysql_server
+            mysql_cleanup
             exit 1
         }
         printf "."

--- a/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
+++ b/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-dir.d/job/backup-bareos-fd.conf
@@ -1,5 +1,0 @@
-Job {
-  Name = "backup-bareos-fd"
-  JobDefs = "DefaultJob"
-  Client = "bareos-fd"
-}

--- a/systemtests/tests/py2plug-fd-mariabackup/CMakeLists.txt
+++ b/systemtests/tests/py2plug-fd-mariabackup/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -24,48 +24,42 @@
 # MARIADB_CLIENT_BINARY=/usr/bin/mysql \ -D
 # MARIADB_MYSQL_INSTALL_DB_SCRIPT=/usr/bin/mysql_install_db
 
-if(TARGET python-fd
-   AND MARIABACKUP_BINARY
-   AND MARIADB_DAEMON_BINARY
-   AND MARIADB_CLIENT_BINARY
-   AND MARIADB_MYSQL_INSTALL_DB_SCRIPT
-)
-  create_systemtest(${SYSTEMTEST_PREFIX} "py2plug-fd-mariabackup")
-else()
-  create_systemtest(
-    ${SYSTEMTEST_PREFIX}
-    "py2plug-fd-mariabackup"
-    DISABLED
-    COMMENT
-    "
-    no python-fd or MARIABACKUP_BINARY,MARIADB_DAEMON_BINARY,MARIADB_CLIENT_BINARY or MARIADB_MYSQL_INSTALL_DB_SCRIPT not set.
-    example:
-    cmake -D MARIABACKUP_BINARY=/usr/bin/mariabackup \
-    -D MARIADB_DAEMON_BINARY=/usr/libexec/mysqld \
-    -D MARIADB_CLIENT_BINARY=/usr/bin/mysql \
-    -D MARIADB_MYSQL_INSTALL_DB_SCRIPT=/usr/bin/mysql_install_db"
-  )
-endif()
+message("BareosPlatForm ${BAREOS_PLATFORM}\n")
 
-if(TARGET python3-fd
-   AND MARIABACKUP_BINARY
-   AND MARIADB_DAEMON_BINARY
-   AND MARIADB_CLIENT_BINARY
-   AND MARIADB_MYSQL_INSTALL_DB_SCRIPT
-)
-  create_systemtest(${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup")
-else()
+if(NOT TARGET python3-fd)
   create_systemtest(
-    ${SYSTEMTEST_PREFIX}
-    "py3plug-fd-mariabackup"
-    DISABLED
-    COMMENT
-    "
-    no python3-fd or MARIABACKUP_BINARY,MARIADB_DAEMON_BINARY,MARIADB_CLIENT_BINARY or MARIADB_MYSQL_INSTALL_DB_SCRIPT not set.
-    example:
-    cmake -D MARIABACKUP_BINARY=/usr/bin/mariabackup \
-    -D MARIADB_DAEMON_BINARY=/usr/libexec/mysqld \
-    -D MARIADB_CLIENT_BINARY=/usr/bin/mysql \
-    -D MARIADB_MYSQL_INSTALL_DB_SCRIPT=/usr/bin/mysql_install_db"
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "python3-fd is not being build."
   )
+elseif(NOT MARIABACKUP_BINARY)
+  create_systemtest(
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "MARIABACKUP_BINARY is not set."
+  )
+elseif(NOT MARIADB_DAEMON_BINARY)
+  create_systemtest(
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "MARIADB_DAEMON_BINARY is not set."
+  )
+elseif(NOT MARIADB_CLIENT_BINARY)
+  create_systemtest(
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "MARIADB_CLIENT_BINARY is not set."
+  )
+elseif(NOT MARIADB_MYSQL_INSTALL_DB_SCRIPT)
+  create_systemtest(
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "MARIADB_MYSQL_INSTALL_DB_SCRIPT is not set."
+  )
+elseif(${BAREOS_PLATFORM} STREQUAL "suse")
+  # We currently disable the test on suse as the plugin does not support loading
+  # a local defaults file when the MySQLdb module is found. As the test only
+  # works with that defaults file (and we do not want to potentially overwrite
+  # the current users configuration), we instead disable the test.
+  create_systemtest(
+    ${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup" DISABLED COMMENT
+    "Test is currently disabled on SUSE."
+  )
+else()
+  create_systemtest(${SYSTEMTEST_PREFIX} "py3plug-fd-mariabackup")
 endif()

--- a/systemtests/tests/py2plug-fd-mariabackup/testrunner
+++ b/systemtests/tests/py2plug-fd-mariabackup/testrunner
@@ -70,7 +70,7 @@ END_OF_DATA2
 run_bareos "$@"
 
 cat <<END_OF_DATA3 >"$tmp/bconcmds"
-restore client=bareos-fd fileset=MariaBackupTest yes restorejob=RestoreFile select all done
+restore client=bareos-fd fileset=MariabackupTest yes restorejob=RestoreFile select all done
 @$out $tmp/log2.out
 wait
 END_OF_DATA3

--- a/systemtests/tests/py3plug-fd-postgres/CMakeLists.txt
+++ b/systemtests/tests/py3plug-fd-postgres/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -20,9 +20,12 @@
 if(TARGET python3-fd)
   check_pymodule_available(3 pg8000)
   check_pymodule_available(3 dateutil)
+  include(FindPostgreSQL)
   if(PYMODULE_3_PG8000_FOUND
+     AND PostgreSQL_FOUND
      AND PYMODULE_3_DATEUTIL_FOUND
      AND (${Python3_VERSION_MAJOR} EQUAL 3)
+     AND (${PostgreSQL_VERSION_STRING} VERSION_LESS "15.0")
   )
     create_systemtest(${SYSTEMTEST_PREFIX} "py3plug-fd-postgres")
   else()

--- a/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -68,9 +68,9 @@ local_db_prepare_files() {
 local_db_start_server() {
   echo "start db server"
   if [ $UID -eq 0 ]; then
-    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl  -w --pgdata=data --log=log/logfile start"
+    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl --timeout=15 --wait --pgdata=data --log=log/logfile start"
   else
-    ${POSTGRES_BIN_PATH}/pg_ctl -w --pgdata=data --log=log/logfile start
+    ${POSTGRES_BIN_PATH}/pg_ctl --timeout=15 --wait --pgdata=data --log=log/logfile start
   fi
 #  tries=60
 #  while ! ${POSTGRES_BIN_PATH}/psql --host="$1" --list > /dev/null 2>&1; do


### PR DESCRIPTION
**Backport of PR #1888 to bareos-22**

- dropped mtx-changer fixes as the backport without perl was not done
- edit suse macro commit to reanable sle12 support
- disable mariadb test on suse 15
- disable py3plug-fd-postgres test on pg >= 15

- added commit 76834e4fed to successfully pass ci tests

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1888 is merged
- [x] All functional differences to the original PR are documented above
