### PR TITLE
cmake: fix not including BareosTargetTools in systemtests, needed for get_target_output_dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- cmake: fix not including BareosTargetTools in systemtests, needed for get_target_output_dir [PR #2235]
+
 ## [24.0.2] - 2025-03-27
 
 ### Fixed
@@ -425,4 +428,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2221]: https://github.com/bareos/bareos/pull/2221
 [PR #2223]: https://github.com/bareos/bareos/pull/2223
 [PR #2229]: https://github.com/bareos/bareos/pull/2229
+[PR #2235]: https://github.com/bareos/bareos/pull/2235
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -85,6 +85,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(BareosTargetTools)
 include(BareosSystemtestFunctions)
 
 # ps is required for systemtests


### PR DESCRIPTION
**Backport of PR #2232 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2232 is merged
- [x] All functional differences to the original PR are documented above
