### PR TITLE
cmake: disable lto when linking gtests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - packaging: use GCC 14 for RHEL 8/9 [PR #2275]
 - setgid on configdirs [PR #2270]
 - Replace Bsnprintf() implementation and add format attributes [PR #1697]
+- cmake: disable lto when linking gtests [PR #2286]
 
 [PR #1697]: https://github.com/bareos/bareos/pull/1697
 [PR #1893]: https://github.com/bareos/bareos/pull/1893
@@ -149,5 +150,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2272]: https://github.com/bareos/bareos/pull/2272
 [PR #2275]: https://github.com/bareos/bareos/pull/2275
 [PR #2278]: https://github.com/bareos/bareos/pull/2278
+[PR #2286]: https://github.com/bareos/bareos/pull/2286
 [PR #2287]: https://github.com/bareos/bareos/pull/2287
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -18,7 +18,7 @@
 #   02110-1301, USA.
 message("Entering ${CMAKE_CURRENT_SOURCE_DIR}")
 
-# if we built the object files as fat lto objects, we add -fno-lto to the 
+# if we built the object files as fat lto objects, we add -fno-lto to the
 # linker-flags of our unit-tests, so we don't spend time optimizing binaries
 # that will only run a few times during testing
 if(CMAKE_CXX_FLAGS MATCHES -ffat-lto-objects)

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -18,6 +18,13 @@
 #   02110-1301, USA.
 message("Entering ${CMAKE_CURRENT_SOURCE_DIR}")
 
+# if we built the object files as fat lto objects, we add -fno-lto to the 
+# linker-flags of our unit-tests, so we don't spend time optimizing binaries
+# that will only run a few times during testing
+if(CMAKE_CXX_FLAGS MATCHES -ffat-lto-objects)
+  add_link_options(-fno-lto)
+endif()
+
 include(BareosConfigureFile)
 
 # required to generate configuration for some SD tests


### PR DESCRIPTION
this disables link-time-optimization when linking our unittests. This is only possible if we have fat lto objects, so we only do it then. The benefit of this is that we save a lot of compile-time on programs that will only run a few times during testing and then will be discarded.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
