### PR TITLE
add Honor No Dump Flag to config output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - deb control files: depend on python3-bareos [PR #1956]
 - fix include-ordering on FreeBSD that could cause build issues [PR #1972]
 - stored: fix volume size mismatch [PR #1992]
+- add Honor No Dump Flag to config output [PR #1994]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -294,5 +295,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1980]: https://github.com/bareos/bareos/pull/1980
 [PR #1990]: https://github.com/bareos/bareos/pull/1990
 [PR #1992]: https://github.com/bareos/bareos/pull/1992
+[PR #1994]: https://github.com/bareos/bareos/pull/1994
 [PR #1998]: https://github.com/bareos/bareos/pull/1998
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -1945,6 +1945,9 @@ void FilesetResource::PrintConfigIncludeExcludeOptions(
       case 'A':
         send.KeyBool("AclSupport", true);
         break;
+      case 'N':
+        send.KeyBool("HonorNoDumpFlag", true);
+        break;
       case 'V': /* verify options */
         send.KeyQuotedString("Verify", GetOptionValue(&p));
         break;

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -276,7 +276,7 @@ ResourceItem options_items[] = {
   { "DriveType", CFG_TYPE_DRIVETYPE, 0, nullptr, 0, 0, NULL, NULL, NULL },
   { "CheckFileChanges", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
   { "StripPath", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
-  { "HonornoDumpFlag", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
+  { "HonorNoDumpFlag", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
   { "XAttrSupport", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
   { "Size", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },
   { "Shadowing", CFG_TYPE_OPTION, 0, nullptr, 0, 0, NULL, NULL, NULL },

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -3356,7 +3356,7 @@
           "code": 0,
           "equals": true
         },
-        "HonornoDumpFlag": {
+        "HonorNoDumpFlag": {
           "datatype": "OPTION",
           "code": 0,
           "equals": true

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -1338,6 +1338,7 @@ FileSet {
       Exclude = Yes
       AclSupport = Yes
       XattrSupport = Yes
+      HonorNoDumpFlag = Yes
       HardLinks = No
       WildDir = "[A-Z]:/RECYCLER"
       WildDir = "[A-Z]:/$RECYCLE.BIN"


### PR DESCRIPTION
this adds support for fileset option "Honor No Dump Flag" when printing the configuration. Previously this option would never show up and yield an error when printing the configuration.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
