### PR TITLE
Fix 32bit compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - scheduler: 'last' keyword doesn't allow job to be visible in status dir [PR #2120]
 - fix autodeflate messages and refactor setup method [PR #2121]
 - stored: fix crash when using jit reservation with no matching device; fix reservation error [PR #2141]
+- Fix 32bit compilation [PR #2175]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -81,5 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2152]: https://github.com/bareos/bareos/pull/2152
 [PR #2153]: https://github.com/bareos/bareos/pull/2153
 [PR #2169]: https://github.com/bareos/bareos/pull/2169
+[PR #2175]: https://github.com/bareos/bareos/pull/2175
 [PR #2191]: https://github.com/bareos/bareos/pull/2191
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2015-2017 Planets Communications B.V.
-   Copyright (C) 2017-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2017-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -681,8 +681,8 @@ ssize_t ChunkedDevice::ReadChunked(int, void* buffer, size_t count)
         && current_chunk_->end_offset >= (boffset_t)((offset_ + count) - 1)) {
       wanted_offset = (offset_ % current_chunk_->chunk_size);
 
-      bytes_left
-          = MIN((ssize_t)count, (current_chunk_->buflen - wanted_offset));
+      bytes_left = MIN((ssize_t)count,
+                       ((ssize_t)current_chunk_->buflen - wanted_offset));
       Dmsg2(200, "Reading complete %d byte read-request from chunk offset %d\n",
             bytes_left, wanted_offset);
 
@@ -709,8 +709,8 @@ ssize_t ChunkedDevice::ReadChunked(int, void* buffer, size_t count)
         // See how much is left in this chunk.
         if (offset_ <= current_chunk_->end_offset) {
           wanted_offset = (offset_ % current_chunk_->chunk_size);
-          bytes_left = MIN((ssize_t)(count - offset),
-                           (ssize_t)(current_chunk_->buflen - wanted_offset));
+          bytes_left = MIN(((ssize_t)count - offset),
+                           ((ssize_t)current_chunk_->buflen - wanted_offset));
 
           if (bytes_left > 0) {
             Dmsg2(200,
@@ -743,8 +743,8 @@ ssize_t ChunkedDevice::ReadChunked(int, void* buffer, size_t count)
         } else {
           /* Calculate how much data we can read from the just freshly read
            * chunk. */
-          bytes_left = MIN((ssize_t)(count - offset),
-                           (ssize_t)(current_chunk_->buflen));
+          bytes_left
+              = MIN(((ssize_t)count - offset), (ssize_t)current_chunk_->buflen);
 
           if (bytes_left > 0) {
             Dmsg2(200,
@@ -829,7 +829,7 @@ ssize_t ChunkedDevice::WriteChunked(int, const void* buffer, size_t count)
         if (offset_ <= current_chunk_->end_offset) {
           wanted_offset = (offset_ % current_chunk_->chunk_size);
           bytes_left
-              = MIN((ssize_t)(count - offset),
+              = MIN(((ssize_t)count - offset),
                     (ssize_t)((current_chunk_->end_offset
                                - (current_chunk_->start_offset + wanted_offset))
                               + 1));
@@ -843,7 +843,8 @@ ssize_t ChunkedDevice::WriteChunked(int, const void* buffer, size_t count)
             memcpy(current_chunk_->buffer + wanted_offset,
                    ((char*)buffer + offset), bytes_left);
             offset_ += bytes_left;
-            if ((wanted_offset + bytes_left) > current_chunk_->buflen) {
+            if ((wanted_offset + bytes_left)
+                > (ssize_t)current_chunk_->buflen) {
               current_chunk_->buflen = wanted_offset + bytes_left;
             }
             current_chunk_->need_flushing = true;
@@ -860,7 +861,7 @@ ssize_t ChunkedDevice::WriteChunked(int, const void* buffer, size_t count)
 
         /* Calculate how much data we can fit into the just freshly created
          * chunk. */
-        bytes_left = MIN((ssize_t)(count - offset),
+        bytes_left = MIN(((ssize_t)count - offset),
                          (ssize_t)((current_chunk_->end_offset
                                     - current_chunk_->start_offset)
                                    + 1));


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

While compiling a debian package for armhf (32bit) I encountered two errors.

The first errors in `src/stored/backends/chunked_device.cc` :
```
core/src/stored/backends/chunked_device.cc: In member function ‘ssize_t storagedaemon::ChunkedDevice::ReadChunked(int, void*, size_t)’:
core/src/include/bc_types.h:113:26: error: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Werror=sign-compare]
  113 | #  define MIN(a, b) ((a) < (b) ? (a) : (b))
      |                      ~~~~^~~~~
core/src/stored/backends/chunked_device.cc:685:13: note: in expansion of macro ‘MIN’
  685 |           = MIN((ssize_t)count, (current_chunk_->buflen - wanted_offset));
      |             ^~~
core/src/stored/backends/chunked_device.cc: In member function ‘ssize_t storagedaemon::ChunkedDevice::WriteChunked(int, const void*, size_t)’:
core/src/stored/backends/chunked_device.cc:846:46: error: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘int’} and ‘uint32_t’ {aka ‘unsigned int’} [-Werror=sign-compare]
  846 |             if ((wanted_offset + bytes_left) > current_chunk_->buflen) {
```

These errors are likely caused because the casts were just forgotten. There are multiple similar code lines around the locations with the appropriate casts.


The second error in `core/src/stored/backends/dedupable/volume.cc`:

```
core/src/stored/backends/dedupable/volume.cc: In constructor ‘dedup::data::data(dedup::{anonymous}::open_context, const dedup::config&)’:
core/src/stored/backends/dedupable/volume.cc:231:61: error: narrowing conversion of ‘(uint64_t)bf.dedup::config::block_file::End’ from ‘uint64_t’ {aka ‘long long unsigned int’} to ‘dedup::fvec<dedup::block>::size_type’ {aka ‘unsigned int’} [-Werror=narrowing]
  231 |   blocks = decltype(blocks){ctx.read_only, bfd.fileno(), bf.End};
      |                                                          ~~~^~~
core/src/stored/backends/dedupable/volume.cc:232:59: error: narrowing conversion of ‘(uint64_t)pf.dedup::config::part_file::End’ from ‘uint64_t’ {aka ‘long long unsigned int’} to ‘dedup::fvec<dedup::part>::size_type’ {aka ‘unsigned int’} [-Werror=narrowing]
  232 |   parts = decltype(parts){ctx.read_only, pfd.fileno(), pf.End};
      |                                                        ~~~^~~
```
These are errors in the new Dedupable Storage Backend. The pull request does not alter any data types of any field because I believe that the dedup::config structures are directly serialized into the files on the storage. So the implementation simply throws. if the config contains values that are too large.

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [X] Is the PR title usable as CHANGELOG entry?
- [X] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [X] Correct milestone is set

##### Source code quality
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR
