### PR TITLE
backport fixes for MariaDB 11.4

### DIFF
--- a/systemtests/tests/py3plug-fd-mariabackup/testrunner
+++ b/systemtests/tests/py3plug-fd-mariabackup/testrunner
@@ -85,8 +85,8 @@ mysql_server_stop
 
 # Check if mariabackup has extracted some files at least
 # TODO: verify that mariabackup --prepare works and eventually do complete datbase restore
-ls -lR  "$tmp/bareos-restores/_mariabackup/"
-if [ -z "$(ls -A "$tmp"/bareos-restores/_mariabackup/)" ]; then
+ls -lR  "$tmp/bareos-restores/_maria-backup/"
+if [ -z "$(ls -A "$tmp"/bareos-restores/_maria-backup/)" ]; then
        echo "No restore data found"
        estat=1
 fi
@@ -96,9 +96,9 @@ fi
 rm -Rf mysql/data/*
 mkdir -p mysql/data/
 
-TARGETDIR=$(find ./tmp/bareos-restores/_mariabackup/4/ -type d  -name '*001')
-INCDIR1=$(find ./tmp/bareos-restores/_mariabackup/4/ -type d  -name '*002')
-INCDIR2=$(find ./tmp/bareos-restores/_mariabackup/4/ -type d  -name '*002')
+TARGETDIR=$(find ./tmp/bareos-restores/_maria-backup/4/ -type d  -name '*001')
+INCDIR1=$(find ./tmp/bareos-restores/_maria-backup/4/ -type d  -name '*002')
+INCDIR2=$(find ./tmp/bareos-restores/_maria-backup/4/ -type d  -name '*002')
 
 ${MARIABACKUP} --prepare --target-dir=${TARGETDIR}
 # after prepare a file is left in data dir, this seems to be a bug


### PR DESCRIPTION
Fix for https://github.com/bareos/bareos/issues/2091
Tested on MariaDB 11.4 and 10.11 on Rocky/RHEL 9.5.
Because 11.4 has removed the mysql commands.
#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
