### PR TITLE
stored: explicitly flush after labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -164,6 +164,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add Honor No Dump Flag to config output [PR #1994]
 - JSON API: make sure, strings are valid UTF8 [PR #1922]
 - dird: fix mark command not accepting full windows paths [PR #1938]
+- stored: explicitly flush after labeling [PR #2022]
 
 [PR #1538]: https://github.com/bareos/bareos/pull/1538
 [PR #1581]: https://github.com/bareos/bareos/pull/1581
@@ -312,6 +313,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #1994]: https://github.com/bareos/bareos/pull/1994
 [PR #1996]: https://github.com/bareos/bareos/pull/1996
 [PR #1998]: https://github.com/bareos/bareos/pull/1998
+[PR #2022]: https://github.com/bareos/bareos/pull/2022
 [PR #2027]: https://github.com/bareos/bareos/pull/2027
 [PR #2029]: https://github.com/bareos/bareos/pull/2029
 [PR #2031]: https://github.com/bareos/bareos/pull/2031

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -944,6 +944,14 @@ static int CompareVolumeName(void* item1, void* item2)
 // Get the current size of a volume.
 ssize_t ChunkedDevice::ChunkedVolumeSize()
 {
+  /* Check if the current chunk needs flushing. In that case, we just wrote to
+   * the chunk. As we can only ever write to the last chunk, it is safe to
+   * assume that the end of the last write in this chunk is the end of the
+   * volume. */
+  if (current_chunk_->need_flushing) {
+    return current_chunk_->start_offset + current_chunk_->buflen;
+  }
+
   /* See if we are using io-threads or not and the ordered CircularBuffer is
    * created. We try to make sure that nothing of the volume being requested is
    * still inflight as then the RemoteVolumeSize() method will fail to

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -427,6 +427,11 @@ bool WriteNewVolumeLabelToDev(DeviceControlRecord* dcr,
     WriteAnsiIbmLabels(dcr, ANSI_EOF_LABEL, dev->VolHdr.VolumeName);
   }
 
+  /* make sure the label block is actually written to the device
+   * otherwise a subsequent read of the label block might fail
+   * (i.e. reading stale data that does not contain the label) */
+  dev->d_flush(dcr);
+
   if (debug_level >= 20) { DumpVolumeLabel(dev); }
   Dmsg0(100, "Call reserve_volume\n");
   if (reserve_volume(dcr, VolName) == NULL) {


### PR DESCRIPTION
this is needed to make sure the volume is flushed to the backing storage so a subsequent read of the label will work.

This fixes #2020.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
