### PR TITLE
FreeBSD: fix sed inplace usage, pkg make director dependent of database-postgresql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - fix include-ordering on FreeBSD that could cause build issues [PR #1973]
+- FreeBSD: fix sed inplace usage, pkg make director dependent of database-postgresql [PR #1964]
 
 ## [23.0.4] - 2024-09-10
 
@@ -549,5 +550,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1948]: https://github.com/bareos/bareos/pull/1948
 [PR #1951]: https://github.com/bareos/bareos/pull/1951
 [PR #1955]: https://github.com/bareos/bareos/pull/1955
+[PR #1964]: https://github.com/bareos/bareos/pull/1964
 [PR #1973]: https://github.com/bareos/bareos/pull/1973
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
+++ b/core/platforms/freebsd/bareos-freebsd/bareos.com-director/Makefile
@@ -20,6 +20,7 @@ LIB_DEPENDS+=  libbareosfind.so:sysutils/bareos.com-common
 LIB_DEPENDS+=  libbareossql.so:sysutils/bareos.com-database-common
 
 RUN_DEPENDS+=  bareos-dbcheck:sysutils/bareos.com-database-tools
+RUN_DEPENDS+=  /usr/local/lib/bareos/scripts/ddl/creates/postgresql.sql:sysutils/bareos.com-database-postgresql
 
 # optional overrides, used by build system.
 .-include "overrides.mk"

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -993,12 +993,12 @@ replace()
                 else
                   info "replacing '${SEARCH}' with '${REPLACE}' in ${file}"
                 fi
+                # trying to refactor in place as a variable will lead to errors. 
                 if [ "$os_type" = "Darwin" ] || [ "$os_type" = "FreeBSD" ]; then
-                     inplace=" ''"
+                     sed -i "" "s#${SEARCH}#${REPLACE}#g" "${file}"
                 else
-                     inplace=""
+                     sed --in-place "s#${SEARCH}#${REPLACE}#g" "${file}"
                 fi
-                sed -i${inplace} "s#${SEARCH}#${REPLACE}#g" "${file}"
             fi
         fi
     done

--- a/core/src/tests/cram_md5.cc
+++ b/core/src/tests/cram_md5.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,6 +39,21 @@
 #include <future>
 #include <map>
 #include <memory>
+#include <signal.h>
+
+static bool InitSignalHandler()
+{
+#if !defined(HAVE_WIN32)
+  struct sigaction sig = {};
+  sig.sa_handler = SIG_IGN;
+  sigaction(SIGUSR2, &sig, nullptr);
+  sigaction(SIGPIPE, &sig, nullptr);
+#endif
+
+  return true;
+}
+
+static bool did_init = InitSignalHandler();
 
 /* clang-format off */
 static std::map<CramMd5Handshake::HandshakeResult, std::string>

--- a/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2020-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
+++ b/systemtests/tests/py3plug-fd-postgres/database/setup_local_db.sh.in
@@ -68,9 +68,9 @@ local_db_prepare_files() {
 local_db_start_server() {
   echo "start db server"
   if [ $UID -eq 0 ]; then
-    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl  -w --pgdata=data --log=log/logfile start"
+    su postgres -c "${POSTGRES_BIN_PATH}/pg_ctl  --timeout=15 --wait --pgdata=data --log=log/logfile start"
   else
-    ${POSTGRES_BIN_PATH}/pg_ctl -w --pgdata=data --log=log/logfile start
+    ${POSTGRES_BIN_PATH}/pg_ctl --timeout=15 --wait --pgdata=data --log=log/logfile start
   fi
 #  tries=60
 #  while ! ${POSTGRES_BIN_PATH}/psql --host="$1" --list > /dev/null 2>&1; do

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -107,6 +107,8 @@ sleep 1
 
 #sometimes the pid file remains
 rm -f database/data/postmaster.pid
+#empty also pg_wal which will be filled by the restore command
+rm -f database/data/pg_wal/*
 
 # use either recovery.conf or recovery.signal
 # Those files should exist after restore, the plugin create them

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-default
@@ -111,18 +111,18 @@ rm -f database/data/postmaster.pid
 # use either recovery.conf or recovery.signal
 # Those files should exist after restore, the plugin create them
 # postgres 11 and lower
+restore_command="restore_command = 'cp ${current_test_directory}/database/wal_archive/%f %p'"
 if (( ${PG_VERSION} < 12 )); then
   echo "PG_VERSION is ${PG_VERSION} so lower than 12, using recovery.conf"
   recovery_file="${current_test_directory}/database/data/recovery.conf"
 else
   # postgres 12+
   echo "PG_VERSION is ${PG_VERSION} so 12+, using postgresql.conf and recovery.signal"
+  echo "${restore_command}" >> "${current_test_directory}/database/data/postgresql.conf"
   recovery_file="${current_test_directory}/database/data/recovery.signal"
 fi
-restore_command="restore_command = 'cp ${current_test_directory}/database/wal_archive/%f %p'"
 echo "${restore_command}" >> "${recovery_file}"
 [ $EUID -eq 0 ] && chown postgres ${recovery_file}
-echo "${restore_command}" >> "${current_test_directory}/database/data/postgresql.conf"
 
 # start DB again - shall recover to latest possible state
 pushd database > /dev/null

--- a/systemtests/tests/py3plug-fd-postgres/testrunner-roles
+++ b/systemtests/tests/py3plug-fd-postgres/testrunner-roles
@@ -95,6 +95,10 @@ expect_grep "Backup OK" "$tmp/rlog1.out" "No Role Backup OK not found in job log
 expect_grep "Backup OK" "$tmp/rlog2.out" "Set Role Backup OK not found in job log"
 
 
+pushd database/ > /dev/null
+local_db_stop_server "$TESTPGHOST"
+popd > /dev/null
+
 check_for_zombie_jobs storage=File
 sleep 1
 


### PR DESCRIPTION
**Backport of PR #1961 to bareos-23**

Differences:
- commit for shebang fix not use as previous changes were not backported
- add a fix for restore_command in old `postgres` plugin

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1961  is merged
- [X] All functional differences to the original PR are documented above
