### PR TITLE
matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -13,7 +13,7 @@ OS:
       IMAGE: "ubuntu20.04"
       BUILD_SCRIPT: CD/deb/build-ulc.sh
       FINISH_SCRIPT: CD/deb/finish-ulc.sh
-      CUSTOM_TEST_IMAGES: [ "Ubuntu-20.04", "Debian-10", "Debian-11" ]
+      CUSTOM_TEST_IMAGES: [ "Debian-11" ]
       ARCH:
         - x86_64
         - aarch64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ### Changed
 - python: fix traceback generation [PR #2305]
+- matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10 [PR #2323]
 
 ## [23.1.3] - 2025-03-27
 
@@ -653,4 +654,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2227]: https://github.com/bareos/bareos/pull/2227
 [PR #2293]: https://github.com/bareos/bareos/pull/2293
 [PR #2305]: https://github.com/bareos/bareos/pull/2305
+[PR #2323]: https://github.com/bareos/bareos/pull/2323
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
**Backport of PR #2321 to bareos-23**

As the previous reduction of the test-matrix in PR #2192 was not backported into bareos-23 yet, Debian 10, Debian 11 and Ubuntu 20.04 were tested. This is now aligned with master, i.e. only test on Debian 11.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2321 is merged
- [x] All functional differences to the original PR are documented above
