### PR TITLE
VMware Plugin: Fix CBT query handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 - macos: update build environment [PR #2074]
 - dedupable device: fix example files [PR #2034]
 - NDMP_NATIVE: enable full restore, eject tape before unload, enable update of NDMP environment [PR #2017]
+- VMware Plugin: Fix CBT query handling [PR #2183]
 
 ### Fixed
 - plugins: postgresql add support for PostgreSQL 17 + improvements [PR #2049]
@@ -618,4 +619,5 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 [PR #2074]: https://github.com/bareos/bareos/pull/2074
 [PR #2134]: https://github.com/bareos/bareos/pull/2134
 [PR #2162]: https://github.com/bareos/bareos/pull/2162
+[PR #2183]: https://github.com/bareos/bareos/pull/2183
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -39,7 +39,7 @@ import hashlib
 import re
 import traceback
 from sys import version_info
-import urllib3.util
+import urllib3
 import requests
 
 try:
@@ -3418,6 +3418,7 @@ class BareosVADPWrapper(object):
         verify_cert = True
         if self.options.get("verifyssl") != "yes":
             verify_cert = False
+            urllib3.disable_warnings()
         cookie = self._get_cookie_from_si()
         request_params = {}
         request_params["dsName"] = datastore_name
@@ -3459,6 +3460,7 @@ class BareosVADPWrapper(object):
         verify_cert = True
         if self.options.get("verifyssl") != "yes":
             verify_cert = False
+            urllib3.disable_warnings()
         cookie = self._get_cookie_from_si()
         request_params = {}
         request_params["dsName"] = datastore_name

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -23,6 +23,13 @@ Status
 
 The Plugin can do full, differential and incremental backup and restore of VM disks.
 
+Since :sinceVersion:`24.0.1: VMware Plugin` Previous versions of this plugin may have produced
+incomplete backups, because the CBT information was not retrieved completely in cases where
+the amount of changes was high, especially differential and incremental jobs were affected
+more probably. The issue is fixed in this version. To ensure consistent backups, it is recommended
+to run new full level jobs, as backups taken with previous versions may have an inconsonsistent
+state when restored.
+
 Since :sinceVersion:`23.0.3: VMware Plugin` the NVRAM of VMs is backed up and restored when recreating a VM to ensure it can boot without issues even when EFI enabled.
 
 Since :sinceVersion:`23.0.0: VMware Plugin` the performance is improved and the cleanup of snapshots is enhanced.


### PR DESCRIPTION
**Backport of PR #2152 to bareos-23**

This PR does _not_ contain the changes to `reschedule_job_as_full.sh` as that file was not backported to 23 to begin with. 

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2152 is merged
- [x] All functional differences to the original PR are documented above
