### PR TITLE
core: add support for Fedora 41

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Documentation
 - docs: fixed typo in the filedaemon service name [PR #2028]
 
+### Changed
+- core: add support for Fedora 41 [PR #2021]
+
 ## [23.1.0] - 2024-11-13
 
 ### Changed
@@ -580,5 +583,6 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2007]: https://github.com/bareos/bareos/pull/2007
 [PR #2010]: https://github.com/bareos/bareos/pull/2010
 [PR #2012]: https://github.com/bareos/bareos/pull/2012
+[PR #2021]: https://github.com/bareos/bareos/pull/2021
 [PR #2028]: https://github.com/bareos/bareos/pull/2028
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/findlib/xattr.cc
+++ b/core/src/findlib/xattr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2008-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -2818,7 +2818,7 @@ BxattrExitCode ParseXattrStreams(JobControlRecord* jcr,
   } else {
     /* Increment error count but don't log an error again for the same
      * filesystem. */
-    xattr_data->u.parse->nr_errors++;
+    if (xattr_data->u.parse) xattr_data->u.parse->nr_errors++;
     retval = BxattrExitCode::kSuccess;
     goto bail_out;
   }

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -1513,12 +1513,6 @@ int InitCrypto(void)
   /* Register OpenSSL ciphers and digests */
   OpenSSL_add_all_algorithms();
 
-#  ifdef HAVE_ENGINE_LOAD_PK11
-#  else
-  // Load all the builtin engines.
-  ALLOW_DEPRECATED()
-#  endif
-
   crypto_initialized = true;
 
   return status;
@@ -1536,10 +1530,6 @@ int CleanupCrypto(void)
   /* Ensure that we've actually been initialized; Doing this here decreases the
    * complexity of client's termination/cleanup code. */
   if (!crypto_initialized) { return 0; }
-
-#  ifndef HAVE_SUN_OS
-  // Cleanup the builtin engines.
-#  endif
 
   OpensslCleanupThreads();
 

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -45,7 +45,6 @@
 #    include <openssl/x509v3.h>
 #    include <openssl/asn1.h>
 #    include <openssl/asn1t.h>
-#    include <openssl/engine.h>
 #    include <openssl/evp.h>
 #    include <iomanip>
 #    include <sstream>
@@ -1515,11 +1514,9 @@ int InitCrypto(void)
   OpenSSL_add_all_algorithms();
 
 #  ifdef HAVE_ENGINE_LOAD_PK11
-  ENGINE_load_pk11();
 #  else
   // Load all the builtin engines.
-  ALLOW_DEPRECATED(ENGINE_load_builtin_engines();
-                   ENGINE_register_all_complete();)
+  ALLOW_DEPRECATED()
 #  endif
 
   crypto_initialized = true;
@@ -1542,7 +1539,6 @@ int CleanupCrypto(void)
 
 #  ifndef HAVE_SUN_OS
   // Cleanup the builtin engines.
-  ENGINE_cleanup();
 #  endif
 
   OpensslCleanupThreads();


### PR DESCRIPTION
**Backport of PR #1996 to bareos-23**

This backport only includes changes to the actual source code, which allows building on fedora 41.
This does not add builds for fedora 41.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [X] Original PR #1996 is merged
- [X] All functional differences to the original PR are documented above
