### PR TITLE
bareos-config-libs: double quote dbconfig values

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -49,13 +49,6 @@ OS:
       CUSTOM_TEST_IMAGES: [ SLE-15_SP3, SLE-15_SP4, openSUSE-Leap_15.4, SLE-15_SP5, openSUSE-Leap_15.5, SLE-15_SP6, openSUSE-Leap_15.6 ]
       ARCH:
       - x86_64
-  SLE:
-    "12_SP5":
-      TYPE: rpm
-      IMAGE: sles12sp5
-      CUSTOM_TEST_IMAGES: []
-      ARCH:
-      - x86_64
   Fedora:
     "40":
       TYPE: rpm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Fixed
 - plugins: postgresql add support for PostgreSQL 17 + improvements [PR #2049]
+- bareos-config-libs: double quote dbconfig values [PR #2134]
 
 ## [23.1.1] - 2024-12-02
 
@@ -614,4 +615,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2049]: https://github.com/bareos/bareos/pull/2049
 [PR #2054]: https://github.com/bareos/bareos/pull/2054
 [PR #2074]: https://github.com/bareos/bareos/pull/2074
+[PR #2134]: https://github.com/bareos/bareos/pull/2134
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/bareos-config-lib.sh.in
+++ b/core/scripts/bareos-config-lib.sh.in
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -946,15 +946,15 @@ apply_dbconfig_settings()
     fi
 
     if [ -n "${dbc_dbuser}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbuser" "${dbc_dbuser}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbuser" "\"${dbc_dbuser}\""
     fi
 
     if [ -n "${dbc_dbname}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbname" "${dbc_dbname}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbname" "\"${dbc_dbname}\""
     fi
 
     if [ "${dbc_authmethod_user}" != "ident" ] && [ "${dbc_dbpass}" ]; then
-        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbpassword" "${dbc_dbpass}"
+        set_config_param "bareos-dir" "Catalog" "MyCatalog" "dbpassword" "\"${dbc_dbpass}\""
     fi
 }
 


### PR DESCRIPTION
**Backport of PR #2111 to bareos-23**

Changes:
* also removes support for sle12

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2111 is merged
- [x] All functional differences to the original PR are documented above
