### PR TITLE
matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -32,7 +32,7 @@ OS:
       IMAGE: "ubuntu20.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
-      CUSTOM_TEST_IMAGES: [ "Debian-10" ]
+      CUSTOM_TEST_IMAGES: [ "Debian-11" ]
       ARCH:
         - x86_64
         - aarch64


### PR DESCRIPTION
**Backport of PR #2321 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

#### Backport quality
- [ ] Original PR #2321 is merged
- [x] All functional differences to the original PR are documented above
