### PR TITLE
mssqlvdi-fd: add support for filestream backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Fixed
+- mssqlvdi-fd: add support for filestream backups [PR #2227]
+
 ## [23.1.2] - 2025-03-12
 
 ### Attention VMware users
@@ -636,4 +639,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2183]: https://github.com/bareos/bareos/pull/2183
 [PR #2185]: https://github.com/bareos/bareos/pull/2185
 [PR #2196]: https://github.com/bareos/bareos/pull/2196
+[PR #2227]: https://github.com/bareos/bareos/pull/2227
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/filed/verify.cc
+++ b/core/src/filed/verify.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -374,6 +374,7 @@ static int ReadDigest(BareosFilePacket* bfd,
     if (jcr->is_JobType(JT_VERIFY)) { jcr->JobBytes += n; }
     jcr->ReadBytes += n;
   }
+  Dmsg0(50, "=== ReadDigest END\n");
   if (n < 0) {
     BErrNo be;
     be.SetErrno(bfd->BErrNo);

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2010 Zilvinas Krapavickas <zkrapavickas@gmail.com>
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -939,11 +939,11 @@ static void SetAdoConnectString(PluginContext* ctx)
 
   if (Bstrcasecmp(p_ctx->instance, DEFAULT_INSTANCE)) {
     Mmsg(ado_connect_string,
-         "Provider=SQLOLEDB.1;Data Source=%s;Initial Catalog=master",
+         "Provider=MSOLEDBSQL.1;Data Source=%s;Initial Catalog=master",
          p_ctx->server_address);
   } else {
     Mmsg(ado_connect_string,
-         "Provider=SQLOLEDB.1;Data Source=%s\\%s;Initial Catalog=master",
+         "Provider=MSOLEDBSQL.1;Data Source=%s\\%s;Initial Catalog=master",
          p_ctx->server_address, p_ctx->instance);
   }
 

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -43,6 +43,7 @@
 #include <adoid.h>
 #include <adoint.h>
 #include <stdexcept>
+#include <map>
 
 namespace filedaemon {
 
@@ -123,34 +124,41 @@ static PluginFunctions pluginFuncs
        endBackupFile, startRestoreFile, endRestoreFile, pluginIO, createFile,
        setFileAttributes, checkFile, nullptr, nullptr, nullptr, nullptr};
 
+enum class Mode
+{
+  Backup,
+  Restore,
+};
 // Plugin private context
 struct plugin_ctx {
-  int RestoreFD;
-  bool RestoreToFile;
-  bool DoNoRecovery;
-  bool ForceReplace;
-  bool RecoverAfterRestore;
-  char* plugin_options;
-  char* filename;
-  char* server_address;
-  char* instance;
-  char* database;
-  char* username;
-  char* password;
-  char* stopbeforemark;
-  char* stopatmark;
-  char* stopat;
-  char* ado_connect_string;
-  char* ado_query;
-  char* ado_errorstr;
-  uint32_t get_configuration_timeout;
-  wchar_t* vdsname;
-  int32_t backup_level;
-  IClientVirtualDeviceSet2* VDIDeviceSet;
-  IClientVirtualDevice* VDIDevice;
-  VDConfig VDIConfig;
-  bool AdoThreadStarted;
-  pthread_t ADOThread;
+  int RestoreFD{};
+  bool RestoreToFile{};
+  bool DoNoRecovery{};
+  bool ForceReplace{};
+  bool RecoverAfterRestore{};
+  char* plugin_options{};
+  char* filename{};
+  char* server_address{};
+  char* instance{};
+  char* database{};
+  char* username{};
+  char* password{};
+  char* stopbeforemark{};
+  char* stopatmark{};
+  char* stopat{};
+  char* ado_connect_string{};
+  char* ado_query{};
+  char* ado_errorstr{};
+  uint32_t get_configuration_timeout{};
+  wchar_t* vdsname{};
+  int32_t backup_level{};
+  IClientVirtualDeviceSet2* VDIDeviceSet{};
+  IClientVirtualDevice* VDIDevice{};
+  VDConfig VDIConfig{};
+  bool AdoThreadStarted{};
+  pthread_t ADOThread{};
+  bool completion_support{};
+  std::optional<Mode> mode{};
 };
 
 struct adoThreadContext {
@@ -230,6 +238,29 @@ bRC unloadPlugin() { return bRC_OK; }
 }
 #endif
 
+static const char* explain_hr(DWORD hr)
+{
+  // Return Value	Explanation
+  // NOERROR	A command was fetched.
+  // VD_E_CLOSE	The device has been closed by the server.
+  // VD_E_TIMEOUT	No command was available and the time-out expired.
+  // VD_E_ABORT	Either the client or the server has used the SignalAbort
+  // to force a shutdown.
+  static const std::map<int, const char*> VdiRetVals{
+      {VD_E_CLOSE, "VD_E_CLOSE"},
+      {VD_E_TIMEOUT, "VD_E_TIMEOUT"},
+      {VD_E_ABORT, "VD_E_ABORT"},
+      {NO_ERROR, "NO_ERROR"},
+  };
+
+  if (auto found = VdiRetVals.find(hr); found != VdiRetVals.end()) {
+    return found->second;
+  } else {
+    return "unknown";
+  }
+}
+
+
 /**
  * The following entry points are accessed through the function pointers we
  * supplied to Bareos. Each plugin type (dir, fd, sd) has its own set of entry
@@ -248,15 +279,15 @@ static bRC newPlugin(PluginContext* ctx)
 
   if (!InitializeComSecurity()) { return bRC_Error; }
 
-  p_ctx = (plugin_ctx*)malloc(sizeof(plugin_ctx));
+  p_ctx = new plugin_ctx{};
   if (!p_ctx) { return bRC_Error; }
-  memset(p_ctx, 0, sizeof(plugin_ctx));
   ctx->plugin_private_context = (void*)p_ctx; /* set our context pointer */
 
   // Only register the events we are really interested in.
   bareos_core_functions->registerBareosEvents(
-      ctx, 6, bEventLevel, bEventRestoreCommand, bEventBackupCommand,
-      bEventPluginCommand, bEventEndRestoreJob, bEventNewPluginOptions);
+      ctx, 8, bEventLevel, bEventRestoreCommand, bEventBackupCommand,
+      bEventPluginCommand, bEventEndRestoreJob, bEventNewPluginOptions,
+      bEventStartBackupJob, bEventStartRestoreJob);
 
   return bRC_OK;
 }
@@ -302,7 +333,7 @@ static bRC freePlugin(PluginContext* ctx)
 
   if (p_ctx->ado_query) { free(p_ctx->ado_query); }
 
-  free(p_ctx);
+  delete p_ctx;
   p_ctx = NULL;
 
   // Tear down COM for this thread.
@@ -328,6 +359,14 @@ static bRC handlePluginEvent(PluginContext* ctx, bEvent* event, void* value)
   if (!p_ctx) { return bRC_Error; }
 
   switch (event->eventType) {
+    case bEventStartBackupJob: {
+      p_ctx->mode = Mode::Backup;
+      retval = bRC_OK;
+    } break;
+    case bEventStartRestoreJob: {
+      p_ctx->mode = Mode::Restore;
+      retval = bRC_OK;
+    } break;
     case bEventLevel:
       p_ctx->backup_level = (int64_t)value;
       retval = bRC_OK;
@@ -712,8 +751,8 @@ static void comReportError(PluginContext* ctx, HRESULT hrErr)
   source = BSTR_2_str(pSource);
   description = BSTR_2_str(pDescription);
   if (source && description) {
-    Jmsg(ctx, M_FATAL, "%s(x%X): %s\n", source, hrErr, description);
-    Dmsg(ctx, debuglevel, "%s(x%X): %s\n", source, hrErr, description);
+    Jmsg(ctx, M_FATAL, "%s(0x%X): %s\n", source, hrErr, description);
+    Dmsg(ctx, debuglevel, "%s(0x%X): %s\n", source, hrErr, description);
   } else {
     Dmsg(ctx, debuglevel, "mssqlvdi-fd: could not print error\n");
   }
@@ -1177,6 +1216,25 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
     return false;
   }
 
+  if (!p_ctx->mode.has_value()) {
+    Jmsg(ctx, M_FATAL, "No Backup/Restore Mode was specified\n");
+    return false;
+  }
+
+  if (io->flags & (O_CREAT | O_WRONLY)) {
+    Dmsg(ctx, debuglevel, "mssqlvdi-fd: creating restore vdi device\n");
+    if (p_ctx->mode.value() != Mode::Restore) {
+      Jmsg(ctx, M_FATAL, "Wrong [Backup]/Restore Mode was specified\n");
+      return false;
+    }
+  } else {
+    Dmsg(ctx, debuglevel, "mssqlvdi-fd: creating backup vdi device\n");
+    if (p_ctx->mode.value() != Mode::Backup) {
+      Jmsg(ctx, M_FATAL, "Wrong Backup/[Restore] Mode was specified\n");
+      return false;
+    }
+  }
+
   CoCreateGuid(&vdsId);
   p_ctx->vdsname = (wchar_t*)malloc((VDS_NAME_LENGTH * sizeof(wchar_t)) + 2);
   StringFromGUID2(vdsId, p_ctx->vdsname, VDS_NAME_LENGTH);
@@ -1195,6 +1253,14 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
   memset(&p_ctx->VDIConfig, 0, sizeof(p_ctx->VDIConfig));
   p_ctx->VDIConfig.deviceCount = 1;
   p_ctx->VDIConfig.features = VDF_LikePipe;
+  if (p_ctx->mode.value() == Mode::Backup) {
+    // for proper filestream backup support we need to distinguish between
+    // a VDC_Flush command and the end of the backup.  We do this
+    // by relying on VDC_Complete if its available.
+    // If its not available, we are not able to correctly handle a VDC_Flush
+    // in the middle of a backup.
+    p_ctx->VDIConfig.features |= VDF_RequestComplete;
+  }
 
   // Create the VDI device set.
   if (Bstrcasecmp(p_ctx->instance, DEFAULT_INSTANCE)) {
@@ -1215,10 +1281,13 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
   }
 
   // Setup the right backup or restore cmdline and connect info.
-  if (io->flags & (O_CREAT | O_WRONLY)) {
-    perform_aDoRestore(ctx);
-  } else {
-    PerformAdoBackup(ctx);
+  switch (p_ctx->mode.value()) {
+    case Mode::Restore: {
+      perform_aDoRestore(ctx);
+    } break;
+    case Mode::Backup: {
+      PerformAdoBackup(ctx);
+    } break;
   }
 
   /* Ask the database server to start a backup or restore via another thread.
@@ -1267,6 +1336,20 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
     const char* fmt
         = "mssqlvdi-fd: IClientVirtualDeviceSet2::GetConfiguration "
           "%s: %0#x (%s)\n";
+
+    if (!(p_ctx->VDIConfig.features & VDF_CompleteEnabled)) {
+      if (p_ctx->mode.value() == Mode::Backup) {
+        Jmsg(ctx, M_INFO,
+             "VDI does not support VDC_Complete."
+             " Backing up Filestreams are not supported\n.");
+      }
+      p_ctx->completion_support = false;
+    } else {
+      p_ctx->completion_support = true;
+    }
+
+    Dmsg(ctx, debuglevel, "completion_support = %s\n",
+         p_ctx->completion_support ? "Yes" : "No");
 
     if (success) {
       snprintf(error_msg.data(), error_msg.size(), fmt, "successful",
@@ -1440,6 +1523,9 @@ const char* command_name(DWORD commandCode)
     case VDC_FileInfoEnd: {
       return "file-info-end";
     }
+    case VDC_Complete: {
+      return "complete";
+    }
     default: {
       return "unknown";
     }
@@ -1455,69 +1541,90 @@ static inline bool PerformVdiIo(PluginContext* ctx,
   VDC_Command* cmd;
   plugin_ctx* p_ctx = (plugin_ctx*)ctx->plugin_private_context;
 
-  // See what command is available on the VDIDevice.
-  hr = p_ctx->VDIDevice->GetCommand(VDI_WAIT_TIMEOUT, &cmd);
-  if (!SUCCEEDED(hr)) {
-    Jmsg(ctx, M_ERROR, "mssqlvdi-fd: IClientVirtualDevice::GetCommand: x%X\n",
-         hr);
-    Dmsg(ctx, debuglevel,
-         "mssqlvdi-fd: IClientVirtualDevice::GetCommand: x%X\n", hr);
-    goto bail_out;
-  }
-
-
-  Dmsg(ctx, debuglevel, "mssqlvdi-fd: Command: %d:%s (size=%d)\n",
-       cmd->commandCode, command_name(cmd->commandCode), cmd->size);
-
-  switch (cmd->commandCode) {
-    case VDC_Read:
-      Dmsg(ctx, debuglevel, "mssqlvdi-fd: Read: %d bytes\n", cmd->size);
-      /* Make sure the write to the VDIDevice will fit e.g. not a to big IO and
-       * that we are currently writing to the device. */
-      if ((DWORD)io->count > cmd->size || io->func != IO_WRITE) {
-        *completionCode = ERROR_BAD_ENVIRONMENT;
-        goto bail_out;
-      } else {
-        memcpy(cmd->buffer, io->buf, io->count);
-        io->status = io->count;
-        *completionCode = ERROR_SUCCESS;
-      }
-      break;
-    case VDC_Write:
-      Dmsg(ctx, debuglevel, "mssqlvdi-fd: Write: %d bytes\n", cmd->size);
-      /* Make sure the read from the VDIDevice will fit e.g. not a to big IO and
-       * that we are currently reading from the device. */
-      if (cmd->size > (DWORD)io->count || io->func != IO_READ) {
-        *completionCode = ERROR_BAD_ENVIRONMENT;
-        goto bail_out;
-      } else {
-        memcpy(io->buf, cmd->buffer, cmd->size);
-        io->status = cmd->size;
-        *completionCode = ERROR_SUCCESS;
-      }
-      break;
-    case VDC_Flush:
-      Dmsg(ctx, debuglevel, "mssqlvdi-fd: Flush\n");
-      io->status = 0;
-      *completionCode = ERROR_SUCCESS;
-      break;
-    case VDC_ClearError:
-      Dmsg(ctx, debuglevel, "mssqlvdi-fd: ClearError\n");
-      *completionCode = ERROR_SUCCESS;
-      break;
-    default:
-      Dmsg(ctx, debuglevel, "mssqlvdi-fd: Unknown = %d\n", cmd->commandCode);
-      *completionCode = ERROR_NOT_SUPPORTED;
+  bool quit = false;
+  while (!quit) {
+    // See what command is available on the VDIDevice.
+    hr = p_ctx->VDIDevice->GetCommand(VDI_WAIT_TIMEOUT, &cmd);
+    if (!SUCCEEDED(hr)) {
+      auto* explanation = explain_hr(hr);
+      Jmsg(ctx, M_ERROR,
+           "mssqlvdi-fd: IClientVirtualDevice::GetCommand: Err=%s (0x%X)\n",
+           explanation, hr);
+      Dmsg(ctx, debuglevel,
+           "mssqlvdi-fd: IClientVirtualDevice::GetCommand: Err=%s (0x%X)\n",
+           explanation, hr);
       goto bail_out;
-  }
+    }
 
-  hr = p_ctx->VDIDevice->CompleteCommand(cmd, *completionCode, io->status, 0);
-  if (!SUCCEEDED(hr)) {
-    Jmsg(ctx, M_ERROR,
-         "mssqlvdi-fd: IClientVirtualDevice::CompleteCommand: x%X\n", hr);
-    Dmsg(ctx, debuglevel,
-         "mssqlvdi-fd: IClientVirtualDevice::CompleteCommand: x%X\n", hr);
-    goto bail_out;
+
+    Dmsg(ctx, debuglevel, "mssqlvdi-fd: Command: %d:%s (size=%d)\n",
+         cmd->commandCode, command_name(cmd->commandCode), cmd->size);
+
+    switch (cmd->commandCode) {
+      case VDC_Read:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: Read: %d bytes\n", cmd->size);
+        /* Make sure the write to the VDIDevice will fit e.g. not a too big IO
+         * and that we are currently writing to the device. */
+        if ((DWORD)io->count > cmd->size || io->func != IO_WRITE) {
+          *completionCode = ERROR_BAD_ENVIRONMENT;
+          goto bail_out;
+        } else {
+          memcpy(cmd->buffer, io->buf, io->count);
+          io->status = io->count;
+          *completionCode = ERROR_SUCCESS;
+        }
+        quit = true;
+        break;
+      case VDC_Write:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: Write: %d bytes\n", cmd->size);
+        /* Make sure the read from the VDIDevice will fit e.g. not a too big IO
+         * and that we are currently reading from the device. */
+        if (cmd->size > (DWORD)io->count || io->func != IO_READ) {
+          *completionCode = ERROR_BAD_ENVIRONMENT;
+          goto bail_out;
+        } else {
+          memcpy(io->buf, cmd->buffer, cmd->size);
+          io->status = cmd->size;
+          *completionCode = ERROR_SUCCESS;
+        }
+        quit = true;
+        break;
+      case VDC_Flush:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: Flush\n");
+        io->status = 0;
+        *completionCode = ERROR_SUCCESS;
+        if (!p_ctx->completion_support) { quit = true; }
+        break;
+      case VDC_ClearError:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: ClearError\n");
+        *completionCode = ERROR_SUCCESS;
+        break;
+      case VDC_Complete:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: Complete\n");
+        io->status = 0;
+        *completionCode = ERROR_SUCCESS;
+        quit = true;
+        break;
+      default:
+        Dmsg(ctx, debuglevel, "mssqlvdi-fd: Unknown = %d\n", cmd->commandCode);
+        *completionCode = ERROR_NOT_SUPPORTED;
+        quit = true;
+        goto bail_out;
+    }
+
+    hr = p_ctx->VDIDevice->CompleteCommand(cmd, *completionCode, io->status, 0);
+    if (!SUCCEEDED(hr)) {
+      auto* explanation = explain_hr(hr);
+      Jmsg(
+          ctx, M_ERROR,
+          "mssqlvdi-fd: IClientVirtualDevice::CompleteCommand: Err=%s (0x%X)\n",
+          explanation, hr);
+      Dmsg(
+          ctx, debuglevel,
+          "mssqlvdi-fd: IClientVirtualDevice::CompleteCommand: Err=%s (0x%X)\n",
+          explanation, hr);
+      goto bail_out;
+    }
   }
 
   io->io_errno = 0;
@@ -1527,7 +1634,7 @@ static inline bool PerformVdiIo(PluginContext* ctx,
   return true;
 
 bail_out:
-  Dmsg(ctx, debuglevel, "mssqlvdi-fd: IO: reached bailout ...\n", cmd->size);
+  Dmsg(ctx, debuglevel, "mssqlvdi-fd: IO: reached bailout ...\n");
   // Report any COM errors.
   comReportError(ctx, hr);
 
@@ -1554,30 +1661,8 @@ static inline bool TearDownVdiDevice(PluginContext* ctx, io_pkt* io)
 
   // Check if the VDI device is closed.
   if (p_ctx->VDIDevice) {
-    // Return Value	Explanation
-    // NOERROR	A command was fetched.
-    // VD_E_CLOSE	The device has been closed by the server.
-    // VD_E_TIMEOUT	No command was available and the time-out expired.
-    // VD_E_ABORT	Either the client or the server has used the SignalAbort
-    // to force a shutdown.
-    static const std::map<int, std::string> VdiRetVals{
-        {VD_E_CLOSE, "VD_E_CLOSE"},
-        {VD_E_TIMEOUT, "VD_E_TIMEOUT"},
-        {VD_E_ABORT, "VD_E_ABORT"},
-        {NO_ERROR, "NO_ERROR"},
-    };
-
-    std::string error_string;
-
   tryagain:
     hr = p_ctx->VDIDevice->GetCommand(VDI_WAIT_TIMEOUT, &cmd);
-    if (auto found = VdiRetVals.find(hr); found != VdiRetVals.end()) {
-      error_string = found->second.c_str();
-    } else {
-      error_string = "Unknown error (res=";
-      error_string += std::to_string(hr);
-      error_string += ")";
-    }
 
     if (hr == NO_ERROR) {
       // we got another command for some reason
@@ -1603,8 +1688,14 @@ static inline bool TearDownVdiDevice(PluginContext* ctx, io_pkt* io)
     }
 
     if (hr != VD_E_CLOSE) {
-      Jmsg(ctx, M_ERROR, "Abnormal termination, VDIDevice not closed.\n");
-      Dmsg(ctx, debuglevel, "Abnormal termination, VDIDevice not closed.\n");
+      auto* explanation = explain_hr(hr);
+
+      Jmsg(ctx, M_ERROR,
+           "Abnormal termination, VDIDevice not closed. Err=%s (0x%X)\n",
+           explanation, hr);
+      Dmsg(ctx, debuglevel,
+           "Abnormal termination, VDIDevice not closed. Err=%s (0x%X)\n",
+           explanation, hr);
       goto bail_out;
     }
   }

--- a/core/src/win32/vdi/include/vdi.h
+++ b/core/src/win32/vdi/include/vdi.h
@@ -161,8 +161,10 @@ enum VDFeatures
   VDF_SnapshotPrepare = 0x400,
   VDF_EnumFrozenFiles = 0x800,
   VDF_VSSWriter = 0x1000,
+  VDF_RequestComplete = 0x2000,
   VDF_WriteMedia = 0x10000,
   VDF_ReadMedia = 0x20000,
+  VDF_CompleteEnabled = 0x40000,
   VDF_LatchStats = 0x80000000,
   VDF_LikePipe = 0,
   VDF_LikeTape
@@ -190,7 +192,9 @@ enum VDCommands
   VDC_MountSnapshot = (VDC_Snapshot + 1),
   VDC_PrepareToFreeze = (VDC_MountSnapshot + 1),
   VDC_FileInfoBegin = (VDC_PrepareToFreeze + 1),
-  VDC_FileInfoEnd = (VDC_FileInfoBegin + 1)
+  VDC_FileInfoEnd = (VDC_FileInfoBegin + 1),
+  VDC_GetError = (VDC_FileInfoEnd + 1),
+  VDC_Complete = (VDC_GetError + 1)
 };
 
 enum VDWhence


### PR DESCRIPTION
**Backport of PR #2072 to bareos-23**

This backport only contains the code changes to the plugin itself.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2072 is merged
- [X] All functional differences to the original PR are documented above
