### PR TITLE
dird: fix bugs in DateTime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: refactor config parser; fix ktls configuration; fix crashes/ub [PR #2222]
 - contrib add support for mariadb 11+ [PR #2215]
 - mariabackup: reset self.mycnf to string type [PR #2252]
+- dird: fix bugs in DateTime [PR #2260]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -126,4 +127,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2232]: https://github.com/bareos/bareos/pull/2232
 [PR #2241]: https://github.com/bareos/bareos/pull/2241
 [PR #2252]: https://github.com/bareos/bareos/pull/2252
+[PR #2260]: https://github.com/bareos/bareos/pull/2260
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/date_time.cc
+++ b/core/src/dird/date_time.cc
@@ -53,7 +53,7 @@ static int LastDayOfMonth(int year, int month)
   }
 }
 
-bool DateTime::WeekOfMonth() const { return day_of_month / 7; }
+int DateTime::WeekOfMonth() const { return day_of_month / 7; }
 bool DateTime::OnLast7DaysOfMonth() const
 {
   auto last_day = LastDayOfMonth(year, month);
@@ -71,6 +71,7 @@ DateTime::DateTime(time_t time_) : time(time_)
   month = tm.tm_mon;
   day_of_year = tm.tm_yday;
   hour = tm.tm_hour;
+  year = tm.tm_year;
 }
 
 void DateTime::PrintDebugMessage(int debug_level) const

--- a/core/src/dird/date_time.h
+++ b/core/src/dird/date_time.h
@@ -29,7 +29,7 @@ namespace directordaemon {
 struct DateTime {
   DateTime(time_t time);
 
-  bool WeekOfMonth() const;
+  int WeekOfMonth() const;
   bool OnLast7DaysOfMonth() const;
   void PrintDebugMessage(int debug_level) const;
 


### PR DESCRIPTION
Note that until this PR is merged, the system:scheduler:scheduler-last-keyword system test will fail.

1.  DateTime::year is not set
2. DateTime::WeekOfMonth should return int not bool

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

