### PR TITLE
logrotate: add mtx-changer debug log config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - plugins: Fix typo in postgresql plugin [PR #2066]
 - Sync EvpDigest between OpenSSL <1.1 and 1.1+ [PR #2086]
 - winbareos-native.nsi: do not package python3 plugins [PR #2076]
+- logrotate: add mtx-changer debug log config [PR #2039]
 
+[PR #2039]: https://github.com/bareos/bareos/pull/2039
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
 [PR #2056]: https://github.com/bareos/bareos/pull/2056
 [PR #2064]: https://github.com/bareos/bareos/pull/2064

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -13,14 +13,14 @@ Comment: BAREOS is a fork of the Bacula source code.
 
 
 Files: *
-Copyright: 2012-2024 Bareos GmbH & Co. KG
+Copyright: 2012-2025 Bareos GmbH & Co. KG
 License: AGPL-3.0-only
 
 
 Files: core/* docs/manuals/source/*
 Copyright: 2000-2012 Free Software Foundation Europe e.V.
            2010-2017 Planets Communications B.V.
-           2012-2024 Bareos GmbH & Co. KG
+           2012-2025 Bareos GmbH & Co. KG
 License: Bareos
     This is basically AGPL-3.0 with Bacula and other exceptions.
     This section is the reformatted version of

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -309,6 +309,7 @@ Provides:   %{name}-sd
 %if 0%{?suse_version}
 Requires(pre): shadow
 Recommends: bareos-tools
+Recommends: logrotate
 %else
 Requires(pre): shadow-utils
 # Recommends would be enough, however only supported by Fedora >= 24.
@@ -992,6 +993,7 @@ for F in  \
     %{_mandir}/man8/bscrypto.8.gz \
     %{_mandir}/man8/btape.8.gz \
     %{_sysconfdir}/logrotate.d/bareos-dir \
+    %{_sysconfdir}/logrotate.d/bareos-mtx \
     %{_sysconfdir}/rc.d/init.d/bareos-dir \
     %{_sysconfdir}/rc.d/init.d/bareos-sd \
     %{script_dir}/disk-changer \
@@ -1244,6 +1246,7 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %{backend_dir}/libbareossd-tape*.so
 %{script_dir}/mtx-changer
 %config(noreplace) %{_sysconfdir}/%{name}/mtx-changer.conf
+%config(noreplace) %{_sysconfdir}/logrotate.d/%{name}-mtx
 %{_mandir}/man8/bscrypto.8.gz
 %{_mandir}/man8/btape.8.gz
 %{_sbindir}/bscrypto

--- a/core/scripts/CMakeLists.txt
+++ b/core/scripts/CMakeLists.txt
@@ -32,6 +32,7 @@ bareos_configure_file(
   disk-changer.in
   logrotate.in
   mtx-changer.in
+  mtx-logrotate.in
 )
 
 install(
@@ -108,5 +109,11 @@ if(NOT client-only)
     FILES ${CMAKE_CURRENT_BINARY_DIR}/logrotate
     DESTINATION "${sysconfdir}/logrotate.d"
     RENAME bareos-dir
+  )
+
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/mtx-logrotate
+    DESTINATION "${sysconfdir}/logrotate.d"
+    RENAME bareos-mtx
   )
 endif()

--- a/core/scripts/mtx-logrotate.in
+++ b/core/scripts/mtx-logrotate.in
@@ -1,0 +1,15 @@
+#
+# If you are using mtx-changer in debug mode, to
+# have your log file compressed, rotated, and after a time
+# deleted, after possibly editing the values below,
+# copy this file to:
+#
+# /etc/logrotate.d/bareos-mtx
+#
+@logdir@/mtx.log {
+    monthly
+    rotate 6
+    notifempty
+    missingok
+    su @sd_user@ @sd_group@
+}

--- a/debian/bareos-storage-tape.install.in
+++ b/debian/bareos-storage-tape.install.in
@@ -1,4 +1,5 @@
 /etc/bareos/mtx-changer.conf
+/etc/logrotate.d/bareos-mtx
 @configtemplatedir@/bareos-dir.d/storage/Tape.conf.example
 @configtemplatedir@/bareos-sd.d/autochanger/autochanger-0.conf.example
 @configtemplatedir@/bareos-sd.d/device/tapedrive-0.conf.example


### PR DESCRIPTION
In case mtx-changer is used with debug mode, it create a log file
in `/var/log/bareos/mtx-changer.log` that need to be rotated from
time to time.

We now deliver a logrotate script for that task.

Fix issue#2005


#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

