### PR TITLE
stored: explicitly flush after labeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bareosfd_test.py: allow a delta of 1.1 [PR #2032]
 - filed: detect integer overflow during backup [PR #2024]
 
+### Fixed
+- stored: explicitly flush after labeling [PR #2044]
+
 ## [23.1.0] - 2024-11-13
 
 ### Changed
@@ -589,4 +592,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2024]: https://github.com/bareos/bareos/pull/2024
 [PR #2028]: https://github.com/bareos/bareos/pull/2028
 [PR #2032]: https://github.com/bareos/bareos/pull/2032
+[PR #2044]: https://github.com/bareos/bareos/pull/2044
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2015-2017 Planets Communications B.V.
-   Copyright (C) 2017-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -944,6 +944,14 @@ static int CompareVolumeName(void* item1, void* item2)
 // Get the current size of a volume.
 ssize_t ChunkedDevice::ChunkedVolumeSize()
 {
+  /* Check if the current chunk needs flushing. In that case, we just wrote to
+   * the chunk. As we can only ever write to the last chunk, it is safe to
+   * assume that the end of the last write in this chunk is the end of the
+   * volume. */
+  if (current_chunk_->need_flushing) {
+    return current_chunk_->start_offset + current_chunk_->buflen;
+  }
+
   /* See if we are using io-threads or not and the ordered CircularBuffer is
    * created. We try to make sure that nothing of the volume being requested is
    * still inflight as then the RemoteVolumeSize() method will fail to

--- a/core/src/stored/label.cc
+++ b/core/src/stored/label.cc
@@ -425,6 +425,11 @@ bool WriteNewVolumeLabelToDev(DeviceControlRecord* dcr,
     WriteAnsiIbmLabels(dcr, ANSI_EOF_LABEL, dev->VolHdr.VolumeName);
   }
 
+  /* make sure the label block is actually written to the device
+   * otherwise a subsequent read of the label block might fail
+   * (i.e. reading stale data that does not contain the label) */
+  dev->d_flush(dcr);
+
   if (debug_level >= 20) { DumpVolumeLabel(dev); }
   Dmsg0(100, "Call reserve_volume\n");
   if (reserve_volume(dcr, VolName) == NULL) {


### PR DESCRIPTION
**Backport of PR #2022 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2022 is merged
- [x] All functional differences to the original PR are documented above
