### PR TITLE
python-bareos: add support for the sslpsk3 module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - matrix.yml: add Fedora 44 [PR #2616]
 - python-dir/sd: fix not registering python thread state correctly [PR #2493]
 - webui: optimize performance and security [PR #2593]
+- python-bareos: add support for the sslpsk3 module [PR #2559]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2253,6 +2254,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2547]: https://github.com/bareos/bareos/pull/2547
 [PR #2548]: https://github.com/bareos/bareos/pull/2548
 [PR #2556]: https://github.com/bareos/bareos/pull/2556
+[PR #2559]: https://github.com/bareos/bareos/pull/2559
 [PR #2565]: https://github.com/bareos/bareos/pull/2565
 [PR #2566]: https://github.com/bareos/bareos/pull/2566
 [PR #2567]: https://github.com/bareos/bareos/pull/2567

--- a/python-bareos/bareos/bsock/__init__.py
+++ b/python-bareos/bareos/bsock/__init__.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -146,7 +146,11 @@ Since Bareos >= 18.2.4, Bareos supports TLS-PSK (Transport-Layer-Security Pre-Sh
 
 Unfortunately the Python core module ``ssl`` does support TLS-PSK only with Python >= 3.13.
 For some older versions of Python,
-the extra module ``sslpsk`` (see https://github.com/drbild/sslpsk) offers limited support.
+the extra modules
+``sslpsk3`` (Python >= 3.7, see https://github.com/kuba2k2/sslpsk3)
+or
+``sslpsk`` (Python <= 3.9, see https://github.com/drbild/sslpsk)
+offers limited support.
 
 Fallback To Unencrypted Connections
 -----------------------------------
@@ -181,6 +185,15 @@ To enforce a encrypted connection, use the ``tls_psk_require=True`` parameter:
 
 
 In this case, an exception is raised, if the connection can not be established via TLS-PSK.
+
+sslpsk3
+-------
+
+The extra module `sslpsk3` (see https://github.com/kuba2k2/sslpsk3)
+is an extended fork of `sslpsk`
+and extends the core module `ssl` by TLS-PSK.
+
+It is installable via **pip**, see https://pypi.org/project/sslpsk3.
 
 sslpsk
 ------

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -1,6 +1,6 @@
 #   BAREOS - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2015-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2015-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -325,7 +325,11 @@ class LowLevel(object):
     @staticmethod
     def is_tls_psk_available():
         """Checks if TLS-PSK is available."""
-        return getattr(ssl, "HAS_PSK", False) or ("sslpsk3" in sys.modules) or ("sslpsk" in sys.modules)
+        return (
+            getattr(ssl, "HAS_PSK", False)
+            or ("sslpsk3" in sys.modules)
+            or ("sslpsk" in sys.modules)
+        )
 
     def get_protocol_version(self):
         """Get the Bareos Console protocol version that is used.

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -60,12 +60,15 @@ if not getattr(ssl, "HAS_PSK", False):
 
     warnings.formatwarning = format_warning_short
     try:
-        import sslpsk
+        import sslpsk3
     except ImportError:
-        warnings.warn(
-            "Connection encryption via TLS-PSK is not available "
-            "(not available in 'ssl' and extra module 'sslpsk' is not installed)."
-        )
+        try:
+            import sslpsk
+        except ImportError:
+            warnings.warn(
+                "Connection encryption via TLS-PSK is not available "
+                "(not available in 'ssl' and extra module 'sslpsk3' or 'sslpsk' is not installed)."
+            )
 
 
 class LowLevel(object):
@@ -285,19 +288,26 @@ class LowLevel(object):
             context.set_psk_client_callback(lambda hint: (identity, password))
             self.socket = context.wrap_socket(client_socket, server_side=False)
         else:
-            try:
-                self.socket = sslpsk.wrap_socket(
-                    client_socket,
-                    ssl_version=self.tls_version,
-                    ciphers=ciphers,
-                    psk=(password, identity),
-                    server_side=False,
-                )
-            except ssl.SSLError as e:
-                # raise ConnectionError(
-                #     "failed to connect to host {0}, port {1}: {2}".format(self.address, self.port, str(e)))
-                # Using a general raise to keep more information about the type of error.
-                raise
+            if "sslpsk3" in sys.modules:
+                context = sslpsk3.SSLPSKContext(ssl.PROTOCOL_TLS_CLIENT)
+                context.check_hostname = False
+                context.set_ciphers(ciphers)
+                context.set_psk_client_callback(lambda hint: (identity, password))
+                self.socket = context.wrap_socket(client_socket, server_side=False)
+            else:
+                try:
+                    self.socket = sslpsk.wrap_socket(
+                        client_socket,
+                        ssl_version=self.tls_version,
+                        ciphers=ciphers,
+                        psk=(password, identity),
+                        server_side=False,
+                    )
+                except ssl.SSLError as e:
+                    # raise ConnectionError(
+                    #     "failed to connect to host {0}, port {1}: {2}".format(self.address, self.port, str(e)))
+                    # Using a general raise to keep more information about the type of error.
+                    raise
         return True
 
     def get_tls_psk_identity(self):
@@ -313,7 +323,7 @@ class LowLevel(object):
     @staticmethod
     def is_tls_psk_available():
         """Checks if TLS-PSK is available."""
-        return getattr(ssl, "HAS_PSK", False) or ("sslpsk" in sys.modules)
+        return getattr(ssl, "HAS_PSK", False) or ("sslpsk3" in sys.modules) or ("sslpsk" in sys.modules)
 
     def get_protocol_version(self):
         """Get the Bareos Console protocol version that is used.

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -291,7 +291,7 @@ class LowLevel(object):
             if "sslpsk3" in sys.modules:
                 context = sslpsk3.SSLPSKContext(ssl.PROTOCOL_TLS_CLIENT)
                 # TLS1.3 only works using Python >= 3.13
-                context.maximum_version = TLSVersion.TLSv1_2
+                context.maximum_version = ssl.TLSVersion.TLSv1_2
                 context.check_hostname = False
                 context.set_ciphers(ciphers)
                 context.set_psk_client_callback(lambda hint: (identity, password))

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -67,7 +67,7 @@ if not getattr(ssl, "HAS_PSK", False):
         except ImportError:
             warnings.warn(
                 "Connection encryption via TLS-PSK is not available "
-                "(not available in 'ssl' and extra module 'sslpsk3' or 'sslpsk' is not installed)."
+                "(not available in 'ssl' and neither extra module 'sslpsk3' nor 'sslpsk' is installed)."
             )
 
 

--- a/python-bareos/bareos/bsock/lowlevel.py
+++ b/python-bareos/bareos/bsock/lowlevel.py
@@ -290,6 +290,8 @@ class LowLevel(object):
         else:
             if "sslpsk3" in sys.modules:
                 context = sslpsk3.SSLPSKContext(ssl.PROTOCOL_TLS_CLIENT)
+                # TLS1.3 only works using Python >= 3.13
+                context.maximum_version = TLSVersion.TLSv1_2
                 context.check_hostname = False
                 context.set_ciphers(ciphers)
                 context.set_psk_client_callback(lambda hint: (identity, password))


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Add support for TLS-PSK to python-bareos for Python versions (3.7  -) 3.12,
by supporting the python module sslpsk3.
The current extra Python module sslpsk does only work for Python <= 3.9.

Fix for https://github.com/bareos/bareos/issues/2558

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_


If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- decided not to add specific tests. It would be tested automatically if sslpsk3 is installed on a worker.
