### PR TITLE
packaging: set all `*.conf.examples` as %config(noreplace)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dird: fix bugs in DateTime [PR #2260]
 - config: fix Director -> Director resource [PR #2259]
 - mtx-changer: make mandatory test mt-st versus cpio-mt [PR #2256]
+- packaging: set all `*.conf.examples` as %config(noreplace) [PR #2268]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -134,4 +135,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2259]: https://github.com/bareos/bareos/pull/2259
 [PR #2260]: https://github.com/bareos/bareos/pull/2260
 [PR #2264]: https://github.com/bareos/bareos/pull/2264
+[PR #2268]: https://github.com/bareos/bareos/pull/2268
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -1094,9 +1094,9 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %dir /etc/bareos-webui
 %config(noreplace) /etc/bareos-webui/directors.ini
 %config(noreplace) /etc/bareos-webui/configuration.ini
-%config %attr(644,root,root) /etc/bareos/bareos-dir.d/console/admin.conf.example
+%config(noreplace) %attr(644,root,root) /etc/bareos/bareos-dir.d/console/admin.conf.example
 %config(noreplace) %attr(644,root,root) /etc/bareos/bareos-dir.d/profile/webui-admin.conf
-%config %attr(644,root,root) /etc/bareos/bareos-dir.d/profile/webui-limited.conf.example
+%config(noreplace) %attr(644,root,root) /etc/bareos/bareos-dir.d/profile/webui-limited.conf.example
 %config(noreplace) %attr(644,root,root) /etc/bareos/bareos-dir.d/profile/webui-readonly.conf
 %config(noreplace) %{_apache_conf_dir}/bareos-webui.conf
 %endif
@@ -1257,47 +1257,47 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %{_mandir}/man8/btape.8.gz
 %{_sbindir}/bscrypto
 %{_sbindir}/btape
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Tape.conf.example
-%attr(0640, %{storage_daemon_user},  %{daemon_group}) %{_sysconfdir}/%{name}/bareos-sd.d/autochanger/autochanger-0.conf.example
-%attr(0640, %{storage_daemon_user},  %{daemon_group}) %{_sysconfdir}/%{name}/bareos-sd.d/device/tapedrive-0.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Tape.conf.example
+%attr(0640, %{storage_daemon_user},  %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/autochanger/autochanger-0.conf.example
+%attr(0640, %{storage_daemon_user},  %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/tapedrive-0.conf.example
 %{plugin_dir}/scsicrypto-sd.so
 %{plugin_dir}/scsitapealert-sd.so
 
 %files storage-fifo
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-fifo*.so
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/NULL.conf.example
-%attr(0640, %{storage_daemon_user}, %{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/NULL.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/NULL.conf.example
+%attr(0640, %{storage_daemon_user}, %{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/NULL.conf.example
 
 %files storage-dedupable
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-dedupable*.so
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Dedupable.conf.example
-%attr(0640, %{storage_daemon_user}, %{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/Dedupable.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Dedupable.conf.example
+%attr(0640, %{storage_daemon_user}, %{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/Dedupable.conf.example
 
 %if 0%{?droplet}
 %files storage-droplet
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-droplet*.so
-%attr(0640, %{director_daemon_user},%{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/S3_Object.conf.example
-%attr(0640, %{storage_daemon_user},%{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/S3_ObjectStorage.conf.example
+%attr(0640, %{director_daemon_user},%{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/S3_Object.conf.example
+%attr(0640, %{storage_daemon_user},%{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/S3_ObjectStorage.conf.example
 %dir %{_sysconfdir}/%{name}/bareos-sd.d/device/droplet/
-%attr(0640, %{storage_daemon_user},%{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/droplet/*.example
+%attr(0640, %{storage_daemon_user},%{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/droplet/*.example
 %endif
 
 %files storage-dplcompat
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-dplcompat*.so
 %{script_dir}/s3cmd-wrapper.sh
-%attr(0640, %{director_daemon_user},%{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/dplcompat.conf.example
-%attr(0640, %{storage_daemon_user},%{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/dplcompat.conf.example
+%attr(0640, %{director_daemon_user},%{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/dplcompat.conf.example
+%attr(0640, %{storage_daemon_user},%{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/dplcompat.conf.example
 
 %if 0%{?glusterfs}
 %files storage-glusterfs
 %defattr(-, root, root)
 %{backend_dir}/libbareossd-gfapi*.so
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Gluster.conf.example
-%attr(0640, %{storage_daemon_user}, %{daemon_group})  %{_sysconfdir}/%{name}/bareos-sd.d/device/GlusterStorage.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/storage/Gluster.conf.example
+%attr(0640, %{storage_daemon_user}, %{daemon_group})  %config(noreplace) %{_sysconfdir}/%{name}/bareos-sd.d/device/GlusterStorage.conf.example
 %endif
 
 # not client_only
@@ -1493,9 +1493,9 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %files filedaemon-ldap-python-plugin
 %defattr(-, root, root)
 %{plugin_dir}/bareos-fd-ldap.py*
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/fileset/plugin-ldap.conf.example
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/job/backup-ldap.conf.example
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/job/restore-ldap.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/fileset/plugin-ldap.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/job/backup-ldap.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/job/restore-ldap.conf.example
 
 %files filedaemon-libcloud-python-plugin
 %defattr(-, root, root)
@@ -1505,8 +1505,8 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %dir %{plugin_dir}/bareos_libcloud_api
 %{plugin_dir}/bareos_libcloud_api/*
 
-#attr(0640, #{director_daemon_user}, #{daemon_group}) #{_sysconfdir}/#{name}/bareos-dir.d/fileset/plugin-libcloud.conf.example
-#attr(0640, #{director_daemon_user}, #{daemon_group}) #{_sysconfdir}/#{name}/bareos-dir.d/job/backup-libcloud.conf.example
+#attr(0640, #{director_daemon_user}, #{daemon_group}) #config(noreplace) #{_sysconfdir}/#{name}/bareos-dir.d/fileset/plugin-libcloud.conf.example
+#attr(0640, #{director_daemon_user}, #{daemon_group}) #config(noreplace) #{_sysconfdir}/#{name}/bareos-dir.d/job/backup-libcloud.conf.example
 
 %files filedaemon-postgresql-python-plugin
 %defattr(-, root, root)
@@ -1548,9 +1548,9 @@ mkdir -p %{?buildroot}/%{_libdir}/bareos/plugins/vmware_plugin
 %files filedaemon-glusterfs-plugin
 %{script_dir}/bareos-glusterfind-wrapper
 %{plugin_dir}/gfapi-fd.so
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/fileset/plugin-gfapi.conf.example
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/job/BackupGFAPI.conf.example
-%attr(0640, %{director_daemon_user}, %{daemon_group}) %{_sysconfdir}/%{name}/bareos-dir.d/job/RestoreGFAPI.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/fileset/plugin-gfapi.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/job/BackupGFAPI.conf.example
+%attr(0640, %{director_daemon_user}, %{daemon_group}) %config(noreplace) %{_sysconfdir}/%{name}/bareos-dir.d/job/RestoreGFAPI.conf.example
 %endif
 
 %if 0%{?contrib}

--- a/systemtests/tests/sd-volume-limit/etc/bareos/bareos-fd.d/client/myself.conf.in
+++ b/systemtests/tests/sd-volume-limit/etc/bareos/bareos-fd.d/client/myself.conf.in
@@ -7,4 +7,5 @@ Client {
   Working Directory =  "@working_dir@"
   Port = @fd_port@
 
+  Maximum Workers Per Job = 0
 }


### PR DESCRIPTION
With bareos/bareos#2090 `*.conf.example` files get modified when installing a package.

on RPM based distributions `rpm -V` should not lead to a altered package warning.
`*.example.conf` files are now marked as config files in the spec file.

Signed-off-by: Bruno Friedmann <bruno.friedmann@bareos.com>

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

