### PR TITLE
VMware Plugin: Adapt to pyVmomi 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - stored: add new volume status 'Unlabeled' [PR #2207]
 - doc: add views & functions to developer catalog service chapter [PR #2328]
 - systemtests: add config-default test [PR #2332]
+- VMware Plugin: Adapt to pyVmomi 9 [PR #2341]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -193,4 +194,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2321]: https://github.com/bareos/bareos/pull/2321
 [PR #2328]: https://github.com/bareos/bareos/pull/2328
 [PR #2332]: https://github.com/bareos/bareos/pull/2332
+[PR #2341]: https://github.com/bareos/bareos/pull/2341
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -52,7 +52,7 @@ from pyVmomi import vim
 from pyVmomi import vmodl
 import pyVim.task
 
-# adapt to change in pyVmomi 9.x
+# Try import pyVmomi 9.x first and fallback to old method
 try:
     from pyVmomi.VmomiJSONEncoder import VmomiJSONEncoder
 except ImportError:

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -51,7 +51,12 @@ from pyVim.connect import SmartConnect, Disconnect
 from pyVmomi import vim
 from pyVmomi import vmodl
 import pyVim.task
-from pyVmomi.VmomiSupport import VmomiJSONEncoder
+
+# adapt to change in pyVmomi 9.x
+try:
+    from pyVmomi.VmomiJSONEncoder import VmomiJSONEncoder
+except ImportError:
+    from pyVmomi.VmomiSupport import VmomiJSONEncoder
 
 # if OrderedDict is not available from collection (eg. SLES11),
 # the additional package python-ordereddict must be used


### PR DESCRIPTION
The import of the VmomiJSONEncoder was changed in pyVmomi9, this change adapts the Bareos VMware plugin so that it works with both the new and the old pyVmomi versions.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

