### PR TITLE
filed: fix python plugin crash on python <3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - python-bareos: add missing `dirname` variable [PR #1848]
 - matrix remove obsolete SUSE [PR #1907]
+- filed: fix python plugin crash on python <3.10 [PR #1916]
 
 ### Fixed
 - create_bareos_database: fix `db_name` not being double quoted [PR #1870]
@@ -692,4 +693,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1891]: https://github.com/bareos/bareos/pull/1891
 [PR #1895]: https://github.com/bareos/bareos/pull/1895
 [PR #1907]: https://github.com/bareos/bareos/pull/1907
+[PR #1916]: https://github.com/bareos/bareos/pull/1916
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -307,10 +307,8 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
 
   if (!plugin_priv_ctx) { goto bail_out; }
 
-  /*
-   * First handle some events internally before calling python if it
-   * want to do some special handling on the event triggered.
-   */
+  /* First handle some events internally before calling python if it
+   * want to do some special handling on the event triggered. */
   switch (event->eventType) {
     case bEventLevel:
       plugin_priv_ctx->backup_level = (int64_t)value;
@@ -361,19 +359,15 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
       break;
   }
 
-  /*
-   * See if we have been triggered in the previous switch if not we have to
+  /* See if we have been triggered in the previous switch if not we have to
    * always dispatch the event. If we already processed the event internally
    * we only do a dispatch to the python entry point when that internal
-   * processing was successful (e.g. retval == bRC_OK).
-   */
+   * processing was successful (e.g. retval == bRC_OK). */
   if (!event_dispatched || retval == bRC_OK) {
     PyEval_AcquireThread(plugin_priv_ctx->interpreter);
 
-    /*
-     * Now dispatch the event to Python.
-     * First the calls that need special handling.
-     */
+    /* Now dispatch the event to Python.
+     * First the calls that need special handling. */
     switch (event->eventType) {
       case bEventBackupCommand:
         /* Fall-through wanted */
@@ -400,10 +394,8 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
 
         rop = (restore_object_pkt*)value;
         if (!rop) {
-          /*
-           * If rop == NULL this means we got the last restore object.
-           * No need to call into python so just return.
-           */
+          /* If rop == NULL this means we got the last restore object.
+           * No need to call into python so just return. */
           retval = bRC_OK;
         } else {
           /* See if we already loaded the Python modules. */
@@ -428,11 +420,9 @@ static bRC handlePluginEvent(PluginContext* plugin_ctx,
         retval = Bareosfd_PyHandleBackupFile(plugin_ctx, (save_pkt*)value);
         break;
       default:
-        /*
-         * Handle the generic events e.g. the ones which are just passed on.
+        /* Handle the generic events e.g. the ones which are just passed on.
          * We only try to call Python when we loaded the right module until
-         * that time we pretend the call succeeded.
-         */
+         * that time we pretend the call succeeded. */
         if (plugin_priv_ctx->python_loaded) {
           retval = Bareosfd_PyHandlePluginEvent(plugin_ctx, event, value);
         } else {
@@ -467,18 +457,14 @@ static bRC startBackupFile(PluginContext* plugin_ctx, save_pkt* sp)
   retval = Bareosfd_PyStartBackupFile(plugin_ctx, sp);
   PyEval_ReleaseThread(plugin_priv_ctx->interpreter);
 
-  /*
-   * For Incremental and Differential backups use checkChanges method to
-   * see if we need to backup this file.
-   */
+  /* For Incremental and Differential backups use checkChanges method to
+   * see if we need to backup this file. */
   switch (plugin_priv_ctx->backup_level) {
     case L_INCREMENTAL:
     case L_DIFFERENTIAL:
-      /*
-       * If the plugin didn't set a save_time but we have a since time
+      /* If the plugin didn't set a save_time but we have a since time
        * from the bEventSince event we use that as basis for the actual
-       * save_time to check.
-       */
+       * save_time to check. */
       if (sp->save_time == 0 && plugin_priv_ctx->since) {
         sp->save_time = plugin_priv_ctx->since;
       }
@@ -741,11 +727,9 @@ static bRC parse_plugin_definition(PluginContext* plugin_ctx,
 
   if (!value) { return bRC_Error; }
 
-  /*
-   * Skip this plugin when getting plugin definition "*all*"
+  /* Skip this plugin when getting plugin definition "*all*"
    * This allows to restore a Windows Backup on a Linux FD with
-   * Python Plugins enabled.
-   */
+   * Python Plugins enabled. */
   if (bstrcmp((char*)value, "*all*")) {
     Dmsg(plugin_ctx, debuglevel,
          LOGPREFIX "Got plugin definition %s, skipping to ignore\n",
@@ -755,20 +739,16 @@ static bRC parse_plugin_definition(PluginContext* plugin_ctx,
 
   keep_existing = (plugin_priv_ctx->plugin_options) ? true : false;
 
-  /*
-   * Parse the plugin definition.
-   * Make a private copy of the whole string.
-   */
+  /* Parse the plugin definition.
+   * Make a private copy of the whole string. */
   if (!plugin_priv_ctx->python_loaded && plugin_priv_ctx->plugin_options) {
     int len;
 
-    /*
-     * We got some option string which got pushed before we actual were able to
+    /* We got some option string which got pushed before we actual were able to
      * send it to the python module as the entry point was not instantiated. So
      * we prepend that now in the option string and append the new option string
      * with the first argument being the pluginname removed as that is already
-     * part of the other plugin option string.
-     */
+     * part of the other plugin option string. */
     len = strlen(plugin_priv_ctx->plugin_options);
     PmStrcpy(plugin_definition, plugin_priv_ctx->plugin_options);
 
@@ -807,8 +787,7 @@ static bRC parse_plugin_definition(PluginContext* plugin_ctx,
   while (bp) {
     if (strlen(bp) == 0) { break; }
 
-    /*
-     * Each argument is in the form:
+    /* Each argument is in the form:
      *    <argument> = <argument_value>
      *
      * So we setup the right pointers here, argument to the beginning


### PR DESCRIPTION
**Backport of PR #1889 to bareos-22**

Only contains the actual crash fix (adapted to the old python-fd plugin).
Additionally contains fixes to the formatting of the python plugn

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

#### Backport quality
- [x] Original PR #1889 is merged
- [x] All functional differences to the original PR are documented above
