### PR TITLE
matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -32,7 +32,7 @@ OS:
       IMAGE: "ubuntu20.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
-      CUSTOM_TEST_IMAGES: [ "Debian-10" ]
+      CUSTOM_TEST_IMAGES: [ "Debian-11" ]
       ARCH:
         - x86_64
         - aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - build: add Debian 13 [PR #2290]
 - bareos-check-sources: add shell_format plugin [PR #2267]
 - Build FreeBSD for major versions 14 / 13 (instead of minor releases) [PR #2117]
+- matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10 [PR #2321]
 
 [Issue #1965]: https://bugs.bareos.org/view.php?id=1965
 [PR #1697]: https://github.com/bareos/bareos/pull/1697
@@ -183,4 +184,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2303]: https://github.com/bareos/bareos/pull/2303
 [PR #2310]: https://github.com/bareos/bareos/pull/2310
 [PR #2315]: https://github.com/bareos/bareos/pull/2315
+[PR #2321]: https://github.com/bareos/bareos/pull/2321
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/tests/admin-job/testrunner-truncate
+++ b/systemtests/tests/admin-job/testrunner-truncate
@@ -23,7 +23,8 @@ set -e
 set -o pipefail
 set -u
 
-file_size() {
+file_size()
+{
   if [ "$(uname)" = FreeBSD ]; then
     stat -f %z "$@"
   else
@@ -46,6 +47,7 @@ cat <<END_OF_DATA >"$tmp/bconcmds"
 @$out ${log_home}/log-purge.out
 label volume=ToBePurged storage=File pool=PurgePool
 run job=backup-bareos-fd pool=PurgePool yes
+wait
 update volstatus=Used volume=ToBePurged
 purge volume=ToBePurged pool=PurgePool yes
 END_OF_DATA
@@ -79,14 +81,14 @@ TRUNCATED_SIZE=$(file_size storage/ToBePurged)
 echo "$SIZE_TO_BEAT < $TRUNCATED_SIZE"
 
 expect_grep "Termination:[[:space:]]*Admin OK" \
-            "${log_home}/log-truncate.out" \
-            "Actual Truncate admin job did not end successfully"
+  "${log_home}/log-truncate.out" \
+  "Actual Truncate admin job did not end successfully"
 
 expect_grep "Termination:[[:space:]]*Admin OK" \
-            "${log_home}/log-truncate-nothing.out" \
-            "Empty Truncate admin job did not end successfully"
+  "${log_home}/log-truncate-nothing.out" \
+  "Empty Truncate admin job did not end successfully"
 
-if ! [ "$SIZE_TO_BEAT" -le "$TRUNCATED_SIZE" ]; then
+if [ "$SIZE_TO_BEAT" -le "$TRUNCATED_SIZE" ]; then
   echo -e "\n*** Fail: Volume was not truncated: old size = ${SIZE_TO_BEAT}, new size = ${TRUNCATED_SIZE}." >&2
   estat=1
 fi


### PR DESCRIPTION
the ULC packages for OpenSSL 1.1 were tested on Debian 10. As the packages for Debian 10 have been removed from the mirrors, we will continue testing on Debian 11 for now.

we also add a bug fix for admin-truncate systemtest

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [X] Is the PR title usable as CHANGELOG entry?
- [X] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)
- [X] Required documentation changes are present and part of the PR

##### Tests
- [X] Decision taken that a test is required (if not, then remove this paragraph)
- [X] The choice of the type of test (unit test or systemtest) is reasonable
- [X] Testname matches exactly what is being tested
- [X] On a fail, output of the test leads quickly to the origin of the fault
