### PR TITLE
windows: fix readlink buffer size issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - plugins: postgresql add support for PostgreSQL 17 + improvements [PR #2049]
 - bareos-config-libs: double quote dbconfig values [PR #2134]
+- windows: fix readlink buffer size issue [PR #2162]
 
 ## [23.1.1] - 2024-12-02
 
@@ -616,4 +617,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2054]: https://github.com/bareos/bareos/pull/2054
 [PR #2074]: https://github.com/bareos/bareos/pull/2074
 [PR #2134]: https://github.com/bareos/bareos/pull/2134
+[PR #2162]: https://github.com/bareos/bareos/pull/2162
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/test_config_parser_console.cc
+++ b/core/src/tests/test_config_parser_console.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,9 +32,23 @@
 
 namespace console {
 
-TEST(ConfigParser, test_console_config)
+static void InitConGlobals()
 {
   OSDependentInit();
+#if HAVE_WIN32
+  WSA_Init();
+#endif
+  my_config = nullptr;
+  director_resource = nullptr;
+  console_resource = nullptr;
+  me = nullptr;
+}
+
+TEST(ConfigParser, test_console_config)
+{
+  InitConGlobals();
+
+  debug_level = 1000;
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -1139,14 +1139,12 @@ static inline ssize_t GetSymlinkData(const char* filename,
   ssize_t nrconverted = -1;
   HANDLE h = INVALID_HANDLE_VALUE;
 
-  if (p_GetFileAttributesW) {
+  if (p_GetFileAttributesW && p_CreateFileW) {
     std::wstring utf16 = make_win32_path_UTF8_2_wchar(filename);
 
-    if (p_CreateFileW) {
-      h = CreateFileW(
-          utf16.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
-          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
-    }
+    h = CreateFileW(
+        utf16.c_str(), GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 
     if (h == INVALID_HANDLE_VALUE) {
       Dmsg1(debuglevel, "Invalid handle from CreateFileW(%s)\n", utf16.c_str());

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -82,16 +82,16 @@ bool InitializeComSecurity()
    public:
     ComSecurityInitializer()
         : h{CoInitializeSecurity(
-            NULL, /*  Allow *all* VSS writers to communicate back! */
-            -1,   /*  Default COM authentication service */
-            NULL, /*  Default COM authorization service */
-            NULL, /*  reserved parameter */
-            RPC_C_AUTHN_LEVEL_PKT_PRIVACY, /*  Strongest COM authentication
-                                              level */
-            RPC_C_IMP_LEVEL_IDENTIFY, /*  Minimal impersonation abilities */
-            NULL,                     /*  Default COM authentication settings */
-            EOAC_NONE,                /*  No special options */
-            NULL) /* reserved */}
+              NULL, /*  Allow *all* VSS writers to communicate back! */
+              -1,   /*  Default COM authentication service */
+              NULL, /*  Default COM authorization service */
+              NULL, /*  reserved parameter */
+              RPC_C_AUTHN_LEVEL_PKT_PRIVACY, /*  Strongest COM authentication
+                                                level */
+              RPC_C_IMP_LEVEL_IDENTIFY, /*  Minimal impersonation abilities */
+              NULL,      /*  Default COM authentication settings */
+              EOAC_NONE, /*  No special options */
+              NULL) /* reserved */}
     {
       if (!InitSuccessFull()) {
         Dmsg1(0,

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1263,7 +1263,7 @@ static int GetWindowsFileInfo(const char* filename,
   if (p_FindFirstFileW) { /* use unicode */
     std::wstring utf16 = make_win32_path_UTF8_2_wchar(filename);
 
-    Dmsg1(debuglevel, "FindFirstFileW=%s\n", utf16.c_str());
+    Dmsg1(debuglevel, "FindFirstFileW=%s\n", FromUtf16(utf16).c_str());
     fh = p_FindFirstFileW(utf16.c_str(), &info_w);
 #if (_WIN32_WINNT >= 0x0600)
     if (fh != INVALID_HANDLE_VALUE) {

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -1166,41 +1166,45 @@ static inline ssize_t GetSymlinkData(const char* filename,
   if (h != INVALID_HANDLE_VALUE) {
     bool ok;
     POOLMEM* buf;
-    int buf_length;
-    REPARSE_DATA_BUFFER* rdb;
     DWORD bytes;
 
-    // Create a buffer big enough to hold all data.
-    buf_length = sizeof(REPARSE_DATA_BUFFER) + MAX_PATH * sizeof(wchar_t);
+    // we want to write a single NUL after the result of GET_REPARSE_POINT;
+    // The result has size at most MAXIMUM_REPARSE_DATA_BUFFER_SIZE, so
+    // buf_length is always enough
+    const DWORD buf_length = MAXIMUM_REPARSE_DATA_BUFFER_SIZE + sizeof(wchar_t);
+
     buf = GetPoolMemory(PM_NAME);
     buf = CheckPoolMemorySize(buf, buf_length);
-    rdb = (REPARSE_DATA_BUFFER*)buf;
 
     memset(buf, 0, buf_length);
+    REPARSE_DATA_BUFFER* rdb = reinterpret_cast<REPARSE_DATA_BUFFER*>(buf);
     rdb->ReparseTag = IO_REPARSE_TAG_SYMLINK;
     ok = DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, NULL,
                          0,                              /* in buffer, bytes */
                          (LPVOID)buf, (DWORD)buf_length, /* out buffer, btyes */
                          (LPDWORD)&bytes, (LPOVERLAPPED)0);
     if (ok) {
-      POOLMEM* path;
-      int len, offset, ofs;
+      int len = rdb->SymbolicLinkReparseBuffer.SubstituteNameLength
+                / sizeof(wchar_t);
+      int offset = rdb->SymbolicLinkReparseBuffer.SubstituteNameOffset
+                   / sizeof(wchar_t);
 
-      len = rdb->SymbolicLinkReparseBuffer.SubstituteNameLength
-            / sizeof(wchar_t);
-      offset = rdb->SymbolicLinkReparseBuffer.SubstituteNameOffset
-               / sizeof(wchar_t);
+      // make sure our buffer is big enough
+      ASSERT((intptr_t)(rdb->SymbolicLinkReparseBuffer.PathBuffer + offset + len
+                        + 1)
+                 - (intptr_t)rdb
+             <= buf_length);
 
       // null-Terminate pathbuffer
       *(wchar_t*)(rdb->SymbolicLinkReparseBuffer.PathBuffer + offset + len)
           = L'\0';
 
       // convert to UTF-8
-      path = GetPoolMemory(PM_FNAME);
+      POOLMEM* path = GetPoolMemory(PM_FNAME);
       nrconverted = wchar_2_UTF8(
           path, (wchar_t*)(rdb->SymbolicLinkReparseBuffer.PathBuffer + offset));
 
-      ofs = 0;
+      int ofs = 0;
       if (bstrncasecmp(path, "\\??\\", 4)) { /* skip \\??\\ if exists */
         ofs = 4;
         Dmsg0(debuglevel, "\\??\\ was in filename, skipping\n");

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -1422,7 +1422,7 @@ static int GetWindowsFileInfo(const char* filename,
           slt = GetPoolMemory(PM_NAME);
           slt = CheckPoolMemorySize(slt, MAX_PATH * sizeof(wchar_t));
 
-          if (GetSymlinkData(filename, slt)) {
+          if (GetSymlinkData(filename, slt) >= 0) {
             Dmsg2(debuglevel, "Symlinked Directory %s points to: %s\n",
                   filename, slt);
           }
@@ -1446,7 +1446,7 @@ static int GetWindowsFileInfo(const char* filename,
           Dmsg0(debuglevel, "We have a symlinked file!\n");
           sb->st_mode |= S_IFLNK;
 
-          if (GetSymlinkData(filename, slt)) {
+          if (GetSymlinkData(filename, slt) >= 0) {
             Dmsg2(debuglevel, "Symlinked File %s points to: %s\n", filename,
                   slt);
           }
@@ -1856,7 +1856,7 @@ ssize_t readlink(const char* path, char* buf, size_t bufsiz)
   POOLMEM* slt = GetPoolMemory(PM_NAME);
 
   Dmsg1(debuglevel, "readlink called for path %s\n", path);
-  GetSymlinkData(path, slt);
+  if (GetSymlinkData(path, slt) < 0) { return -1; }
 
   strncpy(buf, slt, bufsiz - 1);
   buf[bufsiz] = '\0';


### PR DESCRIPTION
**Backport of PR #2153 to bareos-23**

This backport does not include the changes for the grpc test module, as that module does not exist in bareos 23.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2153 is merged
- [x] All functional differences to the original PR are documented above
