### PR TITLE
VMware plugin: fix check_mac_address() for vm.config not present

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -196,6 +196,7 @@ Stephan Duehr
 Stephan Sedlmeier
 Stev Dubau
 Sébastien Marchal
+Sébastien Wenske
 Thomas Duemesnil
 Thomas Glatthor
 Thomas Lohman

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -3124,6 +3124,13 @@ class BareosVADPWrapper(object):
         vm_view.Destroy()
 
         for vm in all_vms:
+            if vm.config is None:
+                bareosfd.DebugMessage(
+                    100,
+                    "cannot read vm.config from VM %s\n" % (vm.name),
+                )
+                continue
+
             for dev in vm.config.hardware.device:
                 if isinstance(dev, vim.vm.device.VirtualEthernetCard):
                     if dev.macAddress not in all_mac_addr:


### PR DESCRIPTION
**Backport of PR #2059 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

#### Backport quality
- [ ] Original PR #2059 is merged
- [ ] All functional differences to the original PR are documented above
