### PR TITLE
docs: Python plugin dependencies installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: fix grpc-fd plugin call [PR #2068]
 - docs: add devtools documentation [PR #2149]
 - docs rear: update to rear >= 2.8 [PR #2220]
+- docs: Python plugin dependencies installation [PR #2315]
 
 ### Added
 - added build-dep to libutfcpp-dev in debian-like environments [PR #2056]
@@ -169,4 +170,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2286]: https://github.com/bareos/bareos/pull/2286
 [PR #2287]: https://github.com/bareos/bareos/pull/2287
 [PR #2303]: https://github.com/bareos/bareos/pull/2303
+[PR #2315]: https://github.com/bareos/bareos/pull/2315
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -97,6 +97,36 @@ There is no dependency in the package. In most Linux distributions,
 the packages providing these modules can be used. The minimum version of
 **requests** must be 2.20.0 and **urllib3** must be at least 1.24.1.
 
+If :command:`pip install ...` returns the message
+**error: externally-managed-environment**, it is possible to install the
+required dependencies only for Bareos Python plugins using the following
+command:
+
+.. code-block:: shell-session
+   :caption: Example Installing Python Modules only for Bareos Plugins
+
+   BPP=$(python3 -c'import sys; print(f"/usr/{sys.platlibdir}/bareos/plugins")')
+   pip install -t $BPP --upgrade pyvmomi
+
+Note that it is currently not possible to use Python virtual environments for
+Bareos Python plugins.
+
+The versions of Python modules which have been installed with the above command
+can be checked as follows:
+
+.. code-block:: shell-session
+   :caption: Listing installed Python Modules only for Bareos Plugins
+
+   BPP=$(python3 -c'import sys; print(f"/usr/{sys.platlibdir}/bareos/plugins")')
+   pip list --path $BPP
+
+System wide installed Pyhton modules, both packaged and installed using **pip**,
+can be listed using the following command:
+
+.. code-block:: shell-session
+   :caption: Listing all installed Python Modules
+
+   pip list -v
 
 Installation
 ^^^^^^^^^^^^
@@ -334,6 +364,11 @@ this to the VMware Tools config:
    vss.disableAppQuiescing = true
 
 For details see https://knowledge.broadcom.com/external/article?legacyId=2146204
+
+It is also possible to disable specific VSS writers with VMware Tools.
+The article https://knowledge.broadcom.com/external/article?legacyId=1031200
+describes how to check VSS writer errors and how to disable specific VSS
+writers in the VMware Tools configuration.
 
 For consistent backups of MS SQL server, please use the Bareos **MSSQL Plugin**.
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -108,8 +108,19 @@ command:
    BPP=$(python3 -c'import sys; print(f"/usr/{sys.platlibdir}/bareos/plugins")')
    pip install -t $BPP --upgrade pyvmomi
 
-Note that it is currently not possible to use Python virtual environments for
-Bareos Python plugins.
+The following warning message is not relevant when using the above command,
+because it installs modules in a path which is not used by system packages:
+
+.. code-block:: shell-session
+   :caption: Warning message when using pip install -t as root
+
+   WARNING: Running pip as the 'root' user can result in broken permissions and conflicting
+   behaviour with the system package manager. It is recommended to use a virtual environment
+
+.. note::
+
+   It is currently not possible to use Python virtual environments for
+   Bareos Python plugins.
 
 The versions of Python modules which have been installed with the above command
 can be checked as follows:
@@ -120,7 +131,7 @@ can be checked as follows:
    BPP=$(python3 -c'import sys; print(f"/usr/{sys.platlibdir}/bareos/plugins")')
    pip list --path $BPP
 
-System wide installed Pyhton modules, both packaged and installed using **pip**,
+System wide installed Python modules, both packaged and installed using **pip**,
 can be listed using the following command:
 
 .. code-block:: shell-session


### PR DESCRIPTION
Some Linux distributions have externally managed python environment, discouring using pip as root. This documentation enhancement describes how to install python modules only for Bareos plugins.

Also add a link to an article that explains how to check VSS writer errors and disable specfic VSS writers when using the VMware Plugin with Windows VMs.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
