### PR TITLE
fix autodeflate messages and refactor setup method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: add cmake_parse_arguments policy CMP0174 [PR #2169]
 - VMware plugin: fix check_mac_address() for vm.config not present [PR #2059]
 - scheduler: 'last' keyword doesn't allow job to be visible in status dir [PR #2120]
+- fix autodeflate messages and refactor setup method [PR #2121]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -66,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2111]: https://github.com/bareos/bareos/pull/2111
 [PR #2116]: https://github.com/bareos/bareos/pull/2116
 [PR #2120]: https://github.com/bareos/bareos/pull/2120
+[PR #2121]: https://github.com/bareos/bareos/pull/2121
 [PR #2122]: https://github.com/bareos/bareos/pull/2122
 [PR #2128]: https://github.com/bareos/bareos/pull/2128
 [PR #2130]: https://github.com/bareos/bareos/pull/2130

--- a/core/cmake/BareosCopyDllsToBinDir.cmake
+++ b/core/cmake/BareosCopyDllsToBinDir.cmake
@@ -28,8 +28,10 @@ set_property(GLOBAL PROPERTY JOB_POOLS copy=1)
 macro(BareosCopyDllsToBinDir)
   if(${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND MSVC)
     set(FNAME "${CMAKE_BINARY_DIR}/required_dlls")
-    set(DLLS_TO_COPY_MANUALLY C:/vcpkg/installed/x64-windows/bin/jansson.dll
-                              C:/vcpkg/installed/x64-windows/bin/lzo2.dll
+    set(DLLS_TO_COPY_MANUALLY
+        C:/vcpkg/installed/x64-windows/bin/jansson.dll
+        C:/vcpkg/installed/x64-windows/bin/lzo2.dll
+        C:/vcpkg/installed/x64-windows/bin/zlib1.dll
     )
     set(REQUIRED_DLLS ${DLLS_TO_COPY_MANUALLY})
     get_property(

--- a/core/src/filed/compression.cc
+++ b/core/src/filed/compression.cc
@@ -119,8 +119,8 @@ bool SetupCompressionContext(b_ctx& bctx)
     bctx.ch.magic = bctx.ff_pkt->Compress_algo;
     bctx.ch.version = COMP_HEAD_VERSION;
     bctx.ch.level = bctx.ff_pkt->Compress_level;
-    return SetupSpecificCompressionContext(*bctx.jcr, bctx.ff_pkt->Compress_algo,
-                                   bctx.ff_pkt->Compress_level);
+    return SetupSpecificCompressionContext(
+        *bctx.jcr, bctx.ff_pkt->Compress_algo, bctx.ff_pkt->Compress_level);
   }
   return true;
 }

--- a/core/src/filed/compression.cc
+++ b/core/src/filed/compression.cc
@@ -118,7 +118,19 @@ bool SetupCompressionContext(b_ctx& bctx)
               bctx.jcr->compress.deflate_buffer; /* encrypt compressed data */
     bctx.ch.magic = bctx.ff_pkt->Compress_algo;
     bctx.ch.version = COMP_HEAD_VERSION;
-    bctx.ch.level = bctx.ff_pkt->Compress_level;
+    switch (bctx.ff_pkt->Compress_algo) {
+      case COMPRESS_GZIP:
+        [[fallthrough]];
+      case COMPRESS_FZFZ:
+        [[fallthrough]];
+      case COMPRESS_FZ4L:
+        [[fallthrough]];
+      case COMPRESS_FZ4H:
+        bctx.ch.level = bctx.ff_pkt->Compress_level;
+        break;
+      default:
+        break;
+    }
     return SetupSpecificCompressionContext(
         *bctx.jcr, bctx.ff_pkt->Compress_algo, bctx.ff_pkt->Compress_level);
   }

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -1628,7 +1628,7 @@ static inline void ClearCompressionFlagInFileset(JobControlRecord* jcr)
                    "%s compression support requested in fileset but not "
                    "available on this platform. Disabling "
                    "...\n",
-                   cmprs_algo_to_text(fo->Compress_algo));
+                   CompressorName(fo->Compress_algo));
               ClearBit(FO_COMPRESS, fo->flags);
               fo->Compress_algo = 0;
               break;

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -1628,7 +1628,7 @@ static inline void ClearCompressionFlagInFileset(JobControlRecord* jcr)
                    "%s compression support requested in fileset but not "
                    "available on this platform. Disabling "
                    "...\n",
-                   CompressorName(fo->Compress_algo));
+                   CompressorName(fo->Compress_algo).c_str());
               ClearBit(FO_COMPRESS, fo->flags);
               fo->Compress_algo = 0;
               break;

--- a/core/src/include/ch.h
+++ b/core/src/include/ch.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,13 +28,31 @@
 #ifndef BAREOS_INCLUDE_CH_H_
 #define BAREOS_INCLUDE_CH_H_
 
+#include <cstdint>
+
+namespace {
+constexpr std::uint32_t compression_constant(const char (&txt)[5])
+{
+  std::uint32_t a32 = txt[0];
+  std::uint32_t b32 = txt[1];
+  std::uint32_t c32 = txt[2];
+  std::uint32_t d32 = txt[3];
+
+  return (a32 << 24) | (b32 << 16) | (c32 << 8) | d32;
+}
+};  // namespace
+
 // Compression algorithm signature. 4 letters as a 32bits integer
-#define COMPRESS_NONE 0x4e4f4e45 /* used for incompressible block */
-#define COMPRESS_GZIP 0x475a4950
-#define COMPRESS_LZO1X 0x4c5a4f58
-#define COMPRESS_FZFZ 0x465A465A
-#define COMPRESS_FZ4L 0x465A344C
-#define COMPRESS_FZ4H 0x465A3448
+enum compression_type : std::uint32_t
+{
+  COMPRESS_NONE
+  = compression_constant("NONE"), /* used for incompressible block */
+  COMPRESS_GZIP = compression_constant("GZIP"),
+  COMPRESS_LZO1X = compression_constant("LZOX"),
+  COMPRESS_FZFZ = compression_constant("FZFZ"),
+  COMPRESS_FZ4L = compression_constant("FZ4L"),
+  COMPRESS_FZ4H = compression_constant("FZ4H"),
+};
 
 // Compression header version
 #define COMP_HEAD_VERSION 0x1

--- a/core/src/include/ch.h
+++ b/core/src/include/ch.h
@@ -54,6 +54,14 @@ enum compression_type : std::uint32_t
   COMPRESS_FZ4H = compression_constant("FZ4H"),
 };
 
+// double check our constants with the previously defined values
+static_assert(0x4e4f4e45 == compression_constant("NONE"));
+static_assert(0x475a4950 == compression_constant("GZIP"));
+static_assert(0x4c5a4f58 == compression_constant("LZOX"));
+static_assert(0x465A465A == compression_constant("FZFZ"));
+static_assert(0x465A344C == compression_constant("FZ4L"));
+static_assert(0x465A3448 == compression_constant("FZ4H"));
+
 // Compression header version
 #define COMP_HEAD_VERSION 0x1
 

--- a/core/src/lib/compression.cc
+++ b/core/src/lib/compression.cc
@@ -53,21 +53,27 @@
     (sourceLen + (sourceLen >> 12) + (sourceLen >> 14) + (sourceLen >> 25) + 13)
 #endif
 
-const char* cmprs_algo_to_text(uint32_t compression_algorithm)
+static constexpr std::string_view kCompressorNameUnknown = "Unknown";
+static constexpr std::string_view kCompressorNameGZIP = "GZIP";
+static constexpr std::string_view kCompressorNameLZO = "LZO";
+static constexpr std::string_view kCompressorNameFZLZ = "FASTLZ";
+static constexpr std::string_view kCompressorNameFZ4L = "LZ4";
+static constexpr std::string_view kCompressorNameFZ4H = "LZ4HC";
+std::string_view CompressorName(uint32_t compression_algorithm)
 {
   switch (compression_algorithm) {
     case COMPRESS_GZIP:
-      return "GZIP";
+      return kCompressorNameGZIP;
     case COMPRESS_LZO1X:
-      return "LZO2";
+      return kCompressorNameLZO;
     case COMPRESS_FZFZ:
-      return "LZFZ";
+      return kCompressorNameFZLZ;
     case COMPRESS_FZ4L:
-      return "LZ4";
+      return kCompressorNameFZ4L;
     case COMPRESS_FZ4H:
-      return "LZ4HC";
+      return kCompressorNameFZ4H;
     default:
-      return "Unknown";
+      return kCompressorNameUnknown;
   }
 }
 
@@ -99,7 +105,7 @@ static inline void UnknownCompressionAlgorithm(JobControlRecord* jcr,
                                                uint32_t compression_algorithm)
 {
   Jmsg(jcr, M_FATAL, 0, T_("%s compression not supported on this platform\n"),
-       cmprs_algo_to_text(compression_algorithm));
+       CompressorName(compression_algorithm));
 }
 
 std::size_t RequiredCompressionOutputBufferSize(uint32_t algo,

--- a/core/src/lib/compression.cc
+++ b/core/src/lib/compression.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -539,8 +539,8 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
 }
 
 bool SetupSpecificCompressionContext(JobControlRecord& jcr,
-                                    uint32_t algo,
-                                    uint32_t compression_level)
+                                     uint32_t algo,
+                                     uint32_t compression_level)
 {
 #if defined(HAVE_LIBZ)
   if (algo == COMPRESS_GZIP) {
@@ -549,7 +549,8 @@ bool SetupSpecificCompressionContext(JobControlRecord& jcr,
       int zstatus
           = deflateParams(pZlibStream, compression_level, Z_DEFAULT_STRATEGY);
       if (zstatus != Z_OK) {
-        Jmsg(&jcr, M_FATAL, 0, T_("Compression deflateParams error: %d\n"), zstatus);
+        Jmsg(&jcr, M_FATAL, 0, T_("Compression deflateParams error: %d\n"),
+             zstatus);
         jcr.setJobStatusWithPriorityCheck(JS_ErrorTerminated);
         return false;
       }
@@ -572,18 +573,18 @@ bool SetupSpecificCompressionContext(JobControlRecord& jcr,
         break;
     }
 
-    auto* pZFastStream = reinterpret_cast<zfast_stream*>(jcr.compress.workset.pZFAST);
+    auto* pZFastStream
+        = reinterpret_cast<zfast_stream*>(jcr.compress.workset.pZFAST);
     if (pZFastStream->total_in == 0) {
-      int zstat = fastlzlibSetCompressor(
-        pZFastStream , compressor);
+      int zstat = fastlzlibSetCompressor(pZFastStream, compressor);
       if (zstat != Z_OK) {
-        Jmsg(&jcr, M_FATAL, 0, T_("Compression fastlzlibSetCompressor error: %d\n"), zstat);
+        Jmsg(&jcr, M_FATAL, 0,
+             T_("Compression fastlzlibSetCompressor error: %d\n"), zstat);
         jcr.setJobStatusWithPriorityCheck(JS_ErrorTerminated);
         return false;
       }
-    }
-    else {
-        // Jmsg(&jcr, M_ERROR, 0, T_("Compression error: %d\n"), zstat);
+    } else {
+      // Jmsg(&jcr, M_ERROR, 0, T_("Compression error: %d\n"), zstat);
     }
   }
   return true;

--- a/core/src/lib/compression.h
+++ b/core/src/lib/compression.h
@@ -23,7 +23,7 @@
 
 #include "lib/util.h"
 
-const char* cmprs_algo_to_text(uint32_t compression_algorithm);
+std::string_view CompressorName(uint32_t compression_algorithm);
 
 bool SetupCompressionBuffers(JobControlRecord* jcr,
                              uint32_t compression_algorithm,

--- a/core/src/lib/compression.h
+++ b/core/src/lib/compression.h
@@ -23,7 +23,7 @@
 
 #include "lib/util.h"
 
-std::string_view CompressorName(uint32_t compression_algorithm);
+const std::string& CompressorName(uint32_t compression_algorithm);
 
 bool SetupCompressionBuffers(JobControlRecord* jcr,
                              uint32_t compression_algorithm,

--- a/core/src/lib/compression.h
+++ b/core/src/lib/compression.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,8 +31,8 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
 bool SetupDecompressionBuffers(JobControlRecord* jcr,
                                uint32_t* decompress_buf_size);
 bool SetupSpecificCompressionContext(JobControlRecord& jcr,
-                                    uint32_t algo,
-                                    uint32_t compression_level);
+                                     uint32_t algo,
+                                     uint32_t compression_level);
 
 // return the number of bytes written to the output on success
 // or std::nullopt on error

--- a/core/src/lib/compression.h
+++ b/core/src/lib/compression.h
@@ -30,7 +30,9 @@ bool SetupCompressionBuffers(JobControlRecord* jcr,
                              uint32_t* compress_buf_size);
 bool SetupDecompressionBuffers(JobControlRecord* jcr,
                                uint32_t* decompress_buf_size);
-
+bool SetupSpecificCompressionContext(JobControlRecord& jcr,
+                                    uint32_t algo,
+                                    uint32_t compression_level);
 
 // return the number of bytes written to the output on success
 // or std::nullopt on error

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -58,13 +58,6 @@ using namespace storagedaemon;
 #define SETTING_NO (char*)"no"
 #define SETTING_UNSET (char*)"unknown"
 
-#define COMPRESSOR_NAME_GZIP (char*)"GZIP"
-#define COMPRESSOR_NAME_LZO (char*)"LZO"
-#define COMPRESSOR_NAME_FZLZ (char*)"FASTLZ"
-#define COMPRESSOR_NAME_FZ4L (char*)"LZ4"
-#define COMPRESSOR_NAME_FZ4H (char*)"LZ4HC"
-#define COMPRESSOR_NAME_UNSET (char*)"unknown"
-
 // Forward referenced functions
 static bRC newPlugin(PluginContext* ctx);
 static bRC freePlugin(PluginContext* ctx);
@@ -431,7 +424,6 @@ static bRC handle_write_translation(PluginContext* ctx, void* value)
 // Setup deflate for auto deflate of data streams.
 static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
 {
-  const char* compressorname = COMPRESSOR_NAME_UNSET;
   JobControlRecord* jcr = dcr->jcr;
 
   if (jcr->buf_size == 0) { jcr->buf_size = DEFAULT_NETWORK_BUFFER_SIZE; }
@@ -457,29 +449,10 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
 
   auto algo = dcr->device_resource->autodeflate_algorithm;
   if (!SetupSpecificCompressionContext(*jcr, algo, dcr->device_resource->autodeflate_level)) {
-      return false;
-    }
-  switch (algo) {
-    case COMPRESS_GZIP:
-      compressorname = COMPRESSOR_NAME_GZIP;
-      break;
-    case COMPRESS_LZO1X:
-      compressorname = COMPRESSOR_NAME_LZO;
-      break;
-      case COMPRESS_FZFZ:
-        compressorname = COMPRESSOR_NAME_FZLZ;
-        break;
-      case COMPRESS_FZ4L:
-        compressorname = COMPRESSOR_NAME_FZ4L;
-        break;
-      case COMPRESS_FZ4H:
-        compressorname = COMPRESSOR_NAME_FZ4H;
-        break;
-      default:
-        break;
-    }
+    return false;
+  }
   Jmsg(ctx, M_INFO, T_("autoxflate-sd: Compressor on device %s is %s\n"),
-       dcr->dev_name, compressorname);
+       dcr->dev_name, CompressorName(algo));
   return true;
 }
 

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -447,13 +447,15 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
     }
   }
 
-  auto algo = dcr->device_resource->autodeflate_algorithm;
-  if (!SetupSpecificCompressionContext(
-          *jcr, algo, dcr->device_resource->autodeflate_level)) {
+  uint32_t algo = dcr->device_resource->autodeflate_algorithm;
+  uint16_t compression_level = dcr->device_resource->autodeflate_level;
+  if (!SetupSpecificCompressionContext(*jcr, algo, compression_level)) {
+    Jmsg(ctx, M_FATAL, 0,
+         T_("autoxflate-sd: failed setting up auto-deflation\n"));
     return false;
   }
   Jmsg(ctx, M_INFO, T_("autoxflate-sd: Compressor on device %s is %s\n"),
-       dcr->dev_name, CompressorName(algo));
+       dcr->dev_name, CompressorName(algo).c_str());
   return true;
 }
 

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -448,7 +448,8 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
   }
 
   auto algo = dcr->device_resource->autodeflate_algorithm;
-  if (!SetupSpecificCompressionContext(*jcr, algo, dcr->device_resource->autodeflate_level)) {
+  if (!SetupSpecificCompressionContext(
+          *jcr, algo, dcr->device_resource->autodeflate_level)) {
     return false;
   }
   Jmsg(ctx, M_INFO, T_("autoxflate-sd: Compressor on device %s is %s\n"),

--- a/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
+++ b/core/src/plugins/stored/autoxflate/autoxflate-sd.cc
@@ -471,7 +471,9 @@ static bool SetupAutoDeflation(PluginContext* ctx, DeviceControlRecord* dcr)
     }
   }
 #endif
+#if defined(HAVE_LZO)
   if (algorithm == COMPRESS_LZO1X) { compressorname = COMPRESSOR_NAME_LZO; }
+#endif
   if (algorithm == COMPRESS_FZFZ || algorithm == COMPRESS_FZ4L
       || algorithm == COMPRESS_FZ4H) {
     zfast_stream_compressor compressor = COMPRESSOR_DEFAULT;

--- a/systemtests/scripts/functions
+++ b/systemtests/scripts/functions
@@ -436,7 +436,6 @@ check_compression()
    BLS_OUT=$(bls_files_verbose "${STORAGE}" "${VOLUME}" )
    print_debug "$BLS_OUT"
    echo "$BLS_OUT"
-   echo "Hallo"
    if OUT=$(echo "$BLS_OUT" | grep -A1 "| ${FILENAME}$" | grep -i "| ${COMPRESSION_DESCRIPTION}, "); then
       print_debug "$OUT"
    else


### PR DESCRIPTION
Fixes #1944: autoxflate lzo & visuals are broken

Remove switch statement to avoid dangerous fallthrough with code in
between which causes the problem (#1944) in the first place.

Note that I did a manual test and got the correct compressor names:
17-Jan 09:01 bareos-sd JobId 13: autoxflate-sd: Compressor on device FileStorage is LZ4
previously this would output LZ4HC besides LZ4 being specified

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR