### PR TITLE
plugins: fix error_string construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - disable bareosfd-python3-module-test on FreeBSD [PR #2278]
 - postgresql: require non-ssl connection [PR #2272]
 - fix problems with msvc 19.44 [PR #2287]
+- plugins: fix error_string construction [PR #2273]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -150,6 +151,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2268]: https://github.com/bareos/bareos/pull/2268
 [PR #2270]: https://github.com/bareos/bareos/pull/2270
 [PR #2272]: https://github.com/bareos/bareos/pull/2272
+[PR #2273]: https://github.com/bareos/bareos/pull/2273
 [PR #2275]: https://github.com/bareos/bareos/pull/2275
 [PR #2278]: https://github.com/bareos/bareos/pull/2278
 [PR #2286]: https://github.com/bareos/bareos/pull/2286

--- a/core/src/plugins/include/python_plugins_common.inc
+++ b/core/src/plugins/include/python_plugins_common.inc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -97,36 +97,50 @@ static inline void SetString(char** destination, std::string_view value)
 static std::string GetStringFromPyErrorHandler()
 {
   PyObject *type, *value, *traceback;
-  PyObject* tracebackModule;
   std::string error_string;
 
   PyErr_Fetch(&type, &value, &traceback);
+  if (!type && !value && !traceback) {
+    return "No python error could be fetched.";
+  }
   PyErr_NormalizeException(&type, &value, &traceback);
 
-  tracebackModule = PyImport_ImportModule("traceback");
-  if (tracebackModule != NULL) {
-    PyObject *tbList, *emptyString, *strRetval;
-
-    tbList = PyObject_CallMethod(tracebackModule, (char*)"format_exception",
-                                 (char*)"OOO", type,
-                                 value == NULL ? Py_None : value,
-                                 traceback == NULL ? Py_None : traceback);
-
-    emptyString = PyUnicode_FromString("");
-    strRetval
-        = PyObject_CallMethod(emptyString, (char*)"join", (char*)"O", tbList);
-
-    error_string = std::string(PyUnicode_AsUTF8(strRetval));
-
-    Py_DECREF(tbList);
-    Py_DECREF(emptyString);
-    Py_DECREF(strRetval);
-    Py_DECREF(tracebackModule);
+  PyObject* tracebackModule = PyImport_ImportModule("traceback");
+  if (!tracebackModule) {
+    PyObject *tbList = nullptr, *emptyString = nullptr, *strRetval = nullptr;
+    if ((tbList = PyObject_CallMethod(tracebackModule, (char*)"format_exception",
+                                      (char*)"OOO", type,
+                                      value == NULL ? Py_None : value,
+                                      traceback == NULL ? Py_None : traceback))) {
+      if ((emptyString = PyUnicode_FromString(""))) {
+        if ((strRetval = PyObject_CallMethod(emptyString, (char*)"join", (char*)"O", tbList))) {
+          if (const char* err = PyUnicode_AsUTF8(strRetval)) {
+            error_string = err;
+          }
+          else {
+            error_string = "Unspecified error, retrieving error message failed.";
+          }
+        }
+        else {
+          error_string = "Calling method 'join' failed.";
+        }
+      }
+      else {
+        error_string = "Unable to retrieve empty-string.";
+      }
+    }
+    else {
+      error_string = "Calling method 'format_exception' failed.";
+    }
+    Py_XDECREF(tbList);
+    Py_XDECREF(emptyString);
+    Py_XDECREF(strRetval);
+    Py_XDECREF(tracebackModule);
   } else {
-    error_string = std::string("Unable to import traceback module.");
+    error_string = "Unable to import traceback module.";
   }
 
-  Py_DECREF(type);
+  Py_XDECREF(type);
   Py_XDECREF(value);
   Py_XDECREF(traceback);
 


### PR DESCRIPTION
This PR fixes a bug introduced with commit ce9f5bc, see #225.

PyUnicode_AsUTF8 can return NULL and doing std::string(NULL) will crash.
With the changes of this PR we explicitly do a null-pointer check before constructing a std::string.

Fixes bareos/internal#225: ce9f5bc introduces creation of std::string from potential nullptr

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
