### PR TITLE
lib: add source_location; fix test crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dird: fix mark command not accepting full windows paths [PR #1938]
 - stored: explicitly flush after labeling [PR #2022]
 - bareos-version-from-git: fix output for wip tags [PR #2019]
+- lib: add source_location; fix test crash [PR #2006]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -320,6 +321,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1994]: https://github.com/bareos/bareos/pull/1994
 [PR #1996]: https://github.com/bareos/bareos/pull/1996
 [PR #1998]: https://github.com/bareos/bareos/pull/1998
+[PR #2006]: https://github.com/bareos/bareos/pull/2006
 [PR #2008]: https://github.com/bareos/bareos/pull/2008
 [PR #2019]: https://github.com/bareos/bareos/pull/2019
 [PR #2022]: https://github.com/bareos/bareos/pull/2022

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -38,10 +38,10 @@ include(BareosHelper)
 
 # switch on CXX 17 Support
 #
-if(NOT MSVC)
-  set(CMAKE_CXX_STANDARD 17)
-else()
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   set(CMAKE_CXX_STANDARD 20)
+else()
+  set(CMAKE_CXX_STANDARD 17)
 endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # enable PIC/PIE by default

--- a/core/cmake/BareosCheckFunctions.cmake
+++ b/core/cmake/BareosCheckFunctions.cmake
@@ -95,3 +95,31 @@ else()
   set(HAVE_GLOB 1)
   set(HAVE_LCHOWN 1)
 endif()
+
+check_cxx_source_compiles(
+  "
+#include <source_location>
+int main() {
+ std::source_location l{};
+ return 0;
+}
+"
+  HAVE_SOURCE_LOCATION
+)
+
+check_cxx_source_compiles(
+  "
+int main() {
+ constexpr auto function = __builtin_FUNCTION();
+ constexpr auto file = __builtin_FILE();
+ constexpr auto line = __builtin_LINE();
+
+ (void) function;
+ (void) file;
+ (void) line;
+
+ return 0;
+}
+"
+  HAVE_BUILTIN_LOCATION
+)

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -85,7 +85,7 @@ void BareosDb::BuildPathHierarchy(JobControlRecord* jcr,
       Mmsg(cmd, "SELECT PPathId FROM PathHierarchy WHERE PathId = %llu",
            pathid);
 
-      if (!QUERY_DB(jcr, cmd)) { goto bail_out; /* Query failed, just leave */ }
+      if (!QueryDb(jcr, cmd)) { goto bail_out; /* Query failed, just leave */ }
 
       if (SqlNumRows() > 0) {
         ppathid_cache.insert(pathid);
@@ -106,7 +106,7 @@ void BareosDb::BuildPathHierarchy(JobControlRecord* jcr,
         Mmsg(cmd,
              "INSERT INTO PathHierarchy (PathId, PPathId) VALUES (%llu,%llu)",
              pathid, (uint64_t)parent.PathId);
-        if (!INSERT_DB(jcr, cmd)) {
+        if (!InsertDb(jcr, cmd)) {
           goto bail_out; /* Can't insert the record, just leave */
         }
 
@@ -142,7 +142,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
 
   Mmsg(cmd, "SELECT 1 FROM Job WHERE JobId = %s AND HasCache=1", jobid);
 
-  if (!QUERY_DB(jcr, cmd) || SqlNumRows() > 0) {
+  if (!QueryDb(jcr, cmd) || SqlNumRows() > 0) {
     Dmsg1(dbglevel, "Already computed %d\n", (uint32_t)JobId);
     retval = true;
     goto bail_out;
@@ -151,7 +151,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
   /* prevent from DB lock waits when already in progress */
   Mmsg(cmd, "SELECT 1 FROM Job WHERE JobId = %s AND HasCache=-1", jobid);
 
-  if (!QUERY_DB(jcr, cmd) || SqlNumRows() > 0) {
+  if (!QueryDb(jcr, cmd) || SqlNumRows() > 0) {
     Dmsg1(dbglevel, "already in progress %d\n", (uint32_t)JobId);
     retval = false;
     goto bail_out;
@@ -159,7 +159,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
 
   /* set HasCache to -1 in Job (in progress) */
   Mmsg(cmd, "UPDATE Job SET HasCache=-1 WHERE JobId=%s", jobid);
-  UPDATE_DB(jcr, cmd);
+  UpdateDb(jcr, cmd);
 
   /* need to COMMIT here to ensure that other concurrent .bvfs_update runs
    * see the current HasCache value. A new transaction must only be started
@@ -178,7 +178,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
        "WHERE BaseFiles.JobId = %s) AS B",
        jobid, jobid);
 
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Dmsg1(dbglevel, "Can't fill PathVisibility %d\n", (uint32_t)JobId);
     goto bail_out;
   }
@@ -198,7 +198,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
        "ORDER BY Path",
        jobid);
 
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Dmsg1(dbglevel, "Can't get new Path %d\n", (uint32_t)JobId);
     goto bail_out;
   }
@@ -224,7 +224,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
      * bvfs update operations are run simultaneously.
      */
     FillQuery(cmd, SQL_QUERY::bvfs_lock_pathhierarchy_0);
-    if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+    if (!QueryDb(jcr, cmd)) { goto bail_out; }
 
     i = 0;
     while (num > 0) {
@@ -236,7 +236,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
     free(result);
 
     FillQuery(cmd, SQL_QUERY::bvfs_unlock_tables_0);
-    if (!QUERY_DB(jcr, cmd)) { goto bail_out; }
+    if (!QueryDb(jcr, cmd)) { goto bail_out; }
   }
 
   StartTransaction(jcr);
@@ -244,11 +244,11 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
   FillQuery(cmd, SQL_QUERY::bvfs_update_path_visibility_3, jobid, jobid, jobid);
 
   do {
-    retval = QUERY_DB(jcr, cmd);
+    retval = QueryDb(jcr, cmd);
   } while (retval && SqlAffectedRows() > 0);
 
   Mmsg(cmd, "UPDATE Job SET HasCache=1 WHERE JobId=%s", jobid);
-  UPDATE_DB(jcr, cmd);
+  UpdateDb(jcr, cmd);
 
 bail_out:
   EndTransaction(jcr);
@@ -278,7 +278,7 @@ void BareosDb::BvfsUpdateCache(JobControlRecord* jcr)
        "DELETE FROM PathVisibility "
        "WHERE NOT EXISTS "
        "(SELECT 1 FROM Job WHERE JobId=PathVisibility.JobId)");
-  nb = DELETE_DB(jcr, cmd);
+  nb = DeleteDb(jcr, cmd);
   Dmsg1(dbglevel, "Affected row(s) = %d\n", nb);
   EndTransaction(jcr);
 }

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -588,16 +588,16 @@ class BareosDb : public BareosDbQueryEnum {
   bool CheckTablesVersion(JobControlRecord* jcr);
   bool QueryDb(JobControlRecord* jcr,
                const char* select_cmd,
-               brs::source_location loc = brs::source_location::current());
+               libbareos::source_location loc = libbareos::source_location::current());
   int InsertDb(JobControlRecord* jcr,
                const char* select_cmd,
-               brs::source_location loc = brs::source_location::current());
+               libbareos::source_location loc = libbareos::source_location::current());
   int DeleteDb(JobControlRecord* jcr,
                const char* DeleteCmd,
-               brs::source_location loc = brs::source_location::current());
+               libbareos::source_location loc = libbareos::source_location::current());
   int UpdateDb(JobControlRecord* jcr,
                const char* UpdateCmd,
-               brs::source_location loc = brs::source_location::current());
+               libbareos::source_location loc = libbareos::source_location::current());
   int GetSqlRecordMax(JobControlRecord* jcr);
   void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
   int ListResult(void* vctx, int nb_col, char** row);
@@ -995,7 +995,7 @@ class BareosDb : public BareosDbQueryEnum {
       = 0;
 
  protected:
-  void AssertOwnership(brs::source_location l = brs::source_location::current())
+  void AssertOwnership(libbareos::source_location l = libbareos::source_location::current())
   {
     if (!is_private_) {
       RwlAssertWriterIsMe(&lock_, l);
@@ -1030,7 +1030,7 @@ class DbLocker {
 
  public:
   DbLocker(BareosDb* db_handle,
-           brs::source_location l = brs::source_location::current())
+           libbareos::source_location l = libbareos::source_location::current())
       : db_handle_(db_handle)
       , file{l.file_name()}
       , line{static_cast<int>(l.line())}

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -588,16 +588,20 @@ class BareosDb : public BareosDbQueryEnum {
   bool CheckTablesVersion(JobControlRecord* jcr);
   bool QueryDb(JobControlRecord* jcr,
                const char* select_cmd,
-               libbareos::source_location loc = libbareos::source_location::current());
+               libbareos::source_location loc
+               = libbareos::source_location::current());
   int InsertDb(JobControlRecord* jcr,
                const char* select_cmd,
-               libbareos::source_location loc = libbareos::source_location::current());
+               libbareos::source_location loc
+               = libbareos::source_location::current());
   int DeleteDb(JobControlRecord* jcr,
                const char* DeleteCmd,
-               libbareos::source_location loc = libbareos::source_location::current());
+               libbareos::source_location loc
+               = libbareos::source_location::current());
   int UpdateDb(JobControlRecord* jcr,
                const char* UpdateCmd,
-               libbareos::source_location loc = libbareos::source_location::current());
+               libbareos::source_location loc
+               = libbareos::source_location::current());
   int GetSqlRecordMax(JobControlRecord* jcr);
   void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
   int ListResult(void* vctx, int nb_col, char** row);
@@ -995,11 +999,10 @@ class BareosDb : public BareosDbQueryEnum {
       = 0;
 
  protected:
-  void AssertOwnership(libbareos::source_location l = libbareos::source_location::current())
+  void AssertOwnership(libbareos::source_location l
+                       = libbareos::source_location::current())
   {
-    if (!is_private_) {
-      RwlAssertWriterIsMe(&lock_, l);
-    }
+    if (!is_private_) { RwlAssertWriterIsMe(&lock_, l); }
   }
 };
 

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -41,6 +41,7 @@
 #include "lib/output_formatter.h"
 #include "lib/crypto.h"
 #include "lib/base64.h"
+#include "lib/source_location.h"
 
 #include <string>
 #include <stdexcept>
@@ -998,9 +999,11 @@ class BareosDb : public BareosDbQueryEnum {
       = 0;
 
  protected:
-  void AssertOwnership()
+  void AssertOwnership(brs::source_location l = brs::source_location::current())
   {
-    if (!is_private_) { RwlAssertWriterIsMe(&lock_); }
+    if (!is_private_) {
+      RwlAssertWriterIsMe(&lock_, l.function_name(), l.file_name(), l.line());
+    }
   }
 };
 

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -1035,13 +1035,19 @@ BareosDb* db_init_database(JobControlRecord* jcr,
 
 class DbLocker {
   BareosDb* db_handle_;
+  const char* file;
+  int line;
 
  public:
-  DbLocker(BareosDb* db_handle) : db_handle_(db_handle)
+  DbLocker(BareosDb* db_handle,
+           brs::source_location l = brs::source_location::current())
+      : db_handle_(db_handle)
+      , file{l.file_name()}
+      , line{static_cast<int>(l.line())}
   {
-    db_handle_->LockDb(__FILE__, __LINE__);
+    db_handle_->LockDb(file, line);
   }
-  ~DbLocker() { db_handle_->UnlockDb(__FILE__, __LINE__); }
+  ~DbLocker() { db_handle_->UnlockDb(file, line); }
 
   DbLocker(const DbLocker& other) = delete;
   DbLocker& operator=(const DbLocker&) = delete;

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -586,22 +586,18 @@ class BareosDb : public BareosDbQueryEnum {
   char* strerror();
   bool CheckMaxConnections(JobControlRecord* jcr, uint32_t max_concurrent_jobs);
   bool CheckTablesVersion(JobControlRecord* jcr);
-  bool QueryDB(const char* file,
-               int line,
-               JobControlRecord* jcr,
-               const char* select_cmd);
-  int InsertDB(const char* file,
-               int line,
-               JobControlRecord* jcr,
-               const char* select_cmd);
-  int DeleteDB(const char* file,
-               int line,
-               JobControlRecord* jcr,
-               const char* DeleteCmd);
-  int UpdateDB(const char* file,
-               int line,
-               JobControlRecord* jcr,
-               const char* UpdateCmd);
+  bool QueryDb(JobControlRecord* jcr,
+               const char* select_cmd,
+               brs::source_location loc = brs::source_location::current());
+  int InsertDb(JobControlRecord* jcr,
+               const char* select_cmd,
+               brs::source_location loc = brs::source_location::current());
+  int DeleteDb(JobControlRecord* jcr,
+               const char* DeleteCmd,
+               brs::source_location loc = brs::source_location::current());
+  int UpdateDb(JobControlRecord* jcr,
+               const char* UpdateCmd,
+               brs::source_location loc = brs::source_location::current());
   int GetSqlRecordMax(JobControlRecord* jcr);
   void SplitPathAndFile(JobControlRecord* jcr, const char* fname);
   int ListResult(void* vctx, int nb_col, char** row);
@@ -1026,12 +1022,6 @@ BareosDb* db_init_database(JobControlRecord* jcr,
 
 /* flush the batch insert connection every x changes */
 #define BATCH_FLUSH 800000
-
-/* Use for better error location printing */
-#define UPDATE_DB(jcr, cmd) UpdateDB(__FILE__, __LINE__, jcr, cmd)
-#define INSERT_DB(jcr, cmd) InsertDB(__FILE__, __LINE__, jcr, cmd)
-#define QUERY_DB(jcr, cmd) QueryDB(__FILE__, __LINE__, jcr, cmd)
-#define DELETE_DB(jcr, cmd) DeleteDB(__FILE__, __LINE__, jcr, cmd)
 
 class DbLocker {
   BareosDb* db_handle_;

--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -998,7 +998,7 @@ class BareosDb : public BareosDbQueryEnum {
   void AssertOwnership(brs::source_location l = brs::source_location::current())
   {
     if (!is_private_) {
-      RwlAssertWriterIsMe(&lock_, l.function_name(), l.file_name(), l.line());
+      RwlAssertWriterIsMe(&lock_, l);
     }
   }
 };

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -308,6 +308,7 @@ void BareosDbPostgresql::EscapeString(JobControlRecord* jcr,
                                       const char* old,
                                       int len)
 {
+  DbLocker _{this};
   int error;
 
   PQescapeStringConn(db_handle_, snew, old, len, &error);
@@ -327,6 +328,7 @@ char* BareosDbPostgresql::EscapeObject(JobControlRecord* jcr,
                                        char* old,
                                        int len)
 {
+  DbLocker _{this};
   size_t new_len;
   unsigned char* obj;
 

--- a/core/src/cats/postgresql.cc
+++ b/core/src/cats/postgresql.cc
@@ -548,7 +548,7 @@ bool BareosDbPostgresql::SqlQueryWithHandler(const char* query,
 /**
  * Note, if this routine returns false (failure), BAREOS expects
  * that no result has been stored.
- * This is where QUERY_DB comes with Postgresql.
+ * This is where QueryDb comes with Postgresql.
  *
  * Returns:  true  on success
  *           false on failure

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -887,8 +887,6 @@ bool BareosDb::OpenBatchConnection(JobControlRecord* jcr)
 
 void BareosDb::DbDebugPrint(FILE* fp)
 {
-  AssertOwnership();
-
   fprintf(fp, "BareosDb=%p db_name=%s db_user=%s connected=%s\n", this,
           NPRTB(get_db_name()), NPRTB(get_db_user()),
           IsConnected() ? "true" : "false");

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -143,7 +143,7 @@ bool BareosDb::CheckMaxConnections(JobControlRecord* jcr,
   // jobs share a connection otherwise
   if (!BatchInsertAvailable()) return true;
 
-  struct max_connections_context context {};
+  struct max_connections_context context{};
   PoolMem query(PM_MESSAGE);
 
   // Check max_connections setting

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -200,7 +200,7 @@ bool BareosDb::CheckTablesVersion(JobControlRecord* jcr)
  */
 bool BareosDb::QueryDb(JobControlRecord* jcr,
                        const char* select_cmd,
-                       brs::source_location loc)
+                       libbareos::source_location loc)
 {
   AssertOwnership();
 
@@ -226,7 +226,7 @@ bool BareosDb::QueryDb(JobControlRecord* jcr,
  */
 int BareosDb::InsertDb(JobControlRecord* jcr,
                        const char* select_cmd,
-                       brs::source_location loc)
+                       libbareos::source_location loc)
 {
   AssertOwnership();
   int num_rows;
@@ -262,7 +262,7 @@ int BareosDb::InsertDb(JobControlRecord* jcr,
  */
 int BareosDb::UpdateDb(JobControlRecord* jcr,
                        const char* UpdateCmd,
-                       brs::source_location loc)
+                       libbareos::source_location loc)
 {
   AssertOwnership();
   if (!SqlQuery(UpdateCmd)) {
@@ -287,7 +287,7 @@ int BareosDb::UpdateDb(JobControlRecord* jcr,
  */
 int BareosDb::DeleteDb(JobControlRecord* jcr,
                        const char* DeleteCmd,
-                       brs::source_location loc)
+                       libbareos::source_location loc)
 {
   AssertOwnership();
   if (!SqlQuery(DeleteCmd)) {

--- a/core/src/cats/sql.cc
+++ b/core/src/cats/sql.cc
@@ -198,20 +198,21 @@ bool BareosDb::CheckTablesVersion(JobControlRecord* jcr)
  * Returns: false on failure
  *          true on success
  */
-bool BareosDb::QueryDB(const char* file,
-                       int line,
-                       JobControlRecord* jcr,
-                       const char* select_cmd)
+bool BareosDb::QueryDb(JobControlRecord* jcr,
+                       const char* select_cmd,
+                       brs::source_location loc)
 {
   AssertOwnership();
 
   SqlFreeResult();
   Dmsg1(1000, "query: %s\n", select_cmd);
   if (!SqlQuery(select_cmd, QF_STORE_RESULT)) {
-    msg_(file, line, errmsg, T_("query %s failed:\n%s\n"), select_cmd,
-         sql_strerror());
-    j_msg(file, line, jcr, M_FATAL, 0, "%s", errmsg);
-    if (g_verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", select_cmd); }
+    msg_(loc.file_name(), loc.line(), errmsg, T_("query %s failed:\n%s\n"),
+         select_cmd, sql_strerror());
+    j_msg(loc.file_name(), loc.line(), jcr, M_FATAL, 0, "%s", errmsg);
+    if (g_verbose) {
+      j_msg(loc.file_name(), loc.line(), jcr, M_INFO, 0, "%s\n", select_cmd);
+    }
     return false;
   }
 
@@ -223,27 +224,31 @@ bool BareosDb::QueryDB(const char* file,
  * Returns: false on failure
  *          true on success
  */
-int BareosDb::InsertDB(const char* file,
-                       int line,
-                       JobControlRecord* jcr,
-                       const char* select_cmd)
+int BareosDb::InsertDb(JobControlRecord* jcr,
+                       const char* select_cmd,
+                       brs::source_location loc)
 {
   AssertOwnership();
   int num_rows;
 
   if (!SqlQuery(select_cmd)) {
-    msg_(file, line, errmsg, T_("insert %s failed:\n%s\n"), select_cmd,
-         sql_strerror());
-    j_msg(file, line, jcr, M_FATAL, 0, "%s", errmsg);
-    if (g_verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", select_cmd); }
+    msg_(loc.file_name(), loc.line(), errmsg, T_("insert %s failed:\n%s\n"),
+         select_cmd, sql_strerror());
+    j_msg(loc.file_name(), loc.line(), jcr, M_FATAL, 0, "%s", errmsg);
+    if (g_verbose) {
+      j_msg(loc.file_name(), loc.line(), jcr, M_INFO, 0, "%s\n", select_cmd);
+    }
     return -1;
   }
   num_rows = SqlAffectedRows();
   if (num_rows != 1) {
     char ed1[30];
-    msg_(file, line, errmsg, T_("Insertion problem: affected_rows=%s\n"),
+    msg_(loc.file_name(), loc.line(), errmsg,
+         T_("Insertion problem: affected_rows=%s\n"),
          edit_uint64(num_rows, ed1));
-    if (g_verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", select_cmd); }
+    if (g_verbose) {
+      j_msg(loc.file_name(), loc.line(), jcr, M_INFO, 0, "%s\n", select_cmd);
+    }
     return num_rows;
   }
   changes++;
@@ -255,17 +260,18 @@ int BareosDb::InsertDB(const char* file,
  * Returns: false on failure
  *          true on success
  */
-int BareosDb::UpdateDB(const char* file,
-                       int line,
-                       JobControlRecord* jcr,
-                       const char* UpdateCmd)
+int BareosDb::UpdateDb(JobControlRecord* jcr,
+                       const char* UpdateCmd,
+                       brs::source_location loc)
 {
   AssertOwnership();
   if (!SqlQuery(UpdateCmd)) {
-    msg_(file, line, errmsg, T_("update %s failed:\n%s\n"), UpdateCmd,
-         sql_strerror());
-    j_msg(file, line, jcr, M_ERROR, 0, "%s", errmsg);
-    if (g_verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", UpdateCmd); }
+    msg_(loc.file_name(), loc.line(), errmsg, T_("update %s failed:\n%s\n"),
+         UpdateCmd, sql_strerror());
+    j_msg(loc.file_name(), loc.line(), jcr, M_ERROR, 0, "%s", errmsg);
+    if (g_verbose) {
+      j_msg(loc.file_name(), loc.line(), jcr, M_INFO, 0, "%s\n", UpdateCmd);
+    }
     return -1;
   }
 
@@ -279,17 +285,18 @@ int BareosDb::UpdateDB(const char* file,
  * Returns: -1 on error
  *           n number of rows affected
  */
-int BareosDb::DeleteDB(const char* file,
-                       int line,
-                       JobControlRecord* jcr,
-                       const char* DeleteCmd)
+int BareosDb::DeleteDb(JobControlRecord* jcr,
+                       const char* DeleteCmd,
+                       brs::source_location loc)
 {
   AssertOwnership();
   if (!SqlQuery(DeleteCmd)) {
-    msg_(file, line, errmsg, T_("delete %s failed:\n%s\n"), DeleteCmd,
-         sql_strerror());
-    j_msg(file, line, jcr, M_ERROR, 0, "%s", errmsg);
-    if (g_verbose) { j_msg(file, line, jcr, M_INFO, 0, "%s\n", DeleteCmd); }
+    msg_(loc.file_name(), loc.line(), errmsg, T_("delete %s failed:\n%s\n"),
+         DeleteCmd, sql_strerror());
+    j_msg(loc.file_name(), loc.line(), jcr, M_ERROR, 0, "%s", errmsg);
+    if (g_verbose) {
+      j_msg(loc.file_name(), loc.line(), jcr, M_INFO, 0, "%s\n", DeleteCmd);
+    }
     return -1;
   }
   changes++;
@@ -310,7 +317,7 @@ int BareosDb::GetSqlRecordMax(JobControlRecord* jcr)
   SQL_ROW row;
   int retval = 0;
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     if ((row = SqlFetchRow()) == NULL) {
       Mmsg1(errmsg, T_("error fetching row: %s\n"), sql_strerror());
       retval = -1;

--- a/core/src/cats/sql_create.cc
+++ b/core/src/cats/sql_create.cc
@@ -126,14 +126,14 @@ bool BareosDb::CreateJobmediaRecord(JobControlRecord* jcr, JobMediaDbRecord* jm)
   /* clang-format on */
 
   Dmsg0(300, cmd);
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create JobMedia record %s failed: ERR=%s\n"), cmd,
           sql_strerror());
   } else {
     // Worked, now update the Media record with the EndFile and EndBlock
     Mmsg(cmd, "UPDATE Media SET EndFile=%lu, EndBlock=%lu WHERE MediaId=%lu",
          jm->EndFile, jm->EndBlock, jm->MediaId);
-    if (UPDATE_DB(jcr, cmd) == -1) {
+    if (UpdateDb(jcr, cmd) == -1) {
       Mmsg2(errmsg, T_("Update Media record %s failed: ERR=%s\n"), cmd,
             sql_strerror());
     } else {
@@ -164,7 +164,7 @@ bool BareosDb::CreatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   Mmsg(cmd, "SELECT PoolId,Name FROM Pool WHERE Name='%s'", esc_poolname);
   Dmsg1(200, "selectpool: %s\n", cmd);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 0) {
       Mmsg1(errmsg, T_("pool record %s already exists\n"), pr->Name);
@@ -232,7 +232,7 @@ bool BareosDb::CreateDeviceRecord(JobControlRecord* jcr, DeviceDbRecord* dr)
        esc, edit_int64(dr->StorageId, ed1));
   Dmsg1(200, "selectdevice: %s\n", cmd);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
 
     if (num_rows > 1) {
@@ -291,7 +291,7 @@ bool BareosDb::CreateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
   sr->StorageId = 0;
   sr->created = false;
   // Check if it already exists
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Storage record!: %d\n"), num_rows);
@@ -348,7 +348,7 @@ bool BareosDb::CreateMediatypeRecord(JobControlRecord* jcr,
        esc);
   Dmsg1(200, "selectmediatype: %s\n", cmd);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 0) {
       Mmsg1(errmsg, T_("mediatype record %s already exists\n"), mr->MediaType);
@@ -400,7 +400,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   Mmsg(cmd, "SELECT MediaId FROM Media WHERE VolumeName='%s'", esc_medianame);
   Dmsg1(500, "selectpool: %s\n", cmd);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 0) {
       Mmsg1(errmsg, T_("Volume \"%s\" already exists.\n"), mr->VolumeName);
@@ -462,7 +462,7 @@ bool BareosDb::CreateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
            "UPDATE Media SET LabelDate='%s' "
            "WHERE MediaId=%d",
            dt, mr->MediaId);
-      retval = UPDATE_DB(jcr, cmd) > 0;
+      retval = UpdateDb(jcr, cmd) > 0;
     }
     /* Make sure that if InChanger is non-zero any other identical slot
      * has InChanger zero. */
@@ -492,7 +492,7 @@ bool BareosDb::CreateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        esc_clientname);
 
   cr->ClientId = 0;
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Client!: %d\n"), num_rows);
@@ -562,7 +562,7 @@ bool BareosDb::CreatePathRecord(JobControlRecord* jcr, AttributesDbRecord* ar)
 
   Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       char ed1[30];
@@ -637,7 +637,7 @@ bool BareosDb::CreateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   FillQuery(SQL_QUERY::insert_counter_values, esc, cr->MinValue, cr->MaxValue,
             cr->CurrentValue, cr->WrapCounter);
 
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB Counters record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -671,7 +671,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
        esc_fs, esc_md5);
 
   fsr->FileSetId = 0;
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
 
     if (num_rows > 1) {
@@ -706,7 +706,7 @@ bool BareosDb::CreateFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
            "= ('%s','%s','%s','%s') WHERE FileSet='%s' AND MD5='%s' ",
            esc_fs, esc_md5, fsr->cCreateTime, esc_filesettext.c_str(), esc_fs,
            esc_md5);
-      if (!QUERY_DB(jcr, cmd)) {
+      if (!QueryDb(jcr, cmd)) {
         Mmsg1(errmsg, T_("error updating FileSet row: ERR=%s\n"),
               sql_strerror());
         Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1024,7 +1024,7 @@ bool BareosDb::CreateBaseFileAttributesRecord(JobControlRecord* jcr,
   Mmsg(cmd, "INSERT INTO basefile%lld (Path, Name) VALUES ('%s','%s')",
        (uint64_t)jcr->JobId, esc_path, esc_name);
 
-  return INSERT_DB(jcr, cmd) == 1;
+  return InsertDb(jcr, cmd) == 1;
 }
 
 void BareosDb::CleanupBaseFile(JobControlRecord* jcr)
@@ -1163,7 +1163,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
   Mmsg(cmd, "SELECT ClientId FROM Quota WHERE ClientId='%s'",
        edit_uint64(cr->ClientId, ed1));
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       SqlFreeResult();
@@ -1177,7 +1177,7 @@ bool BareosDb::CreateQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        " VALUES ('%s', '%s', %s)",
        edit_uint64(cr->ClientId, ed1), "0", "0");
 
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB Quota record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1210,7 +1210,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
        esc_name);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       SqlFreeResult();
@@ -1224,7 +1224,7 @@ bool BareosDb::CreateNdmpLevelMapping(JobControlRecord* jcr,
        " VALUES ('%s', '%s', '%s', %s)",
        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
        esc_name, "0");
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB NDMP Level Map record %s failed. ERR=%s\n"),
           cmd, sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1262,7 +1262,7 @@ bool BareosDb::CreateNdmpEnvironmentString(JobControlRecord* jcr,
        " EnvValue='%s'",
        edit_int64(jr->JobId, ed1), edit_uint64(jr->FileIndex, ed2), esc_envname,
        esc_envvalue, esc_envvalue);
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg,
           T_("Create DB NDMP Job Environment record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
@@ -1299,7 +1299,7 @@ bool BareosDb::CreateJobStatistics(JobControlRecord* jcr,
        edit_uint64(jsr->JobBytes, ed3), edit_int64(jsr->DeviceId, ed4));
   Dmsg1(200, "Create job stats: %s\n", cmd);
 
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB JobStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1352,7 +1352,7 @@ bool BareosDb::CreateDeviceStatistics(JobControlRecord* jcr,
 
   Dmsg1(200, "Create device stats: %s\n", cmd);
 
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB DeviceStats record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
@@ -1393,7 +1393,7 @@ bool BareosDb::CreateTapealertStatistics(JobControlRecord* jcr,
 
   Dmsg1(200, "Create tapealert: %s\n", cmd);
 
-  if (INSERT_DB(jcr, cmd) != 1) {
+  if (InsertDb(jcr, cmd) != 1) {
     Mmsg2(errmsg, T_("Create DB TapeAlerts record %s failed. ERR=%s\n"), cmd,
           sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -62,7 +62,7 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
 
   pr->PoolId = pr->NumVols = 0;
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 0) {
       Mmsg(errmsg, T_("No pool record %s exists\n"), pr->Name);
@@ -84,12 +84,12 @@ bool BareosDb::DeletePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
   /* Delete Media owned by this pool */
   Mmsg(cmd, "DELETE FROM Media WHERE Media.PoolId = %d", pr->PoolId);
 
-  pr->NumVols = DELETE_DB(jcr, cmd);
+  pr->NumVols = DeleteDb(jcr, cmd);
   Dmsg1(200, "Deleted %d Media records\n", pr->NumVols);
 
   /* Delete Pool */
   Mmsg(cmd, "DELETE FROM Pool WHERE Pool.PoolId = %d", pr->PoolId);
-  pr->PoolId = DELETE_DB(jcr, cmd);
+  pr->PoolId = DeleteDb(jcr, cmd);
   Dmsg1(200, "Deleted %d Pool records\n", pr->PoolId);
 
   return true;
@@ -135,7 +135,7 @@ int BareosDb::DeleteNullJobmediaRecords(JobControlRecord* jcr,
        jobid);
   Dmsg1(200, "DeleteNullJobmediaRecords: %s\n", cmd);
 
-  int numrows = DELETE_DB(jcr, cmd);
+  int numrows = DeleteDb(jcr, cmd);
 
   return numrows;
 }
@@ -198,7 +198,7 @@ bool BareosDb::DeleteMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
   }
 
   Mmsg(cmd, "DELETE FROM Media WHERE MediaId=%d", mr->MediaId);
-  return DELETE_DB(jcr, cmd) != -1;
+  return DeleteDb(jcr, cmd) != -1;
 }
 
 void BareosDb::PurgeFiles(const char* jobids)

--- a/core/src/cats/sql_delete.cc
+++ b/core/src/cats/sql_delete.cc
@@ -152,7 +152,7 @@ int BareosDb::DeleteNullJobmediaRecords(JobControlRecord* jcr,
 static int DoMediaPurge(BareosDb* mdb, MediaDbRecord* mr)
 {
   char ed1[50];
-  struct s_del_ctx del {};
+  struct s_del_ctx del{};
   PoolMem query(PM_MESSAGE);
 
   Mmsg(query, "SELECT JobId from JobMedia WHERE MediaId=%d", mr->MediaId);

--- a/core/src/cats/sql_find.cc
+++ b/core/src/cats/sql_find.cc
@@ -88,7 +88,7 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
        *  that a Full backup was done (cmd edited above)
        *  then we do a second look to find the most recent
        *  backup */
-      if (!QUERY_DB(jcr, cmd)) {
+      if (!QueryDb(jcr, cmd)) {
         Mmsg2(errmsg,
               T_("Query error for start time request: ERR=%s\nCMD=%s\n"),
               sql_strerror(), cmd);
@@ -118,7 +118,7 @@ bool BareosDb::FindJobStartTime(JobControlRecord* jcr,
          edit_int64(jr->JobId, ed1));
   }
 
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     PmStrcpy(stime, ""); /* set EOS */
     Mmsg2(errmsg, T_("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
@@ -185,7 +185,7 @@ BareosDb::SqlFindResult BareosDb::FindLastJobStartTimeForJobAndClient(
        " ORDER BY StartTime DESC LIMIT 1",
        esc_jobname.data(), esc_clientname.data());
 
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Mmsg2(errmsg, T_("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
     return SqlFindResult::kError;
@@ -243,7 +243,7 @@ bool BareosDb::FindLastJobStartTime(JobControlRecord* jcr,
        "ORDER BY StartTime DESC LIMIT 1",
        jr->JobType, JobLevel, esc_jobname, edit_int64(jr->ClientId, ed1),
        edit_int64(jr->FileSetId, ed2));
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Mmsg2(errmsg, T_("Query error for start time request: ERR=%s\nCMD=%s\n"),
           sql_strerror(), cmd);
     return false;
@@ -290,7 +290,7 @@ bool BareosDb::FindFailedJobSince(JobControlRecord* jcr,
        "ORDER BY StartTime DESC LIMIT 1",
        jr->JobType, L_FULL, L_DIFFERENTIAL, esc_jobname,
        edit_int64(jr->ClientId, ed1), edit_int64(jr->FileSetId, ed2), stime);
-  if (!QUERY_DB(jcr, cmd)) { return false; }
+  if (!QueryDb(jcr, cmd)) { return false; }
 
   if ((row = SqlFetchRow()) == NULL) {
     SqlFreeResult();
@@ -351,7 +351,7 @@ bool BareosDb::FindLastJobid(JobControlRecord* jcr,
     return false;
   }
   Dmsg1(100, "Query: %s\n", cmd);
-  if (!QUERY_DB(jcr, cmd)) { return false; }
+  if (!QueryDb(jcr, cmd)) { return false; }
   if ((row = SqlFetchRow()) == NULL) {
     Mmsg1(errmsg, T_("No Job found for: %s.\n"), cmd);
     SqlFreeResult();
@@ -381,7 +381,7 @@ bool BareosDb::FindJobById(JobControlRecord* jcr, std::string id)
   DbLocker _{this};
   std::string query = "SELECT JobId FROM Job WHERE JobId=" + id;
   Dmsg1(100, "Query: %s\n", query.c_str());
-  if (!QUERY_DB(jcr, query.c_str())) { return false; }
+  if (!QueryDb(jcr, query.c_str())) { return false; }
   if (SqlFetchRow() == NULL) {
     Mmsg1(errmsg, T_("No Job found with id: %d.\n"), id.c_str());
     SqlFreeResult();
@@ -510,7 +510,7 @@ retry_fetch:
   }
 
   Dmsg1(100, "fnextvol=%s\n", cmd);
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Dmsg1(050, "Rtn numrows=%d\n", num_rows);
     return num_rows;
   }

--- a/core/src/cats/sql_get.cc
+++ b/core/src/cats/sql_get.cc
@@ -133,7 +133,7 @@ bool BareosDb::GetFileRecord(JobControlRecord* jcr,
 
   Dmsg1(100, "Query=%s\n", cmd);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     Dmsg1(050, "GetFileRecord num_rows=%d\n", num_rows);
     if (num_rows >= 1) {
@@ -185,7 +185,7 @@ int BareosDb::GetPathRecord(JobControlRecord* jcr)
   }
 
   Mmsg(cmd, "SELECT PathId FROM Path WHERE Path='%s'", esc_name);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     char ed1[30];
     num_rows = SqlNumRows();
     if (num_rows > 1) {
@@ -260,7 +260,7 @@ bool BareosDb::GetJobRecord(JobControlRecord* jcr, JobDbRecord* jr)
          edit_int64(jr->JobId, ed1));
   }
 
-  if (!QUERY_DB(jcr, cmd)) { return false; }
+  if (!QueryDb(jcr, cmd)) { return false; }
 
   if ((row = SqlFetchRow()) == NULL) {
     if (search_by_jobname) {
@@ -342,7 +342,7 @@ int BareosDb::GetJobVolumeNames(JobControlRecord* jcr,
 
   Dmsg1(130, "VolNam=%s\n", cmd);
   VolumeNames[0] = '\0';
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     Dmsg1(130, "Num rows=%d\n", num_rows);
     if (num_rows <= 0) {
@@ -401,7 +401,7 @@ int BareosDb::GetJobVolumeParameters(JobControlRecord* jcr,
        edit_int64(JobId, ed1));
 
   Dmsg1(130, "VolNam=%s\n", cmd);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     Dmsg1(200, "Num rows=%d\n", num_rows);
     if (num_rows <= 0) {
@@ -449,7 +449,7 @@ int BareosDb::GetJobVolumeParameters(JobControlRecord* jcr,
         if (SId[i] != 0) {
           Mmsg(cmd, "SELECT Name from Storage WHERE StorageId=%s",
                edit_int64(SId[i], ed1));
-          if (QUERY_DB(jcr, cmd)) {
+          if (QueryDb(jcr, cmd)) {
             if ((row = SqlFetchRow()) && row[0]) {
               bstrncpy(Vols[i].Storage, row[0], MAX_NAME_LENGTH);
             }
@@ -480,7 +480,7 @@ int BareosDb::GetPoolIds(JobControlRecord* jcr, int* num_ids, DBId_t** ids)
   DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT PoolId FROM Pool");
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     *num_ids = SqlNumRows();
     if (*num_ids > 0) {
       id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
@@ -515,7 +515,7 @@ int BareosDb::GetStorageIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
   DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT StorageId FROM Storage");
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     *num_ids = SqlNumRows();
     if (*num_ids > 0) {
       id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
@@ -549,7 +549,7 @@ bool BareosDb::GetClientIds(JobControlRecord* jcr, int* num_ids, DBId_t* ids[])
   DbLocker _{this};
   *ids = NULL;
   Mmsg(cmd, "SELECT ClientId FROM Client ORDER BY Name");
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     *num_ids = SqlNumRows();
     if (*num_ids > 0) {
       id = (DBId_t*)malloc(*num_ids * sizeof(DBId_t));
@@ -604,7 +604,7 @@ bool BareosDb::GetPoolRecord(JobControlRecord* jcr, PoolDbRecord* pdbr)
         "Pool.Name='%s'",
         esc);
   }
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Pool!: %s\n"),
@@ -693,7 +693,7 @@ bool BareosDb::GetStorageRecord(JobControlRecord* jcr, StorageDbRecord* sdbr)
          "Storage.Name='%s'",
          esc);
   }
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Storage!: %s\n"),
@@ -747,7 +747,7 @@ bool BareosDb::GetClientRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
          esc);
   }
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Client!: %s\n"),
@@ -796,7 +796,7 @@ bool BareosDb::GetCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
 
   FillQuery(SQL_QUERY::select_counter_values, esc);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
 
     if (num_rows > 1) {
@@ -860,7 +860,7 @@ int BareosDb::GetFilesetRecord(JobControlRecord* jcr, FileSetDbRecord* fsr)
          esc);
   }
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("Error got %s FileSets but expected only one!\n"),
@@ -968,7 +968,7 @@ bool BareosDb::GetMediaIds(JobControlRecord* jcr,
     return false;
   }
 
-  if (!QUERY_DB(jcr, cmd)) {
+  if (!QueryDb(jcr, cmd)) {
     Mmsg(errmsg, T_("Media id select failed: ERR=%s\n"), sql_strerror());
     Jmsg(jcr, M_ERROR, 0, "%s", errmsg);
     return false;
@@ -1003,7 +1003,7 @@ bool BareosDb::GetQueryDbids(JobControlRecord* jcr,
 
   DbLocker _{this};
   ids.num_ids = 0;
-  if (QUERY_DB(jcr, query.c_str())) {
+  if (QueryDb(jcr, query.c_str())) {
     ids.num_ids = SqlNumRows();
     if (ids.num_ids > 0) {
       if (ids.max_ids < ids.num_ids) {
@@ -1095,7 +1095,7 @@ bool BareosDb::GetMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          esc);
   }
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows > 1) {
       Mmsg1(errmsg, T_("More than one Volume!: %s\n"),
@@ -1503,7 +1503,7 @@ bool BareosDb::get_quota_jobbytes(JobControlRecord* jcr,
 
   FillQuery(SQL_QUERY::get_quota_jobbytes, edit_uint64(jr->ClientId, ed1),
             edit_uint64(jr->JobId, ed2), dt);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       row = SqlFetchRow();
@@ -1552,7 +1552,7 @@ bool BareosDb::get_quota_jobbytes_nofailed(JobControlRecord* jcr,
 
   FillQuery(SQL_QUERY::get_quota_jobbytes_nofailed,
             edit_uint64(jr->ClientId, ed1), edit_uint64(jr->JobId, ed2), dt);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       row = SqlFetchRow();
@@ -1588,7 +1588,7 @@ bool BareosDb::GetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cdbr)
        "FROM Quota "
        "WHERE ClientId = %s",
        edit_int64(cdbr->ClientId, ed1));
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       if ((row = SqlFetchRow()) == NULL) {
@@ -1638,7 +1638,7 @@ int BareosDb::GetNdmpLevelMapping(JobControlRecord* jcr,
        edit_uint64(jr->ClientId, ed1), edit_uint64(jr->FileSetId, ed2),
        esc_name);
 
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     num_rows = SqlNumRows();
     if (num_rows == 1) {
       if ((row = SqlFetchRow()) == NULL) {

--- a/core/src/cats/sql_list.cc
+++ b/core/src/cats/sql_list.cc
@@ -152,7 +152,7 @@ void BareosDb::ListPoolRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, query.c_str())) { return; }
+  if (!QueryDb(jcr, query.c_str())) { return; }
 
   sendit->ArrayStart("pools");
   ListResult(jcr, sendit, type);
@@ -183,7 +183,7 @@ void BareosDb::ListClientRecords(JobControlRecord* jcr,
          clientfilter.c_str());
   }
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("clients");
   ListResult(jcr, sendit, type);
@@ -248,7 +248,7 @@ void BareosDb::ListMediaRecords(JobControlRecord* jcr,
 
   DbLocker _{this};
 
-  if (!QUERY_DB(jcr, query.c_str())) { return; }
+  if (!QueryDb(jcr, query.c_str())) { return; }
 
   ListResult(jcr, sendit, type);
 
@@ -294,7 +294,7 @@ void BareosDb::ListJobmediaRecords(JobControlRecord* jcr,
            "FROM JobMedia,Media WHERE Media.MediaId=JobMedia.MediaId ");
     }
   }
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobmedia");
   ListResult(jcr, sendit, type);
@@ -327,7 +327,7 @@ void BareosDb::ListVolumesOfJobid(JobControlRecord* jcr,
          "AND JobMedia.JobId=%s ",
          edit_int64(JobId, ed1));
   }
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("volumes");
   ListResult(jcr, sendit, type);
@@ -360,7 +360,7 @@ void BareosDb::ListCopiesRecords(JobControlRecord* jcr,
        "WHERE Job.Type = '%c' %s ORDER BY Job.PriorJobId DESC %s ",
        (char)JT_JOB_COPY, str_jobids.c_str(), range);
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   if (SqlNumRows()) {
     if (JobIds && JobIds[0]) {
@@ -427,7 +427,7 @@ void BareosDb::ListLogRecords(JobControlRecord* jcr,
 
   DbLocker _{this};
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("log");
   ListResult(jcr, sendit, type);
@@ -462,7 +462,7 @@ void BareosDb::ListJoblogRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("joblog");
   ListResult(jcr, sendit, type);
@@ -490,7 +490,7 @@ void BareosDb::ListJobstatisticsRecords(JobControlRecord* jcr,
        "WHERE JobStats.JobId=%s "
        "ORDER BY JobStats.SampleTime ",
        edit_int64(JobId, ed1));
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobstats");
   ListResult(jcr, sendit, type);
@@ -590,7 +590,7 @@ void BareosDb::ListJobRecords(JobControlRecord* jcr,
     }
   }
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobs");
   ListResult(jcr, sendit, type);
@@ -612,7 +612,7 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
        "AS Files, SUM(JobBytes) AS Bytes, Name AS Job FROM Job WHERE Type IN "
        "('B','A','a','C') GROUP BY Name");
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ArrayStart("jobs");
   ListResult(jcr, sendit, HORZ_LIST);
@@ -627,7 +627,7 @@ void BareosDb::ListJobTotals(JobControlRecord* jcr,
        "AS Files, SUM(JobBytes) AS Bytes FROM Job WHERE Type IN "
        "('B','A','a','C')");
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
 
   sendit->ObjectStart("jobtotals");
   ListResult(jcr, sendit, HORZ_LIST);
@@ -737,7 +737,7 @@ void BareosDb::ListFilesets(JobControlRecord* jcr,
          range);
   }
 
-  if (!QUERY_DB(jcr, cmd)) { return; }
+  if (!QueryDb(jcr, cmd)) { return; }
   sendit->ArrayStart("filesets");
   ListResult(jcr, sendit, type);
   sendit->ArrayEnd("filesets");

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -61,7 +61,7 @@ bool BareosDb::AddDigestToFileRecord(JobControlRecord* jcr,
   Mmsg(cmd, "UPDATE File SET MD5='%s' WHERE FileId=%s", esc_name,
        edit_int64(FileId, ed1));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /* Mark the file record as being visited during database
@@ -77,7 +77,7 @@ bool BareosDb::MarkFileRecord(JobControlRecord* jcr,
   Mmsg(cmd, "UPDATE File SET MarkId=%s WHERE FileId=%s", edit_int64(JobId, ed1),
        edit_int64(FileId, ed2));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -108,7 +108,7 @@ bool BareosDb::UpdateJobStartRecord(JobControlRecord* jcr, JobDbRecord* jr)
        jcr->VolSessionId, jcr->VolSessionTime, edit_int64(jr->JobId, ed5));
 
   changes = 0;
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 bool BareosDb::UpdateRunningJobRecord(JobControlRecord* jcr)
@@ -117,7 +117,7 @@ bool BareosDb::UpdateRunningJobRecord(JobControlRecord* jcr)
   Mmsg(cmd, "UPDATE Job SET JobBytes=%llu,JobFiles=%lu WHERE JobId=%lu",
        jcr->JobBytes, jcr->JobFiles, jcr->JobId);
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 // Update Long term statistics with all jobs that were run before age seconds
@@ -131,7 +131,7 @@ int BareosDb::UpdateStats(JobControlRecord* jcr, utime_t age)
 
   edit_uint64(now - age, ed1);
   FillQuery(SQL_QUERY::fill_jobhisto, ed1);
-  if (QUERY_DB(jcr, cmd)) {
+  if (QueryDb(jcr, cmd)) {
     rows = SqlAffectedRows();
   } else {
     rows = -1;
@@ -185,7 +185,7 @@ bool BareosDb::UpdateJobEndRecord(JobControlRecord* jcr, JobDbRecord* jr)
       jr->PoolId, jr->FileSetId, edit_uint64(JobTDate, ed2), rdt, PriorJobId,
       jr->HasBase, jr->PurgedFiles, edit_int64(jr->JobId, ed3));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -212,7 +212,7 @@ bool BareosDb::UpdateClientRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        cr->AutoPrune, edit_uint64(cr->FileRetention, ed1),
        edit_uint64(cr->JobRetention, ed2), esc_uname, esc_clientname);
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -230,7 +230,7 @@ bool BareosDb::UpdateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr)
   EscapeString(jcr, esc, cr->Counter, strlen(cr->Counter));
   FillQuery(SQL_QUERY::update_counter_values, cr->MinValue, cr->MaxValue,
             cr->CurrentValue, cr->WrapCounter, esc);
-  retval = UPDATE_DB(jcr, cmd) > 0;
+  retval = UpdateDb(jcr, cmd) > 0;
 
   return retval;
 }
@@ -262,7 +262,7 @@ bool BareosDb::UpdatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr)
        pr->LabelType, esc, edit_int64(pr->RecyclePoolId, ed5),
        edit_int64(pr->ScratchPoolId, ed6), pr->ActionOnPurge, pr->MinBlocksize,
        pr->MaxBlocksize, ed4);
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 bool BareosDb::UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
@@ -273,7 +273,7 @@ bool BareosDb::UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr)
   Mmsg(cmd, "UPDATE Storage SET AutoChanger=%d WHERE StorageId=%s",
        sr->AutoChanger, edit_int64(sr->StorageId, ed1));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 
@@ -306,7 +306,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET FirstWritten='%s' "
          "WHERE VolumeName='%s'",
          dt, esc_medianame);
-    UPDATE_DB(jcr, cmd);
+    UpdateDb(jcr, cmd);
     Dmsg1(400, "Firstwritten=%d\n", mr->FirstWritten);
   }
 
@@ -319,7 +319,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media SET LabelDate='%s' "
          "WHERE VolumeName='%s'",
          dt, esc_medianame);
-    UPDATE_DB(jcr, cmd);
+    UpdateDb(jcr, cmd);
   }
 
   if (mr->LastWritten != 0) {
@@ -329,7 +329,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
          "UPDATE Media Set LastWritten='%s' "
          "WHERE VolumeName='%s'",
          dt, esc_medianame);
-    UPDATE_DB(jcr, cmd);
+    UpdateDb(jcr, cmd);
   }
 
   Mmsg(cmd,
@@ -357,7 +357,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 
   Dmsg1(400, "%s\n", cmd);
 
-  bool retval = UPDATE_DB(jcr, cmd) > 0;
+  bool retval = UpdateDb(jcr, cmd) > 0;
 
   // Make sure InChanger is 0 for any record having the same Slot
   MakeInchangerUnique(jcr, mr);
@@ -404,7 +404,7 @@ bool BareosDb::UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr)
 
   Dmsg1(400, "%s\n", cmd);
 
-  return UPDATE_DB(jcr, cmd) != -1;
+  return UpdateDb(jcr, cmd) != -1;
 }
 
 
@@ -441,7 +441,7 @@ void BareosDb::MakeInchangerUnique(JobControlRecord* jcr, MediaDbRecord* mr)
            mr->Slot, edit_int64(mr->StorageId, ed1), mr->VolumeName);
     }
     Dmsg1(100, "%s\n", cmd);
-    UPDATE_DB(jcr, cmd);
+    UpdateDb(jcr, cmd);
   }
 }
 
@@ -461,7 +461,7 @@ bool BareosDb::UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr)
   Mmsg(cmd, "UPDATE Quota SET GraceTime=%s WHERE ClientId='%s'",
        edit_uint64(now, ed1), edit_uint64(jr->ClientId, ed2));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -480,7 +480,7 @@ bool BareosDb::UpdateQuotaSoftlimit(JobControlRecord* jcr, JobDbRecord* jr)
        edit_uint64((jr->JobSumTotalBytes + jr->JobBytes), ed1),
        edit_uint64(jr->ClientId, ed2));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -499,7 +499,7 @@ bool BareosDb::ResetQuotaRecord(JobControlRecord* jcr, ClientDbRecord* cr)
        "UPDATE Quota SET GraceTime='0', QuotaLimit='0' WHERE ClientId='%s'",
        edit_uint64(cr->ClientId, ed1));
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**
@@ -526,7 +526,7 @@ bool BareosDb::UpdateNdmpLevelMapping(JobControlRecord* jcr,
        edit_uint64(level, ed1), edit_uint64(jr->ClientId, ed2),
        edit_uint64(jr->FileSetId, ed3), esc_name);
 
-  return UPDATE_DB(jcr, cmd) > 0;
+  return UpdateDb(jcr, cmd) > 0;
 }
 
 /**

--- a/core/src/dird/msgchan.cc
+++ b/core/src/dird/msgchan.cc
@@ -510,7 +510,8 @@ extern "C" void* msg_thread(void* arg)
     Qmsg(jcr, M_FATAL, 0, T_("Director's comm line to SD dropped.\n"));
   }
   if (IsBnetError(sd)) { jcr->dir_impl->SDJobStatus = JS_ErrorTerminated; }
-  pthread_cleanup_pop(1); /* remove and execute the handler */
+  pthread_cleanup_pop(0); /* remove and execute the handler */
+  MsgThreadCleanup(arg);
   return NULL;
 }
 

--- a/core/src/dird/restore.cc
+++ b/core/src/dird/restore.cc
@@ -404,7 +404,6 @@ bool DoNativeRestore(JobControlRecord* jcr)
   return true;
 
 bail_out:
-  NativeRestoreCleanup(jcr, JS_ErrorTerminated);
   return false;
 }
 

--- a/core/src/include/config.h.in
+++ b/core/src/include/config.h.in
@@ -511,6 +511,9 @@ extern char win_os[];
 #define BAREOS_PLATFORM "@PLATFORM@"
 #define DISTVER "@DISTVER@"
 
+#cmakedefine HAVE_SOURCE_LOCATION @HAVE_SOURCE_LOCATION@
+#cmakedefine HAVE_BUILTIN_LOCATION @HAVE_BUILTIN_LOCATION@
+
 #endif /* defined(WIN32) */
 // clang-format on
 

--- a/core/src/include/config.h.in
+++ b/core/src/include/config.h.in
@@ -32,6 +32,9 @@
 #define DIR_DEFAULT_PORT "@dir_port@"
 #define NDMP_DEFAULT_PORT "10000"
 
+#cmakedefine HAVE_SOURCE_LOCATION @HAVE_SOURCE_LOCATION@
+#cmakedefine HAVE_BUILTIN_LOCATION @HAVE_BUILTIN_LOCATION@
+
 // Define to 1 if you use gcc
 #cmakedefine HAVE_GCC @HAVE_GCC@
 
@@ -510,9 +513,6 @@ extern char win_os[];
 
 #define BAREOS_PLATFORM "@PLATFORM@"
 #define DISTVER "@DISTVER@"
-
-#cmakedefine HAVE_SOURCE_LOCATION @HAVE_SOURCE_LOCATION@
-#cmakedefine HAVE_BUILTIN_LOCATION @HAVE_BUILTIN_LOCATION@
 
 #endif /* defined(WIN32) */
 // clang-format on

--- a/core/src/lib/rwlock.cc
+++ b/core/src/lib/rwlock.cc
@@ -261,9 +261,22 @@ int RwlWriteunlock(brwlock_t* rwl)
   return (status == 0 ? status2 : status);
 }
 
-void RwlAssertWriterIsMe(brwlock_t* rwl)
+void RwlAssertWriterIsMe(brwlock_t* rwl,
+                         const char* function,
+                         const char* file,
+                         int line)
 {
-  ASSERT(rwl->valid == RWLOCK_VALID);
-  ASSERT(rwl->w_active > 0);
-  ASSERT(pthread_equal(rwl->writer_id, pthread_self()));
+  bool is_ok = rwl->valid == RWLOCK_VALID;
+  bool is_locked = rwl->w_active > 0;
+  bool is_me = pthread_equal(rwl->writer_id, pthread_self());
+
+  if (!is_ok || !is_locked || !is_me) {
+    Emsg1(M_ERROR, 0, T_("Failed assert called from %s %s:%d\n"), function,
+          file, line);
+    Pmsg1(000, T_("Failed assert called from %s %s:%d\n"), function, file,
+          line);
+  }
+  ASSERT(is_ok);
+  ASSERT(is_locked);
+  ASSERT(is_me);
 }

--- a/core/src/lib/rwlock.cc
+++ b/core/src/lib/rwlock.cc
@@ -261,11 +261,12 @@ int RwlWriteunlock(brwlock_t* rwl)
   return (status == 0 ? status2 : status);
 }
 
-void RwlAssertWriterIsMe(brwlock_t* rwl,
-                         const char* function,
-                         const char* file,
-                         int line)
+void RwlAssertWriterIsMe(brwlock_t* rwl, brs::source_location loc)
 {
+  auto* function = loc.function_name();
+  auto* file = loc.file_name();
+  auto line = loc.line();
+
   bool is_ok = rwl->valid == RWLOCK_VALID;
   bool is_locked = rwl->w_active > 0;
   bool is_me = pthread_equal(rwl->writer_id, pthread_self());

--- a/core/src/lib/rwlock.cc
+++ b/core/src/lib/rwlock.cc
@@ -261,7 +261,7 @@ int RwlWriteunlock(brwlock_t* rwl)
   return (status == 0 ? status2 : status);
 }
 
-void RwlAssertWriterIsMe(brwlock_t* rwl, brs::source_location loc)
+void RwlAssertWriterIsMe(brwlock_t* rwl, libbareos::source_location loc)
 {
   auto* function = loc.function_name();
   auto* file = loc.file_name();

--- a/core/src/lib/rwlock.h
+++ b/core/src/lib/rwlock.h
@@ -59,6 +59,9 @@ int RwlReadunlock(brwlock_t* rwl);
 int RwlWritelock(brwlock_t* rwl);
 int RwlWritetrylock(brwlock_t* rwl);
 int RwlWriteunlock(brwlock_t* rwl);
-void RwlAssertWriterIsMe(brwlock_t* rwl);
+void RwlAssertWriterIsMe(brwlock_t* rwl,
+                         const char* function,
+                         const char* file,
+                         int line);
 
 #endif  // BAREOS_LIB_RWLOCK_H_

--- a/core/src/lib/rwlock.h
+++ b/core/src/lib/rwlock.h
@@ -60,6 +60,8 @@ int RwlReadunlock(brwlock_t* rwl);
 int RwlWritelock(brwlock_t* rwl);
 int RwlWritetrylock(brwlock_t* rwl);
 int RwlWriteunlock(brwlock_t* rwl);
-void RwlAssertWriterIsMe(brwlock_t* rwl, libbareos::source_location loc = libbareos::source_location::current());
+void RwlAssertWriterIsMe(brwlock_t* rwl,
+                         libbareos::source_location loc
+                         = libbareos::source_location::current());
 
 #endif  // BAREOS_LIB_RWLOCK_H_

--- a/core/src/lib/rwlock.h
+++ b/core/src/lib/rwlock.h
@@ -33,6 +33,7 @@
 #define BAREOS_LIB_RWLOCK_H_
 
 #include <pthread.h>
+#include "lib/source_location.h"
 
 struct brwlock_t {
   pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -59,9 +60,6 @@ int RwlReadunlock(brwlock_t* rwl);
 int RwlWritelock(brwlock_t* rwl);
 int RwlWritetrylock(brwlock_t* rwl);
 int RwlWriteunlock(brwlock_t* rwl);
-void RwlAssertWriterIsMe(brwlock_t* rwl,
-                         const char* function,
-                         const char* file,
-                         int line);
+void RwlAssertWriterIsMe(brwlock_t* rwl, brs::source_location loc = brs::source_location::current());
 
 #endif  // BAREOS_LIB_RWLOCK_H_

--- a/core/src/lib/rwlock.h
+++ b/core/src/lib/rwlock.h
@@ -60,6 +60,6 @@ int RwlReadunlock(brwlock_t* rwl);
 int RwlWritelock(brwlock_t* rwl);
 int RwlWritetrylock(brwlock_t* rwl);
 int RwlWriteunlock(brwlock_t* rwl);
-void RwlAssertWriterIsMe(brwlock_t* rwl, brs::source_location loc = brs::source_location::current());
+void RwlAssertWriterIsMe(brwlock_t* rwl, libbareos::source_location loc = libbareos::source_location::current());
 
 #endif  // BAREOS_LIB_RWLOCK_H_

--- a/core/src/lib/source_location.h
+++ b/core/src/lib/source_location.h
@@ -26,12 +26,12 @@
 
 #if defined(HAVE_SOURCE_LOCATION)
 #  include <source_location>
-namespace brs {
+namespace libbareos {
 using source_location = std::source_location;
 };
 #elif defined(HAVE_BUILTIN_LOCATION)
 #  include <cstdint>
-namespace brs {
+namespace libbareos {
 class source_location {
 public:
   constexpr static source_location current(const char* function
@@ -69,8 +69,8 @@ private:
 #endif
 
 #include <string_view>
-static_assert(std::string_view{brs::source_location::current().file_name()}
+static_assert(std::string_view{libbareos::source_location::current().file_name()}
               == std::string_view{__FILE__});
-static_assert(brs::source_location::current().line() == __LINE__);
+static_assert(libbareos::source_location::current().line() == __LINE__);
 
 #endif  // BAREOS_LIB_SOURCE_LOCATION_H_

--- a/core/src/lib/source_location.h
+++ b/core/src/lib/source_location.h
@@ -1,0 +1,76 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_SOURCE_LOCATION_H_
+#define BAREOS_LIB_SOURCE_LOCATION_H_
+
+#include "include/config.h"
+
+#if defined(HAVE_SOURCE_LOCATION)
+#  include <source_location>
+namespace brs {
+using source_location = std::source_location;
+};
+#elif defined(HAVE_BUILTIN_LOCATION)
+#  include <cstdint>
+namespace brs {
+class source_location {
+public:
+  constexpr static source_location current(const char* function
+                                           = __builtin_FUNCTION(),
+                                           const char* file = __builtin_FILE(),
+                                           std::uint_least32_t line
+                                           = __builtin_LINE()) noexcept
+  {
+    return source_location{ function, file, line };
+  }
+
+  constexpr const char* file_name() const noexcept { return file_; }
+  constexpr const char* function_name() const noexcept { return function_; }
+  constexpr std::uint_least32_t line() const noexcept { return line_; }
+  constexpr std::uint_least32_t column() const noexcept { return 0; }
+
+  constexpr source_location() = default;
+
+private:
+  constexpr source_location(const char* function,
+                  const char* file,
+                  std::uint_least32_t line)
+    : function_{function}
+    , file_{file}
+    , line_{line}
+  {}
+
+  const char* function_{"unset"};
+  const char* file_{"unset"};
+  std::uint_least32_t line_{0};
+};
+}  // namespace brs
+#else
+#error "No source_location implementation available"
+#endif
+
+#include <string_view>
+static_assert(std::string_view{brs::source_location::current().file_name()}
+              == std::string_view{__FILE__});
+static_assert(brs::source_location::current().line() == __LINE__);
+
+#endif  // BAREOS_LIB_SOURCE_LOCATION_H_

--- a/core/src/lib/source_location.h
+++ b/core/src/lib/source_location.h
@@ -33,14 +33,14 @@ using source_location = std::source_location;
 #  include <cstdint>
 namespace libbareos {
 class source_location {
-public:
+ public:
   constexpr static source_location current(const char* function
                                            = __builtin_FUNCTION(),
                                            const char* file = __builtin_FILE(),
                                            std::uint_least32_t line
                                            = __builtin_LINE()) noexcept
   {
-    return source_location{ function, file, line };
+    return source_location{function, file, line};
   }
 
   constexpr const char* file_name() const noexcept { return file_; }
@@ -50,40 +50,42 @@ public:
 
   constexpr source_location() = default;
 
-private:
+ private:
   constexpr source_location(const char* function,
-                  const char* file,
-                  std::uint_least32_t line)
-    : function_{function}
-    , file_{file}
-    , line_{line}
-  {}
+                            const char* file,
+                            std::uint_least32_t line)
+      : function_{function}, file_{file}, line_{line}
+  {
+  }
 
   const char* function_{"unset"};
   const char* file_{"unset"};
   std::uint_least32_t line_{0};
 };
-}  // namespace brs
+}  // namespace libbareos
 #else
-#error "No source_location implementation available"
+#  error "No source_location implementation available"
 #endif
 
 #include <string_view>
 // make sure this works at all
-static_assert(std::string_view{libbareos::source_location::current().file_name()}
+static_assert(std::string_view{
+                  libbareos::source_location::current().file_name()}
               == std::string_view{__FILE__});
 static_assert(libbareos::source_location::current().line() == __LINE__);
 
 namespace {
-  // make sure this works as intended, when used as a defaulted parameter
-  // This was bugged on e.g. clang 15
-  constexpr auto make_source_loc(libbareos::source_location loc = libbareos::source_location::current()) {
-    return loc;
-  }
+// make sure this works as intended, when used as a defaulted parameter
+// This was bugged on e.g. clang 15
+constexpr auto make_source_loc(libbareos::source_location loc
+                               = libbareos::source_location::current())
+{
+  return loc;
+}
 
 static_assert(make_source_loc().line() == __LINE__);
-  static_assert(std::string_view{make_source_loc().file_name()}
-                == std::string_view{__FILE__});
+static_assert(std::string_view{make_source_loc().file_name()}
+              == std::string_view{__FILE__});
 };  // namespace
 
 #endif  // BAREOS_LIB_SOURCE_LOCATION_H_

--- a/core/src/lib/source_location.h
+++ b/core/src/lib/source_location.h
@@ -69,8 +69,21 @@ private:
 #endif
 
 #include <string_view>
+// make sure this works at all
 static_assert(std::string_view{libbareos::source_location::current().file_name()}
               == std::string_view{__FILE__});
 static_assert(libbareos::source_location::current().line() == __LINE__);
+
+namespace {
+  // make sure this works as intended, when used as a defaulted parameter
+  // This was bugged on e.g. clang 15
+  constexpr auto make_source_loc(libbareos::source_location loc = libbareos::source_location::current()) {
+    return loc;
+  }
+
+static_assert(make_source_loc().line() == __LINE__);
+  static_assert(std::string_view{make_source_loc().file_name()}
+                == std::string_view{__FILE__});
+};  // namespace
 
 #endif  // BAREOS_LIB_SOURCE_LOCATION_H_

--- a/core/src/tests/wrap.cc
+++ b/core/src/tests/wrap.cc
@@ -30,6 +30,7 @@
 #include <cstdio>
 #include <cinttypes>
 #include <vector>
+#include <memory>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/rand.h>

--- a/core/src/win32/compat/include/mingwconfig.h
+++ b/core/src/win32/compat/include/mingwconfig.h
@@ -159,4 +159,7 @@
 /* Define to 1 if you have the `inet_ntop' function. */
 #define HAVE_INET_NTOP 1
 
+/* #undef HAVE_SOURCE_LOCATION */
+#define HAVE_BUILTIN_LOCATION 1
+
 #endif  // BAREOS_WIN32_COMPAT_INCLUDE_MINGWCONFIG_H_

--- a/core/src/win32/compat/include/mingwconfig.h
+++ b/core/src/win32/compat/include/mingwconfig.h
@@ -159,7 +159,4 @@
 /* Define to 1 if you have the `inet_ntop' function. */
 #define HAVE_INET_NTOP 1
 
-/* #undef HAVE_SOURCE_LOCATION */
-#define HAVE_BUILTIN_LOCATION 1
-
 #endif  // BAREOS_WIN32_COMPAT_INCLUDE_MINGWCONFIG_H_


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr introduces a "polyfill" for std::source_location and uses it in our db code.  This should make debugging this code easier.
Additionally it fixes a crash inside our DebugCode as it should not need to take a lock before accessing the database during a crash.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR