### PR TITLE
systemtests check runscript failed - improve media_vault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: add encrypt checkbox for label tape [PR #2522]
 - Increase read timeout in Proxmox plugin [PR #2544]
 - packaging: add missing DLLs to windows installer [PR #2569]
+- systemtests check runscript failed - improve media_vault [PR #2556]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2229,6 +2230,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2544]: https://github.com/bareos/bareos/pull/2544
 [PR #2546]: https://github.com/bareos/bareos/pull/2546
 [PR #2548]: https://github.com/bareos/bareos/pull/2548
+[PR #2556]: https://github.com/bareos/bareos/pull/2556
 [PR #2567]: https://github.com/bareos/bareos/pull/2567
 [PR #2569]: https://github.com/bareos/bareos/pull/2569
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/contrib/misc/media_vault/README.md
+++ b/contrib/misc/media_vault/README.md
@@ -40,7 +40,7 @@ python3 -m pip install python_bareos ConfigArgParse
 .. note:
    TLS-PSK native support requires Python version >= 3.12. Alternatively,
    the ``sslpsk`` module can be used for python versions <= 3.9, but it requires gcc.
-   gcc installed). It can also be installed from github repository
+   It can also be installed from github repository
    to support Python version up to 3.10.
 
 ### Without Virtualenv
@@ -320,8 +320,7 @@ For example:
 su bareos -l -s /bin/bash
 source ~/.local/share/virtualenvs/bareos_media_vault/bin/activate && \
 /usr/lib/bareos/scripts/media_vault.py --config /etc/bareos/media_vault_autochanger-0.ini && \
-/usr/lib/bareos/scripts/media_vault.py --config /etc/bareos/media_vault_autochanger-1.ini && \
-deactivate
+/usr/lib/bareos/scripts/media_vault.py --config /etc/bareos/media_vault_autochanger-1.ini
 ```
 
 - Pros: only one job and one wrapper script to maintain.

--- a/contrib/misc/media_vault/job_admin-media_vault.conf.example.in
+++ b/contrib/misc/media_vault/job_admin-media_vault.conf.example.in
@@ -8,9 +8,9 @@ Job {
         Runs On Failure = yes
         Runs On Success = yes
         Runs On Client = no
+        Fail Job On Error = Yes
         Command = "@scriptdir@/media_vault.sh"
   }
-
   Reschedule On Error = yes
   Reschedule Interval = 3600
   Reschedule Times = 2

--- a/contrib/misc/media_vault/media_vault.sh.in
+++ b/contrib/misc/media_vault/media_vault.sh.in
@@ -1,7 +1,7 @@
 #!/bin/bash
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2023-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2023-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -19,8 +19,7 @@
 #   02110-1301, USA.
 #
 # this helper placed in /usr/lib/bareos/scripts/ use the python 
-# virtualenv by default. if you are not using it comment first and
-# last line
+# virtualenv by default. If you are not using it comment source
+# line below.
 source ~/.local/share/virtualenvs/bareos_media_vault/bin/activate
 @plugindir@/media_vault.py --config @confdir@/media_vault.ini $@
-deactivate

--- a/docs/manuals/source/Appendix/DisasterRecoveryUsingBareos.rst
+++ b/docs/manuals/source/Appendix/DisasterRecoveryUsingBareos.rst
@@ -680,6 +680,21 @@ We now import the database dump to the database:
   root@bareos:~ # su postgres -c "psql -d bareos -f /tmp/var/lib/bareos/bareos.sql"
 
 
+We now replay again the database privileges grant:
+
+.. code-block:: shell-session
+
+   root@bareos:~ # su postgres -c /usr/lib/bareos/scripts/grant_bareos_privileges
+
+
+.. code-block:: none
+
+   Info: Granting bareos tables
+   CREATE ROLE
+   GRANT
+   Info: Privileges for user bareos granted ON database bareos.
+
+
 We backup the newly installed configuration to another location
 
 .. code-block:: shell-session

--- a/docs/manuals/source/Appendix/DisasterRecoveryUsingBareos.rst
+++ b/docs/manuals/source/Appendix/DisasterRecoveryUsingBareos.rst
@@ -680,7 +680,7 @@ We now import the database dump to the database:
   root@bareos:~ # su postgres -c "psql -d bareos -f /tmp/var/lib/bareos/bareos.sql"
 
 
-We now replay again the database privileges grant:
+We now reapply the database privileges grant:
 
 .. code-block:: shell-session
 

--- a/docs/manuals/source/Appendix/Troubleshooting.rst
+++ b/docs/manuals/source/Appendix/Troubleshooting.rst
@@ -1132,7 +1132,7 @@ changer works. To do so, we suggest you do the following commands:
 
 Make sure Bareos is not running.
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 list 0 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 list 0 /dev/nst0 0`
 
 .. index::
    single: mtx-changer list
@@ -1153,10 +1153,10 @@ This command should print:
 or one number per line for each slot that is occupied in your changer, and the number should be
 terminated by a colon (:). If your changer has barcodes, the barcode will follow the colon. If an
 error message is printed, you must resolve the problem (e.g. try a different SCSI control device
-name if /dev/sch0 is incorrect). For example, on FreeBSD systems, the autochanger SCSI control device
+name if /dev/sg0 is incorrect). For example, on FreeBSD systems, the autochanger SCSI control device
 is generally /dev/pass2.
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 listall 0 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 listall 0 /dev/nst0 0`
 
 .. index::
    single: mtx-changer listall
@@ -1184,35 +1184,35 @@ This command should print:
 
 
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 transfer 1 2`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 transfer 1 2`
 
 .. index::
    single: mtx-changer transfer
 
 This command should transfer a volume from source (1) to destination (2)
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 slots`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 slots`
 
 .. index::
    single: mtx-changer slots
 
 This command should return the number of slots in your autochanger.
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 unload 1 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 unload 1 /dev/nst0 0`
 
 .. index::
    single: mtx-changer unload
 
 If a tape is loaded from slot 1, this should cause it to be unloaded.
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 load 3 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 load 3 /dev/nst0 0`
 
 .. index::
    single: mtx-changer load
 
 Assuming you have a tape in slot 3, it will be loaded into drive (0).
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 loaded 0 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 loaded 0 /dev/nst0 0`
 
 .. index::
    single: mtx-changer loaded
@@ -1221,7 +1221,7 @@ It should print "3" Note, we have used an "illegal" slot number 0. In this case,
 ignored because the slot number is not used. However, it must be specified because the drive
 parameter at the end of the command is needed to select the correct drive.
 
-:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sch0 unload 3 /dev/nst0 0`
+:command:`/usr/lib/bareos/scripts/mtx-changer /dev/sg0 unload 3 /dev/nst0 0`
 
 .. index::
    single: mtx-changer unload
@@ -1243,8 +1243,8 @@ as a script:
    :caption: Testing if sleep is needed between unload and load
 
    #!/bin/sh
-   /usr/lib/bareos/scripts/mtx-changer /dev/sch0 unload 1 /dev/nst0 0
-   /usr/lib/bareos/scripts/mtx-changer /dev/sch0 load 3 /dev/nst0 0
+   /usr/lib/bareos/scripts/mtx-changer /dev/sg0 unload 1 /dev/nst0 0
+   /usr/lib/bareos/scripts/mtx-changer /dev/sg0 load 3 /dev/nst0 0
    mt -f /dev/st0 rewind
    mt -f /dev/st0 weof
 
@@ -1267,9 +1267,9 @@ after the unload so that the script looks like:
    :caption: Testing if offline is needed
 
    #!/bin/sh
-   /usr/lib/bareos/scripts/mtx-changer /dev/sch0 unload 1 /dev/nst0 0
+   /usr/lib/bareos/scripts/mtx-changer /dev/sg0 unload 1 /dev/nst0 0
    mt -f /dev/st0 offline
-   /usr/lib/bareos/scripts/mtx-changer /dev/sch0 load 3 /dev/nst0 0
+   /usr/lib/bareos/scripts/mtx-changer /dev/sg0 load 3 /dev/nst0 0
    mt -f /dev/st0 rewind
    mt -f /dev/st0 weof
 

--- a/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
+++ b/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
@@ -193,7 +193,7 @@ on upgrade none of the Bareos components
 (**bareos-dir**, **bareos-sd**, **bareos-fd**, **bconsole** and **bareos-traymonitor**)
 modify/extend an existing configuration.
 Package configuration files are stored in the Bareos Template Configuration Path (see :ref:`section-BareosPaths`).
-The package use :command:`bareos-config deploy_config $COMPONENT` to deploy the configuration.
+The package uses :command:`bareos-config deploy_config $COMPONENT` to deploy the configuration.
 On fresh installation it:
 
 * copies the config files from the Bareos Template Configuration Path (Linux: :file:`/usr/lib/bareos/defaultconfigs/`) to the Bareos Configuration Path (Linux: :file:`/etc/bareos/`)
@@ -219,9 +219,10 @@ Behavior
 Add missing
 ~~~~~~~~~~~
 
-In case your local /etc/bareos configuration is missing one of the default file, after a delete,
-or adding a new subcomponent like a plugin. You can always deploy the missing file with the following
-command :command:`bareos-config deploy_config --add-missing $COMPONENT` to deploy the missing files.
+If your local :file:`/etc/bareos` configuration is missing one of the default files
+(for example after deleting a file or adding a new subcomponent such as a plugin),
+you can deploy missing files with
+:command:`bareos-config deploy_config --add-missing $COMPONENT`.
 
 
 .. code-block:: shell-session
@@ -251,7 +252,7 @@ Therefore we use a package pre-script to backup the config files
 and restore them with a post-script (posttrans).
 The normal automated restart of the |fd| will fail in between, but a proper restart will be performed at the end.
 In short: for this scenario we created workarounds
-so that the Administrator should not notice any trouble when upgrading.
+so that the administrator should not notice any trouble when upgrading.
 
 The :os:`FreeBSD` packaging mechanism prevents that a backup of the old configuration could be done,
 therefore unmodified configuration files from the old package get removed.

--- a/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
+++ b/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
@@ -193,7 +193,7 @@ on upgrade none of the Bareos components
 (**bareos-dir**, **bareos-sd**, **bareos-fd**, **bconsole** and **bareos-traymonitor**)
 modify/extend an existing configuration.
 Package configuration files are stored in the Bareos Template Configuration Path (see :ref:`section-BareosPaths`).
-The package use :command:`bareos-config deploy_config $COMPONENT` to deploy the configuration. 
+The package use :command:`bareos-config deploy_config $COMPONENT` to deploy the configuration.
 On fresh installation it:
 
 * copies the config files from the Bareos Template Configuration Path (Linux: :file:`/usr/lib/bareos/defaultconfigs/`) to the Bareos Configuration Path (Linux: :file:`/etc/bareos/`)
@@ -216,6 +216,24 @@ Behavior
 * Configuration files from sub-packages will probably not get installed,
   especially if the sub-package is installed after the main package (e.g. the **bareos-storage-tape** package is installed after the **bareos-storage** package). This also applies to configuration example files (:file:`*.conf.example`).
 
+Add missing
+~~~~~~~~~~~
+
+In case your local /etc/bareos configuration is missing one of the default file, after a delete,
+or adding a new subcomponent like a plugin. You can always deploy the missing file with the following
+command :command:`bareos-config deploy_config --add-missing $COMPONENT` to deploy the missing files.
+
+
+.. code-block:: shell-session
+   :caption: Shell example script to deploy missing example configuration file
+
+   /usr/lib/bareos/scripts/bareos-config deploy_config --add-missing bareos-sd
+
+   '/usr/lib/bareos/defaultconfigs/bareos-sd.d//./autochanger/autochanger-0.conf.example' -> '/etc/bareos/bareos-sd.d/./autochanger/autochanger-0.conf.example'
+   '/usr/lib/bareos/defaultconfigs/bareos-sd.d//./device/tapedrive-0.conf.example' -> '/etc/bareos/bareos-sd.d/./device/tapedrive-0.conf.example'
+   '/usr/lib/bareos/defaultconfigs/bareos-sd.d//./device/dplcompat.conf.example' -> '/etc/bareos/bareos-sd.d/./device/dplcompat.conf.example'
+
+
 Upgrades from Bareos < 25 to Bareos >= 25
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -224,6 +242,7 @@ The other platforms did already use Bareos Template Configuration Path before.
 
 .. index::
    single: Linux; RPM
+   single: FreeBSD; pkg
 
 When upgrading from Bareos < 25 to Bareos >= 25 with RPM packages,
 RPM would delete or rename the old configuration,

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
@@ -143,7 +143,7 @@ The restore basically works like this:
 
 .. warning::
 
-   In order to make coherent backups, it is imperative that :strong:`the same |postgresql| major version`
+   In order to make coherent backups, it is imperative that :strong:`the same PostgreSQL major version`
    is used for :strong:`full and incremental` backups depending on each other.
 
 

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/PostgreSQLPlugin.rst.inc
@@ -172,6 +172,10 @@ backed up from the local filesystem.
    As a minimum this requires that you create an WAL archive directory
    and matching settings in your |postgresql| configuration file :strong:`postgresql.conf`.
 
+   While the PostgreSQL plugin backups only the required files from the WAL archive directory,
+   old files are not removed automatically. It is **your responsability** to setup a cleanup
+   routine doing so.
+
 
 In our examples we assume the WAL archive directory as :file:`/var/lib/pgsql/wal_archive/`.
 
@@ -186,11 +190,6 @@ In our examples we assume the WAL archive directory as :file:`/var/lib/pgsql/wal
    ...
 
 Please refer to the |postgresql| documentation for details.
-
-.. note::
-
-   While the PostgreSQL plugin backups only the required files from the WAL archive directory,
-   old files are not removed automatically.
 
 
 Installation of the PostgreSQL Plugin

--- a/systemtests/python-modules/bareos_unittest/json.py
+++ b/systemtests/python-modules/bareos_unittest/json.py
@@ -2,7 +2,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -252,7 +252,6 @@ class Json(PythonBareosBase):
 
         jobId = self.run_job(director, jobname, level, wait=True)
         self.search_joblog(director, jobId, patterns)
-        return jobId
 
     def list_jobid(self, director, jobid):
         result = director.call("llist jobid={}".format(jobid))

--- a/systemtests/tests/autochanger/functions.local
+++ b/systemtests/tests/autochanger/functions.local
@@ -39,14 +39,15 @@ release_all_devices()
 {
   #release all drives
   # Total of drives ${#tapedevices[@]}
-  d=0
   cat <<END_OF_DATA >"${runner_tmp}/bconcmd_release_all_devices"
 @$out ${runner_tmp}/release_all_devices.out
 END_OF_DATA
 
-  for d in $(seq ${#tapedevices[@]}); do
+  d=0
+  while [ ${d} -lt ${#tapedevices[@]} ]; do
     echo "release storage=Tape-0 drive=${d}" >> \
       "${runner_tmp}/bconcmd_release_all_devices"
+    d=$((d + 1))
   done
 
   cat <<END_OF_DATA >>"${runner_tmp}/bconcmd_release_all_devices"

--- a/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-dir.d/fileset/MariabackupTest.conf.in
+++ b/systemtests/tests/py3plug-fd-mariabackup/etc/bareos/bareos-dir.d/fileset/MariabackupTest.conf.in
@@ -10,7 +10,6 @@ FileSet {
             ":module_name=bareos-fd-mariabackup"
             ":mycnf=my.cnf:"
             ":dumpbinary=@MARIADB_BACKUP_BINARY@"
-            ":extradumpoptions=--user=@USER@@extradumpoptions@"
-            # ":mysqlcmd=@MARIADB_CLIENT_BINARY@ --defaults-file=@PROJECT_BINARY_DIR@/tests/@TEST_NAME@/my.cnf --user=@USER@"
+            ":extradumpoptions="
   }
 }

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-failed-implicit.conf
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-failed-implicit.conf
@@ -1,0 +1,11 @@
+Job {
+  Name = "admin-runscript-server-failed-implicit"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    RunsWhen = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    Command = "/usr/bin/false"
+  }
+}

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-failed.conf
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-failed.conf
@@ -1,0 +1,12 @@
+Job {
+  Name = "admin-runscript-server-failed"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    Runs When = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    Fail Job On Error = Yes
+    Command = "/usr/bin/false" 
+  }
+}

--- a/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-ignore-failure.conf
+++ b/systemtests/tests/python-bareos/etc/bareos/bareos-dir.d/job/admin-runscript-server-ignore-failure.conf
@@ -1,0 +1,12 @@
+Job {
+  Name = "admin-runscript-server-ignore-failure"
+  JobDefs = "DefaultJob"
+  Type = Admin
+  RunScript {
+    Runs When = Before
+    Runs On Failure = Yes
+    Runs On Client = No
+    Fail Job On Error = No
+    Command = "/usr/bin/false" 
+  }
+}

--- a/systemtests/tests/python-bareos/test_runscript.py
+++ b/systemtests/tests/python-bareos/test_runscript.py
@@ -1,7 +1,7 @@
 #
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -46,7 +46,6 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         Run a job which contains a runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -69,16 +68,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: BeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_log
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_log)
 
     def test_backup_runscript_client(self):
         """
         Run a job which contains a runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -101,16 +97,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: ClientBeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_log
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_log)
 
     def test_backup_runscript_server(self):
         """
         Run a job which contains a runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -136,16 +129,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: BeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
 
     def test_backup_runscript_console_client(self):
         """
         Run a job which contains a runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -173,16 +163,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: ClientBeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
 
     def test_backup_runscript_console_server(self):
         """
         Run a job which contains a console runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -207,16 +194,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: BeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
 
     def test_admin_runscript_server(self):
         """
         Run a job which contains a runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -243,16 +227,102 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #    "logtext": "bareos-dir JobId 76: BeforeJob: jobname=admin-runscript-server\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
+
+    def test_admin_runscript_server_failure_implicit(self):
+        """
+        Run a job which contains a runscript that failed.
+        "Fail Job On Error" is not set, but the default is "Yes".
+        Check the JobLog if the runscript failed as expected.
+        """
+
+        username = self.get_operator_username()
+        password = self.get_operator_password(username)
+
+        jobname = "admin-runscript-server-failed-implicit"
+        expected_logs = [
+            ": Error: Runscript: BeforeJob returned non-zero status=",
+        ]
+        director_root = bareos.bsock.DirectorConsoleJson(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
         )
+
+        # Example log entry:
+        # {
+        #   "time": "2026-02-23 10:39:19",
+        #   "logtext": "bareos-dir JobId 6: Error: Runscript: BeforeJob returned non-zero status=1. ERR=Child exited with code 1\n"
+        # },
+
+        jobId = self.run_job(director_root, jobname)
+        self.wait_job(director_root, jobId, expected_status="Error")
+        self.search_joblog(director_root, jobId, expected_logs)
+
+    def test_admin_runscript_server_failure(self):
+        """
+        Run a job which contains a runscript that failed and have "Fail Job On Error = Yes".
+        Check the JobLog if the runscript failed as expected.
+        """
+
+        username = self.get_operator_username()
+        password = self.get_operator_password(username)
+
+        jobname = "admin-runscript-server-failed"
+        expected_logs = [
+            ": Error: Runscript: BeforeJob returned non-zero status=",
+        ]
+        director_root = bareos.bsock.DirectorConsoleJson(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
+        )
+
+        # Example log entry:
+        # {
+        #   "time": "2026-02-23 10:39:19",
+        #   "logtext": "bareos-dir JobId 6: Error: Runscript: BeforeJob returned non-zero status=1. ERR=Child exited with code 1\n"
+        # },
+
+        jobId = self.run_job(director_root, jobname)
+        self.wait_job(director_root, jobId, expected_status="Error")
+        self.search_joblog(director_root, jobId, expected_logs)
+
+    def test_admin_runscript_server_ignore_failure(self):
+        """
+        Run a job which contains a runscript that failed, but ignore the error.
+        """
+
+        username = self.get_operator_username()
+        password = self.get_operator_password(username)
+
+        jobname = "admin-runscript-server-ignore-failure"
+        director_root = bareos.bsock.DirectorConsoleJson(
+            address=self.director_address,
+            port=self.director_port,
+            name=username,
+            password=password,
+            **self.director_extra_options
+        )
+
+        # Example log entry:
+        # {
+        #   "time": "2026-02-23 10:39:19",
+        #   "logtext": "bareos-dir JobId 6: Error: Runscript: BeforeJob returned non-zero status=1. ERR=Child exited with code 1\n"
+        # },
+
+        jobId = self.run_job(director_root, jobname)
+        self.wait_job(director_root, jobId, expected_status="OK")
 
     def test_admin_runscript_console_server_defaults(self):
         """
         Run a job which contains a console runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -287,16 +357,13 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #   "logtext": "bareos-dir JobId 3: console command: run BeforeJob \"list jobid=3\"\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
 
     def test_admin_runscript_console_server(self):
         """
         Run a job which contains a console runscript.
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -331,9 +398,7 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #   "logtext": "bareos-dir JobId 3: console command: run BeforeJob \"list jobid=3\"\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)
 
     def test_admin_runscript_console_server_invalid(self):
         """
@@ -341,7 +406,6 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         (containing the invalid command "INVALID").
         Check the JobLog if the runscript worked as expected.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -370,9 +434,8 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         #   "time": "2022-08-10 13:21:21",
         #   "logtext": "bareos-dir JobId 6: console command: run BeforeJob \"INVALID\"\n"
         # },
-
         jobId = self.run_job(director_root, jobname, level)
-        self.wait_job(director_root, jobId, expected_status=u"Error")
+        self.wait_job(director_root, jobId, expected_status="Error")
         self.search_joblog(director_root, jobId, expected_logs)
 
     def test_admin_runscript_client(self):
@@ -381,7 +444,6 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         are not executed in Admin Jobs.
         Instead, a warning is written to the joblog.
         """
-        logger = logging.getLogger()
 
         username = self.get_operator_username()
         password = self.get_operator_password(username)
@@ -404,6 +466,4 @@ class PythonBareosJsonRunScriptTest(bareos_unittest.Json):
         # "logtext": "bareos-dir JobId 7: Warning: Invalid runscript definition (command=...). Admin Jobs only support local runscripts.\n"
         # },
 
-        jobId = self.run_job_and_search_joblog(
-            director_root, jobname, level, expected_logs
-        )
+        self.run_job_and_search_joblog(director_root, jobname, level, expected_logs)


### PR DESCRIPTION
This PR enhance systemtests by adding a tests to test job failure in case a runscript command failed.

- **python-bareos** is extended by adding expected jobstatus to run and wait functions.

In contrib: media_vault script now capture python return code by removing deactivate call.
Fix bareos/internal#593

- **systemtests**: mariabackup remove not used @USER@ from extraoptions fileset as user in set in the config file.


- **docs**: add deploy_config --add-missing paragraph
Fix #2487 

- **docs**: add apply grant privileges after database import
Fix #2553 

- **docs**: plugin PostgreSQL set note as warning (about wall not deleted)
- **docs**: Revert usage of `/dev/sch0`, prefer generic device `/dev/sg0`

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
