### PR TITLE
python-bareos: fix backslash usage in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - vadp-dumper: fix out of bounds read [PR #1918]
 - dird: disallow running always incremental virtual full jobs with empty jobid list [PR #1901]
 - cats: scripts add option --no-psqlrc to psql [PR #1926]
+- python-bareos: fix backslash usage in regex [PR #1930]
 
 ### Fixed
 - fix sql error on bad virtualfull; detect parsing errors with strtod [PR #1842]
@@ -521,4 +522,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1913]: https://github.com/bareos/bareos/pull/1913
 [PR #1918]: https://github.com/bareos/bareos/pull/1918
 [PR #1926]: https://github.com/bareos/bareos/pull/1926
+[PR #1930]: https://github.com/bareos/bareos/pull/1930
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -542,7 +542,7 @@ class LowLevel(object):
         msg = self.recv_submsg(length)
         return msg
 
-    def recv_msg(self, regex=b"^\d\d\d\d OK.*$"):
+    def recv_msg(self, regex=b"^\\d\\d\\d\\d OK.*$"):
         """Receive a full message.
 
         It retrieves messages (header + message text),


### PR DESCRIPTION
**Backport of PR #1917 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful

#### Backport quality
- [x] Original PR #1917 is merged
- [x] All functional differences to the original PR are documented above
