### PR TITLE
fix include-ordering on FreeBSD that could cause build issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+- fix include-ordering on FreeBSD that could cause build issues [PR #1974]
+
 ## [22.1.6] - 2024-09-10
 
 ### Changed
@@ -707,4 +710,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1925]: https://github.com/bareos/bareos/pull/1925
 [PR #1927]: https://github.com/bareos/bareos/pull/1927
 [PR #1931]: https://github.com/bareos/bareos/pull/1931
+[PR #1974]: https://github.com/bareos/bareos/pull/1974
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -326,7 +326,7 @@ endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
   set(HAVE_FREEBSD_OS 1)
-  include_directories(/usr/local/include)
+  include_directories(SYSTEM /usr/local/include)
   link_directories(/usr/local/lib)
   link_libraries(intl)
   check_cxx_compiler_flag(

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -78,7 +78,6 @@ set(LIBBAREOSSD_SRCS
 
 set(SDSRCS
     append.cc
-    askdir.cc
     authenticate.cc
     checkpoint_handler.cc
     dir_cmd.cc


### PR DESCRIPTION
**Backport of PR #1972 to bareos-22**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1972 is merged
- [x] All functional differences to the original PR are documented above
