### PR TITLE
webui: properly set focus to input box after each command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python-bareos: fix backslash usage in regex [PR #1917]
 - Libcloud Accurate File Backup [PR #1903]
 - cats: add missing database locks [PR #1787]
+- webui: properly set focus to input box after each command [PR #1936]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -251,4 +252,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1908]: https://github.com/bareos/bareos/pull/1908
 [PR #1917]: https://github.com/bareos/bareos/pull/1917
 [PR #1919]: https://github.com/bareos/bareos/pull/1919
+[PR #1936]: https://github.com/bareos/bareos/pull/1936
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/webui/module/Console/view/console/console/index.phtml
+++ b/webui/module/Console/view/console/console/index.phtml
@@ -76,14 +76,14 @@ function send(cmd) {
       request.done(function(msg) {
          $("<div class='output'>"+msg.replace(/(?:\r\n|\r|\n)/g, '<br />')+"</div>").insertBefore(".prompt");
          $('.prompt').show();
+         
+         $('.bconsole').scrollTop($('.bconsole')[0].scrollHeight - $('.bconsole')[0].clientHeight);
+         document.getElementById('cli').focus();
       });
    }
 
-   $('.bconsole').scrollTop($('.bconsole')[0].scrollHeight - $('.bconsole')[0].clientHeight);
-
    document.getElementById('cli').value = "";
-   document.getElementById('cli').focus();
-
+   
 }
 
 var cli = document.getElementById("cli");

--- a/webui/module/Console/view/console/console/index.phtml
+++ b/webui/module/Console/view/console/console/index.phtml
@@ -5,7 +5,7 @@
 * bareos-webui - Bareos Web-Frontend
 *
 * @link      https://github.com/bareos/bareos for the canonical source repository
-* @copyright Copyright (c) 2013-2023 Bareos GmbH & Co. KG (http://www.bareos.org/)
+* @copyright Copyright (c) 2013-2024 Bareos GmbH & Co. KG (https://www.bareos.org/)
 * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
 *
 * This program is free software: you can redistribute it and/or modify
@@ -30,11 +30,11 @@ $this->headTitle($title);
 
 <br />
 
-<?php if($this->acl_alert) : echo $this->ACLAlert($this->invalid_commands); elseif(!$this->acl_alert) : ?>
+<?php if($this->acl_alert) : echo $this->ACLAlert($this->invalid_commands); else : ?>
 
 <pre class="bconsole" id="bconsole" style="font-size: 9pt; padding-left: 5px; overflow: scroll; width: 150vh; height: 75vh; background: #000; color: #fff;" onclick="focusScreen();">
    <p><?php echo $this->translate("bconsole (batch-mode), please handle with care."); ?><br /><?php echo $this->translate("All commands have to be a one liner, dialogs are not working."); ?><br /><?php echo $this->translate("Type help for a list of commands."); ?></p>
-   <div class="prompt"><label> * </label><input type="text" class="cli" id="cli" value ="" size=120 style="display: inline; background: #000; color: #fff; border-color: #000; border-style: hidden; outline: none;"/></div>
+   <div class="prompt"><label>* </label><input type="text" class="cli" id="cli" value ="" size=120 style="display: inline; background: #000; color: #fff; border-color: #000; border-style: hidden; outline: none;"/></div>
 </pre>
 
 <br />
@@ -46,6 +46,7 @@ $this->headTitle($title);
 
 function focusScreen() {
    document.getElementById('cli').focus();
+   $('.bconsole').scrollTop($('.bconsole')[0].scrollHeight - $('.bconsole')[0].clientHeight);
 }
 
 function clearscr() {
@@ -60,9 +61,10 @@ function help() {
 
 function send(cmd) {
 
-   $("<div class='output'> * "+cmd+"</div>").insertBefore(".prompt");
+   $("<div class='output'>* "+cmd+"</div>").insertBefore(".prompt");
 
    if(cmd == "") {
+      focusScreen();
    } else {
       $('.prompt').hide();
       var request = $.ajax({
@@ -76,13 +78,11 @@ function send(cmd) {
       request.done(function(msg) {
          $("<div class='output'>"+msg.replace(/(?:\r\n|\r|\n)/g, '<br />')+"</div>").insertBefore(".prompt");
          $('.prompt').show();
-         
-         $('.bconsole').scrollTop($('.bconsole')[0].scrollHeight - $('.bconsole')[0].clientHeight);
-         document.getElementById('cli').focus();
+         document.getElementById('cli').value = "";
+         focusScreen();
       });
    }
 
-   document.getElementById('cli').value = "";
    
 }
 


### PR DESCRIPTION
The console of webui, among others, could not have the input box focused after issuing each command. 
This patch is to fix this tiny but annoying UX issue. It also fixes the scrolling.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- ~~Your name is present in the AUTHORS file (optional)~~

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
