### PR TITLE
FreeBSD: fix sed inplace usage, use bin/sh as shebang for script, pkg make director dependent of database-postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: fix handling deleted clients in restore browser [PR #1933]
 - console.cc: forbid @exec etc. as privileged user [PR #1950]
 - github actions python-bareos: add workflow_dispatch [PR #1966]
+- FreeBSD: fix sed inplace usage, use bin/sh as shebang for script, pkg make director dependent of database-postgresql [PR #1961]
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]
@@ -275,6 +276,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1947]: https://github.com/bareos/bareos/pull/1947
 [PR #1950]: https://github.com/bareos/bareos/pull/1950
 [PR #1956]: https://github.com/bareos/bareos/pull/1956
+[PR #1961]: https://github.com/bareos/bareos/pull/1961
 [PR #1966]: https://github.com/bareos/bareos/pull/1966
 [PR #1972]: https://github.com/bareos/bareos/pull/1972
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
@@ -20,6 +20,7 @@ LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossql.so:sysutils/bareos.com-database-common
 
 RUN_DEPENDS+=  bareos-dbcheck:sysutils/bareos.com-database-tools
+RUN_DEPENDS+=  /usr/local/lib/bareos/scripts/ddl/creates/postgresql.sql:sysutils/bareos.com-database-postgresql
 
 # optional overrides, used by build system.
 .-include "overrides.mk"

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -993,12 +993,12 @@ replace()
                 else
                   info "replacing '${SEARCH}' with '${REPLACE}' in ${file}"
                 fi
+                # trying to refactor in place as a variable will lead to errors. 
                 if [ "$os_type" = "Darwin" ] || [ "$os_type" = "FreeBSD" ]; then
-                     inplace=" ''"
+                     sed -i "" "s#${SEARCH}#${REPLACE}#g" "${file}"
                 else
-                     inplace=""
+                     sed --in-place "s#${SEARCH}#${REPLACE}#g" "${file}"
                 fi
-                sed -i${inplace} "s#${SEARCH}#${REPLACE}#g" "${file}"
             fi
         fi
     done

--- a/core/src/cats/grant_bareos_privileges.in
+++ b/core/src/cats/grant_bareos_privileges.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
@@ -52,17 +52,20 @@ then
 fi
 
 retval=0
-if [[ "$(uname -s)" =~ _NT ]]; then
-  PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "$(cygpath -w ${temp_sql_grants})" -d "${db_name}" || retval=$?
-else
-  PGOPTIONS='--client-min-messages=warning' psql --no-psqlrc -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
-fi
+case $(uname -s) in
+  *_NT)
+    PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "$(cygpath -w "${temp_sql_grants}")" -d "${db_name}" || retval=$?
+    ;;
+  *)
+    PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_grants}" -d "${db_name}" || retval=$?
+    ;;
+esac   
 if [ ${retval} -eq 0 ]; then
    info "Privileges for user ${db_user} granted ON database ${db_name}."
 else
    error "Error creating privileges."
 fi
-
 rm -f "${temp_sql_grants}"
+
 
 exit ${retval}

--- a/core/src/cats/make_bareos_tables.in
+++ b/core/src/cats/make_bareos_tables.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
@@ -59,11 +59,14 @@ if [ -n "${sql_definitions}" ]; then
 fi
 
 retval=0
-if [[ "$(uname -s)" =~ _NT ]]; then
-  PAGER="" PGOPTIONS="--client-min-messages=warning" psql -f "$(cygpath -w ${temp_sql_schema})" -d "${db_name}" || retval=$?
-else
-  PAGER="" PGOPTIONS="--client-min-messages=warning" psql -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
-fi
+case $(uname -s) in
+  *_NT)
+    PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "$(cygpath -w "${temp_sql_schema}")" -d "${db_name}" || retval=$?
+    ;;
+  *)
+    PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+    ;;
+esac   
 if [ $retval -eq 0 ]; then
    info "Creation ${db_name} tables succeeded."
 else

--- a/core/src/cats/update_bareos_tables.in
+++ b/core/src/cats/update_bareos_tables.in
@@ -107,18 +107,19 @@ do
 
    info "Upgrading database schema from version ${start_version} to ${end_version}"
    retval=0
-   if [[ "$(uname -s)" =~ _NT ]]; then
-     PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "$(cygpath -w ${temp_sql_schema})" -d "${db_name}" || retval=$?
-   else
-     PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
-   fi
-
-   rm -f "${temp_sql_schema}"
-
+   case $(uname -s) in
+    *_NT)
+      PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "$(cygpath -w "${temp_sql_schema}")" -d "${db_name}" || retval=$?
+      ;;
+    *)
+      PAGER="" PGOPTIONS="--client-min-messages=warning" psql --no-psqlrc -f "${temp_sql_schema}" -d "${db_name}" || retval=$?
+      ;;
+   esac
    if [ ${retval} -ne 0 ]; then
       error "Failed to upgrade database schema from version ${start_version} to ${end_version}"
       exit ${retval}
    fi
+   rm -f "${temp_sql_schema}"
    #
    # return value of psql is does says OK when transaction was rolled back.
    # So we verify that the version was set to what we expect.

--- a/core/src/tests/cram_md5.cc
+++ b/core/src/tests/cram_md5.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,6 +39,21 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <signal.h>
+
+static bool InitSignalHandler()
+{
+#if !defined(HAVE_WIN32)
+  struct sigaction sig = {};
+  sig.sa_handler = SIG_IGN;
+  sigaction(SIGUSR2, &sig, nullptr);
+  sigaction(SIGPIPE, &sig, nullptr);
+#endif
+
+  return true;
+}
+
+static bool did_init = InitSignalHandler();
 
 /* clang-format off */
 static std::map<CramMd5Handshake::HandshakeResult, std::string>


### PR DESCRIPTION
- fix issue FreeBSD of sed inplace #1960 
- revert changes made on db script and use again /bin/sh as shebang
- make bareos.com-director dependent of bareos.com-database-postgresql

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
