### PR TITLE
disable bareosfd-python3-module-test on FreeBSD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - config: fix Director -> Director resource [PR #2274]
 - mtx-changer: make mandatory test mt-st versus cpio-mt [PR #2257]
 - packaging: set all `*.conf.examples` as %config(noreplace) [PR #2271]
+- disable bareosfd-python3-module-test on FreeBSD [PR #2280]
 
 ### Changed
 - config: add virtual file changer example + documentation [PR #2248]
@@ -453,4 +454,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2274]: https://github.com/bareos/bareos/pull/2274
 [PR #2276]: https://github.com/bareos/bareos/pull/2276
 [PR #2277]: https://github.com/bareos/bareos/pull/2277
+[PR #2280]: https://github.com/bareos/bareos/pull/2280
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/CMakeLists.txt
+++ b/core/src/plugins/filed/python/CMakeLists.txt
@@ -106,6 +106,11 @@ if(Python3_FOUND)
         LD_LIBRARY_PATH=${CMAKE_CURRENT_BINARY_DIR}/../../../lib
         "ASAN_OPTIONS=detect_leaks=0 verify_asan_link_order=0"
     )
+    if(CMAKE_SYSTEM_NAME MATCHES FreeBSD)
+      # the testscript randomly segfaults on FreeBSD during the CI-build, so we
+      # disable it for now.
+      set_property(TEST bareosfd-python3-module PROPERTY DISABLED true)
+    endif()
     add_test(
       NAME python-simple-test-example
       COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/test/simple-test-example.py


### PR DESCRIPTION
**Backport of PR #2278 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2278 is merged
- [x] All functional differences to the original PR are documented above
