### PR TITLE
Fix btape fill-test problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugin: postgresql use integer for savepkt.object_index [PR #2132]
 - bconsole: enable app icon on windows [PR #2105]
 - windows: fix readlink buffer size issue [PR #2153]
+- Fix btape fill-test problem [PR #2018]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - debian: Add missing build dependencies [PR #2128]
 
 [PR #1893]: https://github.com/bareos/bareos/pull/1893
+[PR #2018]: https://github.com/bareos/bareos/pull/2018
 [PR #2039]: https://github.com/bareos/bareos/pull/2039
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
 [PR #2056]: https://github.com/bareos/bareos/pull/2056

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -314,8 +314,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             return;
             break;
         } /* end switch */
-      }   /* end if Bstrcasecmp */
-    }     /* end for RunFields */
+      } /* end if Bstrcasecmp */
+    } /* end for RunFields */
 
     /* At this point, it is not a keyword. Check for old syle
      * Job Levels without keyword. This form is depreciated!!! */
@@ -527,8 +527,12 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
           // Check for week modulo specification.
           code = atoi(lc->str + 1);
           code2 = atoi(p + 1);
-          if (code < 0 || code > 53 || code2 < 0 || code2 > 53) {
+          if (code < 0 || code > 53) {
             scan_err0(lc, T_("Week number out of range (0-53) in modulo"));
+            return;
+          }
+          if (code2 <= 0 || code2 > 53) {
+            scan_err0(lc, T_("Week interval out of range (1-53) in modulo"));
             return;
           }
           if (code > code2) {
@@ -541,10 +545,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             have_woy = true;
           }
           // Set the bits according to the modulo specification.
-          for (i = 0; i < 53; i++) {
-            if (i % code2 == 0) {
-              SetBit(i + code, res_run.date_time_bitfield.woy);
-            }
+          for (int week = code; week <= 53; week += code2) {
+            SetBit(week, res_run.date_time_bitfield.woy);
           }
         } else {
           scan_err0(lc, T_("Bad modulo time specification. Format for weekdays "

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -2414,7 +2414,6 @@ static void unfillcmd()
  */
 static bool do_unfill()
 {
-  DeviceBlock* block = g_dcr->block;
   int autochanger;
   bool rc = false;
 
@@ -2498,7 +2497,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), g_dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(last_block, block)) {
+  if (CompareBlocks(last_block, g_dcr->block)) {
     if (simple) {
       Pmsg0(-1,
             T_("\nThe last block on the tape matches. Test succeeded.\n\n"));
@@ -2549,7 +2548,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), g_dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(first_block, block)) {
+  if (CompareBlocks(first_block, g_dcr->block)) {
     Pmsg0(-1, T_("\nThe first block on the second tape matches.\n\n"));
   }
 
@@ -2566,7 +2565,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), g_dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(last_block, block)) {
+  if (CompareBlocks(last_block, g_dcr->block)) {
     Pmsg0(-1, T_("\nThe last block on the second tape matches. Test "
                  "succeeded.\n\n"));
     rc = true;

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -2533,12 +2533,18 @@ static bool do_unfill()
     goto bail_out;
   }
 
+  // read volume label
+  if (int err = ReadDevVolumeLabel(g_dcr); err != VOL_OK) {
+    Pmsg1(-1, T_("Error reading label. ERR=%d\n"), err);
+    goto bail_out;
+  }
+
   /* Space to "first" block which is last block not written
    * on the previous tape.
    */
-  Pmsg2(-1, T_("Reposition from %u:%u to 0:1\n"), g_dev->file,
+  Pmsg2(-1, T_("Reposition from %u:%u to 1:0\n"), g_dev->file,
         g_dev->block_num);
-  if (!g_dev->Reposition(g_dcr, 0, 1)) {
+  if (!g_dev->Reposition(g_dcr, 1, 0)) {
     Pmsg1(-1, T_("Reposition error. ERR=%s\n"), g_dev->bstrerror());
     goto bail_out;
   }


### PR DESCRIPTION
This PR fixes a break of `btape` introduced in #1958.

When we disabled the PRE_LABEL, we introduced a file-mark right after the label block. As the `btape` mutli-tape test blindly repositions the tape to the location where it thinks the data starts, tests started to fail.
The PR also fixes two memory-issues in `btape` as well as a possible out-of-bounds access when using the modulo scheduler.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
