### PR TITLE
stored: fix crash when using jit reservation with no matching device; fix reservation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VMware plugin: fix check_mac_address() for vm.config not present [PR #2059]
 - scheduler: 'last' keyword doesn't allow job to be visible in status dir [PR #2120]
 - fix autodeflate messages and refactor setup method [PR #2121]
+- stored: fix crash when using jit reservation with no matching device; fix reservation error [PR #2141]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -72,6 +73,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2128]: https://github.com/bareos/bareos/pull/2128
 [PR #2130]: https://github.com/bareos/bareos/pull/2130
 [PR #2132]: https://github.com/bareos/bareos/pull/2132
+[PR #2141]: https://github.com/bareos/bareos/pull/2141
 [PR #2144]: https://github.com/bareos/bareos/pull/2144
 [PR #2147]: https://github.com/bareos/bareos/pull/2147
 [PR #2149]: https://github.com/bareos/bareos/pull/2149

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2013 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -355,7 +355,7 @@ bool AcquireDeviceForRead(DeviceControlRecord* dcr)
         try_autochanger = true; /* permit trying the autochanger again */
 
         continue; /* try reading again */
-    }             /* end switch */
+    } /* end switch */
     break;
   } /* end while loop */
 
@@ -409,7 +409,6 @@ DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr)
   Device* dev = dcr->dev;
   JobControlRecord* jcr = dcr->jcr;
   bool retval = false;
-  bool have_vol = false;
 
   Enter(200);
   InitDeviceWaitTimers(dcr);
@@ -430,21 +429,8 @@ DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr)
 
   dev->ClearUnload();
 
-  /* have_vol defines whether or not MountNextWriteVolume should
-   * ask the Director again about what Volume to use. */
-  if (dev->CanAppend() && dcr->IsSuitableVolumeMounted()
-      && !bstrcmp(dcr->VolCatInfo.VolCatStatus, "Recycle")) {
-    Dmsg0(190, "device already in append.\n");
-    /* At this point, the correct tape is already mounted, so
-     * we do not need to do MountNextWriteVolume(), unless
-     * we need to recycle the tape. */
-    if (dev->num_writers == 0) {
-      dev->VolCatInfo = dcr->VolCatInfo; /* structure assignment */
-    }
-    have_vol = dcr->IsTapePositionOk();
-  }
 
-  if (!have_vol) {
+  {
     dev->rLock(true);
     BlockDevice(dev, BST_DOING_ACQUIRE);
     dev->Unlock();

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -252,6 +252,8 @@ static bool SetupDCR(JobControlRecord* jcr,
       Jmsg(jcr, M_INFO, 0, T_("Using Device %s to write.\n"),
            jcr->sd_impl->dcr->dev->print_name());
     } else {
+      FreeDeviceControlRecord(jcr->sd_impl->dcr);
+      jcr->sd_impl->dcr = nullptr;
       Jmsg(jcr, M_FATAL, 0, T_("Could not reserve any device for this job.\n"));
       return false;
     }
@@ -515,6 +517,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
         Jmsg(jcr, M_INFO, 0,
              T_("JustInTime Reservation: Finding drive to reserve.\n"));
         if (!SetupDCR(jcr, current_volumeid, current_block_number)) {
+          Jmsg(jcr, M_FATAL, 0, T_("Unable to setup device for this job.\n"));
           ok = false;
           break;
         }
@@ -668,7 +671,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
 
     // Release the device -- and send final Vol info to DIR and unlock it.
     ReleaseDevice(jcr->sd_impl->dcr);
-  } else {
+  } else if (ok) {
     Jmsg(jcr, M_INFO, 0,
          "Because no backup data was received, no device was reserved. As such "
          "no Session Labels were written for this job.\n");

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -186,7 +186,6 @@ class DeviceControlRecord {
   void mark_volume_not_inchanger();
   int TryAutolabel(bool opened);
   bool find_a_volume();
-  bool IsSuitableVolumeMounted();
   bool is_eod_valid();
   int CheckVolumeLabel(bool& ask, bool& autochanger);
   void ReleaseVolume();


### PR DESCRIPTION
Currently, if jit reservation is used but no device could be found, we break out of the backup loop.  Afterwards the sd tries to destroy the dcr if it exists, which includes releasing the acquired device.  This is done even if no device was attached to the dcr.

See #2139 and #2140

Also fixes a reservation related issue, see: bareos/internal#92

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
