### PR TITLE
cleanup: fix multi-config tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stored: fix crash when using jit reservation with no matching device; fix reservation error [PR #2141]
 - Fix 32bit compilation [PR #2175]
 - config: fix issues with config directive aliases [PR #2159]
+- cleanup: fix multi-config tests [PR #2202]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -96,4 +97,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2191]: https://github.com/bareos/bareos/pull/2191
 [PR #2192]: https://github.com/bareos/bareos/pull/2192
 [PR #2194]: https://github.com/bareos/bareos/pull/2194
+[PR #2202]: https://github.com/bareos/bareos/pull/2202
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/scripts/cleanup
+++ b/systemtests/scripts/cleanup
@@ -4,7 +4,9 @@ set -u
 #shellcheck source=../environment.in
 . ./environment
 
-"${rscripts}/bareos" stop >/dev/null
+"bin/bareos" status
+"bin/bareos" stop
+"bin/bareos" status
 
 function deletefiles(){
   rm -rf "${tmp:?}"/*

--- a/systemtests/tests/just-in-time-reservation/test-setup
+++ b/systemtests/tests/just-in-time-reservation/test-setup
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -37,7 +37,6 @@ setup_data
 mkdir -p "${archivedir}/remote"
 
 bin/bareos start
-BAREOS_CONFIG_DIR="${BAREOS_CONFIG_DIR}-remote" BAREOS_SD_PORT=${BAREOS_STORAGE2_PORT} "${rscripts}/bareos-ctl-sd" start
 bin/bareos status
 
 # make sure, director is up and running.


### PR DESCRIPTION
Multi-Config tests start multiple sets of daemons (once per config directory).  This is not reflected in  the cleanup code which only stops the daemons of the "main" config.

We can fix this by simply calling `bin/bareos` in the cleanup code as this script handles multi-config tests correctly.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
