### PR TITLE
fix include-ordering on FreeBSD that could cause build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ## [Unreleased]
 
 ### Changed
-- systemtests: fix plugin postgresql testrunner-*, old postgres `bc` call [PR #1948]
+- systemtests: fix plugin postgresql testrunners, old postgres `bc` call [PR #1948]
 
 ## [23.0.4] - 2024-09-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - systemtests: fix plugin postgresql testrunners, old postgres `bc` call [PR #1948]
 
+### Fixed
+- fix include-ordering on FreeBSD that could cause build issues [PR #1973]
+
 ## [23.0.4] - 2024-09-10
 
 ### Added
@@ -542,4 +545,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1930]: https://github.com/bareos/bareos/pull/1930
 [PR #1940]: https://github.com/bareos/bareos/pull/1940
 [PR #1948]: https://github.com/bareos/bareos/pull/1948
+[PR #1973]: https://github.com/bareos/bareos/pull/1973
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -331,7 +331,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(HAVE_FREEBSD_OS 1)
-  include_directories(/usr/local/include)
+  include_directories(SYSTEM /usr/local/include)
   link_directories(/usr/local/lib)
   link_libraries(intl)
   check_cxx_compiler_flag(

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -78,7 +78,6 @@ set(LIBBAREOSSD_SRCS
 
 set(SDSRCS
     append.cc
-    askdir.cc
     authenticate.cc
     checkpoint_handler.cc
     dir_cmd.cc


### PR DESCRIPTION
**Backport of PR #1972 to bareos-23**

Changes:
* add fix for changelog issue
* add fix for not always setting up signal handlers in bsock tests
* fixed bad copyright date in stored/CMakeLists.txt

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1972 is merged
- [x] All functional differences to the original PR are documented above
