### PR TITLE
openssl: unify ssl error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - logrotate: add mtx-changer debug log config [PR #2039]
 - cmake: add cmake check whether tirpc is installed [PR #2109]
 - bconsole: require only one password in the configuration [PR #2116]
+- openssl: unify ssl error logging [PR #2078]
 
 [PR #2039]: https://github.com/bareos/bareos/pull/2039
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
@@ -36,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2067]: https://github.com/bareos/bareos/pull/2067
 [PR #2068]: https://github.com/bareos/bareos/pull/2068
 [PR #2076]: https://github.com/bareos/bareos/pull/2076
+[PR #2078]: https://github.com/bareos/bareos/pull/2078
 [PR #2079]: https://github.com/bareos/bareos/pull/2079
 [PR #2086]: https://github.com/bareos/bareos/pull/2086
 [PR #2102]: https://github.com/bareos/bareos/pull/2102

--- a/core/src/lib/crypto_openssl.h
+++ b/core/src/lib/crypto_openssl.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -44,6 +44,9 @@ void OpensslPostErrors_impl(const char* file,
 int OpensslInitThreads(void);
 void OpensslCleanupThreads(void);
 DIGEST* OpensslDigestNew(JobControlRecord* jcr, crypto_digest_t type);
+
+void LogSSLError(int ssl_error);
+
 #endif /* HAVE_OPENSSL */
 
 #endif  // BAREOS_LIB_CRYPTO_OPENSSL_H_

--- a/core/src/lib/tls_openssl.cc
+++ b/core/src/lib/tls_openssl.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2014-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2014-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -301,9 +301,7 @@ void TlsOpenSsl::TlsBsockShutdown(BareosSocket* bsock)
   }
 
   int ssl_error = SSL_get_error(d_->openssl_, err_shutdown);
-  if (ssl_error != SSL_ERROR_NONE) {
-    Dmsg1(50, "SSL_get_error() returned error value %d\n", ssl_error);
-  }
+  LogSSLError(ssl_error);
 
   /* There may be more errors on the thread-local error-queue.
    * As we just shutdown our context and looked at the errors that we were

--- a/core/src/lib/tls_openssl_private.cc
+++ b/core/src/lib/tls_openssl_private.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2005-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -324,9 +324,7 @@ int TlsOpenSslPrivate::OpensslBsockReadwrite(BareosSocket* bsock,
     }
 
     int ssl_error = SSL_get_error(openssl_, nwritten);
-    if (ssl_error != SSL_ERROR_NONE) {
-      Dmsg1(50, "SSL_get_error() returned error value %d\n", ssl_error);
-    }
+    LogSSLError(ssl_error);
     switch (ssl_error) {
       case SSL_ERROR_NONE:
         nleft -= nwritten;
@@ -401,9 +399,7 @@ bool TlsOpenSslPrivate::OpensslBsockSessionStart(BareosSocket* bsock,
     }
 
     int ssl_error = SSL_get_error(openssl_, err_accept);
-    if (ssl_error != SSL_ERROR_NONE) {
-      Dmsg1(50, "SSL_get_error() returned error value %d\n", ssl_error);
-    }
+    LogSSLError(ssl_error);
     switch (ssl_error) {
       case SSL_ERROR_NONE:
         bsock->SetTlsEstablished();

--- a/core/src/tests/test_bpipe.cc
+++ b/core/src/tests/test_bpipe.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -128,7 +128,7 @@ TEST(bpipe, timeout)
   // even though we don't intend to write, we have to attach a pipe to our
   // childs stdin, otherwise it will inherit ours which might be closed and
   // would make `cat` exit immediately.
-  Bpipe* bp = OpenBpipe(TEST_PROGRAM " cat", 1, "rw");
+  Bpipe* bp = OpenBpipe(TEST_PROGRAM " cat", 5, "rw");
   ASSERT_THAT(bp, NotNull());
   ASSERT_THAT(bp->timer_id, NotNull());
   ASSERT_FALSE(bp->timer_id->killed);


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

This pr fixes the problem where debug logs where spammed by uninteresting ssl "errors" that were not actually errors.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

