### PR TITLE
disable bareosfd-python3-module-test on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - config: fix Director -> Director resource [PR #2259]
 - mtx-changer: make mandatory test mt-st versus cpio-mt [PR #2256]
 - packaging: set all `*.conf.examples` as %config(noreplace) [PR #2268]
+- disable bareosfd-python3-module-test on FreeBSD [PR #2278]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -138,4 +139,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2260]: https://github.com/bareos/bareos/pull/2260
 [PR #2264]: https://github.com/bareos/bareos/pull/2264
 [PR #2268]: https://github.com/bareos/bareos/pull/2268
+[PR #2278]: https://github.com/bareos/bareos/pull/2278
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -108,6 +108,11 @@ if(Python3_FOUND)
         LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../../lib
         "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
     )
+    if(CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+      # the testscript randomly segfaults on FreeBSD during the CI-build, so we
+      # disable it for now.
+      set_property(TEST bareosfd-python3-module PROPERTY DISABLED true)
+    endif()
     add_test(
       NAME python-simple-test-example
       COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/test/simple-test-example.py


### PR DESCRIPTION
as we cannot figure out why the testscript fails randomly during CI, but works fine when running it manually, we disable the test on FreeBSD.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR