### PR TITLE
python-bareos: fix backslash usage in regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - matrix remove obsolete SUSE [PR #1907]
 - filed: fix python plugin crash on python <3.10 [PR #1916]
 - Use only MinGW VSS [PR #1897]
+- python-bareos: fix backslash usage in regex [PR #1931]
 
 ### Fixed
 - create_bareos_database: fix `db_name` not being double quoted [PR #1870]
@@ -696,4 +697,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1897]: https://github.com/bareos/bareos/pull/1897
 [PR #1907]: https://github.com/bareos/bareos/pull/1907
 [PR #1916]: https://github.com/bareos/bareos/pull/1916
+[PR #1931]: https://github.com/bareos/bareos/pull/1931
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2015-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -55,7 +55,7 @@ try:
     import sslpsk
 except ImportError:
     warnings.warn(
-        u"Connection encryption via TLS-PSK is not available, as the module sslpsk is not installed."
+        "Connection encryption via TLS-PSK is not available, as the module sslpsk is not installed."
     )
 
 
@@ -110,7 +110,7 @@ class LowLevel(object):
         self.requested_protocol_version = None
         self.protocol_messages = ProtocolMessages()
         # identity_prefix have to be set in each class
-        self.identity_prefix = u"R_NONE"
+        self.identity_prefix = "R_NONE"
         self.receive_buffer = b""
 
     def __del__(self):
@@ -154,9 +154,7 @@ class LowLevel(object):
         self.connection_type = connection_type
         self.name = name
         if password is None:
-            raise bareos.exceptions.ConnectionError(
-                u"Parameter 'password' is required."
-            )
+            raise bareos.exceptions.ConnectionError("Parameter 'password' is required.")
         if isinstance(password, Password):
             self.password = password
         else:
@@ -171,11 +169,11 @@ class LowLevel(object):
         if self.tls_psk_require:
             if not self.is_tls_psk_available():
                 raise bareos.exceptions.ConnectionError(
-                    u"TLS-PSK is required, but sslpsk module not loaded/available."
+                    "TLS-PSK is required, but sslpsk module not loaded/available."
                 )
             if not self.tls_psk_enable:
                 raise bareos.exceptions.ConnectionError(
-                    u"TLS-PSK is required, but not enabled."
+                    "TLS-PSK is required, but not enabled."
                 )
 
         if self.tls_psk_enable and self.is_tls_psk_available():
@@ -187,7 +185,7 @@ class LowLevel(object):
                     raise
                 else:
                     self.logger.warning(
-                        u"Failed to connect via TLS-PSK. Trying plain connection."
+                        "Failed to connect via TLS-PSK. Trying plain connection."
                     )
             else:
                 connected = True
@@ -253,7 +251,7 @@ class LowLevel(object):
         if isinstance(self.password, Password):
             password = self.password.md5()
         else:
-            raise bareos.exceptions.ConnectionError(u"No password provided.")
+            raise bareos.exceptions.ConnectionError("No password provided.")
         self.logger.debug("identity = {0}, password = {1}".format(identity, password))
         try:
             self.socket = sslpsk.wrap_socket(
@@ -275,7 +273,7 @@ class LowLevel(object):
         name = str(self.name)
         if isinstance(self.name, bytes):
             name = self.name.decode("utf-8")
-        result = u"{0}{1}{2}".format(
+        result = "{0}{1}{2}".format(
             self.identity_prefix, Constants.record_separator, name
         )
         return bytes(bytearray(result, "utf-8"))
@@ -478,7 +476,7 @@ class LowLevel(object):
             self.logger.debug("expecting {0} bytes.".format(length))
             submsg = self.socket.recv(length)
             if len(submsg) == 0:
-                errormsg = u"Failed to retrieve data. Assuming the connection is lost."
+                errormsg = "Failed to retrieve data. Assuming the connection is lost."
                 self._handleSocketError(errormsg)
                 raise bareos.exceptions.ConnectionLostError(errormsg)
             length -= len(submsg)
@@ -600,7 +598,7 @@ class LowLevel(object):
         """
         msg = self.recv_bytes(length)
         if type(msg) is str:
-            msg = bytearray(msg.decode("utf-8", 'replace'), "utf-8")
+            msg = bytearray(msg.decode("utf-8", "replace"), "utf-8")
         if type(msg) is bytes:
             msg = bytearray(msg)
         self.logger.debug(str(msg))
@@ -642,7 +640,7 @@ class LowLevel(object):
 
     def _show_result(self, msg):
         # print(msg.decode('utf-8'))
-        sys.stdout.write(msg.decode("utf-8", 'replace'))
+        sys.stdout.write(msg.decode("utf-8", "replace"))
         # add a linefeed, if there isn't one already
         if len(msg) >= 2:
             if msg[-2] != ord(b"\n"):

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -512,7 +512,7 @@ class LowLevel(object):
         msg = self.recv_submsg(length)
         return msg
 
-    def recv_msg(self, regex=b"^\d\d\d\d OK.*$"):
+    def recv_msg(self, regex=b"^\\d\\d\\d\\d OK.*$"):
         """Receive a full message.
 
         It retrieves messages (header + message text),


### PR DESCRIPTION
**Backport of PR #1917 to bareos-22**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful

#### Backport quality
- [x] Original PR #1917 is merged
- [x] All functional differences to the original PR are documented above
