### PR TITLE
debian: fix dedupable backend names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - stored: add dedupable backend [PR #1955]
 - bscrypto: fix and update code, and move CLI parsing to cli11, add systemtests [PR #1946]
 - Disable writing PRE_LABEL label-type to support WORM media [PR #1979]
+- debian: fix dedupable backend names [PR #1978]
 
 ### Fixed
 - fix include-ordering on FreeBSD that could cause build issues [PR #1973]
@@ -560,6 +561,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1964]: https://github.com/bareos/bareos/pull/1964
 [PR #1967]: https://github.com/bareos/bareos/pull/1967
 [PR #1973]: https://github.com/bareos/bareos/pull/1973
+[PR #1978]: https://github.com/bareos/bareos/pull/1978
 [PR #1979]: https://github.com/bareos/bareos/pull/1979
 [PR #1985]: https://github.com/bareos/bareos/pull/1985
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/dedupable/fvec.h
+++ b/core/src/stored/backends/dedupable/fvec.h
@@ -51,7 +51,7 @@ struct access {
 namespace {
 template <std::size_t Size> constexpr std::size_t MinGrowthSize()
 {
-  // We want to grow at least 1KiB each time.
+  // We want to grow at least 2MiB each time.
   std::size_t min_growth_size = 1024ull * 1024ull * 2;
 
   return (min_growth_size + Size - 1) / Size;

--- a/core/src/stored/backends/dedupable/volume.h
+++ b/core/src/stored/backends/dedupable/volume.h
@@ -63,7 +63,7 @@ struct block {
 };
 
 struct part {
-  net_u32 FileIdx; /* wich data file has the record */
+  net_u32 FileIdx; /* which data file has the record */
   net_u32 Size;    /* payload size of record */
   net_u64 Begin;   /* offset into datafile from where to start reading */
 };

--- a/core/src/stored/backends/dedupable_device.d/bareos-sd.d/device/dedup.conf.example
+++ b/core/src/stored/backends/dedupable_device.d/bareos-sd.d/device/dedup.conf.example
@@ -9,6 +9,8 @@ Device {
 
   Device Options = "block size=4k"
 
+  ArchiveDevice = "path/to/storage"
+
   Device Type = dedupable
   Label Media = yes                    # lets Bareos label unlabeled media
   Random Access = no

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -29,6 +29,7 @@
  */
 
 #include "include/bareos.h"
+#include "include/protocol_types.h"
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
@@ -317,7 +318,9 @@ static bool UseDeviceCmd(JobControlRecord* jcr)
     return false;
   }
 
-  if (me->just_in_time_reservation && append) {
+  // jit is only available for native backups
+  if (jcr->getJobProtocol() == PT_NATIVE && me->just_in_time_reservation
+      && append) {
     PmStrcpy(dev_name, "JustInTime Device");
     jcr->sd_impl->dcr = nullptr;  // signal to rest of storage daemon that no
                                   // device was reserved.

--- a/core/src/tests/configs/sd_reservation/bareos-sd.d/storage/myself.conf.in
+++ b/core/src/tests/configs/sd_reservation/bareos-sd.d/storage/myself.conf.in
@@ -1,4 +1,5 @@
 Storage {
   Name = test-sd
   @UNCOMMENT_SD_BACKEND_DIRECTORY@Backend Directory = @PROJECT_BINARY_DIR@/src/stored/backends
+  Just In Time Reservation = No
 }

--- a/core/src/tools/CMakeLists.txt
+++ b/core/src/tools/CMakeLists.txt
@@ -75,6 +75,22 @@ if(NOT client-only)
     testfind dird_objects fd_objects bareosfind CLI11::CLI11
   )
   list(APPEND TOOLS_SBIN testfind)
+  if(NOT HAVE_WIN32)
+    add_executable(
+      dedup-conf dedup_conf.cc ../stored/backends/dedupable/volume.cc
+    )
+
+    target_link_libraries(dedup-conf bareos CLI11::CLI11)
+
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
+                                                VERSION_LESS "8.6.0"
+    )
+      # workaround for rhel 8.  It uses an old stdlibc++ that does not yet
+      # contain the filesystem library.
+      message(INFO "enabling rhel 8 filesystem workaround")
+      target_link_libraries(dedup-conf stdc++fs)
+    endif()
+  endif()
 endif()
 
 install(TARGETS ${TOOLS_BIN} DESTINATION "${bindir}")

--- a/core/src/tools/dedup_conf.cc
+++ b/core/src/tools/dedup_conf.cc
@@ -1,0 +1,146 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#include "lib/cli.h"
+#include "lib/version.h"
+
+#include "stored/backends/dedupable/volume.h"
+
+#include <iostream>
+#include <filesystem>
+
+void print_config(const dedup::config& conf)
+{
+  std::cout << "{\n";
+  {
+    std::cout << " \"block files\": [";
+    bool first = true;
+    for (auto& blockfile : conf.bfiles) {
+      if (first) {
+        first = false;
+      } else {
+        std::cout << ",\n                 ";
+      }
+      std::cout << "{ "
+                << "\"Name\": \"" << blockfile.relpath << "\", "
+                << "\"Start\": " << blockfile.Start << ", "
+                << "\"End\": " << blockfile.End << ", "
+                << "\"Index\": " << blockfile.Idx << " }";
+    }
+    std::cout << "],\n";
+  }
+  {
+    std::cout << " \"part files\": [";
+    bool first = true;
+    for (auto& recordfile : conf.pfiles) {
+      if (first) {
+        first = false;
+      } else {
+        std::cout << ",\n                  ";
+      }
+      std::cout << "{ "
+                << "\"Name\": \"" << recordfile.relpath << "\", "
+                << "\"Start\": " << recordfile.Start << ", "
+                << "\"End\": " << recordfile.End << ", "
+                << "\"Index\": " << recordfile.Idx << " }";
+    }
+    std::cout << "],\n";
+  }
+  {
+    std::cout << " \"data files\": [";
+    bool first = true;
+    for (auto& datafile : conf.dfiles) {
+      if (first) {
+        first = false;
+      } else {
+        std::cout << ",\n                ";
+      }
+      std::cout << "{ "
+                << "\"Name\": \"" << datafile.relpath << "\", "
+                << "\"Size\": " << datafile.Size << ", "
+                << "\"BlockSize\": " << datafile.BlockSize << ", "
+                << "\"ReadOnly\": "
+                << (datafile.ReadOnly ? "\"yes\"" : "\"no\"") << ", "
+                << "\"Index\": " << datafile.Idx << " }";
+    }
+    std::cout << "]\n";
+  }
+  std::cout << "}\n";
+}
+
+namespace fs = std::filesystem;
+
+int main(int argc, char* argv[])
+{
+  CLI::App app;
+  std::string desc(1024, '\0');
+  kBareosVersionStrings.FormatCopyright(desc.data(), desc.size(), 2023);
+  desc += "The Bareos Dedup Config Viewer";
+  InitCLIApp(app, desc, 0);
+
+  std::string volume;
+  app.add_option("-v,--volume,volume", volume)
+      ->check(CLI::ExistingDirectory)
+      ->required();
+
+  CLI11_PARSE(app, argc, argv);
+
+  fs::path volume_path = volume;
+  fs::path config_path = volume_path / "config";
+
+  std::error_code error;
+  if (!fs::is_regular_file(config_path, error)) {
+    std::cerr << "'" << config_path << "' could not be loaded (ec = " << error
+              << ").\n";
+    return 1;
+  }
+
+  std::vector<std::byte> data;
+  if (std::ifstream file{config_path, std::ios::binary | std::ios::ate}) {
+    auto size = file.tellg();
+    data.resize(size);
+    file.seekg(0);
+    char* data_ptr = reinterpret_cast<char*>(&*data.begin());
+    if (!file.read(data_ptr, size)) {
+      std::cerr << "'" << config_path << "' could not be read.\n";
+      return 1;
+    }
+    if (file.gcount() != size) {
+      std::cerr << "Bad read from '" << config_path << "'.\n";
+      return 1;
+    }
+  } else {
+    std::cerr << "'" << config_path << "' could not be opened.\n";
+    return 1;
+  }
+
+  try {
+    auto config = dedup::config::deserialize(
+        reinterpret_cast<char*>(data.data()), data.size());
+    print_config(config);
+  } catch (const std::exception& ex) {
+    std::cerr << "'" << config_path
+              << "' does not contain a valid dedup config. Err=" << ex.what()
+              << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/debian/control.bareos-storage
+++ b/debian/control.bareos-storage
@@ -35,11 +35,11 @@ Package:        bareos-storage-dedupable
 Architecture:   any
 Pre-Depends:    debconf (>= 1.4.30) | debconf-2.0
 Depends:        bareos-common (= ${binary:Version}), bareos-storage (= ${binary:Version}), lsb-base (>= 3.2-13), ${shlibs:Depends}, ${misc:Depends}
-Description: Backup Archiving Recovery Open Sourced - storage daemon DEDUP backend
+Description: Backup Archiving Recovery Open Sourced - storage daemon DEDUPABLE backend
  Bareos is a set of programs to manage backup, recovery and verification of
  data across a network of computers of different kinds.
  .
- This package contains the Storage backend for DEDUP files.
+ This package contains the Storage backend for DEDUPABLE files.
  This package is only required, when a resource "Archive Device = dedup"
  should be used by the Bareos Storage Daemon.
 

--- a/docs/manuals/source/DeveloperGuide.rst
+++ b/docs/manuals/source/DeveloperGuide.rst
@@ -27,6 +27,7 @@ Developer Guide
    DeveloperGuide/netprotocol.rst
    DeveloperGuide/directorConsole.rst
    DeveloperGuide/reservation.rst
+   DeveloperGuide/dedupable.rst
    DeveloperGuide/jobexec.rst
    DeveloperGuide/Python.rst
    DeveloperGuide/PythonBareos.rst

--- a/docs/manuals/source/DeveloperGuide/dedupable.rst
+++ b/docs/manuals/source/DeveloperGuide/dedupable.rst
@@ -1,0 +1,174 @@
+Dedupable Backend
+=================
+
+The dedupable storage backend allows bareos to store its data in
+a way that is easier for deduping filesystems to deduplicate.
+The problems with the simple file backend in that regard are
+* interleaving of backup payload data and bareos meta data, and
+* unaligned payload data.
+This means that to support deduping filesystems we have to
+essentially parse the interleaved data stream out into separate data
+& metadata streams and write them to disk in a way where we
+maximize aligned writes.
+
+
+The layout of the data stream is described in
+:ref:`storage-media-output-format`, but the basic gist is:
+
+* data is stored in blocks, which start with a :ref:`sd-block-header`
+
+* each message from the fd is prefixed by a :ref:`sd-record-header`
+  and put into a block.  If the record would not fit the block,
+  then it is split into multiple parts, each part having its own
+  :ref:`sd-record-header`, each written to a different block.
+
+The basic parsing algorithm this stream is simply:
+
+.. uml:: dedupable/parsing.puml
+
+.. note:: Keep in mind that split records can only happen at the
+          end of a block.
+
+Now that we have separated out all block headers, record headers
+and data, we still need to store them in a sensible way.
+
+The first observation is that we do not really need to care about
+record headers anymore.  Their only only use is in delimiting the
+backup payload.  As such we can treat them as normal data from now on.
+
+This means that we think of our data like so:
+Our data consists of **blocks**.  Each block consists **parts**,
+which are data of a known size.
+This means we need to store
+
+* information on when blocks begin and end, essentially storing which parts they contain,
+
+* information on when parts begin and end, and
+
+* the data itself
+
+The information about blocks is stored as a contiguous array of
+block headers inside the volumes *blocks* file,
+similarly the information about parts is stored as a contiguous array
+of part headers in the volumes *parts* file.
+
+The question remains on how we store the rest of the data.
+
+Block Level Deduping Filesystems
+--------------------------------
+
+There are a lot of ways to deduplicate file data.  One common approach
+is block based deduplication.
+
+Files inside a file system are commonly split up into blocks of a
+certain size.  This is done to make it easier to allocate memory
+on disk, similar as to how the operating system splits up your
+virtual memory space into pages to allocate them inside the
+physical ram.
+
+A block based deduplicating filesystem would use these blocks for
+deduplication: Instead of writing multiple copies of the same block
+to disk, it would only write a single copy and reference it multiple
+times.
+
+These are the kind of filesystems we would like to support. Examples
+of filesystems with such functionality are zfs, btrfs, and block based
+filesystems on top of vdo.
+
+Storing data in a dedupable way
+-------------------------------
+
+.. note:: in this section *block* always refers to filesystem blocks,
+          not to the blocks in our data stream.
+
+To store our data in a dedupable manner, we need to ensure that
+each backed up file is written to the volume in such a way that
+the volumes blocks can be deduplicated.
+There are two problems with this however:
+
+#. the storage daemon has no idea about files in the backup stream,
+   it only knows about records.
+#. Not all files consist of all full blocks. E.g. on a filesystem
+   with 128k block size, you can still have files with sizes < 128k.
+
+The general idea we solved problem 1 is to store the records
+themselves in a way that is dedup friendly. This means that if the
+client is consistent in how he divides file data into records, then
+those records are dedupable in our volume.
+
+There are two ways to solve 2.:
+
+* pad all small blocks to their full size, or
+
+* store small blocks separately to full blocks.
+
+We have decided to use the second approach here, as the backup stream
+contains a lot of extremely small parts anyways, e.g. record headers,
+plugin meta data, file permissions, and so on, which would be wasteful
+to store in a padded manner.
+
+So how does this look in practice:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+As discussed above, we just need to figure out how to store the
+payload of a single record!
+
+Lets say the payload has size *X*, and our filesystem uses blocks
+of size *Y*. We split the payload into two sections: one section,
+the aligned section, has size equal to the largest multiple of *Y*
+smaller than *X* and starts at the beginning of the payload.  The
+other section is the rest.  E.g. if the payload has size 13K and
+the filesystem has block size 4K, then the aligned section will
+consist of the first 12K = 4K * 3 bytes, and the rest section will
+contain the last 1K.
+
+
+We then write the aligned section to the *aligned.data* file
+and the rest to the *unaligned.data* file, as we do not want to pad
+it.  As a single record payload may be associated with multiple parts,
+we need to make sure that this split into section is compatible with
+them as each part may only refer to data in a single data file.
+If this is not the case, then we simply split the part containing the
+section border in two.
+
+.. note::
+   In the current implementation we do not need to explicitly split
+   up parts along the aligned/unaligned border, as the parts are
+   directly generated with that split in mind.
+
+As we only store full blocks to the *aligned.data* file, each of them
+will be dedupable.  This means that if the maximum record payload
+size, which is equal to :config:option:`fd/client/MaximumNetworkBufferSize`,
+is divisible by our filesystem block size, then most data is
+potentially dedupable.
+
+.. warning:: If the maximum record payload size is *smaller* than the filesystem
+             block size, then nothing will be written to the *aligned.data* file
+             and almost no data will be deduped.
+
+Volume Structure
+----------------
+
+As described above, each volume, which is in fact a directory,
+will contain at least four files:
+
+* the *blocks* file, containing information about the sd blocks,
+
+* the *parts* file, containing information about each part of the blocks,
+
+* the *aligned.data* file, containing data that can be deduped, and
+
+* the *unaligned.data* file, that contains all data that cannot be
+  easily deduped.
+
+In fact each volume also contains a final, fifth file called
+*config*.  In this file the volume writes down some important
+information about itself.  E.g. the block size for which it was
+generated, also how many blocks, parts, and how much data is actually
+contained in the other four files.
+Without this file, the other files are basically just blobs of data.
+
+Each of the other four files is basically just an array of their
+respective types written to disk (in network byte order).
+Whenever a file needs to grow, we grow it by at least 2MiB, so that
+we do not have to constantly grow it during a back up, as growing a
+file can be quite the slow operation.

--- a/docs/manuals/source/DeveloperGuide/dedupable/parsing.puml
+++ b/docs/manuals/source/DeveloperGuide/dedupable/parsing.puml
@@ -1,0 +1,18 @@
+.. uml::
+  @startuml
+
+  state "Parse Record" as PR
+  state "Block Header" as B
+  state "Record Header" as R
+  state "Data" as D
+
+  [*] --> PR : stream start
+  PR -left-> [*] : stream end
+  PR -> B : block start
+  PR -> R
+  B --> R
+  R --> D
+  D --> B : split record
+  D -up-> PR
+
+  @enduml

--- a/docs/manuals/source/DeveloperGuide/mediaformat.rst
+++ b/docs/manuals/source/DeveloperGuide/mediaformat.rst
@@ -197,15 +197,17 @@ and `Label Records <#Label>`__ are written using Bareos’s serialization
 routines. These routines guarantee that the data is written to the
 output volume in a machine independent format.
 
+.. _sd-block-header:
+
 Block Header
 ------------
 
 The current Block Header version is **BB02**. (The prior version
-`BB01 <#BB01>`__ is unsupported.)
+**BB01** is unsupported.)
 
 Each session or Job use their own private blocks.
 
-The format of a `Block Header <#BlockHeader>`__ is:
+The format of a :ref:`sd-block-header` is:
 
 ::
 
@@ -221,12 +223,14 @@ The Block Header is a fixed length and fixed format.
 The CheckSum field is a 32 bit checksum of the block data and the block
 header but not including the CheckSum field.
 
-The Block Header is always immediately followed by a `Record
-Header <#RecordHeader>`__. If the tape is damaged, a Bareos utility will
+The Block Header is always immediately followed by a :ref:`sd-record-header`.
+If the tape is damaged, a Bareos utility will
 be able to recover as much information as possible from the tape by
 recovering blocks which are valid. The Block header is written using the
 Bareos serialization routines and thus is guaranteed to be in machine
 independent format.
+
+.. _sd-record-header:
 
 Record Header
 -------------

--- a/docs/manuals/source/DeveloperGuide/reservation.rst
+++ b/docs/manuals/source/DeveloperGuide/reservation.rst
@@ -19,7 +19,7 @@ Each swimlane denotes a separate function.
 .. uml:: reservation/legend.puml
 
 UseDeviceCmd
-~~~~~~~~~~~~
+------------
 This function reads the list of storages and devices the director is willing to use for this job.
 Afterwards several different methods of finding a device to reseve are used.
 If no device could be reserved the function waits for up to a minute or until ReleaseDeviceCond() is called and then tries again.
@@ -27,8 +27,8 @@ If no device could be reserved the function waits for up to a minute or until Re
 .. uml:: reservation/UseDeviceCmd.puml
 
 ReserveDevice
-~~~~~~~~~~~~~
-Here we see wether the media type matches and actually try to open the device.
+-------------
+Here we see whether the media type matches and actually try to open the device.
 The actual reservation is delegated to ReserveDeviceForRead() or ReserveDeviceForAppend().
 While the first one is more or less trivial, the latter one is really complicated.
 

--- a/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
+++ b/docs/manuals/source/TasksAndConcepts/StorageBackends.rst
@@ -19,7 +19,7 @@ A Bareos Storage Daemon can use various storage backends:
    is used to access a GlusterFS storage.
 
 **Dedupable**
-   is used to support filesystem block-based deduplication, see :ref:`SdBackendDedup`.
+   is used to support filesystem block-based deduplication, see :ref:`SdBackendDedupable`.
 
 .. _SdBackendDroplet:
 
@@ -378,7 +378,7 @@ Adapt server and volume name to your environment.
 
 :sinceVersion:`15.2.0: GlusterFS Storage`
 
-.. _SdBackendDedup:
+.. _SdBackendDedupable:
 
 Dedupable Backend
 -----------------
@@ -395,5 +395,8 @@ For this to work correctly, the device option **BlockSize** needs to be set to t
 your filesystem uses to deduplicate.  It is also important that :config:option:`fd/client/MaximumNetworkBufferSize`\ is
 divisible by this size.
 
+   .. literalinclude:: /include/config/SdDeviceDeviceOptionsDedupable.conf
+      :language: bareosconfig
+      :caption: example configuration
 
-:sinceVersion:`23.1.0: Dedup Storage`
+:sinceVersion:`23.1.0: Dedupable Storage`

--- a/docs/manuals/source/include/config/SdDeviceDeviceOptionsDedupable.conf
+++ b/docs/manuals/source/include/config/SdDeviceDeviceOptionsDedupable.conf
@@ -1,0 +1,12 @@
+Device {
+  Name = DedupStorage
+  Media Type = Dedup
+  Device Type = dedupable
+  Device Options = "Block Size = 16k"
+  Archive Device = storage
+  LabelMedia = yes
+  Random Access = yes
+  AutomaticMount = yes
+  RemovableMedia = no
+  AlwaysOpen = no
+}

--- a/systemtests/tests/bareos-basic/testrunner-test-make-catalog-backup
+++ b/systemtests/tests/bareos-basic/testrunner-test-make-catalog-backup
@@ -67,32 +67,32 @@ stop_bareos
 
 # Check diff file can't be done as delete_backup_catalog has cleaned up everything.
 
-OLDVERSIONID="$(psql -q -d "${db_name}" -t -c "select max(versionid) from version;")"
+OLDVERSIONID="$(psql --no-psqlrc -q -d "${db_name}" -t -c "select max(versionid) from version;" | head -n1 | sed -e 's, ,,g')"
 
 print_debug "Deleting tables in database \"${db_name}\" "
 "${scripts}/drop_bareos_tables" "${DBTYPE}" >/dev/null 2>&1
 
 # Check if the drop remove all tables
-if [ -n "$(psql -q -d "${db_name}" -t -c "\dt+")" ];then
+if [ -n "$(psql --no-psqlrc -q -d "${db_name}" -t -c "\dt+")" ]; then
     print_debug "There's still tables on \"${db_name}\" the rest of the test is invalid"
     estat=1
     end_test
 fi
 
 print_debug "Restore the database \"${db_name}\" with sql dump"
-if ! psql -q -d "${db_name}" -f "${CATALOG_BACKUP_FILE}"; then
+if ! psql --no-psqlrc -q -d "${db_name}" -f "${CATALOG_BACKUP_FILE}"; then
     print_debug "The restore psql command failed on \"${db_name}\" "
     estat=2
     end_test
 fi
 
-if [ -z "$(psql -q -d "${db_name}" -t -c "\dt+")" ]; then
+if [ -z "$(psql --no-psqlrc -q -d "${db_name}" -t -c "\dt+")" ]; then
     print_debug "There not enough tables restored on \"${db_name}\" test failed"
     estat=3
     end_test
 fi
 
-NEWVERSIONID="$(psql -q -d "${db_name}" -t -c "select max(versionid) from version;")"
+NEWVERSIONID="$(psql --no-psqlrc -q -d "${db_name}" -t -c "select max(versionid) from version;" | head -n1 | sed -e 's, ,,g')"
 print_debug "Compare Old version ${OLDVERSIONID} to ${NEWVERSIONID}"
 
 if [ "$OLDVERSIONID" -ne "$NEWVERSIONID" ]; then

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -9,4 +9,6 @@ Storage {
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@
+
+  Just In Time Reservation = No
 }


### PR DESCRIPTION
**Backport of PR #1977 to bareos-23**

Differences:
* does not include the just in time reservation default value change

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #1977 is merged
- [x] All functional differences to the original PR are documented above
