### PR TITLE
python-bareos: Add missing dh-python build dep

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,6 +14,7 @@ Aleksey Volkov
 Alessandro Rigopoulos
 Alexander Bergolth
 Alexander Kushnirenko
+Alexander Sulfrian
 Alexandre Baron
 Alexandre Bruyelles
 Alexandre Simon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bconsole: require only one password in the configuration [PR #2116]
 - openssl: unify ssl error logging [PR #2078]
 - Inherit RunScript elements between JobDef resources [PR #2097]
+- python-bareos: Add missing dh-python build dep [PR #2130]
 
 [PR #2039]: https://github.com/bareos/bareos/pull/2039
 [PR #2040]: https://github.com/bareos/bareos/pull/2040
@@ -48,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2109]: https://github.com/bareos/bareos/pull/2109
 [PR #2111]: https://github.com/bareos/bareos/pull/2111
 [PR #2116]: https://github.com/bareos/bareos/pull/2116
+[PR #2130]: https://github.com/bareos/bareos/pull/2130
 [PR #2132]: https://github.com/bareos/bareos/pull/2132
 [PR #2153]: https://github.com/bareos/bareos/pull/2153
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/python-bareos/debian/control
+++ b/python-bareos/debian/control
@@ -9,5 +9,5 @@ Package: python3-bareos
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, python3-configargparse
 Description: Backup Archiving REcovery Open Sourced - python module (Python 3)
- This packages contains a python module to interact with a Bareos backup system.
+ This package contains a python module to interact with a Bareos backup system.
  It also includes some tools based on this module.

--- a/python-bareos/debian/control
+++ b/python-bareos/debian/control
@@ -2,7 +2,7 @@ Source: python-bareos
 Maintainer: Bareos Team <packager@bareos.com>
 Section: python
 Priority: optional
-Build-Depends: debhelper (>= 7.4.3), python3-all, python3-setuptools
+Build-Depends: debhelper (>= 7.4.3), dh-python, python3-all, python3-setuptools
 Standards-Version: 3.9.1
 
 Package: python3-bareos


### PR DESCRIPTION
The python-bareos debian package uses pybuild as build system. dh-python is a mandatory build dependency. So this should be in the debian/control file.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
The python-bareos debian package uses pybuild as build system. dh-python is a
mandatory build dependency. So this should be in the debian/control file.