### PR TITLE
dir: fix DbLocker usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - console.cc: forbid @exec etc. as privileged user [PR #1950]
 - github actions python-bareos: add workflow_dispatch [PR #1966]
 - FreeBSD: fix sed inplace usage, use bin/sh as shebang for script, pkg make director dependent of database-postgresql [PR #1961]
+- dir: fix DbLocker usage [PR #1953]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -275,6 +276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1945]: https://github.com/bareos/bareos/pull/1945
 [PR #1947]: https://github.com/bareos/bareos/pull/1947
 [PR #1950]: https://github.com/bareos/bareos/pull/1950
+[PR #1953]: https://github.com/bareos/bareos/pull/1953
 [PR #1956]: https://github.com/bareos/bareos/pull/1956
 [PR #1961]: https://github.com/bareos/bareos/pull/1961
 [PR #1966]: https://github.com/bareos/bareos/pull/1966

--- a/core/src/dird/ua_label.cc
+++ b/core/src/dird/ua_label.cc
@@ -503,6 +503,7 @@ static int do_label(UaContext* ua, const char*, bool relabel)
     i = FindArgWithValue(ua, "oldvolume");
     if (i >= 0) {
       bstrncpy(omr.VolumeName, ua->argv[i], sizeof(omr.VolumeName));
+      DbLocker _{ua->db};
       if (ua->db->GetMediaRecord(ua->jcr, &omr)) { goto checkVol; }
       ua->ErrorMsg("%s", ua->db->strerror());
     }

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -734,7 +734,7 @@ bool SelectPoolDbr(UaContext* ua, PoolDbRecord* pr, const char* argk)
     if (Bstrcasecmp(ua->argk[i], argk) && ua->argv[i]
         && ua->AclAccessOk(Pool_ACL, ua->argv[i])) {
       bstrncpy(pr->Name, ua->argv[i], sizeof(pr->Name));
-      if (!ua->db->GetPoolRecord(ua->jcr, pr)) {
+      if (DbLocker _{ua->db}; !ua->db->GetPoolRecord(ua->jcr, pr)) {
         ua->ErrorMsg(T_("Could not find Pool \"%s\": ERR=%s"), ua->argv[i],
                      ua->db->strerror());
         pr->PoolId = 0;
@@ -745,7 +745,7 @@ bool SelectPoolDbr(UaContext* ua, PoolDbRecord* pr, const char* argk)
   }
 
   pr->PoolId = 0;
-  if (!ua->db->GetPoolIds(ua->jcr, &num_pools, &ids)) {
+  if (DbLocker _{ua->db}; !ua->db->GetPoolIds(ua->jcr, &num_pools, &ids)) {
     ua->ErrorMsg(T_("Error obtaining pool ids. ERR=%s\n"), ua->db->strerror());
     if (ids) { free(ids); }
     return 0;
@@ -783,6 +783,7 @@ bool SelectPoolDbr(UaContext* ua, PoolDbRecord* pr, const char* argk)
   if (!bstrcmp(name, T_("*None*"))) {
     bstrncpy(opr.Name, name, sizeof(opr.Name));
 
+    DbLocker _{ua->db};
     if (!ua->db->GetPoolRecord(ua->jcr, &opr)) {
       ua->ErrorMsg(T_("Could not find Pool \"%s\": ERR=%s"), name,
                    ua->db->strerror());
@@ -954,8 +955,7 @@ bool SelectMediaDbr(UaContext* ua, MediaDbRecord* mr)
     }
   }
 
-
-  if (!ua->db->GetMediaRecord(ua->jcr, mr)) {
+  if (DbLocker _{ua->db}; !ua->db->GetMediaRecord(ua->jcr, mr)) {
     err = ua->db->strerror();
     goto bail_out;
   }


### PR DESCRIPTION
### This PR add **dir: fix DbLocker usage** 

When a remote copy on medium that need manual intervention to manage volume state (new, used, purge), the interaction might crash the director under certain situation.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
