### PR TITLE
fix next-pool overrides by job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VMware Plugin: Adapt to pyVmomi 9 [PR #2341]
 - VMWare Plugin: Fix VirtualSerialPort, NVRAM timeouts configurable [PR #2344]
 - doc: storage backend add note about static build [PR #2350]
+- fix next-pool overrides by job [PR #2279]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -187,6 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2273]: https://github.com/bareos/bareos/pull/2273
 [PR #2275]: https://github.com/bareos/bareos/pull/2275
 [PR #2278]: https://github.com/bareos/bareos/pull/2278
+[PR #2279]: https://github.com/bareos/bareos/pull/2279
 [PR #2283]: https://github.com/bareos/bareos/pull/2283
 [PR #2286]: https://github.com/bareos/bareos/pull/2286
 [PR #2287]: https://github.com/bareos/bareos/pull/2287

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -2150,7 +2150,14 @@ static bool ScanCommandLineArguments(UaContext* ua, RunContext& rc)
       rc.next_pool = select_pool_resource(ua);
     }
   } else if (!rc.next_pool) {
-    rc.next_pool = rc.pool->NextPool; /* use default */
+    // use next pool from job
+    if (rc.job->next_pool) {
+      rc.next_pool = rc.job->next_pool;
+    }
+    // use next pool from pool
+    else {
+      rc.next_pool = rc.pool->NextPool;
+    }
   }
   if (rc.next_pool) {
     Dmsg1(100, "Using next pool %s\n", rc.next_pool->resource_name_);

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1050,6 +1050,8 @@ run
 
    Any information that is needed but not specified will be listed for selection, and before starting the job, you will be prompted to accept, reject, or modify the parameters of the job to be run, unless you have specified yes, in which case the job will be immediately sent to the scheduler.
 
+   All specified options override their counterpart in the configuration, if specified.
+
    If you wish to start a job at a later time, you can do so by setting the When time. Use the mod option and select When (no. 6). Then enter the desired start time in YYYY-MM-DD HH:MM:SS format.
 
    The spooldata argument of the run command cannot be modified through the menu and is only accessible by setting its value on the intial command line. If no spooldata flag is set, the job, storage or schedule flag is used.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-NextPool.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-job-NextPool.rst.inc
@@ -1,1 +1,1 @@
-A Next Pool override used for Migration/Copy and Virtual Backup Jobs.
+A Next Pool override used for Migration/Copy and Virtual Backup Jobs. This directive overrides the :config:option:`dir/pool/NextPool` directive from the source pool, if specified.

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy-with-next-pool-override.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/job/copy-with-next-pool-override.conf
@@ -1,0 +1,20 @@
+Job {
+  Name = "copy-with-next-pool-override"
+  Type = Copy
+  Pool = Full
+  Selection Type = Volume
+  Selection Pattern = "."
+  Client = "bareos-fd"
+  Messages = Standard
+  NextPool = AnotherFullCopy
+  Run Script {
+    Runs On Client = No
+    Runs When = Before
+    Command = "echo 'prevjobid=%O newjobid=%N'"
+  }
+  Run Script {
+    Runs On Client = No
+    Runs When = After
+    Command = "echo 'prevjobid=%O newjobid=%N'"
+  }
+}

--- a/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/pool/AnotherFullCopy.conf
+++ b/systemtests/tests/copy-migrate/etc/bareos/bareos-dir.d/pool/AnotherFullCopy.conf
@@ -1,0 +1,11 @@
+Pool {
+  Name = AnotherFullCopy
+  Pool Type = Backup
+  Recycle = yes                       # Bareos can automatically recycle Volumes
+  AutoPrune = yes                     # Prune expired volumes
+  Volume Retention = 1 sec         # How long should the Full Backups be kept? (#06)
+  Maximum Volume Bytes = 50G          # Limit Volume size to something reasonable
+  Maximum Volumes = 100               # Limit number of Volumes in Pool
+  Label Format = "Full-"              # Volumes will be labeled "Full-<volume-id>"
+  Storage = "File2"
+}

--- a/systemtests/tests/copy-migrate/testrunner-02-copy
+++ b/systemtests/tests/copy-migrate/testrunner-02-copy
@@ -19,6 +19,12 @@ start_test
 cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out ${NULL_DEV}
 messages
+@$out $tmp/copy-summary.out
+run copy
+no
+@$out $tmp/copy-with-next-pool-override-summary.out
+run copy-with-next-pool-override
+no
 @$out $copy_log
 label volume=TestCopyVolume001 storage=File2 pool=FullCopy
 run copy yes
@@ -81,5 +87,15 @@ expect_grep "|.*B.*|" \
             "Copy job was not upgraded to backup after original backup was pruned."
 
 check_for_zombie_jobs storage=File
+
+
+# check whether next-pool directive overrides work (in job resource > in pool resource)
+expect_grep "NextPool:      FullCopy" \
+            "$tmp/copy-summary.out" \
+            "Wrong next pool selected for job 'copy' ."
+
+expect_grep "NextPool:      AnotherFullCopy" \
+            "$tmp/copy-with-next-pool-override-summary.out" \
+            "Wrong next pool selected for job 'copy-with-next-pool-override' ."
 
 end_test


### PR DESCRIPTION
The next pool directive can be defined in the Pool and Job resource, the next pool directive in the Job resource should override the directive in the Pool resource. Currently, The directive in the job resource is not taken into account when running a job via the "run" command in the bconsole. This PR fixes this and takes the directive from the Job resource if specified.

Also, this PR adds a section in the copy-migrate systemtest to test the override behaviour of this directive.

Fixes #2253: Copy job fails, because "Next Pool" is not accepted as an override in the job config.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
