### PR TITLE
vadp-dumper: fix out of bounds read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - matrix remove obsolete SUSE [PR #1888]
 - cats: scripts add option --no-psqlrc to psql [PR #1900]
 - filed: fix python plugin crash on python <3.10 [PR #1889]
+- vadp-dumper: fix out of bounds read [PR #1908]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -239,4 +240,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1888]: https://github.com/bareos/bareos/pull/1888
 [PR #1889]: https://github.com/bareos/bareos/pull/1889
 [PR #1900]: https://github.com/bareos/bareos/pull/1900
+[PR #1908]: https://github.com/bareos/bareos/pull/1908
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1461,7 +1461,10 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
       if (boffset < start_offset + offset_length
           && boffset + blength > start_offset) {
         uint64 offset = std::max(boffset, start_offset);
-        uint64 min_length = std::min(blength, offset_length);
+        uint64 bend = boffset + blength;
+        uint64 oend = start_offset + offset_length;
+
+        uint64 min_length = std::min(bend, oend);
 
         saved_len += min_length;
 

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1530,11 +1530,6 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
         break;
       }
     }
-
-    if (allocated.size() == allocated_index) {
-      // All further sectors are unallocated, so we can stop here.
-      break;
-    }
   }
 
   if (verbose) {

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -1219,6 +1219,16 @@ static bool process_single_cbt(std::vector<uint8>& buffer,
     uint64 sectors_to_read
         = MIN(sectors_per_call, (offset_length / DEFAULT_SECTOR_SIZE));
 
+    if (sectors_to_read == 0) {
+      fprintf(stderr,
+              "Internal logic error (length (%llu) is not divisible by sector "
+              "size (%llu))\n",
+              static_cast<long long unsigned>(offset_length),
+              static_cast<long long unsigned>(DEFAULT_SECTOR_SIZE));
+      retval = false;
+      break;
+    }
+
     if (multi_threaded) {
       if (!send_to_copy_thread(sector_offset,
                                sectors_to_read * DEFAULT_SECTOR_SIZE)) {
@@ -1226,6 +1236,17 @@ static bool process_single_cbt(std::vector<uint8>& buffer,
         break;
       }
     } else {
+      if (buffer.size() < sectors_to_read * DEFAULT_SECTOR_SIZE) {
+        fprintf(stderr,
+                "Internal logic error (buffer is too small.  Wanted %llu; have "
+                "%llu\n",
+                static_cast<long long unsigned>(sectors_to_read
+                                                * DEFAULT_SECTOR_SIZE),
+                static_cast<long long unsigned>(buffer.size()));
+        retval = false;
+        break;
+      }
+
       if (read_from_vmdk(sector_offset, sectors_to_read * DEFAULT_SECTOR_SIZE,
                          buffer.data())
           != sectors_to_read * DEFAULT_SECTOR_SIZE) {
@@ -1554,12 +1575,34 @@ static inline bool process_restore_stream(bool validate_only, json_t* value)
       sectors_to_read
           = MIN(sectors_per_call, (rce.offset_length / DEFAULT_SECTOR_SIZE));
 
+      if (sectors_to_read == 0) {
+        fprintf(
+            stderr,
+            "Internal logic error (length (%llu) is not divisible by sector "
+            "size (%llu))\n",
+            static_cast<long long unsigned>(rce.offset_length),
+            static_cast<long long unsigned>(DEFAULT_SECTOR_SIZE));
+        retval = false;
+        break;
+      }
+
       if (!validate_only && multi_threaded) {
         if (!send_to_copy_thread(sector_offset,
                                  sectors_to_read * DEFAULT_SECTOR_SIZE)) {
           goto bail_out;
         }
       } else {
+        if (buffer.size() < sectors_to_read * DEFAULT_SECTOR_SIZE) {
+          fprintf(stderr,
+                  "Internal logic error (buffer is too small.  Wanted %llu; "
+                  "have %llu\n",
+                  static_cast<long long unsigned>(sectors_to_read
+                                                  * DEFAULT_SECTOR_SIZE),
+                  static_cast<long long unsigned>(buffer.size()));
+          retval = false;
+          break;
+        }
+
         cnt = robust_reader(STDIN_FILENO, (char*)buffer.data(),
                             sectors_to_read * DEFAULT_SECTOR_SIZE);
         if (cnt != sectors_to_read * DEFAULT_SECTOR_SIZE) { goto bail_out; }

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -41,6 +41,7 @@
 #include "copy_thread.h"
 
 #include <jansson.h>
+#include <cassert>
 
 /*
  * json_array_foreach macro was added in jansson version 2.5
@@ -1329,7 +1330,11 @@ struct vec {
 
   size_t size() const { return count; }
 
-  reference operator[](size_t i) { return data[i]; }
+  reference operator[](size_t i)
+  {
+    assert(i < count);
+    return data[i];
+  }
 
   ~vec()
   {
@@ -1435,12 +1440,7 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
 
     changed_len += offset_length;
 
-    if (allocated.size() == current_block) {
-      // All further sectors are unallocated, so we can stop here.
-      break;
-    }
-
-    for (;;) {
+    while (current_block < allocated.size()) {
       auto& block = allocated[current_block];
 
       auto boffset = block.offset * DEFAULT_SECTOR_SIZE;
@@ -1473,6 +1473,11 @@ static inline bool process_cbt(const char* key, vec allocated, json_t* cbt)
       }
 
       if (start_offset + offset_length <= boffset + blength) { break; }
+    }
+
+    if (allocated.size() == current_block) {
+      // All further sectors are unallocated, so we can stop here.
+      break;
     }
   }
 

--- a/core/src/vmware/vadp_dumper/copy_thread.cc
+++ b/core/src/vmware/vadp_dumper/copy_thread.cc
@@ -51,8 +51,8 @@ static void* copy_thread(void* data)
 
     while (save_data) {
       auto total_length = save_data->data_len;
-      cnt = cp_thread->output_function(save_data->sector_offset,
-                                       save_data->data_len, save_data->data);
+      cnt = context->output_function(save_data->sector_offset,
+                                     save_data->data_len, save_data->data);
       // dequeue invalidates save_data!
       context->cb->dequeue();
       if (cnt < total_length) { return NULL; }

--- a/systemtests/scripts/cleanup
+++ b/systemtests/scripts/cleanup
@@ -24,6 +24,7 @@ function deletefiles(){
   rm -rf /tmp/chrome-user-data-*
 }
 
+deletefiles
 
 ${scripts}/drop_bareos_database ${DBTYPE} >/dev/null 2>&1
 


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

We previously did not properly take into account the possibility that there could be unallocated, but changed blocks.
Specifically at the end of a volume.  This caused us to read unallocated memory. 

This PR adds bounds check to our vector implementation as well as properly handling that case during the processing.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
