### PR TITLE
bareos-config-libs: double quote dbconfig values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: fix for PHP < 7.3 [PR #2067]
 - cmake: fix MARIADB_MYSQL_INSTALL_DB_SCRIPT usage [PR #2040]
 - Fix building ndmjob program [PR #2079]
+- bareos-config-libs: double quote dbconfig values [PR #2111]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -35,5 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2079]: https://github.com/bareos/bareos/pull/2079
 [PR #2086]: https://github.com/bareos/bareos/pull/2086
 [PR #2109]: https://github.com/bareos/bareos/pull/2109
+[PR #2111]: https://github.com/bareos/bareos/pull/2111
 [PR #2116]: https://github.com/bareos/bareos/pull/2116
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -946,15 +946,15 @@ apply_dbconfig_settings()
     fi
 
     if [ -n "${dbc_dbuser}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbuser" "${dbc_dbuser}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbuser" "\"${dbc_dbuser}\""
     fi
 
     if [ -n "${dbc_dbname}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbname" "${dbc_dbname}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbname" "\"${dbc_dbname}\""
     fi
 
     if [ "${dbc_authmethod_user}" != "ident" ] && [ "${dbc_dbpass}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbpassword" "${dbc_dbpass}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbpassword" "\"${dbc_dbpass}\""
     fi
 }
 


### PR DESCRIPTION
Returned dbconfig values are unquoted. This commit add double quotes
around each values (except dbaddress)

Unquoted value might create situation where the dbpassword might be
truncated by the parser if it contain for example special meaning
character like start a comment (`;` or `#`)

Fix bareos/internal#224

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
