### PR TITLE
VMWare Plugin: Fix VirtualSerialPort, NVRAM timeouts configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - doc: add views & functions to developer catalog service chapter [PR #2328]
 - systemtests: add config-default test [PR #2332]
 - VMware Plugin: Adapt to pyVmomi 9 [PR #2341]
+- VMWare Plugin: Fix VirtualSerialPort, NVRAM timeouts configurable [PR #2344]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -195,4 +196,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2328]: https://github.com/bareos/bareos/pull/2328
 [PR #2332]: https://github.com/bareos/bareos/pull/2332
 [PR #2341]: https://github.com/bareos/bareos/pull/2341
+[PR #2344]: https://github.com/bareos/bareos/pull/2344
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
+++ b/core/src/plugins/filed/python/vmware/bareos-fd-vmware.py
@@ -76,7 +76,12 @@ import BareosFdPluginBaseclass
 # #define REPLACE_IFOLDER  'o'
 # In python, we get this in restorepkt.replace as integer.
 # This may be added to bareos_fd_consts in the future:
-bReplace = dict(ALWAYS=ord("a"), IFNEWER=ord("w"), NEVER=ord("n"), IFOLDER=ord("o"))
+bReplace = {
+    "ALWAYS": ord("a"),
+    "IFNEWER": ord("w"),
+    "NEVER": ord("n"),
+    "IFOLDER": ord("o"),
+}
 
 
 @BareosPlugin
@@ -1690,8 +1695,8 @@ class BareosVADPWrapper(object):
         self.vm = search_index.FindByUuid(None, self.options["uuid"], True, True)
         if self.vm is None:
             return False
-        else:
-            return True
+
+        return True
 
     def _get_dcftree(self, dcf, folder, vm_folder):
         """
@@ -2230,7 +2235,7 @@ class BareosVADPWrapper(object):
         vm_virtual_usb_devices = [
             device
             for device in self.vm.config.hardware.device
-            if type(device) is vim.vm.device.VirtualUSB
+            if isinstance(device, vim.vm.device.VirtualUSB)
         ]
         if len(backup_virutal_usb_devices) > 0:
             if len(backup_virutal_usb_devices) != len(vm_virtual_usb_devices):
@@ -2332,7 +2337,7 @@ class BareosVADPWrapper(object):
         """
         self.disk_devices = []
         for hw_device in devicespec:
-            if type(hw_device) is vim.vm.device.VirtualDisk:
+            if isinstance(hw_device, vim.vm.device.VirtualDisk):
                 if hw_device.backing.diskMode in self.skip_disk_modes:
                     bareosfd.JobMessage(
                         bareosfd.M_INFO,
@@ -3423,7 +3428,7 @@ class BareosVADPWrapper(object):
             created_disk_backing_filename = [
                 device.backing.fileName
                 for device in self.vm.config.hardware.device
-                if type(device) is vim.vm.device.VirtualDisk
+                if isinstance(device, vim.vm.device.VirtualDisk)
             ][disk_index]
 
             if expected_disk_backing_filename != created_disk_backing_filename:
@@ -3756,8 +3761,8 @@ class StringCodec:
     def encode(var):
         if version_info.major < 3:
             return var.encode("utf-8")
-        else:
-            return var
+
+        return var
 
 
 class BareosVmConfigInfoToSpec(object):

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -796,5 +796,20 @@ restore_allow_disks_mismatch (optional)
 
    Since :sinceVersion:`23.0.4: VMware Plugin`
 
+nvram_connect_timeout (optional)
+   When backing up or restoring NVRAM, this is done by HTTPS connection to
+   the vCenter server. The connect timeout in seconds can be changed using this
+   parameter, the default is 30s.
+
+   Since :sinceVersion:`25.0.5: VMware Plugin`
+
+nvram_readwrite_timeout (optional)
+   When backing up or restoring NVRAM, this is done by reading or writing it
+   via HTTPS connection to/from the vCenter server. The timeout in seconds 
+   can be changed using this parameter, the default is 60s.
+
+   Since :sinceVersion:`25.0.5: VMware Plugin`
+
+
 uuid (deprecated)
    The uuid option could be used instead of *dc*, *folder* and *vmname* to uniquely address a VM for backup. As the plugin since :sinceVersion:`22.0.0: VMware Plugin` is able recreate VMs in a different datacenter, folder or datastore, this option has become useless. When using uuid, restoring is only possible to the same still existing VM. It is recommended to change the configuration, as the uuid option will be dropped in the next version.

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -23,6 +23,9 @@ Status
 
 The Plugin can do full, differential and incremental backup and restore of VM disks.
 
+Since :sinceVersion:`24.0.5: VMware Plugin` The Plugin can now save and recreate
+VMs with VirtualSerialPort devices.
+
 Since :sinceVersion:`24.0.3: VMware Plugin` The Plugin can now save and recreate
 VMs with VirtualUSB devices. Note that VirtualUSB devices could disappear when
 powering on the VM and the USB device is attached to a different running VM,
@@ -87,9 +90,11 @@ Requirements
 
 As the Plugin is based on the |vsphere| Storage APIs for Data Protection, which requires at least a |vsphere| Essentials License. It is tested against |vsphere| Storage APIs for Data Protection of |vmware| 7.0.1. It does not work with standalone unlicensed |vmware| ESXi\ |trade|.
 
-Since Bareos :sinceVersion:`22.0.0: VMware Plugin: VDDK 8.0.0` the plugin is using the Virtual Disk Development Kit (VDDK) 8.0.0, as of the VDDK 8.0 release notes, it should be compatible with vSphere 8 and the next major release (except new features) and backward compatible with vSphere 6.7 and 7, see VDDK release notes at https://developer.broadcom.com/sdks/vmware-virtual-disk-development-kit-vddk/8.0 for details.
+Since Bareos :sinceVersion:`24.0.5: VMware Plugin: VDDK 9.0` the plugin is using the Virtual Disk Development Kit (VDDK) 9.0, as of the VDDK 9.0 release notes, it should be compatible with vSphere 9 and the next major release (except new features) and backward compatible with vSphere 7.0.x and 8.0.x, see VDDK release notes at https://techdocs.broadcom.com/us/en/vmware-cis/vsphere/vsphere-sdks-tools/9-0/release-notes/virtual-disk-development-kit/virtual-disk-development-kit-90-release-notes.html for details.
 
 This plugin requires the pyVmomi module version 7.0.2 or greater. Since Bareos :sinceVersion:`21.0.0: VMware Plugin: pyVmomi` the package **bareos-vmware-plugin** no longer includes a dependency on a pyVmomi package, because some Linux distributions don't provide current versions. Consequently, pyVmomi must be either installed by using :command:`pip install pyvmomi` or by manually installing a distribution provided pyVmomi package.
+Generally, the pyVmomi major version should match the used vSphere major version.
+For available versions see https://pypi.org/project/pyvmomi/
 
 Since :sinceVersion:`23.0.3: VMware Plugin` the plugin requires the modules
 **requests** and **urllib3** for backup and restore of the NVRAM.
@@ -107,6 +112,15 @@ command:
 
    BPP=$(python3 -c'import sys; print(f"/usr/{sys.platlibdir}/bareos/plugins")')
    pip install -t $BPP --upgrade pyvmomi
+   pip install -t $BPP --upgrade requests
+   pip install -t $BPP --upgrade urllib3
+
+.. note::
+
+   Installing the **requests** and **urllib3** modules as described above
+   is only necessary when the required versions are not available packaged
+   for the used operating system. See below how to check the installed
+   versions.
 
 The following warning message is not relevant when using the above command,
 because it installs modules in a path which is not used by system packages:


### PR DESCRIPTION
The VMware Plugin can now save and recreate VMs with VirtualSerialPort devices.

The VMware Plugin have now NVRAM backup/restore timeouts configurable and have improved defaults.

This commit also contains documentation changes about the VDDK Version which was updated to 9.0 and some improvements about the installation of required Python modules.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
