### PR TITLE
dird: fix nextvol crash

### DIFF
--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -1246,39 +1246,43 @@ static bool ListNextvol(UaContext* ua, int ndays)
   jcr = NewDirectorJcr(DirdFreeJcr);
   time_t now = time(NULL);
   bool found = false;
-  for (RunResource* run = job->schedule->run; run; run = run->next) {
-    std::optional<time_t> next_scheduled = run->NextScheduleTime(now, ndays);
-    if (!next_scheduled.has_value()) { continue; }
+  if (job->schedule) {
+    for (RunResource* run = job->schedule->run; run; run = run->next) {
+      std::optional<time_t> next_scheduled = run->NextScheduleTime(now, ndays);
+      if (!next_scheduled.has_value()) { continue; }
 
-    if (!CompleteJcrForJob(jcr, job, run->pool)) {
-      found = false;
-      break;
-    }
-    if (!jcr->dir_impl->jr.PoolId) {
-      ua->ErrorMsg(T_("Could not find Pool for Job %s\n"), job->resource_name_);
-      continue;
-    }
-    PoolDbRecord pr;
-    pr.PoolId = jcr->dir_impl->jr.PoolId;
-    if (!ua->db->GetPoolRecord(jcr, &pr)) {
-      bstrncpy(pr.Name, "*UnknownPool*", sizeof(pr.Name));
-    }
-    MediaDbRecord mr;
-    mr.PoolId = jcr->dir_impl->jr.PoolId;
-    GetJobStorage(&store, job, run);
-    SetStorageidInMr(store.store, &mr);
-    /* no need to set ScratchPoolId, since we use fnv_no_create_vol */
-    if (!FindNextVolumeForAppend(jcr, &mr, 1, NULL, fnv_no_create_vol,
-                                 fnv_prune)) {
-      ua->ErrorMsg(T_("Could not find next Volume for Job %s (Pool=%s, "
-                      "Level=%s).\n"),
-                   job->resource_name_, pr.Name, JobLevelToString(run->level));
-    } else {
-      ua->SendMsg(T_("The next Volume to be used by Job \"%s\" (Pool=%s, "
-                     "Level=%s) will be %s\n"),
-                  job->resource_name_, pr.Name, JobLevelToString(run->level),
-                  mr.VolumeName);
-      found = true;
+      if (!CompleteJcrForJob(jcr, job, run->pool)) {
+        found = false;
+        break;
+      }
+      if (!jcr->dir_impl->jr.PoolId) {
+        ua->ErrorMsg(T_("Could not find Pool for Job %s\n"),
+                     job->resource_name_);
+        continue;
+      }
+      PoolDbRecord pr;
+      pr.PoolId = jcr->dir_impl->jr.PoolId;
+      if (!ua->db->GetPoolRecord(jcr, &pr)) {
+        bstrncpy(pr.Name, "*UnknownPool*", sizeof(pr.Name));
+      }
+      MediaDbRecord mr;
+      mr.PoolId = jcr->dir_impl->jr.PoolId;
+      GetJobStorage(&store, job, run);
+      SetStorageidInMr(store.store, &mr);
+      /* no need to set ScratchPoolId, since we use fnv_no_create_vol */
+      if (!FindNextVolumeForAppend(jcr, &mr, 1, NULL, fnv_no_create_vol,
+                                   fnv_prune)) {
+        ua->ErrorMsg(T_("Could not find next Volume for Job %s (Pool=%s, "
+                        "Level=%s).\n"),
+                     job->resource_name_, pr.Name,
+                     JobLevelToString(run->level));
+      } else {
+        ua->SendMsg(T_("The next Volume to be used by Job \"%s\" (Pool=%s, "
+                       "Level=%s) will be %s\n"),
+                    job->resource_name_, pr.Name, JobLevelToString(run->level),
+                    mr.VolumeName);
+        found = true;
+      }
     }
   }
   if (jcr->db) {

--- a/core/src/dird/ua_select.cc
+++ b/core/src/dird/ua_select.cc
@@ -1332,12 +1332,13 @@ StorageResource* get_storage_resource(UaContext* ua,
     // Ignore any zapped keyword.
     if (*ua->argk[i] == 0) { continue; }
     if (use_default && !ua->argv[i]) {
-      // Ignore barcode, barcodes, encrypt, scan and slots keywords.
+      // Ignore alldrives, barcode, barcodes, encrypt, scan and slots keywords.
       if (Bstrcasecmp("barcode", ua->argk[i])
           || Bstrcasecmp("barcodes", ua->argk[i])
           || Bstrcasecmp("encrypt", ua->argk[i])
           || Bstrcasecmp("scan", ua->argk[i])
-          || Bstrcasecmp("slots", ua->argk[i])) {
+          || Bstrcasecmp("slots", ua->argk[i])
+          || Bstrcasecmp("alldrives", ua->argk[i])) {
         continue;
       }
       // Default argument is storage

--- a/systemtests/tests/file-autochanger/testrunner-swapdev
+++ b/systemtests/tests/file-autochanger/testrunner-swapdev
@@ -15,13 +15,25 @@ export TestName
 start_test
 
 cat <<END_OF_DATA >"$tmp/bconcmds"
+@$out ${NULL_DEV}
+messages
+@$out ${tmp}/label.out
 label barcodes slots=1 drive=0 pool=Incremental yes
+@$out ${tmp}/release.out
 release alldrives
+@$out ${tmp}/mount.out
 mount drive=1 slot=1
+@$out ${tmp}/job.out
 run job=backup-bareos-fd yes
 wait
+messages
 END_OF_DATA
 
 run_bconsole
+
+expect_grep "Catalog record for Volume.*Slot 1 successfully created." "${tmp}/label.out" "record was not created successfully"
+expect_grep "OK label" "${tmp}/label.out" "Volume was not labeled correctly"
+expect_grep "3001 Mounted Volume: .*" "${tmp}/mount.out" "volume was not mounted"
+expect_grep "Backup OK" "${tmp}/job.out" "Backup was not successful"
 
 end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Currently `list nextvol` crashes if a job without a schedule was selected.  This pr fixes this.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
