### PR TITLE
plugin: postgresql use integer for savepkt.object_index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix building ndmjob program [PR #2079]
 - bareos-config-libs: double quote dbconfig values [PR #2111]
 - freebsd: automate creation of pkg-plist.database-postgresql [PR #2102]
+- plugin: postgresql use integer for savepkt.object_index [PR #2132]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -40,4 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2109]: https://github.com/bareos/bareos/pull/2109
 [PR #2111]: https://github.com/bareos/bareos/pull/2111
 [PR #2116]: https://github.com/bareos/bareos/pull/2116
+[PR #2132]: https://github.com/bareos/bareos/pull/2132
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
+++ b/core/src/plugins/filed/python/postgresql/bareos-fd-postgresql.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # BAREOS - Backup Archiving REcovery Open Sourced
 #
-# Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+# Copyright (C) 2023-2025 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public
@@ -1427,7 +1427,7 @@ class BareosFdPluginPostgreSQL(BareosFdPluginBaseclass):  # noqa
             savepkt.object_name = savepkt.fname
             savepkt.object = bytearray(json.dumps(self.rop_data), "utf-8")
             savepkt.object_len = len(savepkt.object)
-            savepkt.object_index = current_time_ns()
+            savepkt.object_index = int(time.time())
             savepkt.statp = my_statp
             savepkt.no_read = True
             bareosfd.DebugMessage(150, f"rop data: {str(self.rop_data)}\n")

--- a/systemtests/tests/py3plug-fd-postgresql/testrunner-default
+++ b/systemtests/tests/py3plug-fd-postgresql/testrunner-default
@@ -145,6 +145,17 @@ if [ ${estat} -ne 0 ]; then
 fi
 check_for_zombie_jobs storage=File
 
+# Check restore objectindex order the sql should not return result
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out ${NULL_DEV}
+messages
+@$out ${tmp}/objectindex_check.out
+sqlquery
+select j1.jobid, j1.objectindex, j2.jobid, j2.objectindex from restoreobject j1, restoreobject j2 where j1.jobid < j2.jobid and j1.objectindex > j2.objectindex;
+END_OF_DATA
+run_bconsole
+expect_grep "No results to list." "${tmp}/objectindex_check.out" "The object indices were created out of order."
+
 sleep 1
 
 pushd database > /dev/null


### PR DESCRIPTION
In previous commit, `object_index` was initialized with
`current_time_ns()` which can return value over integer limit.

To avoid any risk of unsorted restores, we move back to integer.

We recommend to redo a full after installing this update.

- added detection of misordered objectindex during restore in
  testrunner-default

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
