### PR TITLE
mtx-changer: make mandatory test mt-st versus cpio-mt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - mariabackup: reset self.mycnf to string type [PR #2252]
 - dird: fix bugs in DateTime [PR #2260]
 - config: fix Director -> Director resource [PR #2259]
+- mtx-changer: make mandatory test mt-st versus cpio-mt [PR #2256]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -128,6 +129,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2232]: https://github.com/bareos/bareos/pull/2232
 [PR #2241]: https://github.com/bareos/bareos/pull/2241
 [PR #2252]: https://github.com/bareos/bareos/pull/2252
+[PR #2256]: https://github.com/bareos/bareos/pull/2256
 [PR #2259]: https://github.com/bareos/bareos/pull/2259
 [PR #2260]: https://github.com/bareos/bareos/pull/2260
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/scripts/mtx-changer.conf
+++ b/core/scripts/mtx-changer.conf
@@ -30,12 +30,11 @@ debug_log=0
 # mt status output
 # SunOS     No Additional Sense
 # FreeBSD   Current Driver State: at rest.
-# Linux     ONLINE
-#  Note Debian has a different mt than the standard Linux version.
+# Linux     ONLINE or drive status
+#  cpio-mt behave differently than mt-st:
 #    When no tape is in the drive it waits 2 minutes.
 #    When a tape is in the drive, it prints user unfriendly output.
-#  Note, with Ubuntu Gusty (8.04), there are two versions of mt,
-#    so we attempt to figure out which one.
+#  Note so we attempt to figure out which one is in use
 #
 
 OS=`uname`
@@ -48,11 +47,9 @@ case ${OS} in
     ;;
   Linux)
     ready="ONLINE"
-    if test -f /etc/debian_version ; then
-       mt --version|grep "mt-st" >/dev/null 2>&1
-       if test $? -eq 1 ; then
-          ready="drive status"
-       fi
+    mt --version|grep "mt-st" >/dev/null 2>&1
+    if test $? -eq 1 ; then
+      ready="drive status"
     fi
   ;;
 esac


### PR DESCRIPTION
mt-st is no more a default for numerous Linux distributions,
we want to check which mt version is in used on all Linux
platform.

Fix internal issue bareos/internal#322

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [X] Required backport PRs have been created
- [X] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- ~Required documentation changes are present and part of the PR~