### PR TITLE
postgres: add new fast query function

### DIFF
--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -994,6 +994,10 @@ class BareosDb : public BareosDbQueryEnum {
   virtual bool SqlBatchInsertFileTable(JobControlRecord* jcr,
                                        AttributesDbRecord* ar)
       = 0;
+  virtual bool BigQuery(const char* query,
+                        DB_RESULT_HANDLER* ResultHandler,
+                        void* ctx)
+      = 0;
 };
 
 BareosDb* db_init_database(JobControlRecord* jcr,

--- a/core/src/cats/postgresql.h
+++ b/core/src/cats/postgresql.h
@@ -107,6 +107,10 @@ class BareosDbPostgresql : public BareosDb {
 
   bool CheckDatabaseEncoding(JobControlRecord* jcr);
 
+  bool BigQuery(const char* query,
+                DB_RESULT_HANDLER* ResultHandler,
+                void* ctx) override;
+
   int status_ = 0; /**< Status */
   bool fields_fetched_
       = false;         /**< Marker, if field descriptions are already fetched */

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -1238,8 +1238,11 @@ bool BareosDb::GetFileList(JobControlRecord*,
   if (!use_md5) { strip_md5(query.c_str()); }
 
   Dmsg1(100, "q=%s\n", query.c_str());
-
+#  if 1
   return BigSqlQuery(query.c_str(), ResultHandler, ctx);
+#  else
+  return BigQuery(query.c_str(), ResultHandler, ctx);
+#  endif
 }
 
 bool BareosDb::GetUsedBaseJobids(JobControlRecord*,

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -224,6 +224,10 @@ class MockDatabase : public BareosDb {
   {
     return true;
   }
+  virtual bool BigQuery(const char*, DB_RESULT_HANDLER*, void*) override
+  {
+    return true;
+  }
   virtual bool SqlQueryWithoutHandler(const char*, int) override
   {
     return true;


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

We want to take advantage of some of libpqs features to speed up our big queries.
This pr currently implements an alternative for BigSqlQuery() which uses `PQsendQuery()` and `PQgetResult()`
to speed up these large queries dramatically.  See https://www.postgresql.org/docs/current/libpq-single-row-mode.html for motivation.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
