### PR TITLE
systemtest python-bareos: speed up testing

### DIFF
--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1988,6 +1988,12 @@ bool GetUserJobLevelSelection(UaContext* ua, std::vector<char>& joblevel_list)
     for (const auto& level : joblevelinput_list) {
       if (level.size() == 1 && level[0] >= 'A' && level[0] <= 'z') {
         joblevel_list.push_back(level[0]);
+      } else if (Bstrcasecmp(level.c_str(), "Full")) {
+        joblevel_list.push_back('F');
+      } else if (Bstrcasecmp(level.c_str(), "Differential")) {
+        joblevel_list.push_back('D');
+      } else if (Bstrcasecmp(level.c_str(), "Incremental")) {
+        joblevel_list.push_back('I');
       } else {
         /* invalid joblevel */
         return false;

--- a/systemtests/python-modules/bareos_unittest/base.py
+++ b/systemtests/python-modules/bareos_unittest/base.py
@@ -2,7 +2,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -40,7 +40,7 @@ class Base(unittest.TestCase):
 
     config_directory = "/etc/bareos"
 
-    director_name = u"bareos-dir"
+    director_name = "bareos-dir"
 
     director_address = "localhost"
     director_port = 9101
@@ -50,7 +50,7 @@ class Base(unittest.TestCase):
 
     filedaemon_address = "localhost"
     filedaemon_port = 9102
-    filedaemon_director_password = u"secret"
+    filedaemon_director_password = "secret"
 
     dbcheck_binary = "dbcheck"
 
@@ -73,13 +73,6 @@ class Base(unittest.TestCase):
         logger = logging.getLogger()
         if cls.debug:
             logger.setLevel(logging.DEBUG)
-
-        # assertRegexpMatches has been renamed
-        # to assertRegex in Python 3.2
-        # and is deprecated now.
-        # This prevents a deprecation warning.
-        if hasattr(cls, "assertRegexpMatches") and not hasattr(cls, "assertRegex"):
-            cls.assertRegex = cls.assertRegexpMatches
         logger.debug("setUpClass")
 
     def setUp(self):
@@ -100,12 +93,12 @@ class Base(unittest.TestCase):
             else:
                 tls = False
         if tls:
-            return u"admin-tls"
+            return "admin-tls"
         else:
-            return u"admin-notls"
+            return "admin-notls"
 
     def get_operator_password(self, username=None):
-        return bareos.bsock.Password(u"secret")
+        return bareos.bsock.Password("secret")
 
     @staticmethod
     def append_to_file(filename, data):

--- a/systemtests/tests/python-bareos/test_acl.py
+++ b/systemtests/tests/python-bareos/test_acl.py
@@ -65,19 +65,12 @@ class PythonBareosAclTest(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        result = director_root.call("run job=backup-bareos-fd level=Full yes")
-        logger.debug(str(result))
-
-        jobIdBareosFdFull = result["run"]["jobid"]
-
-        result = director_root.call("wait jobid={}".format(jobIdBareosFdFull))
-
-        result = director_root.call("run job=backup-test2-fd level=Full yes")
-        logger.debug(str(result))
-
-        jobIdTestFdFull = result["run"]["jobid"]
-
-        result = director_root.call("wait jobid={}".format(jobIdTestFdFull))
+        jobIdBareosFdFull = self.get_backup_jobid(
+            director_root, "backup-bareos-fd", level="Full"
+        )
+        jobIdTestFdFull = self.get_backup_jobid(
+            director_root, "backup-test2-fd", level="Full"
+        )
 
         #
         # login as console with ACLs
@@ -202,15 +195,7 @@ class PythonBareosAclTest(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        # result = director_root.call('run job=backup-bareos-fd level=Full yes')
-        # logger.debug(str(result))
-
-        # jobIdFull = result['run']['jobid']
-
-        # wait for job to finish, otherwise next incremental is upgraded to Full.
-        # result = director_root.call('wait jobid={}'.format(jobIdFull))
-
-        jobIdFull = self.run_job(director_root, "backup-bareos-fd", "Full", wait=True)
+        jobIdFull = self.get_backup_jobid(director_root, "backup-bareos-fd", "Full")
 
         # make sure, timestamp differs
         sleep(2)
@@ -218,13 +203,6 @@ class PythonBareosAclTest(bareos_unittest.Json):
         self.append_to_file("{}/extrafile.txt".format(self.backup_directory), "Test\n")
 
         sleep(2)
-
-        # result = director_root.call('run job=backup-bareos-fd level=Incremental yes')
-        # logger.debug(str(result))
-
-        # jobIdIncr = result['run']['jobid']
-
-        # result = director_root.call('wait jobid={}'.format(jobIdIncr))
 
         jobIdIncr = self.run_job(
             director_root, "backup-bareos-fd", "Incremental", wait=True
@@ -332,8 +310,8 @@ class PythonBareosAclTest(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        jobid1 = self.run_job(
-            director=director_root, jobname=jobname1, level="Full", wait=True
+        jobid1 = self.get_backup_jobid(
+            director=director_root, jobname=jobname1, level="Full"
         )
 
         self.configure_add(
@@ -343,8 +321,8 @@ class PythonBareosAclTest(bareos_unittest.Json):
             "job name={} client=bareos-fd jobdefs=DefaultJob".format(jobname2),
         )
 
-        jobid2 = self.run_job(
-            director=director_root, jobname=jobname2, level="Full", wait=True
+        jobid2 = self.get_backup_jobid(
+            director=director_root, jobname=jobname2, level="Full"
         )
 
         #
@@ -470,7 +448,7 @@ class PythonBareosAclTest(bareos_unittest.Json):
         )
 
         # retrieve or create a jobid of a valid backup job
-        backup_jobid = self.get_backup_jobid(console, jobname)
+        backup_jobid = self.get_backup_jobid(console, jobname, level="Full")
 
         # restore with default where path
         restore_jobid = self.run_restore(console, client=client, jobid=backup_jobid)

--- a/systemtests/tests/python-bareos/test_bvfs.py
+++ b/systemtests/tests/python-bareos/test_bvfs.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -83,7 +83,7 @@ class PythonBareosBvfsTest(bareos_unittest.Json):
     def prepare_bvfs_jobs(self, director, jobname, format_params):
         self.append_to_file(format_params["BackupFileExtra"], "Test Content: initial\n")
 
-        jobid1 = self.run_job(director, jobname, level="Full", wait=True)
+        jobid1 = self.get_backup_jobid(director, jobname, level="Full")
         files1 = director.call("list files jobid={}".format(jobid1))["filenames"]
 
         # modify file and rerun backup
@@ -101,7 +101,7 @@ class PythonBareosBvfsTest(bareos_unittest.Json):
         self.assertGreaterEqual(
             len(backup_job_ids),
             2,
-            u"Expecting at least 2 jobs, got {}.".format(backup_job_ids),
+            "Expecting at least 2 jobs, got {}.".format(backup_job_ids),
         )
         format_params["BackupJobIds"] = ",".join(backup_job_ids)
 
@@ -191,7 +191,7 @@ class PythonBareosBvfsTest(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd-bpipe"
+        jobname = "backup-bareos-fd-bpipe"
 
         format_params = {
             "Client": self.client,
@@ -365,7 +365,7 @@ class PythonBareosBvfsTest(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd-bpipe"
+        jobname = "backup-bareos-fd-bpipe"
 
         format_params = {
             "Client": self.client,

--- a/systemtests/tests/python-bareos/test_delete.py
+++ b/systemtests/tests/python-bareos/test_delete.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -47,7 +47,7 @@ class PythonBareosDeleteTest(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd"
+        jobname = "backup-bareos-fd"
 
         director = bareos.bsock.DirectorConsoleJson(
             address=self.director_address,
@@ -57,7 +57,7 @@ class PythonBareosDeleteTest(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        jobid = self.run_job(director, jobname, wait=True)
+        jobid = self.get_backup_jobid(director, jobname)
         job = self.list_jobid(director, jobid)
         result = director.call("delete jobid={}".format(jobid))
         logger.debug(str(result))
@@ -146,7 +146,7 @@ class PythonBareosDeleteTest(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd"
+        jobname = "backup-bareos-fd"
 
         director = bareos.bsock.DirectorConsoleJson(
             address=self.director_address,
@@ -156,7 +156,7 @@ class PythonBareosDeleteTest(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        jobid = self.run_job(director, jobname, level="Full", wait=True)
+        jobid = self.get_backup_jobid(director, jobname, "Full")
         job = self.list_jobid(director, jobid)
         result = director.call("list volume jobid={}".format(jobid))
         volume = result["volumes"][0]["volumename"]

--- a/systemtests/tests/python-bareos/test_list_command.py
+++ b/systemtests/tests/python-bareos/test_list_command.py
@@ -58,10 +58,11 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             **self.director_extra_options,
         )
 
-        director.call("run job=backup-bareos-fd yes")
-        director.call("wait")
-        director.call("restore client=bareos-fd fileset=SelfTest select all done yes")
-        director.call("wait")
+        backup_jobid = self.get_backup_jobid(director, "backup-bareos-fd", level="Full")
+        self.run_restore(director, client="bareos-fd", jobid=backup_jobid, wait=True)
+        backup_jobid_incremental = self.get_backup_jobid(
+            director, "backup-bareos-fd", level="Incremental"
+        )
 
         # Regular list jobs
         result = director.call("list jobs")
@@ -245,9 +246,9 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             self.assertTrue(job["jobstatus"], "T")
 
         # running a job a canceling
-        director.call("run job=backup-bareos-fd yes")
-        director.call("cancel job=backup-bareos-fd all yes")
-        director.call("wait")
+        jobid = self.run_job(director, "backup-bareos-fd")
+        director.call(f"cancel jobid={jobid} all yes")
+        director.call(f"wait jobid={jobid}")
 
         # list jobs jobstatus=X,Y,z
         result = director.call("list jobs jobstatus=T,A")
@@ -335,8 +336,7 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             **self.director_extra_options,
         )
 
-        director.call("run job=backup-bareos-fd yes")
-        director.call("wait")
+        self.get_backup_jobid(director, "backup-bareos-fd")
 
         # check for expected keys
         result = director.call("list media")
@@ -366,9 +366,18 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
 
         # check expected behavior when asking for specific volume by name
         test_volume = "test_volume0001"
+
+        result = director.call("list volume={}".format(test_volume))
+        if len(result["volume"]) >= 1:
+            director.call("delete volume={} yes".format(test_volume))
+        try:
+            os.remove("storage/{}".format(test_volume))
+        except FileNotFoundError:
+            pass
+
         director.call("label volume={} pool=Full".format(test_volume))
-        director.call("wait")
-        result = director.call("list media=test_volume0001")
+
+        result = director.call("list media={}".format(test_volume))
         self.assertEqual(
             result["volume"]["volumename"],
             test_volume,
@@ -379,30 +388,32 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             test_volume,
         )
 
+        mediaid = result["volume"]["mediaid"]
+        # raises an exception if not an integer
+        int(mediaid)
+
         # check expected behavior when asking for specific volume by mediaid
-        result = director.call("list mediaid=2")
+        result = director.call(f"list mediaid={mediaid}")
         self.assertEqual(
             result["volume"]["mediaid"],
-            "2",
+            mediaid,
         )
-        result = director.call("list volumeid=2")
+        result = director.call(f"list volumeid={mediaid}")
         self.assertEqual(
             result["volume"]["mediaid"],
-            "2",
+            mediaid,
         )
 
-        result = director.call("llist mediaid=2")
+        result = director.call(f"llist mediaid={mediaid}")
         self.assertEqual(
             result["volume"]["mediaid"],
-            "2",
+            mediaid,
         )
-        result = director.call("llist volumeid=2")
+        result = director.call(f"llist volumeid={mediaid}")
         self.assertEqual(
             result["volume"]["mediaid"],
-            "2",
+            mediaid,
         )
-        director.call("delete volume=test_volume0001 yes")
-        os.remove("storage/{}".format(test_volume))
 
     def test_list_pool(self):
         """
@@ -421,8 +432,7 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             **self.director_extra_options,
         )
 
-        director.call("run job=backup-bareos-fd yes")
-        director.call("wait")
+        self.get_backup_jobid(director, "backup-bareos-fd")
 
         result = director.call("list pool")
         expected_list_pool_keys = [
@@ -531,7 +541,7 @@ class PythonBareosListCommandTest(bareos_unittest.Json):
             director_json,
             jobname="backup-bareos-fd",
             level="Full",
-            extra="fileset=NumberedFiles",
+            fileset="NumberedFiles",
             wait=True,
         )
         result = director_json.call(f"list files jobid={jobid}")

--- a/systemtests/tests/python-bareos/test_python_fd_plugins.py
+++ b/systemtests/tests/python-bareos/test_python_fd_plugins.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -42,7 +42,7 @@ class BareosFdPythonPluginOptions(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd-pluginoptions"
+        jobname = "backup-bareos-fd-pluginoptions"
 
         director = bareos.bsock.DirectorConsoleJson(
             address=self.director_address,
@@ -52,7 +52,7 @@ class BareosFdPythonPluginOptions(bareos_unittest.Json):
             **self.director_extra_options
         )
 
-        jobid = self.run_job(director, jobname, level="Full", wait=True)
+        jobid = self.get_backup_jobid(director, jobname, level="Full")
         jobid = self.run_restore(
             director,
             client=self.client,
@@ -68,7 +68,7 @@ class BareosFdPythonPluginOptions(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd-pluginoptions"
+        jobname = "backup-bareos-fd-pluginoptions"
 
         backup_dumpfile = "tmp/backup-pluginoptions.json"
         restore_dumpfile = "tmp/restore-pluginoptions.json"
@@ -131,7 +131,7 @@ class BareosFdPythonPluginOptions(bareos_unittest.Json):
         username = self.get_operator_username()
         password = self.get_operator_password(username)
 
-        jobname = u"backup-bareos-fd-pluginoptions"
+        jobname = "backup-bareos-fd-pluginoptions"
 
         backup_dumpfile = "tmp/backup-overwrite-pluginoptions.json"
         restore_dumpfile = "tmp/restore-overwrite-pluginoptions.json"


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The python-bareos systemtests do test a lot of functionality.
As every test must be able to run indepently and in random order,
the tests often ensured that test data is available
by running a backup job.
    
This change uses the recently introduced function get_backup_jobid
to ensure the availability of test data in a more efficient way:
if a job with the requested parameter already exists,
it's jobid is returned. Otherwise the requested job is started.


#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
