### PR TITLE
cmake: fix not including BareosTargetTools in systemtests, needed for get_target_output_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - config: fix issues with config directive aliases [PR #2159]
 - cleanup: fix multi-config tests [PR #2202]
 - mssqlvdi-fd: add support for filestream backups [PR #2072]
+- cmake: fix not including BareosTargetTools in systemtests, needed for get_target_output_dir [PR #2232]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -110,4 +111,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2202]: https://github.com/bareos/bareos/pull/2202
 [PR #2211]: https://github.com/bareos/bareos/pull/2211
 [PR #2220]: https://github.com/bareos/bareos/pull/2220
+[PR #2232]: https://github.com/bareos/bareos/pull/2232
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -85,6 +85,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(BareosTargetTools)
 include(BareosSystemtestFunctions)
 
 # ps is required for systemtests


### PR DESCRIPTION
in systemtests/cmake/BareosSystemtestFunctions.cmake.

Only needed if GTest is not available, otherwise provided via core/src/tests/CMakeLists.txt.

Also needed for branch bareos-24.

Fixes #2231

Trivial change, no need to mention me in AUTHORS.

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
~~Your name is present in the AUTHORS file (optional)~~

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR