### PR TITLE
VMware plugin: fix check_mac_address() for vm.config not present

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -192,6 +192,7 @@ Stephan Duehr
 Stephan Sedlmeier
 Stev Dubau
 Sébastien Marchal
+Sébastien Wenske
 Thomas Duemesnil
 Thomas Glatthor
 Thomas Lohman

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - bareos-config-libs: double quote dbconfig values [PR #2134]
 - windows: fix readlink buffer size issue [PR #2162]
 - stored: fix crash when using jit reservation with no matching device; fix reservation error [PR #2185]
+- VMware plugin: fix check_mac_address() for vm.config not present [PR #2178]
 
 ## [23.1.1] - 2024-12-02
 
@@ -620,6 +621,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2074]: https://github.com/bareos/bareos/pull/2074
 [PR #2134]: https://github.com/bareos/bareos/pull/2134
 [PR #2162]: https://github.com/bareos/bareos/pull/2162
+[PR #2178]: https://github.com/bareos/bareos/pull/2178
 [PR #2183]: https://github.com/bareos/bareos/pull/2183
 [PR #2185]: https://github.com/bareos/bareos/pull/2185
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -3210,6 +3210,13 @@ class BareosVADPWrapper(object):
         vm_view.Destroy()
 
         for vm in all_vms:
+            if vm.config is None:
+                bareosfd.DebugMessage(
+                    100,
+                    "cannot read vm.config from VM %s\n" % (vm.name),
+                )
+                continue
+
             for dev in vm.config.hardware.device:
                 if isinstance(dev, vim.vm.device.VirtualEthernetCard):
                     if dev.macAddress not in all_mac_addr:


### PR DESCRIPTION
**Backport of PR #2059 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2059 is merged
- [x] All functional differences to the original PR are documented above
