### PR TITLE
VMware Plugin: Fix for virtual USB devices

### DIFF
--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -1409,6 +1409,19 @@ class BareosVADPWrapper(object):
         if not self.get_vm_details():
             return bareosfd.bRC_Error
 
+        # check if attempting to backup template
+        if self.vm.config.template is True:
+            bareosfd.DebugMessage(
+                100,
+                "Error VM %s is a template\n" % (StringCodec.encode(self.vm.name)),
+            )
+            bareosfd.JobMessage(
+                bareosfd.M_FATAL,
+                "Error VM %s is a template, backing up templates is currently not possible\n"
+                % (StringCodec.encode(self.vm.name)),
+            )
+            return bareosfd.bRC_Error
+
         # check if the VM supports CBT and that CBT is enabled
         if not self.vm.capability.changeTrackingSupported:
             bareosfd.DebugMessage(

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -23,6 +23,11 @@ Status
 
 The Plugin can do full, differential and incremental backup and restore of VM disks.
 
+Since :sinceVersion:`24.0.3: VMware Plugin` The Plugin can now save and recreate
+VMs with VirtualUSB devices. Note that VirtualUSB devices could disappear when
+powering on the VM and the USB device is attached to a different running VM,
+so a warning message will be emitted when such devices are involved.
+
 Since :sinceVersion:`24.0.1: VMware Plugin` Previous versions of this plugin may have produced
 incomplete backups, because the CBT information was not retrieved completely in cases where
 the amount of changes was high, especially differential and incremental jobs were affected
@@ -70,6 +75,12 @@ Current limitations amongst others are:
    When a disk of a VM was removed and then added again on the same datastore with the same name, or when a CBT reset happened, then the plugin will detect this and request the full level CBT information, and all allocated blocks of that disk will be backed up in an incremental or differential job as if it were a full level job. The restore of such a job will work, but it will take longer than necessary. The backup will terminate with a warning and a recommendation to run a full level job to optimize restore time.
 
    Since :sinceVersion:`23.0.3: VMware Plugin` the plugin option **fallback_to_full_cbt=no** (see below) can be used to disable this and terminate the job with failure instead. This can be useful if it is desired to run a new full level job anyway.
+
+.. limitation:: VMware Plugin: Backup of templates is currently not possible
+
+   It is not possible to backup templates, because taking snapshots is not
+   supported on templates, this makes CBT based backups of template impossible.
+
 
 Requirements
 ^^^^^^^^^^^^


### PR DESCRIPTION
The Plugin can now save and recreate VMs with VirtualUSB devices. Note that VirtualUSB devices could disappear when powering on the VM and the USB device is attached to a different running VM, so a warning message will be emitted when such devices are involved.

Additionally, the plugin now detects if attempting to backup a template and emits an appropriate error message in that case, as this is currently not possible.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR
