### PR TITLE
bareos-version-from-git: fix output for wip tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mssql TearDownVdiDevice(): enhance error reporting [PR #2008]
 - macos: update build environment [PR #2035]
 - NDMP_NATIVE: enable full restore, eject tape before unload, enable update of NDMP environment [PR #1862]
+- vmware: upgrade vmware vix disklib to version 8.0.3
 
 ### Removed
 - plugins: remove old deprecated postgres plugin [PR #1606]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON API: make sure, strings are valid UTF8 [PR #1922]
 - dird: fix mark command not accepting full windows paths [PR #1938]
 - stored: explicitly flush after labeling [PR #2022]
+- bareos-version-from-git: fix output for wip tags [PR #2019]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -320,6 +321,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1996]: https://github.com/bareos/bareos/pull/1996
 [PR #1998]: https://github.com/bareos/bareos/pull/1998
 [PR #2008]: https://github.com/bareos/bareos/pull/2008
+[PR #2019]: https://github.com/bareos/bareos/pull/2019
 [PR #2022]: https://github.com/bareos/bareos/pull/2022
 [PR #2027]: https://github.com/bareos/bareos/pull/2027
 [PR #2029]: https://github.com/bareos/bareos/pull/2029

--- a/cmake/BareosVersionFromGit.cmake
+++ b/cmake/BareosVersionFromGit.cmake
@@ -1,6 +1,6 @@
 # BAREOS® - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2019-2019 Bareos GmbH & Co. KG
+# Copyright (C) 2019-2024 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or modify it under
 # the terms of version three of the GNU Affero General Public License as
@@ -38,7 +38,8 @@ if(GIT_COMMIT_TIMESTAMP_RESULT EQUAL 0)
   )
   if(NOT GIT_DESCRIBE_RELEASE_RESULT EQUAL 0)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --tags --match "WIP/*" --long --dirty=.dirty
+      COMMAND ${GIT_EXECUTABLE} describe --tags --match "WIP/*" --long
+              --dirty=.dirty
       RESULT_VARIABLE GIT_DESCRIBE_WIP_RESULT
       OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/cmake/BareosVersionFromGit.cmake
+++ b/cmake/BareosVersionFromGit.cmake
@@ -38,7 +38,7 @@ if(GIT_COMMIT_TIMESTAMP_RESULT EQUAL 0)
   )
   if(NOT GIT_DESCRIBE_RELEASE_RESULT EQUAL 0)
     execute_process(
-      COMMAND ${GIT_EXECUTABLE} describe --tags --match "WIP/*" --dirty=.dirty
+      COMMAND ${GIT_EXECUTABLE} describe --tags --match "WIP/*" --long --dirty=.dirty
       RESULT_VARIABLE GIT_DESCRIBE_WIP_RESULT
       OUTPUT_VARIABLE GIT_DESCRIBE_OUTPUT
       WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}

--- a/systemtests/tests/accurate-lmdb-stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/accurate-lmdb-stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Lmdb Threshold = 0
 

--- a/systemtests/tests/accurate-lmdb-stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/accurate-lmdb-stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/accurate-stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/accurate-stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/accurate-stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/accurate-stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/acl/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/always-incremental-consolidate/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/always-incremental-consolidate/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/always-incremental-consolidate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/always-incremental-consolidate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/autochanger/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/autochanger/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 2000
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/autochanger/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/autochanger/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/autoxflate/etc/bareos-sd1/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/autoxflate/etc/bareos-sd1/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd-1
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd2_port@

--- a/systemtests/tests/autoxflate/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/autoxflate/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/autoxflate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/autoxflate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd-local
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/bareos-acl/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bareos-acl/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bareos-acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bareos-acl/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bareos-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bareos-concurrency/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bareos-concurrency/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bareos-concurrency/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bareos-concurrency/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bconsole-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bconsole-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bconsole-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bconsole-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/block-size/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/block-size/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/block-size/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/block-size/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/bscan-bextract-bls-bcopy/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/checkpoints/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/checkpoints/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/chflags/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/chflags/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/chflags/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/client-initiated/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/client-initiated/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/client-initiated/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/client-initiated/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/commandline-options/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/commandline-options/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/commandline-options/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/commandline-options/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/copy-archive-job/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/copy-archive-job/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/copy-archive-job/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-archive-job/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 10
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd-remote
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/copy-remote-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/dedupable/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/dedupable/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/dedupable/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/dedupable/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/dedupestimate/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/dedupestimate/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/dedupestimate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/dedupestimate/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/deprecation/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/deprecation/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/droplet-s3/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/droplet-s3/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/droplet-s3/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/droplet-s3/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/encrypt-signature-no-tls/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/encrypt-signature-tls-cert/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/file-autochanger/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/file-autochanger/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 2000
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/file-autochanger/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/file-autochanger/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/file-count-regression/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/file-count-regression/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/file-count-regression/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/file-count-regression/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/fileset-multiple-blocks/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/fileset-multiple-blocks/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/fileset-multiple-blocks/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/fileset-multiple-blocks/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/filesets/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/filesets/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/filesets/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/filesets/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/gfapi-fd/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/gfapi-fd/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/gfapi-fd/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/gfapi-fd/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/glusterfs-backend/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/glusterfs-backend/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/glusterfs-backend/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/ignoreduplicatecheck/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/ignoreduplicatecheck/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@
 }

--- a/systemtests/tests/ignoreduplicatecheck/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/ignoreduplicatecheck/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/just-in-time-reservation/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/just-in-time-reservation/etc/bareos-remote/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd-remote
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/just-in-time-reservation/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/just-in-time-reservation/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/just-in-time-reservation/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/just-in-time-reservation/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/list-backups/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/list-backups/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/list-backups/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/list-backups/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/multiple-clients/etc/bareos-secondclient/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/multiple-clients/etc/bareos-secondclient/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = anotherclient
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd2_port@

--- a/systemtests/tests/multiple-clients/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/multiple-clients/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/multiple-clients/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/multiple-clients/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/multiplied-device/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/multiplied-device/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/multiplied-device/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/multiplied-device/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/ndmp-bareos/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/ndmp-bareos/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/ndmp-bareos/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/ndmp-bareos/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   NDMP Enable = yes
   NDMP Log Level = 7
   NDMP Snooping = yes

--- a/systemtests/tests/notls/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/notls/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/notls/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/notls/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/parallel-jobs/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/passive/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/passive/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/passive/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/passive/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/pruning/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/pruning/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/pruning/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/pruning/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-dir/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-dir/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-dir/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-dir/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-contrib-bareos_tasks_mysql/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-contrib-bareos_tasks_mysql/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-contrib-bareos_tasks_mysql/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-contrib-bareos_tasks_mysql/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-contrib-mysql_dump/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-contrib-mysql_dump/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-contrib-mysql_dump/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-contrib-mysql_dump/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-ldap/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-ldap/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-ldap/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-ldap/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-libcloud/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-libcloud/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-libcloud/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-libcloud/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-local-fileset-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-local-fileset-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-local-fileset-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-local-fileset-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-local-fileset-restoreobject/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-local-fileset-restoreobject/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-local-fileset-restoreobject/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-local-fileset-restoreobject/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-percona-xtrabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-percona-xtrabackup/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-percona-xtrabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-percona-xtrabackup/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
   Plugin Directory = "@FD_PLUGINS_DIR_TO_TEST@"
   Plugin Names = "@python_module_name@"
   Working Directory =  "@working_dir@"

--- a/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-postgresql/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-fd-vmware/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-fd-vmware/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-fd-vmware/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-fd-vmware/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/py3plug-sd/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/py3plug-sd/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/py3plug-sd/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/py3plug-sd/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Plugin Directory = "@FD_PLUGINS_DIR_TO_TEST@"
   Plugin Names = "bpipe"

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/quota-softquota/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/quota-softquota/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/quota-softquota/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/quota-softquota/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/restapi/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/restapi/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/restapi/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/restapi/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/scheduler/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/scheduler/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/scheduler/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/scheduler/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/scsicrypto/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/scsicrypto/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 2000
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/scsicrypto/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/scsicrypto/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/sparse-file/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/sparse-file/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/sparse-file/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/sparse-file/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/spool/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/spool/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/spool/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/spool/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/stresstest/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/stresstest/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/strippath/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/strippath/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/strippath/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/strippath/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 10
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/testfind/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/testfind/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/tls-suites/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/tls-suites/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/tls-suites/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/tls-suites/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@

--- a/systemtests/tests/tlsrestricted/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/tlsrestricted/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/tlsrestricted/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/tlsrestricted/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/truncate-command/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/truncate-command/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   Working Directory =  "@working_dir@"
   FD Port = @fd_port@

--- a/systemtests/tests/truncate-command/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/truncate-command/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/virtualfull-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/virtualfull-basic/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/virtualfull-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/virtualfull-basic/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/virtualfull-bscan/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/virtualfull-deletedfiles/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/virtualfull-deletedfiles/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/virtualfull-deletedfiles/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/virtualfull-deletedfiles/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/webui-common/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/webui-common/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/webui-common/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@

--- a/systemtests/tests/xattr/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -1,6 +1,5 @@
 Client {
   Name = @basename@-fd
-  Maximum Concurrent Jobs = 20
 
   # remove comment from "Plugin Directory" to load plugins from specified directory.
   # if "Plugin Names" is defined, only the specified plugins will be loaded,

--- a/systemtests/tests/xattr/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
+++ b/systemtests/tests/xattr/etc/bareos/bareos-sd.d/storage/bareos-sd.conf.in
@@ -1,6 +1,5 @@
 Storage {
   Name = bareos-sd
-  Maximum Concurrent Jobs = 20
   Working Directory =  "@working_dir@"
   SD Port = @sd_port@
   @sd_backend_config@


### PR DESCRIPTION
If the current checkout is tagged as WIP, then git describe will not attach a git hash to its name.  This git hash is needed/expected by some of our build tooling.
As such we should tell git to always emit a git hash (except for releases).

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
