### PR TITLE
python-bareos: fix backslash usage in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - vadp-dumper: fix out of bounds read [PR #1908]
 - webui: fixing selenium tests [PR #1885]
 - plugins: adjust plugin info formatting [PR #1919]
+- python-bareos: fix backslash usage in regex [PR #1917]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -244,5 +245,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1889]: https://github.com/bareos/bareos/pull/1889
 [PR #1900]: https://github.com/bareos/bareos/pull/1900
 [PR #1908]: https://github.com/bareos/bareos/pull/1908
+[PR #1917]: https://github.com/bareos/bareos/pull/1917
 [PR #1919]: https://github.com/bareos/bareos/pull/1919
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -542,7 +542,7 @@ class LowLevel(object):
         msg = self.recv_submsg(length)
         return msg
 
-    def recv_msg(self, regex=b"^\d\d\d\d OK.*$"):
+    def recv_msg(self, regex=b"^\\d\\d\\d\\d OK.*$"):
         """Receive a full message.
 
         It retrieves messages (header + message text),


### PR DESCRIPTION
We used "\d" in a Python regex,
which is ambiguous
and is considered invalid in newer Python versions:
Python >= 3.8 will issue a DeprecationWarning,
Python >= 3.12 a SyntaxWarning
and later version will issue a SyntaxError.

Therefore we adapted it to the unambiguous "\\d" sequence.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
