### PR TITLE
Fix btape fill-test problem

### DIFF
--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -314,8 +314,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             return;
             break;
         } /* end switch */
-      }   /* end if Bstrcasecmp */
-    }     /* end for RunFields */
+      } /* end if Bstrcasecmp */
+    } /* end for RunFields */
 
     /* At this point, it is not a keyword. Check for old syle
      * Job Levels without keyword. This form is depreciated!!! */
@@ -527,8 +527,12 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
           // Check for week modulo specification.
           code = atoi(lc->str + 1);
           code2 = atoi(p + 1);
-          if (code < 0 || code > 53 || code2 < 0 || code2 > 53) {
+          if (code < 0 || code > 53) {
             scan_err0(lc, T_("Week number out of range (0-53) in modulo"));
+            return;
+          }
+          if (code2 <= 0 || code2 > 53) {
+            scan_err0(lc, T_("Week interval out of range (1-53) in modulo"));
             return;
           }
           if (code > code2) {
@@ -541,10 +545,8 @@ void StoreRun(LEX* lc, ResourceItem* item, int index, int pass)
             have_woy = true;
           }
           // Set the bits according to the modulo specification.
-          for (i = 0; i < 53; i++) {
-            if (i % code2 == 0) {
-              SetBit(i + code, res_run.date_time_bitfield.woy);
-            }
+          for (int week = code; week <= 53; week += code2) {
+            SetBit(week, res_run.date_time_bitfield.woy);
           }
         } else {
           scan_err0(lc, T_("Bad modulo time specification. Format for weekdays "

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -2402,7 +2402,6 @@ static void unfillcmd()
  */
 static bool do_unfill()
 {
-  DeviceBlock* block = dcr->block;
   int autochanger;
   bool rc = false;
 
@@ -2485,7 +2484,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(last_block, block)) {
+  if (CompareBlocks(last_block, dcr->block)) {
     if (simple) {
       Pmsg0(-1,
             T_("\nThe last block on the tape matches. Test succeeded.\n\n"));
@@ -2535,7 +2534,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(first_block, block)) {
+  if (CompareBlocks(first_block, g_dcr->block)) {
     Pmsg0(-1, T_("\nThe first block on the second tape matches.\n\n"));
   }
 
@@ -2552,7 +2551,7 @@ static bool do_unfill()
     Pmsg1(-1, T_("Error reading block: ERR=%s\n"), dev->bstrerror());
     goto bail_out;
   }
-  if (CompareBlocks(last_block, block)) {
+  if (CompareBlocks(last_block, g_dcr->block)) {
     Pmsg0(-1, T_("\nThe last block on the second tape matches. Test "
                  "succeeded.\n\n"));
     rc = true;

--- a/core/src/stored/btape.cc
+++ b/core/src/stored/btape.cc
@@ -2520,11 +2520,18 @@ static bool do_unfill()
     goto bail_out;
   }
 
+  // read volume label
+  if (int err = ReadDevVolumeLabel(dcr); err != VOL_OK) {
+    Pmsg1(-1, T_("Error reading label. ERR=%d\n"), err);
+    goto bail_out;
+  }
+
   /* Space to "first" block which is last block not written
    * on the previous tape.
    */
-  Pmsg2(-1, T_("Reposition from %u:%u to 0:1\n"), dev->file, dev->block_num);
-  if (!dev->Reposition(dcr, 0, 1)) {
+  Pmsg2(-1, T_("Reposition from %u:%u to 1:0\n"), dev->file,
+        dev->block_num);
+  if (!dev->Reposition(g_dcr, 1, 0)) {
     Pmsg1(-1, T_("Reposition error. ERR=%s\n"), dev->bstrerror());
     goto bail_out;
   }


### PR DESCRIPTION
**Backport of PR #2018 to bareos-23**

backport hat to honor a naming change dcr -> g_dcr and dev -> g_dev
that had not yet happened in Bareos 23.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

#### Backport quality
- [ ] Original PR #2018 is merged
- [x] All functional differences to the original PR are documented above
