### PR TITLE
stored: fix crash when using jit reservation with no matching device; fix reservation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- stored: fix crash when using jit reservation with no matching device; fix reservation error [PR #2184]
+
 ## [24.0.1] - 2025-02-24
 
 ### Attention VMware users
@@ -394,4 +397,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2164]: https://github.com/bareos/bareos/pull/2164
 [PR #2172]: https://github.com/bareos/bareos/pull/2172
 [PR #2182]: https://github.com/bareos/bareos/pull/2182
+[PR #2184]: https://github.com/bareos/bareos/pull/2184
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/acquire.cc
+++ b/core/src/stored/acquire.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2013 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -355,7 +355,7 @@ bool AcquireDeviceForRead(DeviceControlRecord* dcr)
         try_autochanger = true; /* permit trying the autochanger again */
 
         continue; /* try reading again */
-    }             /* end switch */
+    } /* end switch */
     break;
   } /* end while loop */
 
@@ -409,7 +409,6 @@ DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr)
   Device* dev = dcr->dev;
   JobControlRecord* jcr = dcr->jcr;
   bool retval = false;
-  bool have_vol = false;
 
   Enter(200);
   InitDeviceWaitTimers(dcr);
@@ -430,21 +429,8 @@ DeviceControlRecord* AcquireDeviceForAppend(DeviceControlRecord* dcr)
 
   dev->ClearUnload();
 
-  /* have_vol defines whether or not MountNextWriteVolume should
-   * ask the Director again about what Volume to use. */
-  if (dev->CanAppend() && dcr->IsSuitableVolumeMounted()
-      && !bstrcmp(dcr->VolCatInfo.VolCatStatus, "Recycle")) {
-    Dmsg0(190, "device already in append.\n");
-    /* At this point, the correct tape is already mounted, so
-     * we do not need to do MountNextWriteVolume(), unless
-     * we need to recycle the tape. */
-    if (dev->num_writers == 0) {
-      dev->VolCatInfo = dcr->VolCatInfo; /* structure assignment */
-    }
-    have_vol = dcr->IsTapePositionOk();
-  }
 
-  if (!have_vol) {
+  {
     dev->rLock(true);
     BlockDevice(dev, BST_DOING_ACQUIRE);
     dev->Unlock();

--- a/core/src/stored/append.cc
+++ b/core/src/stored/append.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -252,6 +252,8 @@ static bool SetupDCR(JobControlRecord* jcr,
       Jmsg(jcr, M_INFO, 0, T_("Using Device %s to write.\n"),
            jcr->sd_impl->dcr->dev->print_name());
     } else {
+      FreeDeviceControlRecord(jcr->sd_impl->dcr);
+      jcr->sd_impl->dcr = nullptr;
       Jmsg(jcr, M_FATAL, 0, T_("Could not reserve any device for this job.\n"));
       return false;
     }
@@ -515,6 +517,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
         Jmsg(jcr, M_INFO, 0,
              T_("JustInTime Reservation: Finding drive to reserve.\n"));
         if (!SetupDCR(jcr, current_volumeid, current_block_number)) {
+          Jmsg(jcr, M_FATAL, 0, T_("Unable to setup device for this job.\n"));
           ok = false;
           break;
         }
@@ -668,7 +671,7 @@ bool DoAppendData(JobControlRecord* jcr, BareosSocket* bs, const char* what)
 
     // Release the device -- and send final Vol info to DIR and unlock it.
     ReleaseDevice(jcr->sd_impl->dcr);
-  } else {
+  } else if (ok) {
     Jmsg(jcr, M_INFO, 0,
          "Because no backup data was received, no device was reserved. As such "
          "no Session Labels were written for this job.\n");

--- a/core/src/stored/device_control_record.h
+++ b/core/src/stored/device_control_record.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -186,7 +186,6 @@ class DeviceControlRecord {
   void mark_volume_not_inchanger();
   int TryAutolabel(bool opened);
   bool find_a_volume();
-  bool IsSuitableVolumeMounted();
   bool is_eod_valid();
   int CheckVolumeLabel(bool& ask, bool& autochanger);
   void ReleaseVolume();


### PR DESCRIPTION
**Backport of PR #2141 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

#### Backport quality
- [x] Original PR #2141 is merged
- [X] All functional differences to the original PR are documented above
