### PR TITLE
stored: implicitly create autochanger from device

### DIFF
--- a/core/src/stored/autochanger_resource.cc
+++ b/core/src/stored/autochanger_resource.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,10 +22,10 @@
 */
 
 #include "stored/autochanger_resource.h"
+#include "stored_conf.h"
 #include "lib/alist.h"
 #include "stored/device_resource.h"
 #include "stored/stored_globals.h"
-
 namespace storagedaemon {
 
 AutochangerResource::AutochangerResource()
@@ -34,6 +34,8 @@ AutochangerResource::AutochangerResource()
     , changer_name(nullptr)
     , changer_command(nullptr)
 {
+  rcode_ = R_AUTOCHANGER;
+  rcode_str_ = "Autochanger";
   return;
 }
 

--- a/core/src/stored/autochanger_resource.h
+++ b/core/src/stored/autochanger_resource.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -42,11 +42,11 @@ class AutochangerResource : public BareosResource {
                    bool verbose = false) override;
 
 
-  alist<DeviceResource*>*
-      device_resources;   /**< List of DeviceResource device pointers */
-  char* changer_name;     /**< Changer device name */
-  char* changer_command;  /**< Changer command  -- external program */
-  brwlock_t changer_lock; /**< One changer operation at a time */
+  alist<DeviceResource*>* device_resources{
+      nullptr};                   /**< List of DeviceResource device pointers */
+  char* changer_name{nullptr};    /**< Changer device name */
+  char* changer_command{nullptr}; /**< Changer command  -- external program */
+  brwlock_t changer_lock;         /**< One changer operation at a time */
 };
 } /* namespace storagedaemon */
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -432,38 +432,88 @@ static void ParseConfigCb(LEX* lc,
   }
 }
 
-static void MultiplyDevice(DeviceResource& multiplied_device_resource)
+static DeviceResource* CopyDevice(DeviceResource& original, int serial_number)
 {
-  /* append 0001 to the name of the existing resource */
-  multiplied_device_resource.CreateAndAssignSerialNumber(1);
+  DeviceResource* copy = new DeviceResource(original);
+  copy->CreateAndAssignSerialNumber(serial_number);
+  copy->multiplied_device_resource = std::addressof(original);
+  copy->count = 0;
+  copy->refcnt_ = 1;
+  if (copy->changer_res && copy->changer_res->device_resources) {
+    copy->changer_res->device_resources->append(copy);
+  }
 
-  multiplied_device_resource.multiplied_device_resource
-      = std::addressof(multiplied_device_resource);
+  return copy;
+}
+static void MultiplyDevice(DeviceResource& original,
+                           ConfigurationParser& config)
+{
+  // create device 0
+  std::string device0_name = original.resource_name_ + std::string("0000");
+  DeviceResource* device0 = dynamic_cast<DeviceResource*>(
+      config.GetResWithName(R_DEVICE, device0_name.c_str()));
+  if (!device0) {
+    device0 = CopyDevice(original, 0);
+    device0->autoselect = false;
+    config.AppendToResourcesChain(device0, device0->rcode_);
+  } else {
+    Dmsg0(0,
+          "Device resource \"%s\" will not implicitly create device \"%s\" "
+          "resource since there already exists a device resource with that "
+          "name.\n",
+          original.resource_name_, device0_name.c_str());
+  }
 
-  uint32_t count = multiplied_device_resource.count - 1;
+  // create autochanger
+  if (!original.changer_res) {
+    original.changer_res = new AutochangerResource();
+    original.changer_res->resource_name_
+        = strdup((original.resource_name_ + std::string("Changer")).c_str());
+    original.changer_res->changer_name = strdup("dev/null");
+    original.changer_res->changer_command = strdup("");
+    original.changer_res->device_resources = new alist<DeviceResource*>();
+    original.changer_res->device_resources->append(device0);
+    original.changer_res->device_resources->append(std::addressof(original));
+    original.changer_res->rcode_ = R_AUTOCHANGER;
+    original.changer_res->rcode_str_ = "Autochanger";
+    original.changer_res->refcnt_ = 1;
 
-  /* create the copied devices */
-  for (uint32_t i = 0; i < count; i++) {
-    DeviceResource* copied_device_resource
-        = new DeviceResource(multiplied_device_resource);
+    if (!config.GetResWithName(R_AUTOCHANGER,
+                               original.changer_res->resource_name_)) {
+      config.AppendToResourcesChain(original.changer_res, R_AUTOCHANGER);
+    } else {
+      Emsg0(M_WARNING, 0,
+            "Device resource \"%s\" will not implicitly create an autochanger "
+            "resource \"%s\" since an autochanger resource with that name "
+            "already exists.\n",
+            original.resource_name_, original.changer_res->resource_name_);
+    }
+  } else {
+    Dmsg0(0,
+          "Device resource \"%s\" will not implicitly create an autochanger "
+          "resource since it is already used by autochanger resource \"%s\".\n",
+          original.resource_name_, original.changer_res->resource_name_);
+  }
 
-    /* append 0002, 0003, ... */
-    copied_device_resource->CreateAndAssignSerialNumber(i + 2);
-
-    copied_device_resource->multiplied_device_resource
-        = std::addressof(multiplied_device_resource);
-    copied_device_resource->count = 0;
-
-    my_config->AppendToResourcesChain(copied_device_resource,
-                                      copied_device_resource->rcode_);
-
-    if (copied_device_resource->changer_res) {
-      if (copied_device_resource->changer_res->device_resources) {
-        copied_device_resource->changer_res->device_resources->append(
-            copied_device_resource);
-      }
+  // create devices 2 - count
+  for (uint32_t i = 2; i <= original.count; i++) {
+    std::string serial_number = std::string("0000") + std::to_string(i);
+    std::string copy_name = original.resource_name_
+                            + serial_number.substr(serial_number.size() - 4);
+    if (!config.GetResWithName(R_DEVICE, copy_name.c_str())) {
+      DeviceResource* copy = CopyDevice(original, i);
+      config.AppendToResourcesChain(copy, copy->rcode_);
+    } else {
+      Dmsg0(0,
+            "Device resource \"%s\" will not implicitly create device \"%s\" "
+            "resource since there already exists a device resource with that "
+            "name.\n",
+            original.resource_name_, copy_name.c_str());
     }
   }
+  // create device 1
+  original.CreateAndAssignSerialNumber(1);
+  original.multiplied_device_resource = std::addressof(original);
 }
 
 static void MultiplyConfiguredDevices(ConfigurationParser& config)
@@ -471,7 +521,7 @@ static void MultiplyConfiguredDevices(ConfigurationParser& config)
   BareosResource* p = nullptr;
   while ((p = config.GetNextRes(R_DEVICE, p))) {
     DeviceResource& d = dynamic_cast<DeviceResource&>(*p);
-    if (d.count > 1) { MultiplyDevice(d); }
+    if (d.count > 1) { MultiplyDevice(d, config); }
   }
 }
 


### PR DESCRIPTION
automatically create autochanger and reserved device 0000 if the device resource has directive count != 1

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
