### PR TITLE
Sync EvpDigest between OpenSSL <1.1 and 1.1+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - plugins: Fix typo in postgresql plugin [PR #2066]
+- Sync EvpDigest between OpenSSL <1.1 and 1.1+ [PR #2086]
 
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
 [PR #2056]: https://github.com/bareos/bareos/pull/2056
@@ -26,4 +27,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2067]: https://github.com/bareos/bareos/pull/2067
 [PR #2068]: https://github.com/bareos/bareos/pull/2068
 [PR #2079]: https://github.com/bareos/bareos/pull/2079
+[PR #2086]: https://github.com/bareos/bareos/pull/2086
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/lib/crypto_openssl.cc
+++ b/core/src/lib/crypto_openssl.cc
@@ -283,8 +283,8 @@ struct EvpDigest : public Digest {
   EVP_MD_CTX ctx;
 
  public:
-  EvpDigest(JobControlRecord* jcr, crypto_digest_t type, const EVP_MD* md)
-      : Digest(jcr, type)
+  EvpDigest(JobControlRecord* t_jcr, crypto_digest_t t_type, const EVP_MD* md)
+      : Digest(t_jcr, t_type)
   {
     EVP_MD_CTX_init(&ctx);
     if (EVP_DigestInit_ex(&ctx, md, NULL) == 0) { throw DigestInitException{}; }


### PR DESCRIPTION
Commit PR #1689 (812f9e48f3466c4400ea649773fad6eacf927250) contains a change in core/src/lib/crypto.h, which has only been partially synced with core/src/lib/crypto_openssl.cc. The latter file contains two definitions of EvpDigest(), depending on OpenSSL major version. Only one was fixed.

When compiling e.g. on CentOS 7 one gets an error about shadowing.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created #2087 
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
