### PR TITLE
stored: fix volume size mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix #1775 plugin: fd mariabackup add support mariadb 11+ [PR #1835]
 - deb control files: depend on python3-bareos [PR #1956]
 - fix include-ordering on FreeBSD that could cause build issues [PR #1972]
+- stored: fix volume size mismatch [PR #1992]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -292,5 +293,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1977]: https://github.com/bareos/bareos/pull/1977
 [PR #1980]: https://github.com/bareos/bareos/pull/1980
 [PR #1990]: https://github.com/bareos/bareos/pull/1990
+[PR #1992]: https://github.com/bareos/bareos/pull/1992
 [PR #1998]: https://github.com/bareos/bareos/pull/1998
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/include/version_hex.h
+++ b/core/src/include/version_hex.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,7 +22,6 @@
 #ifndef BAREOS_INCLUDE_VERSION_HEX_H_
 #define BAREOS_INCLUDE_VERSION_HEX_H_
 
-#define VERSION_HEX(maj, min, pat) \
-  (0x##maj << 24 | 0x##min << 16 | 0x##pat << 8)
+#define VERSION_HEX(maj, min, pat) ((maj) << 24 | (min) << 16 | (pat) << 8)
 
 #endif  // BAREOS_INCLUDE_VERSION_HEX_H_

--- a/core/src/plugins/filed/python/python-fd.cc
+++ b/core/src/plugins/filed/python/python-fd.cc
@@ -86,7 +86,7 @@ PluginApiDefinition* bareos_plugin_interface_version = NULL;
 
 namespace {
 
-unsigned long PyVersion()
+uint32_t PyVersion()
 {
 #if PY_VERSION_HEX < VERSION_HEX(3, 11, 0)
   // bake it in statically
@@ -281,6 +281,7 @@ bRC freePlugin(PluginContext* plugin_ctx)
   if (plugin_priv_ctx->pModule) { Py_DECREF(plugin_priv_ctx->pModule); }
 
   Py_EndInterpreter(ts);
+
   if (PyVersion() < VERSION_HEX(3, 12, 0)) {
     // release gil a different way
     PyThreadState_Swap(mainThreadState);

--- a/core/src/stored/mount.cc
+++ b/core/src/stored/mount.cc
@@ -740,7 +740,6 @@ int DeviceControlRecord::TryAutolabel(bool opened)
     }
     Dmsg0(150, "dir_update_vol_info. Set Append\n");
     /* Copy Director's info into the device info */
-    dev->VolCatInfo = VolCatInfo; /* structure assignment */
     if (!dcr->DirUpdateVolumeInfo(
             is_labeloperation::True)) { /* indicate tape labeled */
       return try_error;


### PR DESCRIPTION
We currently overwrite the current volume info on the device with the outdated volume info from the director (which has size = 0) before "updating" the volume info on the director.  This causes the volume size mismatch now that we do not have the pre_label split anymore (previously we would execute RewriteVolumeLabel before writing to the device which would have fixed this issue).

As a quick fix we can just disable this overwriting and just send the real info to the director immediately.

This PR also fixes an issue with the python plugin, where we did not correctly compare versions, which lead to weird behaviour.


### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR