### PR TITLE
dplcompat: fix unsupported size-suffixes on chunksize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - postgresql: require non-ssl connection [PR #2272]
 - fix problems with msvc 19.44 [PR #2287]
 - plugins: fix error_string construction [PR #2273]
+- dplcompat: fix unsupported size-suffixes on chunksize [PR #2240]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -142,6 +143,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2222]: https://github.com/bareos/bareos/pull/2222
 [PR #2225]: https://github.com/bareos/bareos/pull/2225
 [PR #2232]: https://github.com/bareos/bareos/pull/2232
+[PR #2240]: https://github.com/bareos/bareos/pull/2240
 [PR #2241]: https://github.com/bareos/bareos/pull/2241
 [PR #2252]: https://github.com/bareos/bareos/pull/2252
 [PR #2256]: https://github.com/bareos/bareos/pull/2256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,12 @@ set(CMAKE_CXX_SCAN_FOR_MODULES OFF)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/core/cmake")
 
+option(coverage "Enable test coverage analysis" OFF)
+if(coverage)
+  set(CMAKE_BUILD_TYPE Debug)
+  include(BareosTestCoverage)
+endif()
+
 option(ENABLE_SYSTEMTESTS "Enable the systemtest suite" ON)
 option(CPM_ONLY "Add CPM packages and exit" OFF)
 if(CPM_ONLY)

--- a/cmake/BareosTestCoverage.cmake
+++ b/cmake/BareosTestCoverage.cmake
@@ -1,0 +1,66 @@
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2025-2025 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set(COVERAGE_COMPILER_FLAGS
+    "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
+    CACHE INTERNAL ""
+)
+message(
+  STATUS
+    "coverage requested, adding COVERAGE_COMPILER_FLAGS : ${COVERAGE_COMPILER_FLAGS}"
+)
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+  link_libraries(gcov)
+else()
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
+
+add_custom_target(
+  cov-clean
+  COMMENT "Cleaning gcda files from ${CMAKE_BINARY_DIR} and report."
+  COMMAND find "${CMAKE_BINARY_DIR}" -name '*.gcda' -delete
+  COMMAND "${CMAKE_COMMAND}" -E rm -rf "${CMAKE_BINARY_DIR}/coverage"
+)
+
+find_program(PROGRAM_GCOVR gcovr)
+if(PROGRAM_GCOVR)
+  add_custom_target(
+    cov-report
+    COMMENT "Creating HTML coverage report in ${CMAKE_BINARY_DIR}/coverage"
+    # avoid irritating gcov error by removing a broken gcno file
+    COMMAND
+      "${CMAKE_COMMAND}" -E rm -f
+      "${CMAKE_BINARY_DIR}/core/src/droplet/libdroplet/CMakeFiles/droplet.dir/src/getdate.c.gcno"
+    COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/coverage"
+    COMMAND
+      "${PROGRAM_GCOVR}" --html-details
+      "${CMAKE_BINARY_DIR}/coverage/index.html" --root "${CMAKE_SOURCE_DIR}"
+      --filter "${CMAKE_SOURCE_DIR}" --filter "${CMAKE_BINARY_DIR}"
+      "${CMAKE_BINARY_DIR}"
+  )
+else()
+  add_custom_target(
+    cov-report
+    COMMAND
+      "${CMAKE_COMMAND}" -E echo
+      "WARNING: gcovr binary not found, cannot create HTML coverage report"
+  )
+endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -198,58 +198,6 @@ endif()
 
 include(BareosFindPrograms)
 
-if(coverage)
-  set(COVERAGE_COMPILER_FLAGS
-      "-g -O0 --coverage -fprofile-arcs -ftest-coverage"
-      CACHE INTERNAL ""
-  )
-  message(
-    STATUS
-      "coverage requested, adding COVERAGE_COMPILER_FLAGS : ${COVERAGE_COMPILER_FLAGS}"
-  )
-  set(CMAKE_BUILD_TYPE Debug)
-  if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    link_libraries(gcov)
-  else()
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-  endif()
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COVERAGE_COMPILER_FLAGS}")
-
-  add_custom_target(
-    cov-clean
-    COMMENT "Cleaning gcda files from ${CMAKE_BINARY_DIR} and report."
-    COMMAND find "${CMAKE_BINARY_DIR}" -name '*.gcda' -delete
-    COMMAND "${CMAKE_COMMAND}" -E rm -rf "${CMAKE_BINARY_DIR}/coverage"
-  )
-
-  find_program(PROGRAM_GCOVR gcovr)
-  if(PROGRAM_GCOVR)
-    add_custom_target(
-      cov-report
-      COMMENT "Creating HTML coverage report in ${CMAKE_BINARY_DIR}/coverage"
-      # avoid irritating gcov error by removing a broken gcno file
-      COMMAND
-        "${CMAKE_COMMAND}" -E rm -f
-        "${CMAKE_BINARY_DIR}/core/src/droplet/libdroplet/CMakeFiles/droplet.dir/src/getdate.c.gcno"
-      COMMAND "${CMAKE_COMMAND}" -E make_directory
-              "${CMAKE_BINARY_DIR}/coverage"
-      COMMAND
-        "${PROGRAM_GCOVR}" --html-details
-        "${CMAKE_BINARY_DIR}/coverage/index.html" --root "${CMAKE_SOURCE_DIR}"
-        --filter "${CMAKE_SOURCE_DIR}" --filter "${CMAKE_BINARY_DIR}"
-        "${CMAKE_BINARY_DIR}"
-    )
-  else()
-    add_custom_target(
-      cov-report
-      COMMAND
-        "${CMAKE_COMMAND}" -E echo
-        "WARNING: gcovr binary not found, cannot create HTML coverage report"
-    )
-  endif()
-endif()
-
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(HAVE_LINUX_OS 1)
 endif()

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -87,7 +87,7 @@ target_sources(
           wait.cc
 )
 
-target_link_libraries(bareossd PRIVATE Bareos::Lib fmt::fmt-header-only)
+target_link_libraries(bareossd PRIVATE Bareos::Lib fmt)
 set_target_properties(
   bareossd PROPERTIES VERSION "${BAREOS_NUMERIC_VERSION}"
                       SOVERSION "${BAREOS_VERSION_MAJOR}"

--- a/core/src/stored/backends/CMakeLists.txt
+++ b/core/src/stored/backends/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(chunked-device PRIVATE ordered_cbuf.cc chunked_device.cc)
 
 add_library(backend-utils STATIC)
 target_sources(backend-utils PRIVATE util.cc)
+target_link_libraries(backend-utils PUBLIC Bareos::Lib fmt::fmt)
 
 if(HAVE_GFAPI)
   add_sd_backend(bareossd-gfapi)
@@ -53,8 +54,8 @@ endif()
 add_sd_backend(bareossd-dplcompat)
 target_sources(bareossd-dplcompat PRIVATE dplcompat_device.cc crud_storage.cc)
 target_link_libraries(
-  bareossd-dplcompat PRIVATE Microsoft.GSL::GSL fmt::fmt-header-only
-                             tl::expected chunked-device backend-utils
+  bareossd-dplcompat PRIVATE Microsoft.GSL::GSL fmt::fmt tl::expected
+                             chunked-device backend-utils
 )
 if(HAVE_WIN32)
   target_link_libraries(bareossd-dplcompat PRIVATE shlwapi)

--- a/core/src/stored/backends/chunked_device.cc
+++ b/core/src/stored/backends/chunked_device.cc
@@ -209,7 +209,7 @@ auto ChunkedDevice::getInflightLease(chunk_io_request* request)
 {
   try {
     return InflightLease(this, request);
-  } catch (InflightChunkException&) {
+  } catch (const InflightChunkException&) {
     return std::nullopt;
   }
 }

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -277,7 +277,8 @@ bool DropletCompatibleDevice::ReadRemoteChunk(chunk_io_request* request)
 {
   const std::string_view obj_name{request->volname};
   const std::string obj_chunk = get_chunk_name(request);
-  Dmsg1(debug_trace, "Reading chunk %s\n", obj_name.data());
+  Dmsg1(debug_trace, "Reading chunk %s/%s\n", obj_name.data(),
+        obj_chunk.data());
 
   // check object metadata
   auto obj_stat = m_storage.stat(obj_name, obj_chunk);

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -59,6 +59,26 @@ static const utl::options option_defaults{
     {"program_timeout", "0"},  // use default in crud_storage
 };
 
+unsigned long long stoull_notrailing(const std::string& str)
+{
+  size_t pos;
+  unsigned long long val = std::stoull(str, &pos);
+  if (!std::all_of(str.begin() + pos, str.end(), b_isjunkchar)) {
+    throw std::invalid_argument{"unparseable trailing characters"};
+  }
+  return val;
+}
+
+unsigned long stoul_notrailing(const std::string& str)
+{
+  size_t pos;
+  unsigned long val = std::stoul(str, &pos);
+  if (!std::all_of(str.begin() + pos, str.end(), b_isjunkchar)) {
+    throw std::invalid_argument{"unparseable trailing characters"};
+  }
+  return val;
+}
+
 // delete this, so only specializations will be considered
 template <typename T> void convert_value(T&, const std::string&) = delete;
 
@@ -66,24 +86,24 @@ template <>
 [[maybe_unused]] void convert_value<>(unsigned long long& to,
                                       const std::string& from)
 {
-  to = std::stoull(from);
+  to = stoull_notrailing(from);
 }
 
 template <>
 [[maybe_unused]] void convert_value<>(unsigned long& to,
                                       const std::string& from)
 {
-  to = std::stoul(from);
+  to = stoul_notrailing(from);
 }
 
 template <> void convert_value<>(uint8_t& to, const std::string& from)
 {
-  to = gsl::narrow<uint8_t>(std::stoul(from));
+  to = gsl::narrow<uint8_t>(stoul_notrailing(from));
 }
 
 template <> void convert_value<>(uint32_t& to, const std::string& from)
 {
-  to = gsl::narrow<uint32_t>(std::stoul(from));
+  to = gsl::narrow<uint32_t>(stoul_notrailing(from));
 }
 
 

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -60,13 +60,21 @@ static const utl::options option_defaults{
                                                        // crud_storage
 };
 
+void throw_if_junk(const std::string& str, size_t pos = 0)
+{
+  if (auto iter = std::find_if_not(str.begin() + pos, str.end(), b_isjunkchar);
+      iter != str.end()) {
+    throw std::invalid_argument{fmt::format(
+        FMT_STRING("unparseable character '{0}' (0x{0:x}) at pos {1}"), *iter,
+        iter - str.begin())};
+  }
+}
+
 unsigned long long stoull_notrailing(const std::string& str)
 {
   size_t pos;
   unsigned long long val = std::stoull(str, &pos);
-  if (!std::all_of(str.begin() + pos, str.end(), b_isjunkchar)) {
-    throw std::invalid_argument{"unparseable trailing characters"};
-  }
+  throw_if_junk(str, pos);
   return val;
 }
 
@@ -74,9 +82,7 @@ unsigned long stoul_notrailing(const std::string& str)
 {
   size_t pos;
   unsigned long val = std::stoul(str, &pos);
-  if (!std::all_of(str.begin() + pos, str.end(), b_isjunkchar)) {
-    throw std::invalid_argument{"unparseable trailing characters"};
-  }
+  throw_if_junk(str, pos);
   return val;
 }
 
@@ -116,7 +122,8 @@ template <> void convert_value<>(std::string& to, const std::string& from)
 void convert_size(uint64_t& to, const std::string& from)
 {
   if (!size_to_uint64(from.c_str(), &to)) {
-    throw std::invalid_argument("Hello, World!");
+    throw std::invalid_argument(fmt::format(
+        FMT_STRING("value '{}' is not a valid size specification"), from));
   }
 }
 

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -143,15 +143,15 @@ tl::expected<utl::options*, std::string> convert(
 
   try {
     converter(target, value);
-  } catch (std::invalid_argument& e) {
+  } catch (const std::invalid_argument& e) {
     return tl::unexpected(
         fmt::format(FMT_STRING("invalid argument '{}' for option '{}': {}\n"),
                     value, key, e.what()));
-  } catch (std::out_of_range& e) {
+  } catch (const std::out_of_range& e) {
     return tl::unexpected(fmt::format(
         FMT_STRING("value '{}' for option '{}' is out of range: {}\n"), value,
         key, e.what()));
-  } catch (gsl::narrowing_error& e) {
+  } catch (const gsl::narrowing_error& e) {
     return tl::unexpected(fmt::format(
         FMT_STRING("value '{}' for option '{}' would be truncated: {}\n"),
         value, key, e.what()));

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -19,6 +19,7 @@
    02110-1301, USA.
 */
 
+#define FMT_ENFORCE_COMPILE_STRING
 #include "include/bareos.h"
 
 #include "stored/stored.h"
@@ -129,23 +130,24 @@ tl::expected<utl::options*, std::string> convert(
   auto node_handle = options->extract(key);
   if (node_handle.empty()) {
     return tl::unexpected(
-        fmt::format("no value provided for option '{}'\n", key));
+        fmt::format(FMT_STRING("no value provided for option '{}'\n"), key));
   }
   auto value = node_handle.mapped();
 
   try {
     converter(target, value);
   } catch (std::invalid_argument& e) {
-    return tl::unexpected(fmt::format(
-        "invalid argument '{}' for option '{}': {}\n", value, key, e.what()));
-  } catch (std::out_of_range& e) {
     return tl::unexpected(
-        fmt::format("value '{}' for option '{}' is out of range: {}\n", value,
-                    key, e.what()));
-  } catch (gsl::narrowing_error& e) {
-    return tl::unexpected(
-        fmt::format("value '{}' for option '{}' would be truncated: {}\n",
+        fmt::format(FMT_STRING("invalid argument '{}' for option '{}': {}\n"),
                     value, key, e.what()));
+  } catch (std::out_of_range& e) {
+    return tl::unexpected(fmt::format(
+        FMT_STRING("value '{}' for option '{}' is out of range: {}\n"), value,
+        key, e.what()));
+  } catch (gsl::narrowing_error& e) {
+    return tl::unexpected(fmt::format(
+        FMT_STRING("value '{}' for option '{}' would be truncated: {}\n"),
+        value, key, e.what()));
   }
   return options;
 }
@@ -194,19 +196,17 @@ tl::expected<void, std::string> DropletCompatibleDevice::setup_impl()
 {
   auto res = utl::parse_options(dev_options);
   if (std::holds_alternative<utl::error>(res)) {
-    return tl::unexpected(
-        fmt::format("device option error: {}\n", std::get<utl::error>(res)));
+    return tl::unexpected(fmt::format(FMT_STRING("device option error: {}\n"),
+                                      std::get<utl::error>(res)));
   }
   auto options = std::get<utl::options>(res);
 
   // apply default values
   options.merge(utl::options(option_defaults));
-
-  Dmsg0(debug_info, "dev_options: %s\n", dev_options);
+  utl::Dfmt(debug_info, FMT_STRING("dev_options: {}"), dev_options);
   for (const auto& [key, value] : options) {
-    Dmsg0(debug_trace, "'%s' = '%s'\n", key.c_str(), value.c_str());
+    utl::Dfmt(debug_trace, FMT_STRING("'{}' = '{}'"), key, value);
   }
-
   std::string program;
   uint32_t program_timeout{0};
 
@@ -226,7 +226,8 @@ tl::expected<void, std::string> DropletCompatibleDevice::setup_impl()
     return tl::unexpected("Option 'program' is required\n"s);
   }
 
-  Dmsg0(debug_trace, "configured chunksize in bytes: %llu\n", chunk_size_);
+  utl::Dfmt(debug_trace, FMT_STRING("configured chunksize in bytes: {}"),
+            chunk_size_);
 
   if (auto result = m_storage.set_program(program); !result) { return result; }
 
@@ -238,13 +239,14 @@ tl::expected<void, std::string> DropletCompatibleDevice::setup_impl()
     for (const auto& option_name : *supported_options) {
       if (auto value = fetch_value(options, option_name);
           value && !m_storage.set_option(option_name, *value)) {
-        return tl::unexpected(fmt::format("Error setting option '{}' to '{}'\n",
-                                          option_name, *value));
+        return tl::unexpected(
+            fmt::format(FMT_STRING("Error setting option '{}' to '{}'\n"),
+                        option_name, *value));
       }
     }
   } else {
     return tl::unexpected(
-        fmt::format("Cannot get supported options.\nCause: {}\n",
+        fmt::format(FMT_STRING("Cannot get supported options.\nCause: {}\n"),
                     supported_options.error()));
   }
 
@@ -252,8 +254,9 @@ tl::expected<void, std::string> DropletCompatibleDevice::setup_impl()
   if (!options.empty()) {
     BStringList option_names;
     for (const auto& [name, value] : options) { option_names.push_back(name); }
-    return tl::unexpected(fmt::format("Unknown options encountered: {}\n",
-                                      option_names.Join(", ")));
+    return tl::unexpected(
+        fmt::format(FMT_STRING("Unknown options encountered: {}\n"),
+                    option_names.Join(", ")));
   }
   return {};
 }
@@ -269,17 +272,18 @@ bool DropletCompatibleDevice::FlushRemoteChunk(chunk_io_request* request)
   const std::string_view obj_name{request->volname};
   const std::string obj_chunk = get_chunk_name(request);
   if (request->wbuflen == 0) {
-    Dmsg1(debug_info, "Not flushing empty chunk %s/%s\n", obj_name.data(),
-          obj_chunk.c_str());
+    utl::Dfmt(debug_info, FMT_STRING("Not flushing empty chunk {}/{})"),
+              obj_name, obj_chunk);
     return true;
   }
-  Dmsg1(debug_trace, "Flushing chunk %s/%s\n", obj_name.data(),
-        obj_chunk.c_str());
+  utl::Dfmt(debug_trace, FMT_STRING("Flushing chunk {}/{}"), obj_name,
+            obj_chunk);
 
   auto inflight_lease = getInflightLease(request);
   if (!inflight_lease) {
-    Dmsg0(debug_info, "Could not acquire inflight lease for %s %s\n",
-          obj_name.data(), obj_chunk.c_str());
+    utl::Dfmt(debug_info,
+              FMT_STRING("Could not acquire inflight lease for {}/{}"),
+              obj_name, obj_chunk);
     return false;
   }
 
@@ -294,15 +298,17 @@ bool DropletCompatibleDevice::FlushRemoteChunk(chunk_io_request* request)
   auto obj_stat = m_storage.stat(obj_name, obj_chunk);
 
   if (obj_stat && obj_stat->size > request->wbuflen) {
-    Dmsg1(debug_info,
-          "Not uploading chunk %s with size %zu, as chunk with size %d is "
-          "already present\n",
-          obj_name.data(), obj_stat->size, request->wbuflen);
+    utl::Dfmt(
+        debug_info,
+        FMT_STRING("Not uploading chunk {} with size {}, as chunk with size "
+                   "{} is already present"),
+        obj_name, request->wbuflen, obj_stat->size);
     return true;
   }
 
   auto obj_data = gsl::span{request->buffer, request->wbuflen};
-  Dmsg1(debug_info, "Uploading %" PRIu32 " bytes of data\n", request->wbuflen);
+  utl::Dfmt(debug_info, FMT_STRING("Uploading {} bytes of data"),
+            request->wbuflen);
   if (auto result = m_storage.upload(obj_name, obj_chunk, obj_data)) {
     return true;
   } else {
@@ -317,8 +323,8 @@ bool DropletCompatibleDevice::ReadRemoteChunk(chunk_io_request* request)
 {
   const std::string_view obj_name{request->volname};
   const std::string obj_chunk = get_chunk_name(request);
-  Dmsg1(debug_trace, "Reading chunk %s/%s\n", obj_name.data(),
-        obj_chunk.data());
+  utl::Dfmt(debug_trace, FMT_STRING("Reading chunk {}/{}"), obj_name.data(),
+            obj_chunk.data());
 
   // check object metadata
   auto obj_stat = m_storage.stat(obj_name, obj_chunk);
@@ -433,7 +439,7 @@ boffset_t DropletCompatibleDevice::d_lseek(DeviceControlRecord*,
 
       volumesize = ChunkedVolumeSize();
 
-      Dmsg1(debug_info, "Current volumesize: %zi\n", volumesize);
+      utl::Dfmt(debug_info, FMT_STRING("Current volumesize: {}"), volumesize);
 
       if (volumesize >= 0) {
         offset_ = volumesize + offset;

--- a/core/src/stored/backends/util.h
+++ b/core/src/stored/backends/util.h
@@ -27,6 +27,7 @@
 #include <map>
 #include <variant>
 #include <fmt/format.h>
+#include <lib/message.h>
 #include <lib/source_location.h>
 
 namespace backends::util {
@@ -63,10 +64,12 @@ struct LevelAndLocation {
 template <typename Fmt, typename... Args>
 void Dfmt(LevelAndLocation lal, Fmt fmt, Args&&... args)
 {
-  const auto formatted
-      = fmt::format(std::forward<Fmt>(fmt), std::forward<Args>(args)...);
-  d_msg(lal.loc.file_name(), lal.loc.line(), lal.level, "%s\n",
-        formatted.c_str());
+  if (debug_level >= lal.level) {
+    const auto formatted
+        = fmt::format(std::forward<Fmt>(fmt), std::forward<Args>(args)...);
+    d_msg(lal.loc.file_name(), lal.loc.line(), lal.level, "%s\n",
+          formatted.c_str());
+  }
 }
 
 };  // namespace backends::util

--- a/core/src/stored/backends/util.h
+++ b/core/src/stored/backends/util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,8 @@
 #include <string>
 #include <map>
 #include <variant>
+#include <fmt/format.h>
+#include <lib/source_location.h>
 
 namespace backends::util {
 
@@ -42,6 +44,31 @@ using options = std::map<std::string, std::string, key_comparator>;
 using error = std::string;
 
 std::variant<options, error> parse_options(std::string_view v);
+
+
+/* wrap an integer with its source location for logging */
+struct LevelAndLocation {
+  int level;
+  libbareos::source_location loc;
+
+  constexpr LevelAndLocation(int t_level,
+                             const libbareos::source_location& t_loc
+                             = libbareos::source_location::current())
+      : level(t_level), loc(t_loc)
+  {
+  }
+};
+
+/* emit a fmt-formatted debug message */
+template <typename Fmt, typename... Args>
+void Dfmt(LevelAndLocation lal, Fmt fmt, Args&&... args)
+{
+  const auto formatted
+      = fmt::format(std::forward<Fmt>(fmt), std::forward<Args>(args)...);
+  d_msg(lal.loc.file_name(), lal.loc.line(), lal.level, "%s\n",
+        formatted.c_str());
+}
+
 };  // namespace backends::util
 
 #endif  // BAREOS_STORED_BACKENDS_UTIL_H_

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -495,11 +495,11 @@ if(NOT HAVE_WIN32)
   bareos_add_test(fvec LINK_LIBRARIES GTest::gtest_main)
 endif()
 
-bareos_add_test(
-  backend_parse
-  LINK_LIBRARIES Bareos::Lib GTest::gtest_main
-  ADDITIONAL_SOURCES "../stored/backends/util.cc"
-)
+if(NOT client-only)
+  bareos_add_test(
+    backend_parse LINK_LIBRARIES Bareos::Lib GTest::gtest_main backend-utils
+  )
+endif()
 
 add_executable(env_tester env_tester.cc)
 target_link_libraries(env_tester PRIVATE Bareos::Lib)


### PR DESCRIPTION
Add support for size-suffixes to chunksize parameter to be more compatible with the droplet backend. 
This will now also detect trailing junk after numbers and changes debugging at crud_storage's trace level (130) will now log the output of the program the stat operation is run. This also slightly improves some other trace information.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
