### PR TITLE
plugins: Fix typo in postgresql plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
 
+### Changed
+- plugins: Fix typo in postgresql plugin [PR #2066]
+
 [PR #2064]: https://github.com/bareos/bareos/pull/2064
+[PR #2066]: https://github.com/bareos/bareos/pull/2066
 [PR #2067]: https://github.com/bareos/bareos/pull/2067
 [PR #2068]: https://github.com/bareos/bareos/pull/2068
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
+++ b/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
@@ -1547,7 +1547,7 @@ class BareosFdPluginPostgreSQL(BareosFdPluginBaseclass):  # noqa
                     100,
                     (
                         "rop_data[last_backup_stop_time] < LAST_BACKUP_TIME_WITH_SECONDS\n"
-                        f" convert_to_ns returned {self.last_backup_stop_time}\n",
+                        f" convert_to_ns returned {self.last_backup_stop_time}\n"
                     ),
                 )
             bareosfd.JobMessage(


### PR DESCRIPTION
This is a typo introduced in 0901b6f6613f05e47fc10b431952960e0ac6654d. The parentheses are only used to group the string concatenation and should not contain a comma. The error results in this error message:

> Fatal error: bareosfd: Traceback (most recent call last):
>  File "/usr/lib/bareos/plugins/BareosFdWrapper.py", line 94, in restore_object_data
>    return bareos_fd_plugin_object.restore_object_data(rop)
>  File "/usr/lib/bareos/plugins/bareos-fd-postgresql.py", line 1546, in restore_object_data
>    bareosfd.DebugMessage(
> TypeError: BareosDebugMessage() argument 2 must be str or None, not tuple

and a failed backup job.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_


If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
