### PR TITLE
cmake: add cmake_parse_arguments policy CMP0174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bconsole: enable app icon on windows [PR #2105]
 - windows: fix readlink buffer size issue [PR #2153]
 - Fix btape fill-test problem [PR #2018]
+- cmake: add cmake_parse_arguments policy CMP0174 [PR #2169]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -66,4 +67,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2144]: https://github.com/bareos/bareos/pull/2144
 [PR #2147]: https://github.com/bareos/bareos/pull/2147
 [PR #2153]: https://github.com/bareos/bareos/pull/2153
+[PR #2169]: https://github.com/bareos/bareos/pull/2169
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
                                 # on MSVC
 else()
   cmake_minimum_required(VERSION 3.17)
-  cmake_policy(VERSION 3.17...3.19)
+  cmake_policy(VERSION 3.17...3.31)
 endif()
 
 project(bareos NONE)

--- a/core/cmake/BareosCopyDllsToBinDir.cmake
+++ b/core/cmake/BareosCopyDllsToBinDir.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -44,7 +44,7 @@ macro(BareosCopyDllsToBinDir)
       )
         add_custom_command(
           TARGET ${TGT}
-          POST_BUILD JOB_POOL copy
+          POST_BUILD
           COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:${TGT}>
                   $<TARGET_RUNTIME_DLLS:${TGT}>;${DLLS_TO_COPY_MANUALLY}
           COMMAND_EXPAND_LISTS


### PR DESCRIPTION
This PR fix issue bareos/internal#189 warning with cmake 3.31 in
  cmake_parse_arguments.

```
-- ✓ system:spool (baseport=30591)
--      └─ ✓ system:spool
CMake Warning (dev) at systemtests/cmake/BareosSystemtestFunctions.cmake:673 (cmake_parse_arguments):
  The COMMENT keyword was followed by an empty string or no value at all.
  Policy CMP0174 is not set, so cmake_parse_arguments() will unset the
  ARG_COMMENT variable rather than setting it to an empty string.
Call Stack (most recent call first):
  systemtests/cmake/BareosSystemtestFunctions.cmake:846 (add_disabled_systemtest)
  systemtests/tests/stresstest/CMakeLists.txt:21 (create_systemtest)
This warning is for project developers.  Use -Wno-dev to suppress it.

``` 

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

