### PR TITLE
VMware Plugin: Fix CBT query handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - systemtests: fail if daemons have config warnings [PR #2144]
 - contrib: check_chunk.py improve README.md instructions [PR #2147]
 - build: add support for el10 [PR #2106]
+- VMware Plugin: Fix CBT query handling [PR #2152]
 
 [PR #1893]: https://github.com/bareos/bareos/pull/1893
 [PR #2018]: https://github.com/bareos/bareos/pull/2018
@@ -68,6 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2132]: https://github.com/bareos/bareos/pull/2132
 [PR #2144]: https://github.com/bareos/bareos/pull/2144
 [PR #2147]: https://github.com/bareos/bareos/pull/2147
+[PR #2152]: https://github.com/bareos/bareos/pull/2152
 [PR #2153]: https://github.com/bareos/bareos/pull/2153
 [PR #2169]: https://github.com/bareos/bareos/pull/2169
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/contrib/misc/reschedule_job_as_full/reschedule_job_as_full.sh
+++ b/contrib/misc/reschedule_job_as_full/reschedule_job_as_full.sh
@@ -46,7 +46,7 @@ debug_log_file=${6:-/dev/null}
 } >> "${debug_log_file}"
 
 if [ "${JobExitStatus}" == "Fatal Error" ] && [ "${JobLevel}" == "Incremental" ] && [ "${JobType}" == "Backup" ]; then
-  if (bconsole <<< "list joblog jobid=${JobId}" | tee -a "${debug_log_file}" | grep -q -F "A new full level backup of this job is required."); then
+  if (bconsole <<< "list joblog jobid=${JobId}" | tee -a "${debug_log_file}" | grep -q -F "new full level backup of this job is required."); then
     echo "Required new full level run will be started in 1 minute."
     if ! bconsole <<< "run job=${JobName} level=Full when=\"$(date -d "now 1min" +"%Y-%m-%d %H:%M:%S")\" yes"; then
       echo "Error while rescheduling ${JobName}"

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -39,7 +39,7 @@ import hashlib
 import re
 import traceback
 from sys import version_info
-import urllib3.util
+import urllib3
 import requests
 
 try:
@@ -3425,6 +3425,7 @@ class BareosVADPWrapper(object):
         verify_cert = True
         if self.options.get("verifyssl") != "yes":
             verify_cert = False
+            urllib3.disable_warnings()
         cookie = self._get_cookie_from_si()
         request_params = {}
         request_params["dsName"] = datastore_name
@@ -3466,6 +3467,7 @@ class BareosVADPWrapper(object):
         verify_cert = True
         if self.options.get("verifyssl") != "yes":
             verify_cert = False
+            urllib3.disable_warnings()
         cookie = self._get_cookie_from_si()
         request_params = {}
         request_params["dsName"] = datastore_name

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -1252,6 +1252,7 @@ class BareosVADPWrapper(object):
         self.restore_vm_created = False
         self.fallback_to_full_cbt = True
         self.restore_allow_disks_mismatch = False
+        self.disk_change_info = {}
 
     def connect_vmware(self):
         # this prevents from repeating on second call
@@ -1307,9 +1308,9 @@ class BareosVADPWrapper(object):
 
         self.si_last_keepalive = int(time.time())
 
-        bareosfd.DebugMessage(
-            100,
-            ("Successfully connected to VSphere API on host %s with user %s\n")
+        bareosfd.JobMessage(
+            bareosfd.M_INFO,
+            "Successfully connected to VSphere API on host %s with user %s\n"
             % (self.options["vcserver"], self.options["vcuser"]),
         )
 
@@ -2261,6 +2262,7 @@ class BareosVADPWrapper(object):
                             hw_device.backing
                         ),
                         "changeId": hw_device.backing.changeId,
+                        "capacityInBytes": hw_device.capacityInBytes,
                     }
                 )
 
@@ -2318,12 +2320,7 @@ class BareosVADPWrapper(object):
             )
 
         try:
-            self.changed_disk_areas = self.vm.QueryChangedDiskAreas(
-                snapshot=self.create_snap_result,
-                deviceKey=self.disk_device_to_backup["deviceKey"],
-                startOffset=0,
-                changeId=cbt_changeId,
-            )
+            self._get_cbt(cbt_change_id=cbt_changeId)
         except vim.fault.FileFault as error:
             if cbt_changeId == "*":
                 bareosfd.JobMessage(bareosfd.M_FATAL, "Get CBT failed:\n")
@@ -2350,12 +2347,7 @@ class BareosVADPWrapper(object):
                     return False
 
                 bareosfd.JobMessage(bareosfd.M_WARNING, "Falling back to full CBT\n")
-                self.changed_disk_areas = self.vm.QueryChangedDiskAreas(
-                    snapshot=self.create_snap_result,
-                    deviceKey=self.disk_device_to_backup["deviceKey"],
-                    startOffset=0,
-                    changeId="*",
-                )
+                self._get_cbt(cbt_change_id="*")
                 bareosfd.JobMessage(bareosfd.M_INFO, "Successfully got full CBT\n")
                 bareosfd.JobMessage(
                     bareosfd.M_WARNING,
@@ -2364,6 +2356,65 @@ class BareosVADPWrapper(object):
 
         self.cbt2json()
         return True
+
+    def _get_cbt(self, cbt_change_id):
+        """
+        Get CBT info for a disk
+        """
+        self.disk_change_info["startOffset"] = 0
+        self.disk_change_info["length"] = 0
+        self.disk_change_info["changedArea"] = []
+        start_position = 0
+
+        if cbt_change_id == "*":
+            # Using CBT for full level backups is deprecated. Instead we send
+            # the full range so that bareo_vadp_dumper will effectively only
+            # use the allocated blocks.
+            bareosfd.DebugMessage(100, "Skipping CBT Query for full backup")
+            self.disk_change_info["length"] = self.disk_device_to_backup[
+                "capacityInBytes"
+            ]
+            self.disk_change_info["changedArea"].append(
+                {"start": 0, "length": self.disk_device_to_backup["capacityInBytes"]}
+            )
+            return
+
+        while start_position < self.disk_device_to_backup["capacityInBytes"]:
+            bareosfd.DebugMessage(
+                100,
+                "CBT Query: startOffset=%s capacityInBytes=%s\n"
+                % (start_position, self.disk_device_to_backup["capacityInBytes"]),
+            )
+            changed_disk_areas = self.vm.QueryChangedDiskAreas(
+                snapshot=self.create_snap_result,
+                deviceKey=self.disk_device_to_backup["deviceKey"],
+                startOffset=start_position,
+                changeId=cbt_change_id,
+            )
+            bareosfd.DebugMessage(
+                100,
+                "CBT Query: Got %s changedArea entries\n"
+                % (len(changed_disk_areas.changedArea),),
+            )
+            start_position = changed_disk_areas.startOffset + changed_disk_areas.length
+            bareosfd.DebugMessage(
+                100,
+                "CBT Query: New startOffset: %s (%s + %s)\n"
+                % (
+                    start_position,
+                    changed_disk_areas.startOffset,
+                    changed_disk_areas.length,
+                ),
+            )
+            self.disk_change_info["length"] += changed_disk_areas.length
+            bareosfd.DebugMessage(
+                100,
+                "CBT Query: New length: %s\n" % (self.disk_change_info["length"],),
+            )
+            for extent in changed_disk_areas.changedArea:
+                self.disk_change_info["changedArea"].append(
+                    {"start": extent.start, "length": extent.length}
+                )
 
     def check_vm_disks_match(self):
         """
@@ -2532,14 +2583,7 @@ class BareosVADPWrapper(object):
         cbt_data["DiskParams"]["changeId"] = self.disk_device_to_backup["changeId"]
 
         # cbt data for bareos_vadp_dumper
-        cbt_data["DiskChangeInfo"] = {}
-        cbt_data["DiskChangeInfo"]["startOffset"] = self.changed_disk_areas.startOffset
-        cbt_data["DiskChangeInfo"]["length"] = self.changed_disk_areas.length
-        cbt_data["DiskChangeInfo"]["changedArea"] = []
-        for extent in self.changed_disk_areas.changedArea:
-            cbt_data["DiskChangeInfo"]["changedArea"].append(
-                {"start": extent.start, "length": extent.length}
-            )
+        cbt_data["DiskChangeInfo"] = self.disk_change_info
 
         self.changed_disk_areas_json = json.dumps(cbt_data)
         self.writeStringToFile(

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -23,6 +23,13 @@ Status
 
 The Plugin can do full, differential and incremental backup and restore of VM disks.
 
+Since :sinceVersion:`24.0.1: VMware Plugin` Previous versions of this plugin may have produced
+incomplete backups, because the CBT information was not retrieved completely in cases where
+the amount of changes was high, especially differential and incremental jobs were affected
+more probably. The issue is fixed in this version. To ensure consistent backups, it is recommended
+to run new full level jobs, as backups taken with previous versions may have an inconsonsistent
+state when restored.
+
 Since :sinceVersion:`23.0.3: VMware Plugin` the NVRAM of VMs is backed up and restored when recreating a VM to ensure it can boot without issues even when EFI enabled.
 
 Since :sinceVersion:`23.0.0: VMware Plugin` the performance is improved and the cleanup of snapshots is enhanced.


### PR DESCRIPTION
The CBT query API call QueryChangedDiskAreas must be used repeatedly to get the complete change information. Additionally, for full backups the changeId * should not be used, the plugin now sends the whole capacity disk range so that bareos_vadp_dumper will effectively only use the allocated blocks information in this case. Also successful API connects and reconnects are now reported as informational job message for more clarity.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
