### PR TITLE
cats: scripts add option --no-psqlrc to psql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - filed: fix python plugin crash on python <3.10 [PR #1913]
 - vadp-dumper: fix out of bounds read [PR #1918]
 - dird: disallow running always incremental virtual full jobs with empty jobid list [PR #1901]
+- cats: scripts add option --no-psqlrc to psql [PR #1926]
 
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
@@ -519,4 +520,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1906]: https://github.com/bareos/bareos/pull/1906
 [PR #1913]: https://github.com/bareos/bareos/pull/1913
 [PR #1918]: https://github.com/bareos/bareos/pull/1918
+[PR #1926]: https://github.com/bareos/bareos/pull/1926
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/create_bareos_database.in
+++ b/core/src/cats/create_bareos_database.in
@@ -45,7 +45,7 @@ info "Creating database '${db_name}'"
 # use SQL_ASCII to be able to put any filename into
 # the database even those created with unusual character sets
 retval=0
-psql -f - -d template1 << END-OF-DATA || retval=$?
+psql --no-psqlrc -f - -d template1 << END-OF-DATA || retval=$?
 \set ON_ERROR_STOP on
 CREATE DATABASE "${db_name}" ENCODING 'SQL_ASCII' LC_COLLATE 'C' LC_CTYPE 'C' TEMPLATE template0;
 ALTER DATABASE "${db_name}" SET datestyle TO 'ISO, YMD';
@@ -54,7 +54,7 @@ END-OF-DATA
 QUERY="SELECT pg_catalog.pg_encoding_to_char(d.encoding) as encoding \
  FROM pg_catalog.pg_database d WHERE d.datname='${db_name}';"
 
-if [ "$(psql --tuples-only --no-align --command="${QUERY}")" = "SQL_ASCII" ]
+if [ "$(psql --no-psqlrc --tuples-only --no-align --command="${QUERY}" | tr -d '\r')" = "SQL_ASCII" ]
 then
     info "Database encoding OK"
 else

--- a/core/src/cats/drop_bareos_database.in
+++ b/core/src/cats/drop_bareos_database.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/cats/drop_bareos_database.in
+++ b/core/src/cats/drop_bareos_database.in
@@ -42,7 +42,7 @@ fi
 info "Dropping of ${db_name} database"
 
 retval=0
-dropdb "${db_name}" || retval=$?
+dropdb --if-exists "${db_name}" || retval=$?
 if [ ${retval} -eq 0 ]; then
    info "Drop of ${db_name} database succeeded."
 else

--- a/core/src/cats/drop_bareos_tables.in
+++ b/core/src/cats/drop_bareos_tables.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -59,7 +59,7 @@ if [ -n "${sql_definitions}" ]; then
 fi
 
 retval=0
-PGOPTIONS='--client-min-messages=warning' psql -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
 if [ $retval -eq 0 ]; then
     info "Dropping ${db_name} tables succeeded."
 else

--- a/core/src/cats/grant_bareos_privileges.in
+++ b/core/src/cats/grant_bareos_privileges.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -52,7 +52,7 @@ then
 fi
 
 retval=0
-PGOPTIONS='--client-min-messages=warning' psql -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
+PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
 if [ ${retval} -eq 0 ]; then
    info "Privileges for user ${db_user} granted ON database ${db_name}."
 else

--- a/core/src/cats/update_bareos_tables.in
+++ b/core/src/cats/update_bareos_tables.in
@@ -3,7 +3,7 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
 # Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-# Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+# Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -49,7 +49,7 @@ info "Updating ${db_name} tables"
 
 while true
 do
-    DBVERSION=$(PGOPTIONS='--client-min-messages=warning' psql -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;")
+    DBVERSION=$(PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
     if [ -z "${DBVERSION}" ]; then
         error "Unable to determine version of Bareos database"
         exit 1
@@ -106,7 +106,9 @@ do
 
    info "Upgrading database schema from version ${start_version} to ${end_version}"
    retval=0
-   PAGER="" PGOPTIONS="--client-min-messages=warning" psql -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+   PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+
+
    rm -f "${temp_sql_schema}"
 
    if [ ${retval} -ne 0 ]; then
@@ -117,7 +119,7 @@ do
    # return value of psql is does says OK when transaction was rolled back.
    # So we verify that the version was set to what we expect.
    #
-   DBVERSION_AFTER=$(PGOPTIONS='--client-min-messages=warning' psql -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;")
+   DBVERSION_AFTER=$(PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -d "${db_name}" -t --pset format=unaligned -c "SELECT MAX(VersionId) FROM Version;" | tr -d '\r')
    if [ "${DBVERSION_AFTER}" -ne "${end_version}" ]; then
       error "Failed to upgrade database schema from version ${DBVERSION} to ${end_version}, is still on ${DBVERSION_AFTER}"
       exit 1


### PR DESCRIPTION
**Backport of PR #1900 to bareos-23**

Windows native build changes hasn't been backported.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1900 is merged
- [X] All functional differences to the original PR are documented above
