### PR TITLE
core: fix ktls configuration; fix crashes/ub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: fix not including BareosTargetTools in systemtests, needed for get_target_output_dir [PR #2235]
 - fix MaximumConcurrentJobs in docs and defaultsconfig [PR #2238]
 - cli-test: fix test on freebsd [PR #2242]
+- core: fix ktls configuration; fix crashes/ub [PR #2246]
 
 ## [24.0.2] - 2025-03-27
 
@@ -433,4 +434,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2235]: https://github.com/bareos/bareos/pull/2235
 [PR #2238]: https://github.com/bareos/bareos/pull/2238
 [PR #2242]: https://github.com/bareos/bareos/pull/2242
+[PR #2246]: https://github.com/bareos/bareos/pull/2246
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/authenticate.cc
+++ b/core/src/dird/authenticate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -137,6 +137,8 @@ bool AuthenticateWithFileDaemon(JobControlRecord* jcr)
           "Could not generate qualified resource name for a client resource\n");
       return false;
     }
+
+    fd->SetEnableKtls(me->enable_ktls);
 
     if (!fd->DoTlsHandshake(TlsPolicy::kBnetTlsAuto, client, false,
                             qualified_resource_name.c_str(),

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -151,6 +151,7 @@ static ResourceItem dir_items[] = {
   { "SecureEraseCommand", CFG_TYPE_STR, ITEM(res_dir, secure_erase_cmdline), 0, 0, NULL, "15.2.1-",
      "Specify command that will be called when bareos unlinks files." },
   { "LogTimestampFormat", CFG_TYPE_STR, ITEM(res_dir, log_timestamp_format), 0, CFG_ITEM_DEFAULT, "%d-%b %H:%M", "15.2.3-", NULL },
+  { "EnableKtls", CFG_TYPE_BOOL, ITEM(res_dir, enable_ktls), 0, CFG_ITEM_DEFAULT, "false", "23.0.0-", "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."},
    TLS_COMMON_CONFIG(res_dir),
    TLS_CERT_CONFIG(res_dir),
   {nullptr, 0, 0, nullptr, 0, 0, nullptr, nullptr, nullptr}

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -138,8 +138,8 @@ static ResourceItem dir_items[] = {
   { "FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_dir, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "180" /* 3 minutes */, NULL, NULL },
   { "SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_dir, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL },
   { "HeartbeatInterval", CFG_TYPE_TIME, ITEM(res_dir, heartbeat_interval), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
-  { "StatisticsRetention", CFG_TYPE_TIME, ITEM(res_dir, stats_retention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "160704000" /* 5 years */, NULL, NULL },
-  { "StatisticsCollectInterval", CFG_TYPE_PINT32, ITEM(res_dir, stats_collect_interval), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "0", "14.2.0-", NULL },
+  { "StatisticsRetention", CFG_TYPE_TIME, ITEM(res_dir, stats_retention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "160704000" /* 5 years */, "-22.0.0", NULL },
+  { "StatisticsCollectInterval", CFG_TYPE_PINT32, ITEM(res_dir, stats_collect_interval), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "0", "14.2.0-22.0.0", NULL },
   { "VerId", CFG_TYPE_STR, ITEM(res_dir, verid), 0, 0, NULL, NULL, NULL },
   { "KeyEncryptionKey", CFG_TYPE_AUTOPASSWORD, ITEM(res_dir, keyencrkey), 1, 0, NULL, NULL, NULL },
   { "NdmpSnooping", CFG_TYPE_BOOL, ITEM(res_dir, ndmp_snooping), 0, 0, NULL, "13.2.0-", NULL },
@@ -243,10 +243,10 @@ static ResourceItem client_items[] = {
   { "SoftQuotaGracePeriod", CFG_TYPE_TIME, ITEM(res_client, SoftQuotaGracePeriod), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
   { "StrictQuotas", CFG_TYPE_BOOL, ITEM(res_client, StrictQuotas), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
   { "QuotaIncludeFailedJobs", CFG_TYPE_BOOL, ITEM(res_client, QuotaIncludeFailedJobs), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL },
-  { "FileRetention", CFG_TYPE_TIME, ITEM(res_client, FileRetention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "5184000" /* 60 days */, NULL, NULL },
-  { "JobRetention", CFG_TYPE_TIME, ITEM(res_client, JobRetention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "15552000" /* 180 days */, NULL, NULL },
+  { "FileRetention", CFG_TYPE_TIME, ITEM(res_client, FileRetention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "5184000" /* 60 days */, "-23.0.0", NULL },
+  { "JobRetention", CFG_TYPE_TIME, ITEM(res_client, JobRetention), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "15552000" /* 180 days */, "-23.0.0", NULL },
   { "HeartbeatInterval", CFG_TYPE_TIME, ITEM(res_client, heartbeat_interval), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
-  { "AutoPrune", CFG_TYPE_BOOL, ITEM(res_client, AutoPrune), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", NULL, NULL },
+  { "AutoPrune", CFG_TYPE_BOOL, ITEM(res_client, AutoPrune), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", "-23.0.0", NULL },
   { "MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_client, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL },
   { "MaximumBandwidthPerJob", CFG_TYPE_SPEED, ITEM(res_client, max_bandwidth), 0, 0, NULL, NULL, NULL },
   { "NdmpLogLevel", CFG_TYPE_PINT32, ITEM(res_client, ndmp_loglevel), 0, CFG_ITEM_DEFAULT, "4", NULL, NULL },
@@ -284,7 +284,7 @@ static ResourceItem store_items[] = {
   { "MaximumConcurrentReadJobs", CFG_TYPE_PINT32, ITEM(res_store, MaxConcurrentReadJobs), 0, CFG_ITEM_DEFAULT, "0", NULL, NULL },
   { "PairedStorage", CFG_TYPE_RES, ITEM(res_store, paired_storage), R_STORAGE, 0, NULL, NULL, NULL },
   { "MaximumBandwidthPerJob", CFG_TYPE_SPEED, ITEM(res_store, max_bandwidth), 0, 0, NULL, NULL, NULL },
-  { "CollectStatistics", CFG_TYPE_BOOL, ITEM(res_store, collectstats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", NULL, NULL },
+  { "CollectStatistics", CFG_TYPE_BOOL, ITEM(res_store, collectstats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", "-22.0.0", NULL },
   { "NdmpChangerDevice", CFG_TYPE_STRNAME, ITEM(res_store, ndmp_changer_device), 0, 0, NULL, "16.2.4-",
      "Allows direct control of a Storage Daemon Auto Changer device by the Director. Only used in NDMP_NATIVE environments." },
    TLS_COMMON_CONFIG(res_store),
@@ -400,7 +400,7 @@ ResourceItem job_items[] = {
   { "SelectionType", CFG_TYPE_MIGTYPE, ITEM(res_job, selection_type), 0, 0, NULL, NULL, NULL },
   { "Accurate", CFG_TYPE_BOOL, ITEM(res_job, accurate), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
   { "AllowDuplicateJobs", CFG_TYPE_BOOL, ITEM(res_job, AllowDuplicateJobs), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL },
-  { "AllowHigherDuplicates", CFG_TYPE_BOOL, ITEM(res_job, AllowHigherDuplicates), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "true", NULL, NULL },
+  { "AllowHigherDuplicates", CFG_TYPE_BOOL, ITEM(res_job, AllowHigherDuplicates), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "true", "-24.0.0", NULL },
   { "CancelLowerLevelDuplicates", CFG_TYPE_BOOL, ITEM(res_job, CancelLowerLevelDuplicates), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
   { "CancelQueuedDuplicates", CFG_TYPE_BOOL, ITEM(res_job, CancelQueuedDuplicates), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
   { "CancelRunningDuplicates", CFG_TYPE_BOOL, ITEM(res_job, CancelRunningDuplicates), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },
@@ -454,7 +454,7 @@ static ResourceItem pool_items[] = {
   { "Description", CFG_TYPE_STR, ITEM(res_pool, description_), 0, 0, NULL, NULL, NULL },
   { "PoolType", CFG_TYPE_POOLTYPE, ITEM(res_pool, pool_type), 0, CFG_ITEM_DEFAULT, "Backup", NULL, NULL },
   { "LabelFormat", CFG_TYPE_STRNAME, ITEM(res_pool, label_format), 0, 0, NULL, NULL, NULL },
-  { "LabelType", CFG_TYPE_LABEL, ITEM(res_pool, LabelType), 0, CFG_ITEM_DEPRECATED, NULL, NULL, NULL },
+  { "LabelType", CFG_TYPE_LABEL, ITEM(res_pool, LabelType), 0, CFG_ITEM_DEPRECATED, NULL, "-23.0.0", NULL },
   { "CleaningPrefix", CFG_TYPE_STRNAME, ITEM(res_pool, cleaning_prefix), 0, CFG_ITEM_DEFAULT, "CLN", NULL, NULL },
   { "UseCatalog", CFG_TYPE_BOOL, ITEM(res_pool, use_catalog), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL },
   { "PurgeOldestVolume", CFG_TYPE_BOOL, ITEM(res_pool, purge_oldest_volume), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL },

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -145,6 +145,8 @@ class DirectorResource
   char* log_timestamp_format = nullptr; /* Timestamp format to use in generic
                                  logging messages */
   s_password keyencrkey;                /* Key Encryption Key */
+
+  bool enable_ktls{false};
 };
 
 /*

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -773,7 +773,7 @@ static FilesetResource* GetStaticFilesetResource()
 {
   FilesetResource* res_fs = nullptr;
   ResourceTable* t = my_config->GetResourceTable("FileSet");
-  assert(t);
+  ASSERT(t);
   if (t) { res_fs = dynamic_cast<FilesetResource*>(*t->allocated_resource_); }
   assert(res_fs);
   return res_fs;

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -33,7 +33,7 @@ JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr)
   jcr->dir_impl = new DirectorJcrImpl(my_config->config_resources_container_);
   register_jcr(jcr);
   Dmsg1(10, "NewDirectorJcr: configuration_resources_ is at %p %s\n",
-        my_config->config_resources_container_->configuration_resources_,
+        my_config->config_resources_container_->configuration_resources_.data(),
         my_config->config_resources_container_->TimeStampAsString().c_str());
   return jcr;
 }

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -250,6 +250,11 @@ bool DoReloadConfig()
       && InitializeSqlPooling()) {
     Scheduler::GetMainScheduler().ClearQueue();
     reloaded = true;
+
+    // make sure that jobs that keep the last configuration alive
+    // also keep alive this config in case they (accidentally) access it.
+    backup_container->SetNext(my_config->GetResourcesContainer());
+
     Dmsg0(10, "Director's configuration file reread successfully.\n");
   } else {  // parse config failed
     Jmsg(nullptr, M_ERROR, 0, T_("Please correct the configuration in %s\n"),

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -132,6 +132,8 @@ bool ConnectToStorageDaemon(JobControlRecord* jcr,
       sd->close();
       return false;
     }
+
+    sd->SetEnableKtls(me->enable_ktls);
 
     if (!sd->DoTlsHandshake(TlsPolicy::kBnetTlsAuto, store, false,
                             qualified_resource_name.c_str(),

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1009,7 +1009,7 @@ static bool SetipCmd(UaContext* ua, const char*)
 
   if (client->address) { free(client->address); }
 
-  SockaddrToAscii(&(ua->UA_sock->client_addr), buf, sizeof(buf));
+  SockaddrToAscii(&ua->UA_sock->client_addr, buf, sizeof(buf));
   client->address = strdup(buf);
   ua->SendMsg(T_("Client \"%s\" address set to %s\n"), client->resource_name_,
               client->address);

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1496,6 +1496,8 @@ static bool StorageCmd(JobControlRecord* jcr)
       goto bail_out;
     }
 
+    storage_daemon_socket->SetEnableKtls(me->enable_ktls);
+
     if (!storage_daemon_socket->DoTlsHandshake(
             TlsPolicy::kBnetTlsAuto, me, false, qualified_resource_name.c_str(),
             jcr->sd_auth_key, jcr)) {
@@ -2078,6 +2080,8 @@ static BareosSocket* connect_to_director(JobControlRecord* jcr,
             "resource\n");
       return nullptr;
     }
+
+    director_socket->SetEnableKtls(me->enable_ktls);
 
     if (!director_socket->DoTlsHandshake(TlsPolicy::kBnetTlsAuto, dir_res,
                                          false, qualified_resource_name.c_str(),

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -91,7 +91,7 @@ static ResourceItem cli_items[] = {
   {"PluginDirectory", CFG_TYPE_DIR, ITEM(res_client, plugin_directory), 0, 0, NULL, NULL, NULL},
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_client, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_client, scripts_directory), 0, CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_SCRIPTDIR, NULL, "Path to directory containing script files"},
-  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_client, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "1000", NULL, NULL},
+  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_client, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "1000", "-24.0.0", NULL},
   {"MaximumWorkersPerJob", CFG_TYPE_PINT32, ITEM(res_client, MaxWorkersPerJob), 0, CFG_ITEM_DEFAULT, "2", "23.0.0-",
    "The maximum number of worker threads that bareos will use during backup."},
   {"Messages", CFG_TYPE_RES, ITEM(res_client, messages), R_MSGS, 0, NULL, NULL, NULL},
@@ -114,7 +114,7 @@ static ResourceItem cli_items[] = {
   {"AllowedScriptDir", CFG_TYPE_ALIST_DIR, ITEM(res_client, allowed_script_dirs), 0, 0, NULL, NULL, NULL},
   {"AllowedJobCommand", CFG_TYPE_ALIST_STR, ITEM(res_client, allowed_job_cmds), 0, 0, NULL, NULL, NULL},
   {"AbsoluteJobTimeout", CFG_TYPE_PINT32, ITEM(res_client, jcr_watchdog_time), 0, 0, NULL, "14.2.0-", "Absolute time after which a Job gets terminated regardless of its progress" },
-  {"AlwaysUseLmdb", CFG_TYPE_BOOL, ITEM(res_client, always_use_lmdb), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "false", NULL,
+  {"AlwaysUseLmdb", CFG_TYPE_BOOL, ITEM(res_client, always_use_lmdb), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "false", "-24.0.0",
    "Ensure that bareos always chooses the lmdb backend for accurate information regardless of the file list size.  Use LmdbThreshold = 0 instead."
   },
   {"LmdbThreshold", CFG_TYPE_PINT32, ITEM(res_client, lmdb_threshold), 0, 0, NULL, NULL,

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -124,6 +124,7 @@ static ResourceItem cli_items[] = {
   {"LogTimestampFormat", CFG_TYPE_STR, ITEM(res_client, log_timestamp_format), 0, CFG_ITEM_DEFAULT, "%d-%b %H:%M", "15.2.3-", NULL},
   {"GrpcModule", CFG_TYPE_STDSTR, ITEM(res_client, grpc_module), 0, CFG_ITEM_DEFAULT, "bareos-grpc-fd-plugin-bridge",
    "25.0.0-", "The grpc module to use for grpc fallback."},
+  {"EnableKtls", CFG_TYPE_BOOL, ITEM(res_client, enable_ktls), 0, CFG_ITEM_DEFAULT, "false", "23.0.0-", "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."},
     TLS_COMMON_CONFIG(res_client),
     TLS_CERT_CONFIG(res_client),
   {nullptr, 0, 0, nullptr, 0, 0, nullptr, nullptr, nullptr}

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -48,9 +48,13 @@ enum
   R_DIRECTOR = 0,
   R_CLIENT,
   R_MSGS,
+  R_NUM, /* number of entires */
+
+
+  // these two do not really exist in the configuration
+  // they exist for other purposes
   R_STORAGE,
   R_JOB,
-  R_NUM /* number of entires */
 };
 
 // Some resource attributes

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -135,6 +135,7 @@ class ClientResource
   uint64_t max_bandwidth_per_job = 0;   /* Bandwidth limitation (global) */
 
   std::string grpc_module{};
+  bool enable_ktls{false};
 };
 
 

--- a/core/src/filed/filed_conf.h
+++ b/core/src/filed/filed_conf.h
@@ -48,7 +48,7 @@ enum
   R_DIRECTOR = 0,
   R_CLIENT,
   R_MSGS,
-  R_NUM, /* number of entires */
+  R_NUM, /* number of entries */
 
 
   // these two do not really exist in the configuration

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -552,12 +552,13 @@ void FreeAddresses(dlist<IPADDR>* addrs)
   delete addrs;
 }
 
-char* SockaddrToAscii(const struct sockaddr* sa, char* buf, int len)
+char* SockaddrToAscii(const struct sockaddr_storage* sa, char* buf, int len)
 {
+  auto* addr = reinterpret_cast<const sockaddr*>(sa);
 #ifdef HAVE_INET_NTOP
   /* MA Bug 5 the problem was that i mixed up sockaddr and in_addr */
-  inet_ntop(sa->sa_family,
-            sa->sa_family == AF_INET
+  inet_ntop(addr->sa_family,
+            addr->sa_family == AF_INET
                 ? (void*)&(((struct sockaddr_in*)sa)->sin_addr)
                 : (void*)&(((struct sockaddr_in6*)sa)->sin6_addr),
             buf, len);

--- a/core/src/lib/address_conf.cc
+++ b/core/src/lib/address_conf.cc
@@ -49,40 +49,28 @@
 #  include <arpa/nameser.h>
 #endif
 
-IPADDR::IPADDR()
-    : type(R_UNDEFINED), saddr(nullptr), saddr4(nullptr), saddr6(nullptr)
-{
-  memset(&saddrbuf, 0, sizeof(saddrbuf));
-}
-
-IPADDR::IPADDR(const IPADDR& src) : IPADDR()
+IPADDR::IPADDR(const IPADDR& src)
 {
   type = src.type;
-  memcpy(&saddrbuf, &src.saddrbuf, sizeof(saddrbuf));
-  saddr = &saddrbuf.dontuse;
-  saddr4 = &saddrbuf.dontuse4;
-  saddr6 = &saddrbuf.dontuse6;
+  memcpy(&addr_storage, &src.addr_storage, sizeof(addr_storage));
 }
 
-IPADDR::IPADDR(int af) : IPADDR()
+IPADDR::IPADDR(int af)
 {
   type = R_EMPTY;
-  if (!(af == AF_INET6 || af == AF_INET)) {
+  if (af != AF_INET6 && af != AF_INET) {
     Emsg1(M_ERROR_TERM, 0, T_("Only ipv4 and ipv6 are supported (%d)\n"), af);
   }
 
-  memset(&saddrbuf, 0, sizeof(saddrbuf));
-  saddr = &saddrbuf.dontuse;
-  saddr4 = &saddrbuf.dontuse4;
-  saddr6 = &saddrbuf.dontuse6;
-  saddr->sa_family = af;
   switch (af) {
-    case AF_INET:
-      saddr4->sin_port = 0xffff;
-      break;
-    case AF_INET6:
-      saddr6->sin6_port = 0xffff;
-      break;
+    case AF_INET: {
+      addr_in.sin_family = af;
+      addr_in.sin_port = 0xffff;
+    } break;
+    case AF_INET6: {
+      addr_in6.sin6_family = af;
+      addr_in6.sin6_port = 0xffff;
+    } break;
   }
 
   SetAddrAny();
@@ -95,79 +83,79 @@ IPADDR::i_type IPADDR::GetType() const { return type; }
 unsigned short IPADDR::GetPortNetOrder() const
 {
   unsigned short port = 0;
-  if (saddr->sa_family == AF_INET) {
-    port = saddr4->sin_port;
+  if (addr.sa_family == AF_INET) {
+    port = addr_in.sin_port;
   } else {
-    port = saddr6->sin6_port;
+    port = addr_in6.sin6_port;
   }
   return port;
 }
 
 void IPADDR::SetPortNet(unsigned short port)
 {
-  if (saddr->sa_family == AF_INET) {
-    saddr4->sin_port = port;
+  if (addr.sa_family == AF_INET) {
+    addr_in.sin_port = port;
   } else {
-    saddr6->sin6_port = port;
+    addr_in6.sin6_port = port;
   }
 }
 
-int IPADDR::GetFamily() const { return saddr->sa_family; }
+int IPADDR::GetFamily() const { return addr.sa_family; }
 
-struct sockaddr* IPADDR::get_sockaddr() { return saddr; }
+struct sockaddr* IPADDR::get_sockaddr() { return &addr; }
 
 int IPADDR::GetSockaddrLen()
 {
-  return saddr->sa_family == AF_INET ? sizeof(*saddr4) : sizeof(*saddr6);
+  return addr.sa_family == AF_INET ? sizeof(addr_in) : sizeof(addr_in6);
 }
 void IPADDR::CopyAddr(IPADDR* src)
 {
-  if (saddr->sa_family == AF_INET) {
-    saddr4->sin_addr.s_addr = src->saddr4->sin_addr.s_addr;
+  if (addr.sa_family == AF_INET) {
+    addr_in.sin_addr.s_addr = src->addr_in.sin_addr.s_addr;
   } else {
-    saddr6->sin6_addr = src->saddr6->sin6_addr;
+    addr_in6.sin6_addr = src->addr_in6.sin6_addr;
   }
 }
 
 void IPADDR::SetAddrAny()
 {
-  if (saddr->sa_family == AF_INET) {
-    saddr4->sin_addr.s_addr = INADDR_ANY;
+  if (addr.sa_family == AF_INET) {
+    addr_in.sin_addr.s_addr = INADDR_ANY;
   } else {
-    saddr6->sin6_addr = in6addr_any;
+    addr_in6.sin6_addr = in6addr_any;
   }
 }
 
 void IPADDR::SetAddr4(struct in_addr* ip4)
 {
-  if (saddr->sa_family != AF_INET) {
+  if (addr.sa_family != AF_INET) {
     Emsg1(M_ERROR_TERM, 0,
           T_("It was tried to assign a ipv6 address to a ipv4(%d)\n"),
-          saddr->sa_family);
+          addr.sa_family);
   }
-  saddr4->sin_addr = *ip4;
+  addr_in.sin_addr = *ip4;
 }
 
 void IPADDR::SetAddr6(struct in6_addr* ip6)
 {
-  if (saddr->sa_family != AF_INET6) {
+  if (addr.sa_family != AF_INET6) {
     Emsg1(M_ERROR_TERM, 0,
           T_("It was tried to assign a ipv4 address to a ipv6(%d)\n"),
-          saddr->sa_family);
+          addr.sa_family);
   }
-  saddr6->sin6_addr = *ip6;
+  addr_in6.sin6_addr = *ip6;
 }
 
 const char* IPADDR::GetAddress(char* outputbuf, int outlen)
 {
   outputbuf[0] = '\0';
 #ifdef HAVE_INET_NTOP
-  inet_ntop(saddr->sa_family,
-            saddr->sa_family == AF_INET ? (void*)&(saddr4->sin_addr)
-                                        : (void*)&(saddr6->sin6_addr),
+  inet_ntop(addr.sa_family,
+            addr.sa_family == AF_INET ? (void*)&(addr_in.sin_addr)
+                                      : (void*)&(addr_in6.sin6_addr),
             outputbuf, outlen);
 #else
-  bstrncpy(outputbuf, inet_ntoa(saddr4->sin_addr), outlen);
+  bstrncpy(outputbuf, inet_ntoa(addr_in.sin_addr), outlen);
 #endif
   return outputbuf;
 }

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2004-2007 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -112,7 +112,7 @@ const char* BuildAddressesString(dlist<IPADDR>* addrs,
                                  char* buf,
                                  int blen,
                                  bool print_port = true);
-char* SockaddrToAscii(const struct sockaddr* sa, char* buf, int len);
+char* SockaddrToAscii(const struct sockaddr_storage* sa, char* buf, int len);
 #ifdef WIN32
 #  undef HAVE_OLD_SOCKOPT
 #endif

--- a/core/src/lib/address_conf.h
+++ b/core/src/lib/address_conf.h
@@ -58,16 +58,14 @@ class IPADDR {
   IPADDR(const IPADDR& src);
 
  private:
-  IPADDR();
   i_type type = R_UNDEFINED;
   union {
-    struct sockaddr dontuse;
-    struct sockaddr_in dontuse4;
-    struct sockaddr_in6 dontuse6;
-  } saddrbuf;
-  struct sockaddr* saddr = nullptr;
-  struct sockaddr_in* saddr4 = nullptr;
-  struct sockaddr_in6* saddr6 = nullptr;
+    sockaddr addr;
+    sockaddr_in addr_in;
+    sockaddr_in6 addr_in6;
+    sockaddr_storage addr_storage = {};
+  };
+
  public:
   void SetType(i_type o);
   i_type GetType() const;

--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -327,9 +327,7 @@ void BnetThreadServerTcp(
       maxfd = std::max(sock.fd, maxfd);
     }
 
-    struct timeval timeout {
-      .tv_sec = 1, .tv_usec = 0
-    };
+    struct timeval timeout{.tv_sec = 1, .tv_usec = 0};
 
     errno = 0;
     int status = select(maxfd + 1, &sockset, NULL, NULL, &timeout);
@@ -403,8 +401,7 @@ void BnetThreadServerTcp(
         char buf[128];
 
         lock_mutex(mutex);
-        SockaddrToAscii(reinterpret_cast<sockaddr*>(&cli_addr), buf,
-                        sizeof(buf));
+        SockaddrToAscii(&cli_addr, buf, sizeof(buf));
         unlock_mutex(mutex);
 
         BareosSocket* bs;

--- a/core/src/lib/bsock.cc
+++ b/core/src/lib/bsock.cc
@@ -422,7 +422,7 @@ bool BareosSocket::TwoWayAuthenticate(JobControlRecord* jcr,
 
     if (!auth_success) {
       char ipaddr_str[MAXHOSTNAMELEN]{};
-      SockaddrToAscii(&(client_addr), ipaddr_str, sizeof(ipaddr_str));
+      SockaddrToAscii(&client_addr, ipaddr_str, sizeof(ipaddr_str));
 
       switch (cram_md5_handshake.result) {
         case CramMd5Handshake::HandshakeResult::REPLAY_ATTACK: {

--- a/core/src/lib/bsock.cc
+++ b/core/src/lib/bsock.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -511,7 +511,6 @@ void BareosSocket::ParameterizeTlsCert(Tls* conn_init,
   conn_init->SetCipherList(tls_resource->cipherlist_);
   conn_init->SetCipherSuites(tls_resource->ciphersuites_);
   conn_init->SetVerifyPeer(tls_resource->tls_cert_.verify_peer_);
-  conn_init->SetEnableKtls(tls_resource->enable_ktls_);
 }
 
 bool BareosSocket::ParameterizeAndInitTlsConnectionAsAServer(
@@ -539,6 +538,7 @@ bool BareosSocket::ParameterizeAndInitTlsConnectionAsAServer(
   ParameterizeTlsCert(tls_conn_init.get(), tls_resource);
 
   tls_conn_init->SetTlsPskServerContext(config);
+  tls_conn_init->SetEnableKtls(enable_ktls_);
 
   if (!tls_conn_init->init()) {
     tls_conn_init.reset();
@@ -622,6 +622,8 @@ bool BareosSocket::ParameterizeAndInitTlsConnection(TlsResource* tls_resource,
   } else {
     Dmsg2(200, "Tls is not configured %s\n", identity);
   }
+
+  tls_conn_init->SetEnableKtls(enable_ktls_);
 
   if (!tls_conn_init->init()) {
     tls_conn_init.reset();

--- a/core/src/lib/bsock.h
+++ b/core/src/lib/bsock.h
@@ -84,7 +84,7 @@ class BareosSocket {
   int sleep_time_after_authentication_error;
 
   struct sockaddr_storage client_addr; /* Client's IP address */
-  struct sockaddr_in peer_addr;        /* Peer's IP address */
+  struct sockaddr_storage peer_addr;   /* Peer's IP address */
   void SetTlsEstablished() { tls_established_ = true; }
   bool TlsEstablished() const { return tls_established_; }
   std::shared_ptr<Tls> tls_conn;      /* Associated tls connection */

--- a/core/src/lib/bsock.h
+++ b/core/src/lib/bsock.h
@@ -83,8 +83,8 @@ class BareosSocket {
   std::atomic<bool> suppress_error_msgs_; /* Set to suppress error messages */
   int sleep_time_after_authentication_error;
 
-  struct sockaddr client_addr;  /* Client's IP address */
-  struct sockaddr_in peer_addr; /* Peer's IP address */
+  struct sockaddr_storage client_addr; /* Client's IP address */
+  struct sockaddr_in peer_addr;        /* Peer's IP address */
   void SetTlsEstablished() { tls_established_ = true; }
   bool TlsEstablished() const { return tls_established_; }
   std::shared_ptr<Tls> tls_conn;      /* Associated tls connection */

--- a/core/src/lib/bsock.h
+++ b/core/src/lib/bsock.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -82,6 +82,7 @@ class BareosSocket {
   std::atomic<int> errors; /* Incremented for each error on socket */
   std::atomic<bool> suppress_error_msgs_; /* Set to suppress error messages */
   int sleep_time_after_authentication_error;
+  bool enable_ktls_{false};
 
   struct sockaddr_storage client_addr; /* Client's IP address */
   struct sockaddr_storage peer_addr;   /* Peer's IP address */
@@ -285,6 +286,7 @@ class BareosSocket {
   void SetBnetDumpDestinationQualifiedName(
       std::string destination_qualified_name);
   bool IsBnetDumpEnabled() const { return bnet_dump_.get() != nullptr; }
+  void SetEnableKtls(bool enable_ktls) { enable_ktls_ = enable_ktls; }
 };
 
 /**

--- a/core/src/lib/bsock_tcp.cc
+++ b/core/src/lib/bsock_tcp.cc
@@ -200,7 +200,11 @@ void BareosSocketTCP::FinInit(JobControlRecord* jcr,
   SetWho(strdup(who));
   SetHost(strdup(host));
   SetPort(port);
-  memcpy(&client_addr, lclient_addr, sizeof(client_addr));
+  if (lclient_addr->sa_family == AF_INET) {
+    memcpy(&client_addr, lclient_addr, sizeof(sockaddr_in));
+  } else {
+    memcpy(&client_addr, lclient_addr, sizeof(sockaddr_in6));
+  }
   SetJcr(jcr);
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -313,6 +313,7 @@ ResourceTable* ConfigurationParser::GetResourceTable(
     const char* resource_type_name)
 {
   int res_table_index = GetResourceTableIndex(resource_type_name);
+  if (res_table_index == -1) { return nullptr; }
   return &resource_definitions_[res_table_index];
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -112,7 +112,6 @@ ConfigurationParser::ConfigurationParser(
   err_type_ = err_type;
   r_num_ = r_num;
   resource_definitions_ = resource_definitions;
-  config_resources_container_.reset(new ConfigResourcesContainer(this));
   config_default_filename_
       = config_default_filename == nullptr ? "" : config_default_filename;
   config_include_dir_ = config_include_dir == nullptr ? "" : config_include_dir;
@@ -124,6 +123,11 @@ ConfigurationParser::ConfigurationParser(
   SaveResourceCb_ = SaveResourceCb;
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
+
+  // config resources container needs to access our members, so this
+  // needs to always happen after we initialised everything else
+  config_resources_container_
+      = std::make_shared<ConfigResourcesContainer>(this);
 }
 
 void ConfigurationParser::InitializeQualifiedResourceNameTypeConverter(

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -427,34 +427,28 @@ class ConfigurationParser {
 class ConfigResourcesContainer {
  private:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
-  ConfigurationParser* config_ = nullptr;
+  FreeResourceCb_t free_res = nullptr;
 
  public:
-  BareosResource** configuration_resources_ = nullptr;
+  std::vector<BareosResource*> configuration_resources_ = {};
   ConfigResourcesContainer(ConfigurationParser* config)
+      : free_res{config->FreeResourceCb_}
+      , configuration_resources_(config->r_num_)
   {
-    config_ = config;
-    int num = config_->r_num_;
-    configuration_resources_
-        = (BareosResource**)malloc(num * sizeof(BareosResource*));
-
-    for (int i = 0; i < num; i++) { configuration_resources_[i] = nullptr; }
     Dmsg1(10, "ConfigResourcesContainer: new configuration_resources_ %p\n",
-          configuration_resources_);
+          configuration_resources_.data());
   }
 
   ~ConfigResourcesContainer()
   {
     Dmsg1(10, "ConfigResourcesContainer freeing %p %s\n",
-          configuration_resources_, TPAsString(timestamp_).c_str());
-    int num = config_->r_num_;
-    for (int j = 0; j < num; j++) {
-      config_->FreeResourceCb_(configuration_resources_[j], j);
-      configuration_resources_[j] = nullptr;
+          configuration_resources_.data(), TPAsString(timestamp_).c_str());
+
+    for (size_t i = 0; i < configuration_resources_.size(); ++i) {
+      free_res(configuration_resources_[i], i);
     }
-    free(configuration_resources_);
-    configuration_resources_ = nullptr;
   }
+
   void SetTimestampToNow() { timestamp_ = std::chrono::system_clock::now(); }
   std::string TimeStampAsString() { return TPAsString(timestamp_); }
 };

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -427,6 +427,13 @@ class ConfigurationParser {
 class ConfigResourcesContainer {
  private:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
+  /* `next_` points to the immediate successor of this configuration.  This
+   * ensures that if something (i.e. a job) keeps alive its configuration,
+   * and accidentally accesses the global configuration afterwards (without
+   * saving it as well), then the daemon will not crash because of use
+   * after free, as the newer configurations are now also kept alive
+   * implicitly as well. */
+  std::shared_ptr<ConfigResourcesContainer> next_ = nullptr;
   FreeResourceCb_t free_res = nullptr;
 
  public:
@@ -451,6 +458,11 @@ class ConfigResourcesContainer {
 
   void SetTimestampToNow() { timestamp_ = std::chrono::system_clock::now(); }
   std::string TimeStampAsString() { return TPAsString(timestamp_); }
+
+  void SetNext(std::shared_ptr<ConfigResourcesContainer> next)
+  {
+    next_ = std::move(next);
+  }
 };
 
 

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -151,7 +151,7 @@ ConfigParserStateMachine::ScanResource(int token)
             my_config_.store_res_(lexical_parser_, item, resource_item_index,
                                   parser_pass_number_,
                                   my_config_.config_resources_container_
-                                      ->configuration_resources_);
+                                      ->configuration_resources_.data());
           }
         }
       } else {

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -225,6 +225,12 @@ ConfigParserStateMachine::ParserInitResource(int token)
 
   ResourceTable* resource_table;
   resource_table = my_config_.GetResourceTable(resource_identifier);
+  if (!resource_table) {
+    scan_err1(lexical_parser_,
+              T_("Expected a Resource name identifier, got: %s"),
+              resource_identifier);
+    return ParseInternalReturnCode::kError;
+  }
 
   bool init_done = false;
 

--- a/core/src/lib/tls_conf.h
+++ b/core/src/lib/tls_conf.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,7 +47,6 @@ class TlsResource {
   bool authenticate_{false}; /* Authenticate only with TLS */
   bool tls_enable_{false};
   bool tls_require_{false};
-  bool enable_ktls_{false}; /* enable support for ktls */
 
   bool IsTlsConfigured() const;
   TlsPolicy GetPolicy() const;

--- a/core/src/lib/tls_resource_items.h
+++ b/core/src/lib/tls_resource_items.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,9 +35,6 @@
   { "TlsRequire", CFG_TYPE_BOOL, ITEM(res, tls_require_), 0, CFG_ITEM_DEFAULT, "true", \
      NULL, "If set to \"no\", Bareos can fall back to use unencrypted " \
      "connections. " }, \
-  { "EnableKtls", CFG_TYPE_BOOL, ITEM(res, enable_ktls_), 0, CFG_ITEM_DEFAULT, "false", \
-     NULL, "If set to \"yes\", Bareos will allow the SSL implementation to use " \
-     "Kernel TLS. " }, \
   { "TlsCipherList", CFG_TYPE_STDSTR, ITEM(res, cipherlist_), 0, CFG_ITEM_PLATFORM_SPECIFIC, NULL, \
      NULL, "Colon separated list of valid TLSv1.2 and lower Ciphers; see \"openssl ciphers\" command." \
      " Leftmost element has the highest priority."}, \

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -93,7 +93,6 @@ set(SDSRCS
     ndmp_tape.cc
     read.cc
     sd_cmds.cc
-    sd_stats.cc
     socket_server.cc
     status.cc
 )

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1640,6 +1640,8 @@ static bool ReplicateCmd(JobControlRecord* jcr)
   Dmsg0(110, "Connection OK to SD.\n");
   connect_state(ReplicateCmdState::kConnected);
 
+  storage_daemon_socket->SetEnableKtls(me->enable_ktls);
+
   if (tls_policy == TlsPolicy::kBnetTlsAuto) {
     std::string qualified_resource_name;
     if (!my_config->GetQualifiedResourceNameTypeConverter()->ResourceToString(
@@ -1732,6 +1734,8 @@ static bool PassiveCmd(JobControlRecord* jcr)
     goto bail_out;
   }
   Dmsg0(110, "Connection OK to FD.\n");
+
+  fd->SetEnableKtls(me->enable_ktls);
 
   if (tls_policy == TlsPolicy::kBnetTlsAuto) {
     std::string qualified_resource_name;

--- a/core/src/stored/ndmp_tape.cc
+++ b/core/src/stored/ndmp_tape.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1121,7 +1121,7 @@ extern "C" void* ndmp_thread_server(void* arg)
   struct ndmp_thread_server_args* ntsa;
   int new_sockfd, status;
   socklen_t clilen;
-  struct sockaddr cli_addr; /* client's address */
+  struct sockaddr_storage cli_addr; /* client's address */
   int tlog, tmax;
   int turnon = 1;
   IPADDR *ipaddr, *next;
@@ -1233,7 +1233,8 @@ extern "C" void* ndmp_thread_server(void* arg)
         // Got a connection, now accept it.
         do {
           clilen = sizeof(cli_addr);
-          new_sockfd = accept(fd_ptr->fd, &cli_addr, &clilen);
+          new_sockfd = accept(fd_ptr->fd,
+                              reinterpret_cast<sockaddr*>(&cli_addr), &clilen);
         } while (new_sockfd < 0 && errno == EINTR);
         if (new_sockfd < 0) { continue; }
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -119,6 +119,7 @@ static ResourceItem store_items[] = {
   {"SecureEraseCommand", CFG_TYPE_STR, ITEM(res_store, secure_erase_cmdline), 0, 0, NULL, "15.2.1-",
       "Specify command that will be called when bareos unlinks files."},
   {"LogTimestampFormat", CFG_TYPE_STR, ITEM(res_store, log_timestamp_format), 0, CFG_ITEM_DEFAULT, "%d-%b %H:%M", "15.2.3-", NULL},
+  {"EnableKtls", CFG_TYPE_BOOL, ITEM(res_store, enable_ktls), 0, CFG_ITEM_DEFAULT, "false", "23.0.0-", "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."},
     TLS_COMMON_CONFIG(res_store),
     TLS_CERT_CONFIG(res_store),
   {nullptr, 0, 0, nullptr, 0, 0, nullptr, nullptr, nullptr}

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -92,7 +92,7 @@ static ResourceItem store_items[] = {
   {"PluginDirectory", CFG_TYPE_DIR, ITEM(res_store, plugin_directory), 0, 0, NULL, NULL, NULL},
   {"PluginNames", CFG_TYPE_PLUGIN_NAMES, ITEM(res_store, plugin_names), 0, 0, NULL, NULL, NULL},
   {"ScriptsDirectory", CFG_TYPE_DIR, ITEM(res_store, scripts_directory), 0, CFG_ITEM_DEFAULT | CFG_ITEM_PLATFORM_SPECIFIC, PATH_BAREOS_SCRIPTDIR, NULL, "Path to directory containing script files"},
-  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_store, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "1000", NULL, NULL},
+  {"MaximumConcurrentJobs", CFG_TYPE_PINT32, ITEM(res_store, MaxConcurrentJobs), 0, CFG_ITEM_DEFAULT | CFG_ITEM_DEPRECATED, "1000", "-24.0.0", NULL},
   {"Messages", CFG_TYPE_RES, ITEM(res_store, messages), R_MSGS, 0, NULL, NULL, NULL},
   {"SdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, SDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
   {"FdConnectTimeout", CFG_TYPE_TIME, ITEM(res_store, FDConnectTimeout), 0, CFG_ITEM_DEFAULT, "1800" /* 30 minutes */, NULL, NULL},
@@ -111,9 +111,9 @@ static ResourceItem store_items[] = {
   {"NdmpPort", CFG_TYPE_ADDRESSES_PORT, ITEM(res_store, NDMPaddrs), 0, CFG_ITEM_DEFAULT, "10000", NULL, NULL},
   {"AutoXFlateOnReplication", CFG_TYPE_BOOL, ITEM(res_store, autoxflateonreplication), 0, CFG_ITEM_DEFAULT, "false", "13.4.0-", NULL},
   {"AbsoluteJobTimeout", CFG_TYPE_PINT32, ITEM(res_store, jcr_watchdog_time), 0, 0, NULL, "14.2.0-", "Absolute time after which a Job gets terminated regardless of its progress" },
-  {"CollectDeviceStatistics", CFG_TYPE_BOOL, ITEM(res_store, collect_dev_stats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", NULL, NULL},
-  {"CollectJobStatistics", CFG_TYPE_BOOL, ITEM(res_store, collect_job_stats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", NULL, NULL},
-  {"StatisticsCollectInterval", CFG_TYPE_PINT32, ITEM(res_store, stats_collect_interval), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "0", NULL, NULL},
+  {"CollectDeviceStatistics", CFG_TYPE_BOOL, ITEM(res_store, collect_dev_stats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", "-22.0.0", NULL},
+  {"CollectJobStatistics", CFG_TYPE_BOOL, ITEM(res_store, collect_job_stats), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "false", "-22.0.0", NULL},
+  {"StatisticsCollectInterval", CFG_TYPE_PINT32, ITEM(res_store, stats_collect_interval), 0, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "0", "-22.0.0", NULL},
   {"DeviceReserveByMediaType", CFG_TYPE_BOOL, ITEM(res_store, device_reserve_by_mediatype), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
   {"FileDeviceConcurrentRead", CFG_TYPE_BOOL, ITEM(res_store, filedevice_concurrent_read), 0, CFG_ITEM_DEFAULT, "false", NULL, NULL},
   {"SecureEraseCommand", CFG_TYPE_STR, ITEM(res_store, secure_erase_cmdline), 0, 0, NULL, "15.2.1-",
@@ -173,7 +173,7 @@ static ResourceItem dev_items[] = {
   {"CloseOnPoll", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_CLOSEONPOLL, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"BlockPositioning", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_POSITIONBLOCKS, CFG_ITEM_DEFAULT, "on", NULL, NULL},
   {"UseMtiocget", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_MTIOCGET, CFG_ITEM_DEFAULT, "on", NULL, NULL},
-  {"CheckLabels", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_CHECKLABELS, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "off", NULL, NULL},
+  {"CheckLabels", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_CHECKLABELS, CFG_ITEM_DEPRECATED | CFG_ITEM_DEFAULT, "off", "-23.0.0", NULL},
   {"RequiresMount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_REQMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"OfflineOnUnmount", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_OFFLINEUNMOUNT, CFG_ITEM_DEFAULT, "off", NULL, NULL},
   {"BlockChecksum", CFG_TYPE_BIT, ITEM(res_dev, cap_bits), CAP_BLOCKCHECKSUM, CFG_ITEM_DEFAULT, "on", NULL, NULL},
@@ -187,7 +187,7 @@ static ResourceItem dev_items[] = {
       "300" /* 5 minutes */, NULL, NULL},
   {"MaximumOpenWait", CFG_TYPE_TIME, ITEM(res_dev, max_open_wait), 0, CFG_ITEM_DEFAULT, "300" /* 5 minutes */, NULL, NULL},
   {"MaximumOpenVolumes", CFG_TYPE_PINT32, ITEM(res_dev, max_open_vols), 0, CFG_ITEM_DEFAULT, "1", NULL, NULL},
-  {"MaximumNetworkBufferSize", CFG_TYPE_PINT32, ITEM(res_dev, max_network_buffer_size), CFG_ITEM_DEPRECATED, 0, NULL, NULL,
+  {"MaximumNetworkBufferSize", CFG_TYPE_PINT32, ITEM(res_dev, max_network_buffer_size), 0, CFG_ITEM_DEPRECATED, NULL, "-24.0.0",
    "Replaced by MaximumNetworkBufferSize (SD->Storage)."},
   {"VolumePollInterval", CFG_TYPE_TIME, ITEM(res_dev, vol_poll_interval), 0, CFG_ITEM_DEFAULT, "300" /* 5 minutes */, NULL, NULL},
   {"MaximumRewindWait", CFG_TYPE_TIME, ITEM(res_dev, max_rewind_wait), 0, CFG_ITEM_DEFAULT,
@@ -206,7 +206,7 @@ static ResourceItem dev_items[] = {
   {"MountPoint", CFG_TYPE_STRNAME, ITEM(res_dev, mount_point), 0, 0, NULL, NULL, NULL},
   {"MountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, mount_command), 0, 0, NULL, NULL, NULL},
   {"UnmountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, unmount_command), 0, 0, NULL, NULL, NULL},
-  {"LabelType", CFG_TYPE_LABEL, ITEM(res_dev, label_type), 0, CFG_ITEM_DEPRECATED, NULL, NULL, NULL},
+  {"LabelType", CFG_TYPE_LABEL, ITEM(res_dev, label_type), 0, CFG_ITEM_DEPRECATED, NULL, "-23.0.0", NULL},
   {"NoRewindOnClose", CFG_TYPE_BOOL, ITEM(res_dev, norewindonclose), 0, CFG_ITEM_DEFAULT, "true", NULL, NULL},
   {"DriveTapeAlertEnabled", CFG_TYPE_BOOL, ITEM(res_dev, drive_tapealert_enabled), 0, 0, NULL, NULL, NULL},
   {"DriveCryptoEnabled", CFG_TYPE_BOOL, ITEM(res_dev, drive_crypto_enabled), 0, 0, NULL, NULL, NULL},

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -137,6 +137,8 @@ class StorageResource
   uint64_t max_bandwidth_per_job = 0;   /**< Bandwidth limitation (global) */
 
   bool just_in_time_reservation{false};
+
+  bool enable_ktls{false};
 
   StorageResource() = default;
   virtual ~StorageResource() = default;

--- a/core/src/stored/stored_conf.h
+++ b/core/src/stored/stored_conf.h
@@ -53,7 +53,7 @@ enum
   R_MSGS,
   R_AUTOCHANGER,
   R_JOB,           // needed for Job name conversion
-  R_NUM,           // number of entires
+  R_NUM,           // number of entries
   R_CLIENT = 0xff  // dummy for bsock printing
 };
 

--- a/core/src/tests/alist_test.cc
+++ b/core/src/tests/alist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -114,7 +114,7 @@ void test_alist_dynamic()
   // does foreach work for empty lists?
   TestForeachAlist(list);
 
-  // create empty list, which is prepared for a number of entires
+  // create empty list, which is prepared for a number of entries
   list = new alist<const char*>(10);
   EXPECT_EQ(list->size(), 0);
 
@@ -136,7 +136,7 @@ void test_alist_dynamic()
   EXPECT_STREQ(buf, "18");
   free(buf);
 
-  // added more entires
+  // added more entries
   AlistFill(list, 20);
   TestForeachAlist(list);
 

--- a/core/src/tests/bsock_constructor_test.cc
+++ b/core/src/tests/bsock_constructor_test.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -18,6 +18,7 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
+#include <cstring>
 #if defined(HAVE_MINGW)
 #  include "include/bareos.h"
 #  include "gtest/gtest.h"
@@ -56,10 +57,14 @@ TEST(bsock, bareossockettcp_standard_constructor_test)
   EXPECT_EQ(p->errors, 0);
   EXPECT_EQ(p->suppress_error_msgs_, false);
   EXPECT_EQ(p->sleep_time_after_authentication_error, 5);
-  EXPECT_EQ(p->client_addr.sa_family, AF_UNSPEC);
-  EXPECT_EQ(p->client_addr.sa_data[0], 0);
-  EXPECT_EQ(p->peer_addr.sin_port, 0);
-  EXPECT_EQ(p->peer_addr.sin_addr.s_addr, 0);
+
+  auto* client_as_sockaddr = reinterpret_cast<sockaddr*>(&p->client_addr);
+  EXPECT_EQ(p->client_addr.ss_family, AF_UNSPEC);
+  EXPECT_EQ(client_as_sockaddr->sa_data[0], 0);
+
+  char all_zero[sizeof(p->peer_addr)] = {};
+  EXPECT_EQ(p->peer_addr.ss_family, AF_UNSPEC);
+  EXPECT_EQ(std::memcmp(&p->peer_addr, all_zero, sizeof(p->peer_addr)), 0);
 
   /* protected BAREOS_SOCKET: */
   EXPECT_EQ(p->jcr_, nullptr);

--- a/core/src/tests/dlist_test.cc
+++ b/core/src/tests/dlist_test.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2003-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -154,7 +154,7 @@ TEST(dlist, dynamic)
   EXPECT_STREQ(item->buf, "18");
   FreeItem(item);
 
-  // added more entires
+  // added more entries
   DlistFill(list, 20);
   TestForeachDlist(list);
 

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -128,7 +128,8 @@
           "code": 0,
           "default_value": "160704000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-22.0.0"
         },
         "StatisticsCollectInterval": {
           "datatype": "PINT32",
@@ -136,7 +137,7 @@
           "default_value": "0",
           "deprecated": true,
           "equals": true,
-          "versions": "14.2.0-"
+          "versions": "14.2.0-22.0.0"
         },
         "VerId": {
           "datatype": "STRING",
@@ -449,14 +450,16 @@
           "code": 0,
           "default_value": "5184000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "JobRetention": {
           "datatype": "TIME",
           "code": 0,
           "default_value": "15552000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "HeartbeatInterval": {
           "datatype": "TIME",
@@ -469,7 +472,8 @@
           "code": 0,
           "default_value": "false",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "MaximumConcurrentJobs": {
           "datatype": "PINT32",
@@ -981,7 +985,8 @@
           "code": 0,
           "default_value": "true",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-24.0.0"
         },
         "CancelLowerLevelDuplicates": {
           "datatype": "BOOLEAN",
@@ -1465,7 +1470,8 @@
           "code": 0,
           "default_value": "true",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-24.0.0"
         },
         "CancelLowerLevelDuplicates": {
           "datatype": "BOOLEAN",
@@ -1715,7 +1721,8 @@
           "code": 0,
           "default_value": "false",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-22.0.0"
         },
         "NdmpChangerDevice": {
           "datatype": "STRNAME",
@@ -2039,7 +2046,8 @@
           "datatype": "LABEL",
           "code": 0,
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "CleaningPrefix": {
           "datatype": "STRNAME",

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -203,6 +203,14 @@
           "equals": true,
           "versions": "15.2.3-"
         },
+        "EnableKtls": {
+          "datatype": "BOOLEAN",
+          "code": 0,
+          "default_value": "false",
+          "equals": true,
+          "versions": "23.0.0-",
+          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."
+        },
         "TlsAuthenticate": {
           "datatype": "BOOLEAN",
           "code": 0,
@@ -223,13 +231,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",
@@ -524,13 +525,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",
@@ -1752,13 +1746,6 @@
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
         },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
-        },
         "TlsCipherList": {
           "datatype": "STRING",
           "code": 0,
@@ -2506,13 +2493,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -93,13 +93,6 @@
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
         },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
-        },
         "TlsCipherList": {
           "datatype": "STRING",
           "code": 0,
@@ -381,6 +374,14 @@
           "versions": "25.0.0-",
           "description": "The grpc module to use for grpc fallback."
         },
+        "EnableKtls": {
+          "datatype": "BOOLEAN",
+          "code": 0,
+          "default_value": "false",
+          "equals": true,
+          "versions": "23.0.0-",
+          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."
+        },
         "TlsAuthenticate": {
           "datatype": "BOOLEAN",
           "code": 0,
@@ -401,13 +402,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",
@@ -690,6 +684,14 @@
           "versions": "25.0.0-",
           "description": "The grpc module to use for grpc fallback."
         },
+        "EnableKtls": {
+          "datatype": "BOOLEAN",
+          "code": 0,
+          "default_value": "false",
+          "equals": true,
+          "versions": "23.0.0-",
+          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."
+        },
         "TlsAuthenticate": {
           "datatype": "BOOLEAN",
           "code": 0,
@@ -710,13 +712,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",

--- a/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-fd-config-schema.json
@@ -239,7 +239,8 @@
           "code": 0,
           "default_value": "1000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-24.0.0"
         },
         "MaximumWorkersPerJob": {
           "datatype": "PINT32",
@@ -349,6 +350,7 @@
           "default_value": "false",
           "deprecated": true,
           "equals": true,
+          "versions": "-24.0.0",
           "description": "Ensure that bareos always chooses the lmdb backend for accurate information regardless of the file list size.  Use LmdbThreshold = 0 instead."
         },
         "LmdbThreshold": {
@@ -546,7 +548,8 @@
           "code": 0,
           "default_value": "1000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-24.0.0"
         },
         "MaximumWorkersPerJob": {
           "datatype": "PINT32",
@@ -656,6 +659,7 @@
           "default_value": "false",
           "deprecated": true,
           "equals": true,
+          "versions": "-24.0.0",
           "description": "Ensure that bareos always chooses the lmdb backend for accurate information regardless of the file list size.  Use LmdbThreshold = 0 instead."
         },
         "LmdbThreshold": {

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -254,7 +254,8 @@
           "code": 0,
           "default_value": "1000",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-24.0.0"
         },
         "Messages": {
           "datatype": "RES",
@@ -367,21 +368,24 @@
           "code": 0,
           "default_value": "false",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-22.0.0"
         },
         "CollectJobStatistics": {
           "datatype": "BOOLEAN",
           "code": 0,
           "default_value": "false",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-22.0.0"
         },
         "StatisticsCollectInterval": {
           "datatype": "PINT32",
           "code": 0,
           "default_value": "0",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-22.0.0"
         },
         "DeviceReserveByMediaType": {
           "datatype": "BOOLEAN",
@@ -665,7 +669,8 @@
           "code": 22,
           "default_value": "off",
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "RequiresMount": {
           "datatype": "BIT",
@@ -733,8 +738,10 @@
         },
         "MaximumNetworkBufferSize": {
           "datatype": "PINT32",
-          "code": 8,
+          "code": 0,
+          "deprecated": true,
           "equals": true,
+          "versions": "-24.0.0",
           "description": "Replaced by MaximumNetworkBufferSize (SD->Storage)."
         },
         "VolumePollInterval": {
@@ -822,7 +829,8 @@
           "datatype": "LABEL",
           "code": 0,
           "deprecated": true,
-          "equals": true
+          "equals": true,
+          "versions": "-23.0.0"
         },
         "NoRewindOnClose": {
           "datatype": "BOOLEAN",

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -57,13 +57,6 @@
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
         },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
-        },
         "TlsCipherList": {
           "datatype": "STRING",
           "code": 0,
@@ -413,6 +406,14 @@
           "equals": true,
           "versions": "15.2.3-"
         },
+        "EnableKtls": {
+          "datatype": "BOOLEAN",
+          "code": 0,
+          "default_value": "false",
+          "equals": true,
+          "versions": "23.0.0-",
+          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS."
+        },
         "TlsAuthenticate": {
           "datatype": "BOOLEAN",
           "code": 0,
@@ -433,13 +434,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",

--- a/docs/manuals/source/include/autogenerated/bareos-tray-monitor-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-tray-monitor-config-schema.json
@@ -66,13 +66,6 @@
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
         },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
-        },
         "TlsCipherList": {
           "datatype": "STRING",
           "code": 0,
@@ -189,13 +182,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",
@@ -319,13 +305,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",
@@ -459,13 +438,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",

--- a/docs/manuals/source/include/autogenerated/bconsole-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bconsole-config-schema.json
@@ -70,13 +70,6 @@
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
         },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
-        },
         "TlsCipherList": {
           "datatype": "STRING",
           "code": 0,
@@ -203,13 +196,6 @@
           "default_value": "true",
           "equals": true,
           "description": "If set to \"no\", Bareos can fall back to use unencrypted connections. "
-        },
-        "EnableKtls": {
-          "datatype": "BOOLEAN",
-          "code": 0,
-          "default_value": "false",
-          "equals": true,
-          "description": "If set to \"yes\", Bareos will allow the SSL implementation to use Kernel TLS. "
         },
         "TlsCipherList": {
           "datatype": "STRING",

--- a/systemtests/scripts/check_for_zombie_jobs
+++ b/systemtests/scripts/check_for_zombie_jobs
@@ -38,6 +38,7 @@ then
   echo "  !!!! Zombie Jobs in Director !!!!"
   echo "  !!!! Zombie Jobs in Director !!!!" >>test.out
   cat "${tmp}"/dir.out
+  cat "${tmp}"/dir.out >>test.out
   echo " "
   zstat=1
   exit 1
@@ -48,6 +49,7 @@ then
   echo "  !!!! Zombie Jobs in File daemon !!!!"
   echo "  !!!! Zombie Jobs in File daemon !!!!" >>test.out
   cat "${tmp}"/fd.out
+  cat "${tmp}"/fd.out >>test.out
   echo " "
   zstat=1
   exit 1
@@ -58,6 +60,7 @@ then
   echo "  !!!! Zombie Jobs in Storage daemon !!!!"
   echo "  !!!! Zombie Jobs in Storage daemon !!!!" >>test.out
   cat "${tmp}"/sd.out
+  cat "${tmp}"/sd.out >>test.out
   echo " "
   zstat=1
   exit 1

--- a/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
+++ b/systemtests/tests/config-dump/etc/bareos/bareos-dir-full.conf.in
@@ -29,10 +29,10 @@ Director {
   AuditEvents = "item11", "item12", ".*"
   # SecureEraseCommand =
   # LogTimestampFormat = "%d-%b %H:%M"
+  # EnableKtls = No
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -75,7 +75,6 @@ Client {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -118,7 +117,6 @@ Client {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -164,7 +162,6 @@ Client {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -1267,7 +1264,6 @@ Storage {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -1739,7 +1735,6 @@ Console {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -1772,7 +1767,6 @@ Console {
   # TlsAuthenticate = No
   TlsEnable = No
   # TlsRequire = Yes
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""
@@ -1805,7 +1799,6 @@ Console {
   # TlsAuthenticate = No
   # TlsEnable = Yes
   # TlsRequire = No
-  # EnableKtls = No
   # TlsCipherList = ""
   # TlsCipherSuites = ""
   # TlsDhFile = ""

--- a/systemtests/tests/python-bareos/test_bvfs.py
+++ b/systemtests/tests/python-bareos/test_bvfs.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -288,7 +288,7 @@ class PythonBareosBvfsTest(bareos_unittest.Json):
             **format_params
         )
         bvfs_lsfiles_BackupDirectory_limit1 = director.call(cmd)["files"]
-        # TODO: bug, this returns multiple entires
+        # TODO: bug, this returns multiple entries
         # self.assertEqual(len(bvfs_lsfiles_BackupDirectory_limit1), 1, 'Expecting 1 file from "{}", instead received: {}'.format(cmd, bvfs_lsfiles_BackupDirectory_limit1))
 
         cmd = ".bvfs_versions jobid=0 client={Client} path={BackupDirectory}/ fname={BackupFileNameExtra}".format(


### PR DESCRIPTION
**Backport of PR #2222 to bareos-24**

This PR only contains the bug fixes from the original PR.
Additionally the json configs also contain changes to the FileDaemon alias
where applicable, as they were removed in 25, but not in 24.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2222 is merged
- [x] All functional differences to the original PR are documented above
