### PR TITLE
webui: apply fix for CVE-2021-3007 in laminas-http

### DIFF
--- a/webui/vendor/laminas/laminas-http/src/Response/Stream.php
+++ b/webui/vendor/laminas/laminas-http/src/Response/Stream.php
@@ -287,7 +287,7 @@ class Stream extends Response
         if (is_resource($this->stream)) {
             $this->stream = null; //Could be listened by others
         }
-        if ($this->cleanup) {
+        if ($this->cleanup && is_string($this->streamName) && file_exists($this->streamName)) {
             ErrorHandler::start(E_WARNING);
             unlink($this->streamName);
             ErrorHandler::stop();


### PR DESCRIPTION
webui: apply fix for CVE-2021-3007 in laminas-http
- backported from laminas-http 2.14.2, taken from https://github.com/laminas/laminas-http/pull/48

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
