### PR TITLE
backport configuration parser fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -188,6 +188,7 @@ debian/bareos-filedaemon.preinst
 debian/bareos-filedaemon-python3-plugin.install
 debian/bareos-filedaemon-python-plugins-common.install
 debian/bareos-filedaemon.service
+debian/bareos-storage-dedupable.install
 debian/bareos-storage-droplet.install
 debian/bareos-storage-fifo.install
 debian/bareos-storage-glusterfs.install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - deb control files: depend on python3-bareos [PR #1967]
 - stored: fix volume size mismatch [PR #2003]
 - add Honor No Dump Flag to config output [PR #2007]
+- backport configuration parser fixes [PR #2012]
 
 ### Documentation
 - docs: improve debuginfo install description (fix issue #1943) [PR #1985]
@@ -572,4 +573,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2003]: https://github.com/bareos/bareos/pull/2003
 [PR #2007]: https://github.com/bareos/bareos/pull/2007
 [PR #2010]: https://github.com/bareos/bareos/pull/2010
+[PR #2012]: https://github.com/bareos/bareos/pull/2012
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2742,6 +2742,18 @@ static void StoreAutopassword(LEX* lc, ResourceItem* item, int index, int pass)
       }
       break;
     case R_CLIENT:
+      if (pass == 2) {
+        auto* res = dynamic_cast<ClientResource*>(my_config->GetResWithName(
+            R_CLIENT, (*item->allocated_resource)->resource_name_));
+        ASSERT(res);
+
+        if (res_client->Protocol != res->Protocol) {
+          scan_err1(lc,
+                    "Trying to store password to resource \"%s\", but protocol "
+                    "is not known.\n",
+                    (*item->allocated_resource)->resource_name_);
+        }
+      }
       switch (res_client->Protocol) {
         case APT_NDMPV2:
         case APT_NDMPV3:
@@ -2755,6 +2767,18 @@ static void StoreAutopassword(LEX* lc, ResourceItem* item, int index, int pass)
       }
       break;
     case R_STORAGE:
+      if (pass == 2) {
+        auto* res = dynamic_cast<StorageResource*>(my_config->GetResWithName(
+            R_STORAGE, (*item->allocated_resource)->resource_name_));
+        ASSERT(res);
+
+        if (res_store->Protocol != res->Protocol) {
+          scan_err1(lc,
+                    "Trying to store password to resource \"%s\", but protocol "
+                    "is not known.\n",
+                    (*item->allocated_resource)->resource_name_);
+        }
+      }
       switch (res_store->Protocol) {
         case APT_NDMPV2:
         case APT_NDMPV3:

--- a/core/src/lib/parse_conf_init_resource.cc
+++ b/core/src/lib/parse_conf_init_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -202,6 +202,8 @@ void ConfigurationParser::SetAllResourceDefaultsIterateOverItems(
       SetBit(res_item_index,
              (*items[res_item_index].allocated_resource)->inherit_content_);
     }
+
+    (*items[res_item_index].allocated_resource)->rcode_ = rcode;
 
     res_item_index++;
 


### PR DESCRIPTION
This PR backports two fixes from #1912 into bareos-23. Previously you could accidentially configure a NDMP client or storage with an encrypted password, which would eventually lead to a failed assertion in the director. With these fixes applied this situation will be detected by the configuration parser and the configuration will be reported as ill-formed.

The PR also adds a file to .gitignore that was overlooked previously.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [X] Is the PR title usable as CHANGELOG entry?
- [X] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [X] Correct milestone is set

##### Source code quality
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR
