### PR TITLE
windows: fix readlink buffer size issue

### DIFF
--- a/.quality-gates.yml
+++ b/.quality-gates.yml
@@ -6,6 +6,16 @@ coverage:
     unhealthy: 38
     unstable: 40
 
+SLE_12_SP5:
+  ctest_unstable: 9
+  warnings_unhealthy: 1
+  warnings_healthy: 0
+
+Debian_10:
+  ctest_unstable: 9
+  warnings_unhealthy: 1
+  warnings_healthy: 0
+
 default:
   ctest_unstable: 0
   warnings_unhealthy: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Fixed
 - fix include-ordering on FreeBSD that could cause build issues [PR #1974]
 - deb control files: depend on python3-bareos [PR #1968]
+- windows: fix readlink buffer size issue [PR #2163]
 
 ### Documentation
 - docs: improve debuginfo install description (fix issue #1943) [PR #1986]
@@ -723,4 +724,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #1986]: https://github.com/bareos/bareos/pull/1986
 [PR #2033]: https://github.com/bareos/bareos/pull/2033
 [PR #2075]: https://github.com/bareos/bareos/pull/2075
+[PR #2163]: https://github.com/bareos/bareos/pull/2163
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/test_config_parser_console.cc
+++ b/core/src/tests/test_config_parser_console.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,9 +32,23 @@
 
 namespace console {
 
-TEST(ConfigParser, test_console_config)
+static void InitConGlobals()
 {
   OSDependentInit();
+#if HAVE_WIN32
+  WSA_Init();
+#endif
+  my_config = nullptr;
+  director_resource = nullptr;
+  console_resource = nullptr;
+  me = nullptr;
+}
+
+TEST(ConfigParser, test_console_config)
+{
+  InitConGlobals();
+
+  debug_level = 1000;
 
   std::string path_to_config_file = std::string(
       RELATIVE_PROJECT_SOURCE_DIR "/configs/bareos-configparser-tests");

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -363,22 +363,18 @@ static inline void conv_unix_to_vss_win32_path(const char* name,
     name++;
   }
 
-  /**
-   * Strip any trailing slash, if we stored something
-   * but leave "c:\" with backslash (root directory case)
-   */
+  /* Strip any trailing slash, if we stored something
+   * but leave "c:\" with backslash (root directory case) */
   if (*fname != 0 && win32_name[-1] == '\\' && strlen(fname) != 3) {
     win32_name[-1] = 0;
   } else {
     *win32_name = 0;
   }
 
-  /**
-   * Here we convert to VSS specific file name which
+  /* Here we convert to VSS specific file name which
    * can get longer because VSS will make something like
    * \\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\bareos\\uninstall.exe
-   * from c:\bareos\uninstall.exe
-   */
+   * from c:\bareos\uninstall.exe */
   Dmsg1(debuglevel, "path=%s\n", tname);
   if (tvpc) {
     POOLMEM* pszBuf = GetPoolMemory(PM_FNAME);
@@ -397,10 +393,8 @@ void unix_name_to_win32(POOLMEM*& win32_name, const char* name)
 {
   DWORD dwSize;
 
-  /*
-   * One extra byte should suffice, but we double it
-   * add MAX_PATH bytes for VSS shadow copy name.
-   */
+  /* One extra byte should suffice, but we double it
+   * add MAX_PATH bytes for VSS shadow copy name. */
   dwSize = 2 * strlen(name) + MAX_PATH;
   win32_name = CheckPoolMemorySize(win32_name, dwSize);
   conv_unix_to_vss_win32_path(name, win32_name, dwSize);
@@ -445,11 +439,9 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
   pwszBuf = (wchar_t*)CheckPoolMemorySize((POOLMEM*)pwszBuf,
                                           dwBufCharsNeeded * sizeof(wchar_t));
 
-  /*
-   * Add \\?\ to support 32K long filepaths
+  /* Add \\?\ to support 32K long filepaths
    * it is important to make absolute paths, so we add drive and
-   * current path if necessary
-   */
+   * current path if necessary */
   BOOL bAddDrive = TRUE;
   BOOL bAddCurrentPath = TRUE;
   BOOL bAddPrefix = TRUE;
@@ -487,10 +479,8 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
   if (bAddDrive || bAddCurrentPath) {
     dwCurDirPathSize = p_GetCurrentDirectoryW(0, NULL);
     if (dwCurDirPathSize > 0) {
-      /*
-       * Get directory into own buffer as it may either return c:\... or
-       * \\?\C:\....
-       */
+      /* Get directory into own buffer as it may either return c:\... or
+       * \\?\C:\.... */
       pwszCurDirBuf = (wchar_t*)CheckPoolMemorySize(
           (POOLMEM*)pwszCurDirBuf, (dwCurDirPathSize + 1) * sizeof(wchar_t));
       p_GetCurrentDirectoryW(dwCurDirPathSize, pwszCurDirBuf);
@@ -528,10 +518,8 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
     pwszBuf = (wchar_t*)CheckPoolMemorySize((POOLMEM*)pwszBuf,
                                             dwBufCharsNeeded * sizeof(wchar_t));
 
-    /*
-     * Get directory into own buffer as it may either return c:\... or
-     * \\?\C:\....
-     */
+    /* Get directory into own buffer as it may either return c:\... or
+     * \\?\C:\.... */
     if (IsPathSeparator(pwszCurDirBuf[0]) && IsPathSeparator(pwszCurDirBuf[1])
         && pwszCurDirBuf[2] == '?' && IsPathSeparator(pwszCurDirBuf[3])) {
       // Copy complete string
@@ -556,10 +544,8 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
   wchar_t next_char = 0;
 
   while (*name) {
-    /*
-     * Check for Unix separator and convert to Win32, eliminating duplicate
-     * separators.
-     */
+    /* Check for Unix separator and convert to Win32, eliminating duplicate
+     * separators. */
     if (IsPathSeparator(*name)) {
       // Don't add a trailing slash.
       next_char = *(name + 1);
@@ -570,10 +556,8 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
       previous_char = '\\';
       *win32_name++ = '\\'; /* convert char */
 
-      /*
-       * Eliminate consecutive slashes, but not at the start so that \\.\ still
-       * works.
-       */
+      /* Eliminate consecutive slashes, but not at the start so that \\.\ still
+       * works. */
       if (name_start != name && IsPathSeparator(name[1])) { name++; }
     } else {
       previous_char = *name;
@@ -585,12 +569,10 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
   // NULL Terminate string
   *win32_name = 0;
 
-  /*
-   * Here we convert to VSS specific file name which can get longer because VSS
+  /* Here we convert to VSS specific file name which can get longer because VSS
    * will make something like
    * \\\\?\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy1\\bareos\\uninstall.exe
-   * from c:\bareos\uninstall.exe
-   */
+   * from c:\bareos\uninstall.exe */
   thread_vss_path_convert* tvpc = Win32GetPathConvert();
   if (tvpc) {
     // Is output buffer large enough?
@@ -621,10 +603,8 @@ static inline POOLMEM* make_wchar_win32_path(POOLMEM* pszUCSPath,
 // Convert from WCHAR (UCS) to UTF-8
 int wchar_2_UTF8(POOLMEM*& pszUTF, const WCHAR* pszUCS)
 {
-  /**
-   * The return value is the number of bytes written to the buffer.
-   * The number includes the byte for the null terminator.
-   */
+  /* The return value is the number of bytes written to the buffer.
+   * The number includes the byte for the null terminator. */
   if (p_WideCharToMultiByte) {
     int nRet
         = p_WideCharToMultiByte(CP_UTF8, 0, pszUCS, -1, NULL, 0, NULL, NULL);
@@ -639,10 +619,8 @@ int wchar_2_UTF8(POOLMEM*& pszUTF, const WCHAR* pszUCS)
 // Convert from WCHAR (UCS) to UTF-8
 int wchar_2_UTF8(char* pszUTF, const WCHAR* pszUCS, int cchChar)
 {
-  /**
-   * The return value is the number of bytes written to the buffer.
-   * The number includes the byte for the null terminator.
-   */
+  /* The return value is the number of bytes written to the buffer.
+   * The number includes the byte for the null terminator. */
   if (p_WideCharToMultiByte) {
     int nRet = p_WideCharToMultiByte(CP_UTF8, 0, pszUCS, -1, pszUTF, cchChar,
                                      NULL, NULL);
@@ -655,11 +633,9 @@ int wchar_2_UTF8(char* pszUTF, const WCHAR* pszUCS, int cchChar)
 
 int UTF8_2_wchar(POOLMEM*& ppszUCS, const char* pszUTF)
 {
-  /*
-   * The return value is the number of wide characters written to the buffer.
+  /* The return value is the number of wide characters written to the buffer.
    * convert null terminated string from utf-8 to ucs2, enlarge buffer if
-   * necessary
-   */
+   * necessary */
   if (p_MultiByteToWideChar) {
     // strlen of UTF8 +1 is enough
     DWORD cchSize = (strlen(pszUTF) + 1);
@@ -730,11 +706,9 @@ int make_win32_path_UTF8_2_wchar(POOLMEM*& pszUCS,
   int nRet;
   thread_conversion_cache* tcc;
 
-  /*
-   * If we find the utf8 string in cache, we use the cached ucs2 version.
+  /* If we find the utf8 string in cache, we use the cached ucs2 version.
    * we compare the stringlength first (quick check) and then compare the
-   * content.
-   */
+   * content. */
   tcc = Win32GetCache();
   if (!tcc) {
     tcc = Win32ConvInitCache();
@@ -751,10 +725,8 @@ int make_win32_path_UTF8_2_wchar(POOLMEM*& pszUCS,
     }
   }
 
-  /*
-   * Helper to convert from utf-8 to UCS-2 and to complete a path for 32K path
-   * syntax
-   */
+  /* Helper to convert from utf-8 to UCS-2 and to complete a path for 32K path
+   * syntax */
   nRet = UTF8_2_wchar(pszUCS, pszUTF);
 
 #ifdef USE_WIN32_32KPATHCONVERSION
@@ -876,10 +848,8 @@ bool CreateJunction(const char* szJunction, const char* szPath)
   PoolMem szDestDir(PM_FNAME);
   POOLMEM *buf, *szJunctionW, *szPrintName, *szSubstituteName;
 
-  /*
-   * We only implement a Wide string version of CreateJunction.
-   * So if p_CreateDirectoryW is not available we refuse to do anything.
-   */
+  /* We only implement a Wide string version of CreateJunction.
+   * So if p_CreateDirectoryW is not available we refuse to do anything. */
   if (!p_CreateDirectoryW) {
     Dmsg0(debuglevel,
           "CreateJunction: CreateDirectoryW not found, doing nothing\n");
@@ -949,10 +919,8 @@ bool CreateJunction(const char* szJunction, const char* szPath)
       = rdb->ReparseDataLength + MOUNTPOINTREPARSEBUFFER_FIXED_HEADER_SIZE;
   rdb->ReparseTag = IO_REPARSE_TAG_MOUNT_POINT;
 
-  /*
-   * Write reparse point
-   * For debugging use "fsutil reparsepoint query"
-   */
+  /* Write reparse point
+   * For debugging use "fsutil reparsepoint query" */
   if (!DeviceIoControl(hDir, FSCTL_SET_REPARSE_POINT, (LPVOID)buf, data_length,
                        NULL, 0, &dwRet, 0)) {
     Dmsg1(debuglevel, "DeviceIoControl Failed:%s\n", errorString());
@@ -1002,11 +970,9 @@ static inline bool GetVolumeMountPointData(const char* filename,
 {
   HANDLE h = INVALID_HANDLE_VALUE;
 
-  /*
-   * Now to find out if the directory is a mount point or a reparse point.
+  /* Now to find out if the directory is a mount point or a reparse point.
    * Explicitly open the file to read the reparse point, then call
-   * DeviceIoControl to find out if it points to a Volume or to a directory.
-   */
+   * DeviceIoControl to find out if it points to a Volume or to a directory. */
   if (p_GetFileAttributesW && p_CreateFileW) {
     POOLMEM* pwszBuf = GetPoolMemory(PM_FNAME);
     make_win32_path_UTF8_2_wchar(pwszBuf, filename);
@@ -1302,11 +1268,9 @@ static int GetWindowsFileInfo(const char* filename,
     }
 #endif
 
-    /*
-     * See if we got anything from the GetFileInformationByHandleEx() call if
+    /* See if we got anything from the GetFileInformationByHandleEx() call if
      * not fallback to the normal info data returned by FindFirstFileW() or
-     * FindFirstFileA()
-     */
+     * FindFirstFileA() */
     if (use_fallback_data) {
       if (p_FindFirstFileW) { /* use unicode */
         pftLastAccessTime = &info_w.ftLastAccessTime;
@@ -1323,10 +1287,8 @@ static int GetWindowsFileInfo(const char* filename,
   } else {
     const char* err = errorString();
 
-    /*
-     * Note, in creating leading paths, it is normal that the file does not
-     * exist.
-     */
+    /* Note, in creating leading paths, it is normal that the file does not
+     * exist. */
     Dmsg2(2099, "FindFirstFile(%s):%s\n", filename, err);
     LocalFree((void*)err);
     errno = b_errno_win32;
@@ -1348,24 +1310,20 @@ static int GetWindowsFileInfo(const char* filename,
     // Directory
     sb->st_mode |= S_IFDIR;
 
-    /*
-     * Store reparse/mount point info in st_rdev.  Note a Win32 reparse point
+    /* Store reparse/mount point info in st_rdev.  Note a Win32 reparse point
      * (junction point) is like a link though it can have many properties
      * (directory link, soft link, hard link, HSM, ...
      * The IO_REPARSE_TAG_* tag values describe what type of reparse point
      * it actually is.
      *
      * A mount point is a reparse point where another volume is mounted,
-     * so it is like a Unix mount point (change of filesystem).
-     */
+     * so it is like a Unix mount point (change of filesystem). */
     if ((*pdwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT)) {
       switch (*pdwReserved0) {
         case IO_REPARSE_TAG_MOUNT_POINT: {
-          /*
-           * A mount point can be:
+          /* A mount point can be:
            * Volume Mount Point "\\??\\volume{..."
-           * Junction Point     "\\??\\..."
-           */
+           * Junction Point     "\\??\\..." */
           POOLMEM* vmp = GetPoolMemory(PM_NAME);
           if (GetVolumeMountPointData(filename, vmp)) {
             if (bstrncasecmp(vmp, "\\??\\volume{", 11)) {
@@ -1598,11 +1556,9 @@ static int stat2(const char* filename, struct stat* sb)
   rval = fstat((intptr_t)h, sb);
   CloseHandle(h);
 
-  /*
-   * See if this is a directory or a reparse point and its not a single drive
+  /* See if this is a directory or a reparse point and its not a single drive
    * letter. If so we call GetWindowsFileInfo() which retrieves the lowlevel
-   * information we need.
-   */
+   * information we need. */
   if (((attr & FILE_ATTRIBUTE_DIRECTORY)
        || (attr & FILE_ATTRIBUTE_REPARSE_POINT))
       && !IsDriveLetterOnly(filename)) {
@@ -1646,13 +1602,11 @@ int stat(const char* filename, struct stat* sb)
     goto bail_out;
   }
 
-  /*
-   * See if this is a directory or a reparse point and not a single drive
+  /* See if this is a directory or a reparse point and not a single drive
    * letter. If so we call GetWindowsFileInfo() which retrieves the lowlevel
    * information we need. As GetWindowsFileInfo() fills the complete stat
    * structs we only need to perform the other part of the code when we don't
-   * call the GetWindowsFileInfo() function.
-   */
+   * call the GetWindowsFileInfo() function. */
   if (((data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
        || (data.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT))
       && !IsDriveLetterOnly(filename)) {
@@ -1689,10 +1643,8 @@ int stat(const char* filename, struct stat* sb)
     if (p_GetFileInformationByHandleEx) {
       HANDLE h = INVALID_HANDLE_VALUE;
 
-      /*
-       * The GetFileInformationByHandleEx need a file handle so we have to
-       * open the file or directory read-only.
-       */
+      /* The GetFileInformationByHandleEx need a file handle so we have to
+       * open the file or directory read-only. */
       if (p_CreateFileW) {
         POOLMEM* pwszBuf;
 
@@ -1881,12 +1833,10 @@ int win32_symlink(const char* name1, const char* name2, _dev_t st_rdev)
 
   Dmsg2(debuglevel, "symlink called name1=%s, name2=%s\n", name1, name2);
   if (p_CreateSymbolicLinkW) {
-    /*
-     * Dynamically allocate enough space for UCS2 filename
+    /* Dynamically allocate enough space for UCS2 filename
      *
      * pwszBuf1: lpTargetFileName
-     * pwszBuf2: lpSymlinkFileName
-     */
+     * pwszBuf2: lpSymlinkFileName */
     POOLMEM* pwszBuf1 = GetPoolMemory(PM_FNAME);
     POOLMEM* pwszBuf2 = GetPoolMemory(PM_FNAME);
 
@@ -2210,10 +2160,8 @@ static DWORD fill_attribute(DWORD attr, mode_t mode, _dev_t rdev)
     attr &= ~FILE_ATTRIBUTE_HIDDEN;
   }
 
-  /*
-   * Other can read/write/execute ?
-   * => Not system
-   */
+  /* Other can read/write/execute ?
+   * => Not system */
   if (mode & S_IRWXO) {
     attr &= ~FILE_ATTRIBUTE_SYSTEM;
   } else {
@@ -2221,12 +2169,10 @@ static DWORD fill_attribute(DWORD attr, mode_t mode, _dev_t rdev)
     compatible = true;
   }
 
-  /*
-   * See if there are any compatible mode settings in the to restore mode.
+  /* See if there are any compatible mode settings in the to restore mode.
    * If so we don't trust the rdev setting as it is from an Bacula compatible
    * Filedaemon and as such doesn't encode the windows file flags in st_rdev
-   * but uses st_rdev for marking reparse points.
-   */
+   * but uses st_rdev for marking reparse points. */
   if (!compatible) {
     // Based on the setting of rdev restore any special file flags.
     if (rdev & FILE_ATTRIBUTE_READONLY) {
@@ -2398,10 +2344,8 @@ char* win32_getcwd(char* buf, int maxlen)
 
 int win32_fputs(const char* string, FILE* stream)
 {
-  /*
-   * We use WriteConsoleA / WriteConsoleA so we can be sure that unicode support
-   * works on win32. with fallback if something fails
-   */
+  /* We use WriteConsoleA / WriteConsoleA so we can be sure that unicode support
+   * works on win32. with fallback if something fails */
   HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
   if (hOut && (hOut != INVALID_HANDLE_VALUE) && p_WideCharToMultiByte
       && p_MultiByteToWideChar && (stream == stdout)) {
@@ -2440,10 +2384,8 @@ int win32_fputs(const char* string, FILE* stream)
 
 char* win32_cgets(char* buffer, int len)
 {
-  /*
-   * We use console ReadConsoleA / ReadConsoleW to be able to read unicode
-   * from the win32 console and fallback if seomething fails
-   */
+  /* We use console ReadConsoleA / ReadConsoleW to be able to read unicode
+   * from the win32 console and fallback if seomething fails */
   HANDLE hIn = GetStdHandle(STD_INPUT_HANDLE);
   if (hIn && (hIn != INVALID_HANDLE_VALUE) && p_WideCharToMultiByte
       && p_MultiByteToWideChar) {
@@ -2720,11 +2662,9 @@ bool GetApplicationName(const char* cmdline, char** pexe, const char** pargs)
   *pargs = NULL;
   *pexe = NULL;
 
-  /*
-   * Scan command line looking for path separators (/ and \\) and the
+  /* Scan command line looking for path separators (/ and \\) and the
    * terminator, either a quote or a blank.  The location of the
-   * extension is also noted.
-   */
+   * extension is also noted. */
   for (; *current != '\0'; current++) {
     if (*current == '.') {
       pExtension = current;
@@ -2740,10 +2680,8 @@ bool GetApplicationName(const char* cmdline, char** pexe, const char** pargs)
       if (*current != ' ') { continue; }
     }
 
-    /*
-     * Hit terminator, remember end of name (address of terminator) and start of
-     * arguments
-     */
+    /* Hit terminator, remember end of name (address of terminator) and start of
+     * arguments */
     pExeEnd = current;
 
     if (bQuoted && *current == '"') {
@@ -2763,10 +2701,8 @@ bool GetApplicationName(const char* cmdline, char** pexe, const char** pargs)
 
   bool bHasPathSeparators = pExeStart != pBasename;
 
-  /*
-   * We have pointers to all the useful parts of the name
-   * Default extensions in the order cmd.exe uses to search
-   */
+  /* We have pointers to all the useful parts of the name
+   * Default extensions in the order cmd.exe uses to search */
   static const char ExtensionList[][5] = {".com", ".exe", ".bat", ".cmd"};
   DWORD dwBasePathLength = pExeEnd - pExeStart;
 
@@ -2945,10 +2881,8 @@ HANDLE CreateChildProcess(const char* cmdline,
   // Set up members of the PROCESS_INFORMATION structure.
   ZeroMemory(&piProcInfo, sizeof(PROCESS_INFORMATION));
 
-  /*
-   * if supplied handles are not used the send a copy of our STD_HANDLE as
-   * appropriate.
-   */
+  /* if supplied handles are not used the send a copy of our STD_HANDLE as
+   * appropriate. */
   if (in == INVALID_HANDLE_VALUE) in = GetStdHandle(STD_INPUT_HANDLE);
 
   if (out == INVALID_HANDLE_VALUE) out = GetStdHandle(STD_OUTPUT_HANDLE);

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -1007,15 +1007,13 @@ static inline bool GetVolumeMountPointData(const char* filename,
    * Explicitly open the file to read the reparse point, then call
    * DeviceIoControl to find out if it points to a Volume or to a directory.
    */
-  if (p_GetFileAttributesW) {
+  if (p_GetFileAttributesW && p_CreateFileW) {
     POOLMEM* pwszBuf = GetPoolMemory(PM_FNAME);
     make_win32_path_UTF8_2_wchar(pwszBuf, filename);
 
-    if (p_CreateFileW) {
-      h = CreateFileW(
-          (LPCWSTR)pwszBuf, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
-          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
-    }
+    h = CreateFileW(
+        (LPCWSTR)pwszBuf, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, NULL);
 
     if (h == INVALID_HANDLE_VALUE) {
       Dmsg1(debuglevel, "Invalid handle from CreateFileW(%s)\n", pwszBuf);

--- a/core/src/win32/compat/compat.cc
+++ b/core/src/win32/compat/compat.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1396,7 +1396,7 @@ static int GetWindowsFileInfo(const char* filename,
           slt = GetPoolMemory(PM_NAME);
           slt = CheckPoolMemorySize(slt, MAX_PATH * sizeof(wchar_t));
 
-          if (GetSymlinkData(filename, slt)) {
+          if (GetSymlinkData(filename, slt) >= 0) {
             Dmsg2(debuglevel, "Symlinked Directory %s points to: %s\n",
                   filename, slt);
           }
@@ -1420,7 +1420,7 @@ static int GetWindowsFileInfo(const char* filename,
           Dmsg0(debuglevel, "We have a symlinked file!\n");
           sb->st_mode |= S_IFLNK;
 
-          if (GetSymlinkData(filename, slt)) {
+          if (GetSymlinkData(filename, slt) >= 0) {
             Dmsg2(debuglevel, "Symlinked File %s points to: %s\n", filename,
                   slt);
           }
@@ -1849,7 +1849,7 @@ ssize_t readlink(const char* path, char* buf, size_t bufsiz)
   POOLMEM* slt = GetPoolMemory(PM_NAME);
 
   Dmsg1(debuglevel, "readlink called for path %s\n", path);
-  GetSymlinkData(path, slt);
+  if (GetSymlinkData(path, slt) < 0) { return -1; }
 
   strncpy(buf, slt, bufsiz - 1);
   buf[bufsiz] = '\0';


### PR DESCRIPTION
**Backport of PR #2153 to bareos-22**

This backport does not include the changes for the grpc test module, as that module does not exist in bareos 23.
It also does not contain the new debug messages.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2153 is merged
- [x] All functional differences to the original PR are documented above
