### PR TITLE
webui: fix for PHP < 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - cats: fix version.map.in [PR #2064]
+- webui: fix for PHP < 7.3 [PR #2067]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
 
 [PR #2064]: https://github.com/bareos/bareos/pull/2064
+[PR #2067]: https://github.com/bareos/bareos/pull/2067
 [PR #2068]: https://github.com/bareos/bareos/pull/2068
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/webui/module/Restore/src/Restore/Controller/RestoreController.php
+++ b/webui/module/Restore/src/Restore/Controller/RestoreController.php
@@ -596,7 +596,8 @@ class RestoreController extends AbstractActionController
             $this->restore_params['restoreclient'] = $restore_target_clients[0]['name'];
         }
         if($restorejobresources && (count($restorejobresources) == 1)) {
-            $this->restore_params['restorejob'] = array_key_first($restorejobresources);
+            // PHP < 7.3 requires  array_keys(...)[0] instead of array_key_first(...)
+            $this->restore_params['restorejob'] = array_keys($restorejobresources)[0];
         }
     }
 

--- a/webui/module/Restore/view/restore/restore/index.phtml
+++ b/webui/module/Restore/view/restore/restore/index.phtml
@@ -335,7 +335,6 @@ echo $this->headLink()->prependStylesheet($this->basePath() . '/css/jstree.min.c
       p['restorejob'] = '<?php echo $this->restore_params['restorejob']; ?>';
       p['where'] = '<?php echo $this->restore_params['where']; ?>';
       p['pluginoptions'] = '<?php echo $this->restore_params['pluginoptions']; ?>';
-      p['fileset'] = '<?php echo $this->restore_params['fileset']; ?>';
       p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
       p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
       p['limit'] = '<?php echo $this->restore_params['limit']; ?>';

--- a/webui/module/Restore/view/restore/restore/versions.phtml
+++ b/webui/module/Restore/view/restore/restore/versions.phtml
@@ -490,7 +490,6 @@ function updateRestoreParams(k, v) {
    p['restorejob'] = '<?php echo $this->restore_params['restorejob']; ?>';
    p['where'] = '<?php echo $this->restore_params['where']; ?>';
    p['pluginoptions'] = '<?php echo $this->restore_params['pluginoptions']; ?>';
-   p['fileset'] = '<?php echo $this->restore_params['fileset']; ?>';
    p['mergefilesets'] = '<?php echo $this->restore_params['mergefilesets']; ?>';
    p['mergejobs'] = '<?php echo $this->restore_params['mergejobs']; ?>';
    p['limit'] = '<?php echo $this->restore_params['limit']; ?>';

--- a/webui/tests/selenium/webui-selenium-test.py
+++ b/webui/tests/selenium/webui-selenium-test.py
@@ -141,7 +141,7 @@ class SeleniumTest(unittest.TestCase):
     base_url = "http://127.0.0.1/bareos-webui"
     username = "admin"
     password = "secret"
-    profile = None
+    profile = "admin"
     client = "bareos-fd"
     restorefile = "/usr/sbin/bconsole"
     # path to store logging files


### PR DESCRIPTION
The Bareos WebUI uses a function, only available in PHP >= 7.3, while EL8 ships with PHP 7.2.
This PR rewrite the code to circumvent this, making the restore dialog work again.
Also it cleans up the code to prevent a PHP Notice.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

