### PR TITLE
python: fix traceback generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Breaking changes
+- Bareos 25 disables SSL on the PostgreSQL connection, as we have observed strange issues with SSL enabled.[Issue #1965]
+
 ### Removed
 - config: deprecate file daemon as alias for client in FD config [PR #2187]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,7 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: disable lto when linking gtests [PR #2286]
 - VMware Plugin: Fix for virtual USB devices [PR #2213]
 - build: add Fedora 42 [PR #2263]
+- python: fix traceback generation [PR #2303]
 
+[Issue #1965]: https://bugs.bareos.org/view.php?id=1965
 [PR #1697]: https://github.com/bareos/bareos/pull/1697
 [PR #1893]: https://github.com/bareos/bareos/pull/1893
 [PR #2018]: https://github.com/bareos/bareos/pull/2018
@@ -166,4 +168,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2278]: https://github.com/bareos/bareos/pull/2278
 [PR #2286]: https://github.com/bareos/bareos/pull/2286
 [PR #2287]: https://github.com/bareos/bareos/pull/2287
+[PR #2303]: https://github.com/bareos/bareos/pull/2303
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/include/python_plugins_common.inc
+++ b/core/src/plugins/include/python_plugins_common.inc
@@ -106,7 +106,7 @@ static std::string GetStringFromPyErrorHandler()
   PyErr_NormalizeException(&type, &value, &traceback);
 
   PyObject* tracebackModule = PyImport_ImportModule("traceback");
-  if (!tracebackModule) {
+  if (tracebackModule) {
     PyObject *tbList = nullptr, *emptyString = nullptr, *strRetval = nullptr;
     if ((tbList = PyObject_CallMethod(tracebackModule, (char*)"format_exception",
                                       (char*)"OOO", type,


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

PR #2273 enhanced the error detection in our stack trace generation, but sadly broke the actual generation due to a typo.  This pr fixes that typo.

- [x] postgres changelog entry was added.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [X] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR