### PR TITLE
stored: fix race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - VMWare Plugin: Fix VirtualSerialPort, NVRAM timeouts configurable [PR #2344]
 - doc: storage backend add note about static build [PR #2350]
 - fix next-pool overrides by job [PR #2279]
+- stored: fix race condition [PR #2359]
 
 ### Documentation
 - docs: fix grpc-fd plugin call [PR #2068]
@@ -207,4 +208,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [PR #2341]: https://github.com/bareos/bareos/pull/2341
 [PR #2344]: https://github.com/bareos/bareos/pull/2344
 [PR #2350]: https://github.com/bareos/bareos/pull/2350
+[PR #2359]: https://github.com/bareos/bareos/pull/2359
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -748,6 +748,8 @@ bool FreeVolume(Device* dev)
       if (other_vol == vol) {
         vol_list->remove(vol);
         is_on_list = true;
+        Dmsg2(debuglevel, "=== remove volume %s dev=%s\n", vol->vol_name,
+              dev->print_name());
         break;
       }
     }
@@ -771,11 +773,9 @@ bool FreeVolume(Device* dev)
       }
       // this message is split up so we get at least the first message
       // if vol->vol_name points to unallocated memory ...
-      Emsg1(M_ERROR, 0, T_("  volume = %s\n"),
-            vol->vol_name ? vol->vol_name : "unset");
+      Emsg1(M_ERROR, 0, T_("  volume = %s (dev = %s)\n"),
+            vol->vol_name ? vol->vol_name : "unset", dev->print_name());
     }
-    Dmsg2(debuglevel, "=== remove volume %s dev=%s\n", vol->vol_name,
-          dev->print_name());
     FreeVolItem(vol);
 
     if (debug_level >= debuglevel) { DebugListVolumes("FreeVolume"); }

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -740,13 +740,39 @@ bool FreeVolume(Device* dev)
     Dmsg1(debuglevel, "=== clear in_use vol=%s\n", vol->vol_name);
     dev->vol = NULL;
 
+    bool is_on_list = false;
+
+    // this is ok, since we locked the volume list
+    for (VolumeReservationItem* other_vol = vol_list->first(); other_vol;
+         other_vol = vol_list->next(other_vol)) {
+      if (other_vol == vol) {
+        vol_list->remove(vol);
+        is_on_list = true;
+        break;
+      }
+    }
+
     /* Volume is on write volume list if one of the folling is applicable:
      *  - The volume is written to.
      *  - Config option filedevice_concurrent_read is not on.
      *  - The device is not of type File. */
-    if (vol->IsWriting() || !me->filedevice_concurrent_read
-        || !dev->CanReadConcurrently()) {
-      vol_list->remove(vol);
+    bool should_be_on_list = vol->IsWriting() || !me->filedevice_concurrent_read
+                             || !dev->CanReadConcurrently();
+
+    if (should_be_on_list != is_on_list) {
+      if (is_on_list) {
+        Emsg0(M_ERROR, 0,
+              T_("logic error detected! trying to free item still on volume "
+                 "list\n"));
+      } else {
+        Emsg0(M_ERROR, 0,
+              T_("logic error detected! trying to remove item not in the "
+                 "volume list\n"));
+      }
+      // this message is split up so we get at least the first message
+      // if vol->vol_name points to unallocated memory ...
+      Emsg1(M_ERROR, 0, T_("  volume = %s\n"),
+            vol->vol_name ? vol->vol_name : "unset");
     }
     Dmsg2(debuglevel, "=== remove volume %s dev=%s\n", vol->vol_name,
           dev->print_name());

--- a/core/src/stored/vol_mgr.cc
+++ b/core/src/stored/vol_mgr.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2013 Free Software Foundation Europe e.V.
-   Copyright (C) 2015-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2025 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -280,8 +280,8 @@ static void FreeVolItem(VolumeReservationItem* vol)
 {
   Device* dev = nullptr;
 
-  vol->DecUseCount();
   vol->Lock();
+  vol->DecUseCount();
   if (vol->UseCount() > 0) {
     vol->Unlock();
     return;


### PR DESCRIPTION
Because the decrement does not happen inside the lock, multiple threads can run into the "else" branch, which then causes a double free.

The better solution would be for decrement to return the value after the decrement, but as this is not performance cricital, the easy fix is probably the better one

fixes issue #2339.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
