### PR TITLE
systemtest: always incremental add one job with one removed file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Build FreeBSD for major versions 14 / 13 (instead of minor releases) [PR #2117]
 - matrix: test the Debian ULC packages for OpenSSL 1.1 on Debian 11 instead of Debian 10 [PR #2321]
 - ndmp-bareos: Introduce incremental loop, restore 2nd file explicitly [PR #2269]
+- systemtest: always incremental add one job with one removed file [PR #2329]
 
 [Issue #1965]: https://bugs.bareos.org/view.php?id=1965
 [PR #1697]: https://github.com/bareos/bareos/pull/1697
@@ -192,5 +193,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2315]: https://github.com/bareos/bareos/pull/2315
 [PR #2321]: https://github.com/bareos/bareos/pull/2321
 [PR #2328]: https://github.com/bareos/bareos/pull/2328
+[PR #2329]: https://github.com/bareos/bareos/pull/2329
 [PR #2332]: https://github.com/bareos/bareos/pull/2332
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/tests/always-incremental-consolidate/CMakeLists.txt
+++ b/systemtests/tests/always-incremental-consolidate/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -26,7 +26,7 @@ if(NOT ISDISABLED)
     system:always-incremental-consolidate:01-full+incr
     PROPERTIES FIXTURES_SETUP
                "system:always-incremental-consolidate:full+incr-fixture"
-               FIXTURES_REQURIED
+               FIXTURES_REQUIRED
                "system:always-incremental-consolidate-fixture"
   )
   set_tests_properties(

--- a/systemtests/tests/always-incremental-consolidate/CMakeLists.txt
+++ b/systemtests/tests/always-incremental-consolidate/CMakeLists.txt
@@ -50,13 +50,19 @@ if(NOT ISDISABLED)
       "system:always-incremental-consolidate:full+incr-fixture;system:always-incremental-consolidate-fixture"
   )
   set_tests_properties(
-    system:always-incremental-consolidate:05-priority
+    system:always-incremental-consolidate:05-consolidate-deleted-file
     PROPERTIES
       FIXTURES_REQUIRED
       "system:always-incremental-consolidate:full+incr-fixture;system:always-incremental-consolidate-fixture"
   )
   set_tests_properties(
-    system:always-incremental-consolidate:06-consolidate-duplicates
+    system:always-incremental-consolidate:06-priority
+    PROPERTIES
+      FIXTURES_REQUIRED
+      "system:always-incremental-consolidate:full+incr-fixture;system:always-incremental-consolidate-fixture"
+  )
+  set_tests_properties(
+    system:always-incremental-consolidate:07-consolidate-duplicates
     PROPERTIES
       FIXTURES_REQUIRED
       "system:always-incremental-consolidate:full+incr-fixture;system:always-incremental-consolidate-fixture"

--- a/systemtests/tests/always-incremental-consolidate/testrunner-04-virtualfull
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-04-virtualfull
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/always-incremental-consolidate/testrunner-05-consolidate-deleted-file
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-05-consolidate-deleted-file
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+JobName=ai-backup-bareos-fd
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${rscripts}"/functions
+start_test
+
+# Delete file during incremental, do a consolidation and check deleted file disappears
+
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out $tmp/extra.log
+messages
+.api 2
+@$out $tmp/delete-file_start.out
+@exec "sh -c 'echo \"tobedelete\" > ${tmp}/data/weird-files/tobedeleted'"
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'rm ${tmp}/data/weird-files/tobedeleted'"
+run job=$JobName level=Incremental yes
+wait
+run job=$JobName level=Incremental yes
+wait
+@exec "sh -c 'touch ${tmp}/data/weird-files/another-file'"
+run job=$JobName level=Incremental yes
+wait
+@$out $tmp/delete-file_consolidate.out
+run job=Consolidate yes
+wait
+@$out $tmp/delete-file_messages.out
+.api 1
+status director
+status client
+status storage=File
+messages
+END_OF_DATA
+
+run_bconsole
+
+# get the first to last jobid (taking into account test restarts)
+create_job=$(grep "jobid" "$tmp/delete-file_start.out" | tail -n 4 | head -n 1 | sed 's/["jobid:]//g' | xargs)
+delete_job=$(grep "jobid" "$tmp/delete-file_start.out" | tail -n 3 | head -n 1 | sed 's/["jobid:]//g' | xargs)
+empty_job=$(grep "jobid" "$tmp/delete-file_start.out" | tail -n 2 | head -n 1 | sed 's/["jobid:]//g' | xargs)
+lastinc_job=$(grep "jobid" "$tmp/delete-file_start.out" | tail -n 1 | sed 's/["jobid:]//g' | xargs)
+cons_job=$(grep "jobid" "$tmp/delete-file_consolidate.out" | tail -n 1 | sed 's/["jobid:]//g' | xargs)
+
+jobid=$((cons_job + 1))
+
+# Check if deleted file still present
+cat <<END_OF_DATA >$tmp/bconcmds
+@$out $tmp/delete-file_bvfs.out
+.bvfs_lsdirs jobid=${jobid} path=
+.bvfs_update
+.bvfs_lsdirs jobid=${jobid} path=
+.bvfs_versions jobid=${jobid} path=${tmp}/data/weird-files/ client=bareos-fd fname=tobedeleted
+messages
+END_OF_DATA
+run_bconsole
+
+expect_grep " A A C.*0.*AI-Consolidated-0003.*0" \
+            "$tmp/delete-file_bvfs.out" \
+            ".bvfs_versions did not find a deleted file backup."
+
+expect_grep "purging empty jobids ${empty_job}" \
+            "$tmp/delete-file_messages.out" \
+            "Removal of expected empty jobs was not successful"
+
+expect_grep "purged JobIds .*${delete_job} as they were consolidated into Job ${jobid}" \
+            "$tmp/delete-file_messages.out" \
+            "consolidation of expected jobs did not happen."
+
+expect_not_grep "purged JobIds .*${empty_job}.* as they were consolidated into Job ${jobid}" \
+		"$tmp/delete-file_messages.out" \
+		"consolidation of empty happened."
+
+expect_not_grep "purged JobIds .*${lastinc_job}.* as they were consolidated into Job ${jobid}" \
+		"$tmp/delete-file_messages.out" \
+		"consolidation of last incremental happened."
+
+end_test

--- a/systemtests/tests/always-incremental-consolidate/testrunner-05-consolidate-deleted-file
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-05-consolidate-deleted-file
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2025-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -32,6 +32,7 @@ JobName=ai-backup-bareos-fd
 start_test
 
 # Delete file during incremental, do a consolidation and check deleted file disappears
+# We also add another file to be pick so the deleted file is no more the last one of the list.
 
 cat <<END_OF_DATA >$tmp/bconcmds
 @$out $tmp/extra.log
@@ -73,18 +74,15 @@ jobid=$((cons_job + 1))
 
 # Check if deleted file still present
 cat <<END_OF_DATA >$tmp/bconcmds
-@$out $tmp/delete-file_bvfs.out
-.bvfs_lsdirs jobid=${jobid} path=
-.bvfs_update
-.bvfs_lsdirs jobid=${jobid} path=
-.bvfs_versions jobid=${jobid} path=${tmp}/data/weird-files/ client=bareos-fd fname=tobedeleted
-messages
+@$out $tmp/delete-file_sql.out
+.api 2
+.sql query="select fileindex from file where jobid=${jobid} AND name='tobedeleted';"
 END_OF_DATA
 run_bconsole
-
-expect_grep " A A C.*0.*AI-Consolidated-0003.*0" \
-            "$tmp/delete-file_bvfs.out" \
-            ".bvfs_versions did not find a deleted file backup."
+# Deleted files always have a fileindex of 0, where as non deleted files always have a fileindex > 0.
+expect_grep " \"fileindex\": \"0\"" \
+            "$tmp/delete-file_sql.out" \
+            ".sql did not find a deleted file backup."
 
 expect_grep "purging empty jobids ${empty_job}" \
             "$tmp/delete-file_messages.out" \
@@ -92,14 +90,14 @@ expect_grep "purging empty jobids ${empty_job}" \
 
 expect_grep "purged JobIds .*${delete_job} as they were consolidated into Job ${jobid}" \
             "$tmp/delete-file_messages.out" \
-            "consolidation of expected jobs did not happen."
+            "consolidation of job with deletion did not happen."
 
 expect_not_grep "purged JobIds .*${empty_job}.* as they were consolidated into Job ${jobid}" \
 		"$tmp/delete-file_messages.out" \
-		"consolidation of empty happened."
+		"empty job was consolidated."
 
 expect_not_grep "purged JobIds .*${lastinc_job}.* as they were consolidated into Job ${jobid}" \
 		"$tmp/delete-file_messages.out" \
-		"consolidation of last incremental happened."
+		"last incremental job was consolidated."
 
 end_test

--- a/systemtests/tests/always-incremental-consolidate/testrunner-06-priority
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-06-priority
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/always-incremental-consolidate/testrunner-07-consolidate-duplicates
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-07-consolidate-duplicates
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/systemtests/tests/always-incremental-consolidate/testrunner-08-rerun-ai-vf
+++ b/systemtests/tests/always-incremental-consolidate/testrunner-08-rerun-ai-vf
@@ -2,7 +2,7 @@
 
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public


### PR DESCRIPTION
This PR aims to fix the fact that We don't test deleted files in AI test scenario, but only 2 time empty job.

We adjust the tests to also tests deleted files job with a result looking like
file 2 | size 0

The case mentioned in https://groups.google.com/u/0/g/bareos-users/c/NB4Z3uYGfuU then is fully covered.


- **systemtest: CMakefile fix typo and year copyright**
- **systemtest: add one job with one removed file**


#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
