### PR TITLE
mariabackup: reset self.mycnf to string type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cli-test: fix test on freebsd [PR #2241]
 - core: refactor config parser; fix ktls configuration; fix crashes/ub [PR #2222]
 - contrib add support for mariadb 11+ [PR #2215]
+- mariabackup: reset self.mycnf to string type [PR #2252]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -124,4 +125,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2225]: https://github.com/bareos/bareos/pull/2225
 [PR #2232]: https://github.com/bareos/bareos/pull/2232
 [PR #2241]: https://github.com/bareos/bareos/pull/2241
+[PR #2252]: https://github.com/bareos/bareos/pull/2252
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/mariabackup/bareos-fd-mariabackup.py
+++ b/core/src/plugins/filed/python/mariabackup/bareos-fd-mariabackup.py
@@ -59,7 +59,7 @@ class BareosFdMariabackup(BareosFdPluginBaseclass):
         self.dumpbinary = "mariadb-backup"
         self.restorecommand = None
         self.mysqlcmd = None
-        self.mycnf = None
+        self.mycnf = ""
         self.strictIncremental = False
         self.dumpoptions = ""
         # xtrabackup_checkpoints for <11 and mariadb_backup_checkpoints for >=11


### PR DESCRIPTION
Revert None type conversion introduced by mistake in b4948f5

Fix issue #2251

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
