### PR TITLE
Disable writing PRE_LABEL label-type to support WORM media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - github actions python-bareos: add workflow_dispatch [PR #1966]
 - FreeBSD: fix sed inplace usage, use bin/sh as shebang for script, pkg make director dependent of database-postgresql [PR #1961]
 - dir: fix DbLocker usage [PR #1953]
+- Disable writing PRE_LABEL label-type to support WORM media [PR #1958]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -278,6 +279,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1950]: https://github.com/bareos/bareos/pull/1950
 [PR #1953]: https://github.com/bareos/bareos/pull/1953
 [PR #1956]: https://github.com/bareos/bareos/pull/1956
+[PR #1958]: https://github.com/bareos/bareos/pull/1958
 [PR #1961]: https://github.com/bareos/bareos/pull/1961
 [PR #1966]: https://github.com/bareos/bareos/pull/1966
 [PR #1972]: https://github.com/bareos/bareos/pull/1972

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -417,9 +417,9 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
        "VolStatus,Slot,VolBytes,InChanger,VolReadTime,VolWriteTime,"
        "EndFile,EndBlock,LabelType,StorageId,DeviceId,LocationId,"
        "ScratchPoolId,RecyclePoolId,Enabled,ActionOnPurge,EncryptionKey,"
-       "MinBlocksize,MaxBlocksize) "
+       "MinBlocksize,MaxBlocksize,VolFiles) "
        "VALUES ('%s','%s',0,%u,%s,%s,%d,%s,%s,%u,%u,'%s',%d,%s,%d,%s,%s,0,0,%d,%s,"
-       "%s,%s,%s,%s,%d,%d,'%s',%d,%d)",
+       "%s,%s,%s,%s,%d,%d,'%s',%d,%d,%d)",
        esc_medianame,
        esc_mtype, mr->PoolId,
        edit_uint64(mr->MaxVolBytes,ed1),
@@ -443,7 +443,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
        edit_int64(mr->RecyclePoolId, ed12),
        mr->Enabled, mr->ActionOnPurge,
        mr->EncrKey, mr->MinBlocksize,
-       mr->MaxBlocksize);
+       mr->MaxBlocksize, mr->VolFiles);
   /* clang-format on */
 
   Dmsg1(500, "Create Volume: %s\n", cmd);

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -766,9 +766,10 @@ static void LabelVolumeIfOk(DeviceControlRecord* dcr,
       bstrncpy(dcr->VolumeName, newname, sizeof(dcr->VolumeName));
 
       // The following 3000 OK label. string is scanned in ua_label.c
-      dir->fsend("3000 OK label. VolBytes=%s Volume=\"%s\" Device=%s\n",
-                 edit_uint64(dev->VolCatInfo.VolCatBytes, ed1), newname,
-                 dev->print_name());
+      dir->fsend(
+          "3000 OK label. VolFiles=%lu VolBytes=%s Volume=\"%s\" Device=%s\n",
+          dev->file, edit_uint64(dev->VolCatInfo.VolCatBytes, ed1), newname,
+          dev->print_name());
       break;
     case VOL_NO_MEDIA:
       dir->fsend(T_("3914 Failed to label Volume (no media): ERR=%s\n"),

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -521,7 +521,7 @@ void CreateVolumeLabel(Device* dev, const char* VolName, const char* PoolName)
   bstrncpy(dev->VolHdr.Id, BareosId, sizeof(dev->VolHdr.Id));
   dev->VolHdr.VerNum = BareosTapeVersion;
 
-  dev->VolHdr.LabelType = PRE_LABEL; /* Mark tape as unused */
+  dev->VolHdr.LabelType = VOL_LABEL; /* Mark tape as unused */
   bstrncpy(dev->VolHdr.VolumeName, VolName, sizeof(dev->VolHdr.VolumeName));
   bstrncpy(dev->VolHdr.PoolName, PoolName, sizeof(dev->VolHdr.PoolName));
   bstrncpy(dev->VolHdr.MediaType, device_resource->media_type,

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -312,8 +312,7 @@ read_volume:
         100,
         "Device previously written, moving to end of data. Expect %lld bytes\n",
         dev->VolCatInfo.VolCatBytes);
-    Jmsg(jcr, M_INFO, 0,
-         T_("Volume \"%s\" previously written, moving to end of data.\n"),
+    Jmsg(jcr, M_INFO, 0, T_("Moving to end of data on volume \"%s\"\n"),
          VolumeName);
 
     if (!dev->eod(dcr)) {

--- a/core/src/stored/record.h
+++ b/core/src/stored/record.h
@@ -131,14 +131,17 @@ struct DeviceRecord {
  * Note, these values are negative to distinguish them
  * from user records where the FileIndex is forced positive.
  */
-#define PRE_LABEL -1 /**< Vol label on unwritten tape */
-#define VOL_LABEL -2 /**< Volume label first file */
-#define EOM_LABEL -3 /**< Writen at end of tape */
-#define SOS_LABEL -4 /**< Start of Session */
-#define EOS_LABEL -5 /**< End of Session */
-#define EOT_LABEL -6 /**< End of physical tape (2 eofs) */
-#define SOB_LABEL -7 /**< Start of object -- file/directory */
-#define EOB_LABEL -8 /**< End of object (after all streams) */
+enum : int32_t
+{
+  PRE_LABEL = -1, /**< Vol label on unwritten tape */
+  VOL_LABEL = -2, /**< Volume label first file */
+  EOM_LABEL = -3, /**< Writen at end of tape */
+  SOS_LABEL = -4, /**< Start of Session */
+  EOS_LABEL = -5, /**< End of Session */
+  EOT_LABEL = -6, /**< End of physical tape (2 eofs) */
+  SOB_LABEL = -7, /**< Start of object -- file/directory */
+  EOB_LABEL = -8, /**< End of object (after all streams) */
+};
 
 /*
  * Volume Label Record.  This is the in-memory definition. The

--- a/systemtests/tests/multiplied-device/testrunner
+++ b/systemtests/tests/multiplied-device/testrunner
@@ -125,9 +125,9 @@ fi
 
 
 #make sure all volumes are correctly truncated with the correct drive
-grep "3000 OK label. VolBytes=... Volume=\"Full-0001\" Device=\"MultiFileStorage0001\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
-grep "3000 OK label. VolBytes=... Volume=\"Full-0002\" Device=\"MultiFileStorage0002\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
-grep "3000 OK label. VolBytes=... Volume=\"Full-0003\" Device=\"MultiFileStorage0003\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolFiles=0 VolBytes=... Volume=\"Full-0001\" Device=\"MultiFileStorage0001\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolFiles=0 VolBytes=... Volume=\"Full-0002\" Device=\"MultiFileStorage0002\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
+grep "3000 OK label. VolFiles=0 VolBytes=... Volume=\"Full-0003\" Device=\"MultiFileStorage0003\" (storage)" "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0001' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0002' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1 &&
 grep "The volume 'Full-0003' has been truncated." "${tmp}"/log3.out >/dev/null 2>&1
@@ -146,7 +146,7 @@ for i in 1 2 3; do
 done
 
 # check if the relabel went correctly
-grep "3000 OK label. VolBytes=... Volume=\"fakevolume\" Device=\"FileStorage\" (storage)" "${tmp}"/log4.out >/dev/null 2>&1
+grep "3000 OK label. VolFiles=0 VolBytes=... Volume=\"fakevolume\" Device=\"FileStorage\" (storage)" "${tmp}"/log4.out >/dev/null 2>&1
 if test $? -ne 0 ; then
   echo "The fakevolume relabel failed."
   estat=1;

--- a/systemtests/tests/py3plug-sd/testrunner
+++ b/systemtests/tests/py3plug-sd/testrunner
@@ -40,7 +40,6 @@ cat <<END_OF_DATA >$tmp/bconcmds
 messages
 @$out $tmp/log1.out
 setdebug level=100 storage=File
-label volume=TestVolume001 storage=File pool=Full
 run job=$JobName yes
 status director
 status client


### PR DESCRIPTION
This change disables the use of PRE_LABEL label-type when labeling volumes without writing data to them.
Instead a normal volume label is written and the label will not be overwritten when the volume appended to afterwards.
With this change append-only media can now be used.

Resolves #1781

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
