### PR TITLE
core: unify parsing of bools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - webui: optimize performance and security [PR #2593]
 - python-bareos: add support for the sslpsk3 module [PR #2559]
 - matrix: add ubuntu 26.04 [PR #2635]
+- core: unify parsing of bools [PR #2578]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2263,6 +2264,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2567]: https://github.com/bareos/bareos/pull/2567
 [PR #2569]: https://github.com/bareos/bareos/pull/2569
 [PR #2572]: https://github.com/bareos/bareos/pull/2572
+[PR #2578]: https://github.com/bareos/bareos/pull/2578
 [PR #2581]: https://github.com/bareos/bareos/pull/2581
 [PR #2585]: https://github.com/bareos/bareos/pull/2585
 [PR #2588]: https://github.com/bareos/bareos/pull/2588

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -652,6 +652,12 @@ bareos_configure_file(
   GLOB_RECURSE "${CMAKE_CURRENT_SOURCE_DIR}/src/defaultconfigs/*" COPY
 )
 
+# https://learn.microsoft.com/en-us/cpp/build/reference/zc-preprocessor?view=msvc-170
+# "Enable preprocessor conformance mode" Historically, msvc parses macros
+# incorrectly; it also does not support newer construct such as __VA_OPT__.  To
+# work around this issue, we can simply tell msvc to parse macros correctly.
+add_compile_options($<$<CXX_COMPILER_ID:MSVC>:/Zc:preprocessor>)
+
 add_subdirectory(platforms)
 add_subdirectory(src)
 add_subdirectory(scripts)

--- a/core/src/console/console_conf.cc
+++ b/core/src/console/console_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2009 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -255,10 +255,9 @@ static void ConfigReadyCallback(ConfigurationParser&) {}
 ConfigurationParser* InitConsConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code, R_NUM,
-      resources, default_config_filename.c_str(), "bconsole.d",
-      ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
-      FreeResource);
+      configfile, nullptr, nullptr, nullptr, exit_code, R_NUM, resources,
+      default_config_filename.c_str(), "bconsole.d", ConfigBeforeCallback,
+      ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
   if (config) { config->r_own_ = R_CONSOLE; }
   return config;
 }

--- a/core/src/dird/dbcheck.cc
+++ b/core/src/dird/dbcheck.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,7 @@
 #include "include/bareos.h"
 #include "include/exit_codes.h"
 #include "cats/cats.h"
+#include "lib/bool_string.h"
 #include "lib/runscript.h"
 #include "lib/cli.h"
 #include "dird/dird_conf.h"
@@ -128,7 +129,15 @@ static bool yes_no(const char* prompt, bool batchvalue = true)
     quit = true;
     return false;
   }
-  return (Bstrcasecmp(cmd, "yes")) || (Bstrcasecmp(cmd, T_("yes")));
+
+  switch (parse_user_bool(cmd)) {
+    case parse_bool_result::True: {
+      return true;
+    } break;
+    default: {
+      return false;
+    } break;
+  }
 }
 
 static void set_quit() { quit = true; }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -44,6 +44,7 @@
  *
  */
 
+#include "lib/bool_string.h"
 #include "lib/resource_item.h"
 #define NEED_JANSSON_NAMESPACE 1
 #include "include/bareos.h"
@@ -2921,13 +2922,18 @@ static void StoreShortRunscript(lexer* lc,
 static void StoreRunscriptBool(lexer* lc, const ResourceItem* item, int, int)
 {
   LexGetToken(lc, BCT_NAME);
-  if (Bstrcasecmp(lc->str, "yes") || Bstrcasecmp(lc->str, "true")) {
-    SetItemVariable<bool>(*item, true);
-  } else if (Bstrcasecmp(lc->str, "no") || Bstrcasecmp(lc->str, "false")) {
-    SetItemVariable<bool>(*item, false);
-  } else {
-    scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
-              lc->str); /* YES and NO must not be translated */
+  switch (parse_user_bool(lc->str)) {
+    case parse_bool_result::True: {
+      SetItemVariable<bool>(*item, true);
+    } break;
+    case parse_bool_result::False: {
+      SetItemVariable<bool>(*item, false);
+    } break;
+    case parse_bool_result::Error: {
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+                lc->str); /* YES and NO must not be translated */
+      return;
+    } break;
   }
   ScanToEol(lc);
 }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2420,7 +2420,7 @@ static void StorePooltype(lexer* lc,
     }
 
     if (!found) {
-      scan_err1(lc, T_("Expected a Pool Type option, got: %s"), lc->str);
+      scan_err(lc, T_("Expected a Pool Type option, got: %s"), lc->str);
     }
   }
 
@@ -2449,7 +2449,7 @@ static void StoreActiononpurge(lexer* lc,
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected an Action On Purge option, got: %s"), lc->str);
+    scan_err(lc, T_("Expected an Action On Purge option, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2498,8 +2498,7 @@ static void StoreMigtype(lexer* lc, const ResourceItem* item, int index)
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Migration Job Type keyword, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Migration Job Type keyword, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2522,7 +2521,7 @@ static void StoreJobtype(lexer* lc, const ResourceItem* item, int index, int)
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Job Type keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a Job Type keyword, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2548,7 +2547,7 @@ static void StoreProtocoltype(lexer* lc,
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Protocol Type keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a Protocol Type keyword, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2570,8 +2569,7 @@ static void StoreReplace(lexer* lc, const ResourceItem* item, int index, int)
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Restore replacement option, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Restore replacement option, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2597,8 +2595,7 @@ static void StoreAuthprotocoltype(lexer* lc,
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Auth Protocol Type keyword, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Auth Protocol Type keyword, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2621,8 +2618,8 @@ static void StoreAuthtype(lexer* lc, const ResourceItem* item, int index, int)
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Authentication Type keyword, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Authentication Type keyword, got: %s"),
+             lc->str);
   }
 
   ScanToEol(lc);
@@ -2646,7 +2643,7 @@ static void StoreLevel(lexer* lc, const ResourceItem* item, int index, int)
   }
 
   if (!found) {
-    scan_err1(lc, T_("Expected a Job Level keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a Job Level keyword, got: %s"), lc->str);
   }
 
   ScanToEol(lc);
@@ -2685,10 +2682,10 @@ static void StoreAutopassword(lexer* lc,
         ASSERT(res);
 
         if (res_client->Protocol != res->Protocol) {
-          scan_err1(lc,
-                    "Trying to store password to resource \"%s\", but protocol "
-                    "is not known.\n",
-                    (*item->allocated_resource)->resource_name_);
+          scan_err(lc,
+                   "Trying to store password to resource \"%s\", but protocol "
+                   "is not known.\n",
+                   (*item->allocated_resource)->resource_name_);
         }
       }
       switch (res_client->Protocol) {
@@ -2710,10 +2707,10 @@ static void StoreAutopassword(lexer* lc,
         ASSERT(res);
 
         if (res_store->Protocol != res->Protocol) {
-          scan_err1(lc,
-                    "Trying to store password to resource \"%s\", but protocol "
-                    "is not known.\n",
-                    (*item->allocated_resource)->resource_name_);
+          scan_err(lc,
+                   "Trying to store password to resource \"%s\", but protocol "
+                   "is not known.\n",
+                   (*item->allocated_resource)->resource_name_);
         }
       }
       switch (res_store->Protocol) {
@@ -2754,7 +2751,7 @@ static void StoreAcl(lexer* lc, const ResourceItem* item, int index, int pass)
     LexGetToken(lc, BCT_STRING);
     if (pass == 1) {
       if (!IsAclEntryValid(lc->str, msg)) {
-        scan_err1(lc, T_("Cannot store Acl: %s"), msg.c_str());
+        scan_err(lc, T_("Cannot store Acl: %s"), msg.c_str());
         return;
       }
       list->append(strdup(lc->str));
@@ -2806,8 +2803,8 @@ static void StoreRunscriptWhen(lexer* lc, const ResourceItem* item, int, int)
   } else if (Bstrcasecmp(lc->str, "always")) {
     value = SCRIPT_Any;
   } else {
-    scan_err2(lc, T_("Expect %s, got: %s"), "Before, After, AfterVSS or Always",
-              lc->str);
+    scan_err(lc, T_("Expect %s, got: %s"), "Before, After, AfterVSS or Always",
+             lc->str);
   }
   if (value != SCRIPT_INVALID) { SetItemVariable<uint32_t>(*item, value); }
   ScanToEol(lc);
@@ -2832,10 +2829,10 @@ static void StoreRunscriptTarget(lexer* lc,
       BareosResource* res;
 
       if (!(res = my_config->GetResWithName(R_CLIENT, lc->str))) {
-        scan_err3(lc,
-                  T_("Could not find config Resource %s referenced on line %d "
-                     ": %s\n"),
-                  lc->str, lc->line_no, lc->line);
+        scan_err(lc,
+                 T_("Could not find config Resource %s referenced on line %d "
+                    ": %s\n"),
+                 lc->str, lc->line_no, lc->line);
       }
 
       r->SetTarget(lc->str);
@@ -2930,8 +2927,8 @@ static void StoreRunscriptBool(lexer* lc, const ResourceItem* item, int, int)
       SetItemVariable<bool>(*item, false);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
-                lc->str); /* YES and NO must not be translated */
+      scan_err(lc, T_("Expect %s, got: %s"), "YES or NO",
+               lc->str); /* YES and NO must not be translated */
       return;
     } break;
   }
@@ -2955,7 +2952,7 @@ static void StoreRunscript(lexer* lc,
   int token = LexGetToken(lc, BCT_SKIP_EOL);
 
   if (token != BCT_BOB) {
-    scan_err1(lc, T_("Expecting open brace. Got %s"), lc->str);
+    scan_err(lc, T_("Expecting open brace. Got %s"), lc->str);
     return;
   }
 
@@ -2971,7 +2968,7 @@ static void StoreRunscript(lexer* lc,
     if (token == BCT_EOB) { break; }
 
     if (token != BCT_IDENTIFIER) {
-      scan_err1(lc, T_("Expecting keyword, got: %s\n"), lc->str);
+      scan_err(lc, T_("Expecting keyword, got: %s\n"), lc->str);
       goto bail_out;
     }
 
@@ -2980,7 +2977,7 @@ static void StoreRunscript(lexer* lc,
       if (Bstrcasecmp(runscript_items[i].name, lc->str)) {
         token = LexGetToken(lc, BCT_SKIP_EOL);
         if (token != BCT_EQUALS) {
-          scan_err1(lc, T_("Expected an equals, got: %s"), lc->str);
+          scan_err(lc, T_("Expected an equals, got: %s"), lc->str);
           goto bail_out;
         }
         switch (runscript_items[i].type) {
@@ -3005,7 +3002,7 @@ static void StoreRunscript(lexer* lc,
     }
 
     if (!keyword_ok) {
-      scan_err1(lc, T_("Keyword %s not permitted in this resource"), lc->str);
+      scan_err(lc, T_("Keyword %s not permitted in this resource"), lc->str);
       goto bail_out;
     }
   }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2930,7 +2930,7 @@ static void StoreRunscriptBool(lexer* lc, const ResourceItem* item, int, int)
       SetItemVariable<bool>(*item, false);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
                 lc->str); /* YES and NO must not be translated */
       return;
     } break;

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3654,10 +3654,10 @@ static void CreateAndAddUserAgentConsoleResource(ConfigurationParser& t_config)
 ConfigurationParser* InitDirConfig(const char* t_configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      t_configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb,
-      PrintConfigCb, exit_code, R_NUM, dird_resource_tables,
-      default_config_filename.c_str(), "bareos-dir.d", ConfigBeforeCallback,
-      ConfigReadyCallback, SaveResource, DumpResource, FreeResource);
+      t_configfile, InitResourceCb, ParseConfigCb, PrintConfigCb, exit_code,
+      R_NUM, dird_resource_tables, default_config_filename.c_str(),
+      "bareos-dir.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
+      DumpResource, FreeResource);
   if (config) { config->r_own_ = R_DIRECTOR; }
   return config;
 }

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -2922,7 +2922,7 @@ static void StoreShortRunscript(lexer* lc,
 static void StoreRunscriptBool(lexer* lc, const ResourceItem* item, int, int)
 {
   LexGetToken(lc, BCT_NAME);
-  switch (parse_user_bool(lc->str)) {
+  switch (parse_conf_bool(lc)) {
     case parse_bool_result::True: {
       SetItemVariable<bool>(*item, true);
     } break;

--- a/core/src/dird/inc_conf.cc
+++ b/core/src/dird/inc_conf.cc
@@ -360,8 +360,8 @@ static inline void IsInPermittedSet(lexer* lc,
     }
 
     if (!found) {
-      scan_err3(lc, T_("Illegal %s option %c, got option string: %s:"), SetType,
-                *p, lc->str);
+      scan_err(lc, T_("Illegal %s option %c, got option string: %s:"), SetType,
+               *p, lc->str);
     }
   }
 }
@@ -463,8 +463,8 @@ static void ScanIncludeOptions(lexer* lc, int keyword, char* opts, int optlen)
     Dmsg3(900, "Catopts=%s option=%s optlen=%d\n", opts, option, optlen);
   } else if (keyword == INC_KW_STRIPPATH) { /* special case */
     if (!IsAnInteger(lc->str)) {
-      scan_err1(lc, T_("Expected a strip path positive integer, got: %s:"),
-                lc->str);
+      scan_err(lc, T_("Expected a strip path positive integer, got: %s:"),
+               lc->str);
       return;
     }
     bstrncat(opts, "P", optlen); /* indicate strip path */
@@ -473,7 +473,7 @@ static void ScanIncludeOptions(lexer* lc, int keyword, char* opts, int optlen)
     Dmsg3(900, "Catopts=%s option=%s optlen=%d\n", opts, option, optlen);
   } else if (keyword == INC_KW_SIZE) { /* special case */
     if (!ParseSizeMatch(lc->str, &size_matching)) {
-      scan_err1(lc, T_("Expected a parseable size, got: %s:"), lc->str);
+      scan_err(lc, T_("Expected a parseable size, got: %s:"), lc->str);
       return;
     }
     bstrncat(opts, "z", optlen); /* indicate size */
@@ -491,7 +491,7 @@ static void ScanIncludeOptions(lexer* lc, int keyword, char* opts, int optlen)
       }
     }
     if (i != 0) {
-      scan_err1(lc, T_("Expected a FileSet option keyword, got: %s:"), lc->str);
+      scan_err(lc, T_("Expected a FileSet option keyword, got: %s:"), lc->str);
       return;
     } else { /* add option */
       bstrncat(opts, option, optlen);
@@ -525,7 +525,7 @@ static void StoreRegex(lexer* lc, const ResourceItem* item, int pass)
         if (rc != 0) {
           regerror(rc, &preg, prbuf, sizeof(prbuf));
           regfree(&preg);
-          scan_err1(lc, T_("Regex compile error. ERR=%s\n"), prbuf);
+          scan_err(lc, T_("Regex compile error. ERR=%s\n"), prbuf);
           return;
         }
         regfree(&preg);
@@ -546,7 +546,7 @@ static void StoreRegex(lexer* lc, const ResourceItem* item, int pass)
               newsize, lc->str);
         break;
       default:
-        scan_err1(lc, T_("Expected a regex string, got: %s\n"), lc->str);
+        scan_err(lc, T_("Expected a regex string, got: %s\n"), lc->str);
         return;
     }
   }
@@ -601,7 +601,7 @@ static void StoreWild(lexer* lc, const ResourceItem* item, int pass)
               newsize, lc->str);
         break;
       default:
-        scan_err1(lc, T_("Expected a wild-card string, got: %s\n"), lc->str);
+        scan_err(lc, T_("Expected a wild-card string, got: %s\n"), lc->str);
         return;
     }
   }
@@ -625,7 +625,7 @@ static void StoreFstype(lexer* lc, const ResourceItem*, int pass)
               res_incexe->current_opts->fstype.size(), lc->str);
         break;
       default:
-        scan_err1(lc, T_("Expected a fstype string, got: %s\n"), lc->str);
+        scan_err(lc, T_("Expected a fstype string, got: %s\n"), lc->str);
         return;
     }
   }
@@ -649,7 +649,7 @@ static void StoreDrivetype(lexer* lc, const ResourceItem*, int pass)
               res_incexe->current_opts->Drivetype.size(), lc->str);
         break;
       default:
-        scan_err1(lc, T_("Expected a Drivetype string, got: %s\n"), lc->str);
+        scan_err(lc, T_("Expected a Drivetype string, got: %s\n"), lc->str);
         return;
     }
   }
@@ -672,7 +672,7 @@ static void StoreMeta(lexer* lc, const ResourceItem*, int pass)
               res_incexe->current_opts->meta.size(), lc->str);
         break;
       default:
-        scan_err1(lc, T_("Expected a meta string, got: %s\n"), lc->str);
+        scan_err(lc, T_("Expected a meta string, got: %s\n"), lc->str);
         return;
     }
   }
@@ -705,7 +705,7 @@ static void StoreOption(
   }
 
   if (keyword == INC_KW_NONE) {
-    scan_err1(lc, T_("Expected a FileSet keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a FileSet keyword, got: %s"), lc->str);
     return;
   }
 
@@ -717,8 +717,8 @@ static void StoreOption(
 
     if (strlen(res_incexe->current_opts->opts) + 1
         >= std::size(res_incexe->current_opts->opts)) {
-      scan_err0(lc, T_("Too many fileset options specified; cannot parse this "
-                       "correctly\n"));
+      scan_err(lc, T_("Too many fileset options specified; cannot parse this "
+                      "correctly\n"));
     }
 
     Dmsg2(900, "new pass=%d incexe opts=%s\n", pass,
@@ -758,7 +758,7 @@ static void ApplyDefaultValuesForUnsetOptions(
     if (!was_set_in_config) {
       if (strlen(res_incexe->current_opts->opts) + default_value.size()
           >= std::size(res_incexe->current_opts->opts)) {
-        scan_err0(
+        scan_err(
             lc, T_("Options value is too long; cannot append default options"));
         return;
       }
@@ -787,12 +787,12 @@ static void StoreOptionsRes(lexer* lc,
   OptionsDefaultValues default_values;
 
   if (exclude) {
-    scan_err0(lc, T_("Options section not permitted in Exclude\n"));
+    scan_err(lc, T_("Options section not permitted in Exclude\n"));
     return;
   }
   token = LexGetToken(lc, BCT_SKIP_EOL);
   if (token != BCT_BOB) {
-    scan_err1(lc, T_("Expecting open brace. Got %s"), lc->str);
+    scan_err(lc, T_("Expecting open brace. Got %s"), lc->str);
     return;
   }
 
@@ -802,7 +802,7 @@ static void StoreOptionsRes(lexer* lc,
     if (token == BCT_EOL) { continue; }
     if (token == BCT_EOB) { break; }
     if (token != BCT_IDENTIFIER) {
-      scan_err1(lc, T_("Expecting keyword, got: %s\n"), lc->str);
+      scan_err(lc, T_("Expecting keyword, got: %s\n"), lc->str);
       return;
     }
     bool found = false;
@@ -810,7 +810,7 @@ static void StoreOptionsRes(lexer* lc,
       if (Bstrcasecmp(options_items[i].name, lc->str)) {
         token = LexGetToken(lc, BCT_SKIP_EOL);
         if (token != BCT_EQUALS) {
-          scan_err1(lc, T_("expected an equals, got: %s"), lc->str);
+          scan_err(lc, T_("expected an equals, got: %s"), lc->str);
           return;
         }
         /* Call item handler */
@@ -845,7 +845,7 @@ static void StoreOptionsRes(lexer* lc,
       }
     }
     if (!found) {
-      scan_err1(lc, T_("Keyword %s not permitted in this resource"), lc->str);
+      scan_err(lc, T_("Keyword %s not permitted in this resource"), lc->str);
       return;
     }
   }
@@ -880,10 +880,10 @@ static void StoreFname(lexer* lc, const ResourceItem*, int pass, bool)
       case BCT_IDENTIFIER:
       case BCT_UNQUOTED_STRING:
         if (strchr(lc->str, '\\')) {
-          scan_err1(lc,
-                    T_("Backslash found. Use forward slashes or quote the "
-                       "string.: %s\n"),
-                    lc->str);
+          scan_err(lc,
+                   T_("Backslash found. Use forward slashes or quote the "
+                      "string.: %s\n"),
+                   lc->str);
           return;
         }
         FALLTHROUGH_INTENDED;
@@ -903,7 +903,7 @@ static void StoreFname(lexer* lc, const ResourceItem*, int pass, bool)
         break;
       }
       default:
-        scan_err1(lc, T_("Expected a filename, got: %s"), lc->str);
+        scan_err(lc, T_("Expected a filename, got: %s"), lc->str);
         return;
     }
   }
@@ -923,7 +923,7 @@ static void StorePluginName(lexer* lc,
   int token;
 
   if (exclude) {
-    scan_err0(lc, T_("Plugin directive not permitted in Exclude\n"));
+    scan_err(lc, T_("Plugin directive not permitted in Exclude\n"));
     return;
   }
   token = LexGetToken(lc, BCT_SKIP_EOL);
@@ -933,10 +933,10 @@ static void StorePluginName(lexer* lc,
       case BCT_IDENTIFIER:
       case BCT_UNQUOTED_STRING:
         if (strchr(lc->str, '\\')) {
-          scan_err1(lc,
-                    T_("Backslash found. Use forward slashes or quote the "
-                       "string.: %s\n"),
-                    lc->str);
+          scan_err(lc,
+                   T_("Backslash found. Use forward slashes or quote the "
+                      "string.: %s\n"),
+                   lc->str);
           return;
         }
         FALLTHROUGH_INTENDED;
@@ -956,7 +956,7 @@ static void StorePluginName(lexer* lc,
         break;
       }
       default:
-        scan_err1(lc, T_("Expected a filename, got: %s"), lc->str);
+        scan_err(lc, T_("Expected a filename, got: %s"), lc->str);
         return;
     }
   }
@@ -970,8 +970,8 @@ static void StoreExcludedir(lexer* lc,
                             bool exclude)
 {
   if (exclude) {
-    scan_err0(lc,
-              T_("ExcludeDirContaining directive not permitted in Exclude.\n"));
+    scan_err(lc,
+             T_("ExcludeDirContaining directive not permitted in Exclude.\n"));
     return;
   }
 
@@ -1015,7 +1015,7 @@ static void StoreNewinc(lexer* lc,
   while ((token = LexGetToken(lc, BCT_SKIP_EOL)) != BCT_EOF) {
     if (token == BCT_EOB) { break; }
     if (token != BCT_IDENTIFIER) {
-      scan_err1(lc, T_("Expecting keyword, got: %s\n"), lc->str);
+      scan_err(lc, T_("Expecting keyword, got: %s\n"), lc->str);
       return;
     }
     bool found = false;
@@ -1025,7 +1025,7 @@ static void StoreNewinc(lexer* lc,
         if (!options) {
           token = LexGetToken(lc, BCT_SKIP_EOL);
           if (token != BCT_EQUALS) {
-            scan_err1(lc, T_("expected an equals, got: %s"), lc->str);
+            scan_err(lc, T_("expected an equals, got: %s"), lc->str);
             return;
           }
         }
@@ -1051,7 +1051,7 @@ static void StoreNewinc(lexer* lc,
       }
     }
     if (!found) {
-      scan_err1(lc, T_("Keyword %s not permitted in this resource"), lc->str);
+      scan_err(lc, T_("Keyword %s not permitted in this resource"), lc->str);
       return;
     }
   }
@@ -1096,7 +1096,7 @@ void StoreInc(lexer* lc, const ResourceItem* item, int index, int pass)
     StoreNewinc(lc, item, index, pass);
     return;
   }
-  scan_err0(lc, T_("Old style Include/Exclude not supported\n"));
+  scan_err(lc, T_("Old style Include/Exclude not supported\n"));
 }
 
 json_t* json_incexc(const int type)

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -193,7 +193,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         switch (RunFields[i].token) {
           case 's': /* Data spooling */
             token = LexGetToken(lc, BCT_NAME);
-            switch (parse_user_bool(lc->str)) {
+            switch (parse_conf_bool(lc)) {
               case parse_bool_result::True: {
                 res_run.spool_data = true;
                 res_run.spool_data_set = true;
@@ -302,7 +302,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             break;
           case 'a': /* Accurate */
             token = LexGetToken(lc, BCT_NAME);
-            switch (parse_user_bool(lc->str)) {
+            switch (parse_conf_bool(lc)) {
               case parse_bool_result::True: {
                 res_run.accurate = true;
                 res_run.accurate_set = true;

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -203,8 +203,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.spool_data_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect a YES, NO, TRUE, or FALSE; got: %s"),
-                          lc->str);
+                scan_err1(lc, T_("Expect a YES or NO; got: %s"), lc->str);
                 return;
               } break;
             }
@@ -312,8 +311,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.accurate_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect YES, NO, TRUE, or FALSE, got: %s"),
-                          lc->str);
+                scan_err1(lc, T_("Expect YES or NO, got: %s"), lc->str);
                 return;
               } break;
             }

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -203,7 +203,8 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.spool_data_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
+                scan_err1(lc, T_("Expect a YES, NO, TRUE, or FALSE; got: %s"),
+                          lc->str);
                 return;
               } break;
             }
@@ -311,7 +312,8 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.accurate_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
+                scan_err1(lc, T_("Expect YES, NO, TRUE, or FALSE, got: %s"),
+                          lc->str);
                 return;
               } break;
             }

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -30,6 +30,7 @@
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
+#include "lib/bool_string.h"
 #include "lib/edit.h"
 #include "lib/keyword_table_s.h"
 #include "lib/parse_conf.h"
@@ -192,16 +193,19 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         switch (RunFields[i].token) {
           case 's': /* Data spooling */
             token = LexGetToken(lc, BCT_NAME);
-            if (Bstrcasecmp(lc->str, "yes") || Bstrcasecmp(lc->str, "true")) {
-              res_run.spool_data = true;
-              res_run.spool_data_set = true;
-            } else if (Bstrcasecmp(lc->str, "no")
-                       || Bstrcasecmp(lc->str, "false")) {
-              res_run.spool_data = false;
-              res_run.spool_data_set = true;
-            } else {
-              scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
-              return;
+            switch (parse_user_bool(lc->str)) {
+              case parse_bool_result::True: {
+                res_run.spool_data = true;
+                res_run.spool_data_set = true;
+              } break;
+              case parse_bool_result::False: {
+                res_run.spool_data = false;
+                res_run.spool_data_set = true;
+              } break;
+              case parse_bool_result::Error: {
+                scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
+                return;
+              } break;
             }
             break;
           case 'L': /* Level */
@@ -297,16 +301,19 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             break;
           case 'a': /* Accurate */
             token = LexGetToken(lc, BCT_NAME);
-            if (strcasecmp(lc->str, "yes") == 0
-                || strcasecmp(lc->str, "true") == 0) {
-              res_run.accurate = true;
-              res_run.accurate_set = true;
-            } else if (strcasecmp(lc->str, "no") == 0
-                       || strcasecmp(lc->str, "false") == 0) {
-              res_run.accurate = false;
-              res_run.accurate_set = true;
-            } else {
-              scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
+            switch (parse_user_bool(lc->str)) {
+              case parse_bool_result::True: {
+                res_run.accurate = true;
+                res_run.accurate_set = true;
+              } break;
+              case parse_bool_result::False: {
+                res_run.accurate = false;
+                res_run.accurate_set = true;
+              } break;
+              case parse_bool_result::Error: {
+                scan_err1(lc, T_("Expect a YES or NO, got: %s"), lc->str);
+                return;
+              } break;
             }
             break;
           default:

--- a/core/src/dird/run_conf.cc
+++ b/core/src/dird/run_conf.cc
@@ -187,7 +187,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
       if (Bstrcasecmp(lc->str, RunFields[i].name)) {
         found = true;
         if (LexGetToken(lc, BCT_ALL) != BCT_EQUALS) {
-          scan_err1(lc, T_("Expected an equals, got: %s"), lc->str);
+          scan_err(lc, T_("Expected an equals, got: %s"), lc->str);
           return;
         }
         switch (RunFields[i].token) {
@@ -203,7 +203,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.spool_data_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect a YES or NO; got: %s"), lc->str);
+                scan_err(lc, T_("Expect a YES or NO; got: %s"), lc->str);
                 return;
               } break;
             }
@@ -219,8 +219,8 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
               }
             }
             if (j != 0) {
-              scan_err1(lc, T_("Job level field: %s not found in run record"),
-                        lc->str);
+              scan_err(lc, T_("Job level field: %s not found in run record"),
+                       lc->str);
               return;
             }
             break;
@@ -238,8 +238,8 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             if (pass == 2) {
               res = my_config->GetResWithName(R_POOL, lc->str);
               if (res == NULL) {
-                scan_err1(lc, T_("Could not find specified Pool Resource: %s"),
-                          lc->str);
+                scan_err(lc, T_("Could not find specified Pool Resource: %s"),
+                         lc->str);
                 return;
               }
               switch (RunFields[i].token) {
@@ -269,9 +269,9 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             if (pass == 2) {
               res = my_config->GetResWithName(R_STORAGE, lc->str);
               if (res == NULL) {
-                scan_err1(lc,
-                          T_("Could not find specified Storage Resource: %s"),
-                          lc->str);
+                scan_err(lc,
+                         T_("Could not find specified Storage Resource: %s"),
+                         lc->str);
                 return;
               }
               res_run.storage = (StorageResource*)res;
@@ -282,9 +282,9 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             if (pass == 2) {
               res = my_config->GetResWithName(R_MSGS, lc->str);
               if (res == NULL) {
-                scan_err1(lc,
-                          T_("Could not find specified Messages Resource: %s"),
-                          lc->str);
+                scan_err(lc,
+                         T_("Could not find specified Messages Resource: %s"),
+                         lc->str);
                 return;
               }
               res_run.msgs = (MessagesResource*)res;
@@ -293,7 +293,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           case 'm': /* Max run sched time */
             token = LexGetToken(lc, BCT_QUOTED_STRING);
             if (!DurationToUtime(lc->str, &utime)) {
-              scan_err1(lc, T_("expected a time period, got: %s"), lc->str);
+              scan_err(lc, T_("expected a time period, got: %s"), lc->str);
               return;
             }
             res_run.MaxRunSchedTime = utime;
@@ -311,13 +311,13 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
                 res_run.accurate_set = true;
               } break;
               case parse_bool_result::Error: {
-                scan_err1(lc, T_("Expect YES or NO, got: %s"), lc->str);
+                scan_err(lc, T_("Expect YES or NO, got: %s"), lc->str);
                 return;
               } break;
             }
             break;
           default:
-            scan_err1(lc, T_("Expected a keyword name, got: %s"), lc->str);
+            scan_err(lc, T_("Expected a keyword name, got: %s"), lc->str);
             return;
             break;
         } /* end switch */
@@ -352,7 +352,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         state = s_mday;
         code = atoi(lc->str) - 1;
         if (code < 0 || code > 30) {
-          scan_err0(lc, T_("Day number out of range (1-31)"));
+          scan_err(lc, T_("Day number out of range (1-31)"));
           return;
         }
         break;
@@ -374,7 +374,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             && IsAnInteger(lc->str + 1)) {
           code = atoi(lc->str + 1);
           if (code < 0 || code > 53) {
-            scan_err0(lc, T_("Week number out of range (0-53)"));
+            scan_err(lc, T_("Week number out of range (0-53)"));
             return;
           }
           state = s_woy; /* Week of year */
@@ -390,15 +390,15 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           }
         }
         if (i != 0) {
-          scan_err1(lc, T_("Job type field: %s in run record not found"),
-                    lc->str);
+          scan_err(lc, T_("Job type field: %s in run record not found"),
+                   lc->str);
           return;
         }
         break;
       case BCT_COMMA:
         continue;
       default:
-        scan_err2(lc, T_("Unexpected token: %d:%s"), token, lc->str);
+        scan_err(lc, T_("Unexpected token: %d:%s"), token, lc->str);
         return;
         break;
     }
@@ -442,14 +442,14 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         break;
       case s_time: /* Time */
         if (!have_at) {
-          scan_err0(lc, T_("Time must be preceded by keyword AT."));
+          scan_err(lc, T_("Time must be preceded by keyword AT."));
           return;
         }
         if (!have_hour) { ClearBitRange(0, 23, res_run.date_time_mask.hour); }
         //       Dmsg1(000, "s_time=%s\n", lc->str);
         p = strchr(lc->str, ':');
         if (!p) {
-          scan_err0(lc, T_("Time logic error.\n"));
+          scan_err(lc, T_("Time logic error.\n"));
           return;
         }
         *p++ = 0;             /* Separate two halves */
@@ -462,7 +462,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         } else if (Bstrcasecmp(p, "am")) {
           am = true;
         } else if (len != 2) {
-          scan_err0(lc, T_("Bad time specification."));
+          scan_err(lc, T_("Bad time specification."));
           return;
         }
         /* Note, according to NIST, 12am and 12pm are ambiguous and
@@ -477,7 +477,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           code -= 12;
         }
         if (code < 0 || code > 23 || code2 < 0 || code2 > 59) {
-          scan_err0(lc, T_("Bad time specification."));
+          scan_err(lc, T_("Bad time specification."));
           return;
         }
         SetBit(code, res_run.date_time_mask.hour);
@@ -497,7 +497,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
       case s_modulo:
         p = strchr(lc->str, '/');
         if (!p) {
-          scan_err0(lc, T_("Modulo logic error.\n"));
+          scan_err(lc, T_("Modulo logic error.\n"));
           return;
         }
         *p++ = 0; /* Separate two halves */
@@ -507,12 +507,12 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           code = atoi(lc->str) - 1;
           code2 = atoi(p);
           if (code < 0 || code > 30 || code2 < 0 || code2 > 30) {
-            scan_err0(lc, T_("Bad day specification in modulo."));
+            scan_err(lc, T_("Bad day specification in modulo."));
             return;
           }
           if (code > code2) {
-            scan_err0(lc, T_("Bad day specification, offset must always be <= "
-                             "than modulo."));
+            scan_err(lc, T_("Bad day specification, offset must always be <= "
+                            "than modulo."));
             return;
           }
           if (!have_mday) {
@@ -533,16 +533,16 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           code = atoi(lc->str + 1);
           code2 = atoi(p + 1);
           if (code < 0 || code > 53) {
-            scan_err0(lc, T_("Week number out of range (0-53) in modulo"));
+            scan_err(lc, T_("Week number out of range (0-53) in modulo"));
             return;
           }
           if (code2 <= 0 || code2 > 53) {
-            scan_err0(lc, T_("Week interval out of range (1-53) in modulo"));
+            scan_err(lc, T_("Week interval out of range (1-53) in modulo"));
             return;
           }
           if (code > code2) {
-            scan_err0(lc, T_("Bad week number specification in modulo, offset "
-                             "must always be <= than modulo."));
+            scan_err(lc, T_("Bad week number specification in modulo, offset "
+                            "must always be <= than modulo."));
             return;
           }
           if (!have_woy) {
@@ -554,15 +554,15 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             SetBit(week, res_run.date_time_mask.woy);
           }
         } else {
-          scan_err0(lc, T_("Bad modulo time specification. Format for weekdays "
-                           "is '01/02', for yearweeks is 'w01/w02'."));
+          scan_err(lc, T_("Bad modulo time specification. Format for weekdays "
+                          "is '01/02', for yearweeks is 'w01/w02'."));
           return;
         }
         break;
       case s_range:
         p = strchr(lc->str, '-');
         if (!p) {
-          scan_err0(lc, T_("Range logic error.\n"));
+          scan_err(lc, T_("Range logic error.\n"));
           return;
         }
         *p++ = 0; /* Separate two halves */
@@ -572,7 +572,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           code = atoi(lc->str) - 1;
           code2 = atoi(p) - 1;
           if (code < 0 || code > 30 || code2 < 0 || code2 > 30) {
-            scan_err0(lc, T_("Bad day range specification."));
+            scan_err(lc, T_("Bad day range specification."));
             return;
           }
           if (!have_mday) {
@@ -593,7 +593,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           code = atoi(lc->str + 1);
           code2 = atoi(p + 1);
           if (code < 0 || code > 53 || code2 < 0 || code2 > 53) {
-            scan_err0(lc, T_("Week number out of range (0-53)"));
+            scan_err(lc, T_("Week number out of range (0-53)"));
             return;
           }
           if (!have_woy) {
@@ -619,7 +619,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
           }
           if (i != 0
               || (state != s_month && state != s_wday && state != s_wom)) {
-            scan_err0(lc, T_("Invalid month, week or position day range"));
+            scan_err(lc, T_("Invalid month, week or position day range"));
             return;
           }
 
@@ -634,7 +634,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
             }
           }
           if (i != 0 || state != state2 || code == code2) {
-            scan_err0(lc, T_("Invalid month, weekday or position range"));
+            scan_err(lc, T_("Invalid month, weekday or position range"));
             return;
           }
           if (state == s_wday) {
@@ -694,7 +694,7 @@ void StoreRun(lexer* lc, const ResourceItem* item, int index, int pass)
         SetBitRange(0, 11, res_run.date_time_mask.month);
         break;
       default:
-        scan_err0(lc, T_("Unexpected run state\n"));
+        scan_err(lc, T_("Unexpected run state\n"));
         return;
         break;
     }

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1549,10 +1549,8 @@ auto SetDeviceCommand::ScanCommandLine(UaContext* ua)
       arguments->autoselect = false;
     } break;
     case parse_bool_result::Error: {
-      ua->ErrorMsg(
-          "Bad value for argument %s: %s (expect one of YES, NO, TRUE, "
-          "FALSE)\n",
-          argument_name[2], argument_value[2]);
+      ua->ErrorMsg("Bad value for argument %s: %s (expected YES or NO)\n",
+                   argument_name[2], argument_value[2]);
       return std::nullopt;
     } break;
   }
@@ -1821,8 +1819,7 @@ static bool EstimateCmd(UaContext* ua, const char*)
           } break;
           case parse_bool_result::Error: {
             ua->ErrorMsg(
-                T_("Invalid value for accurate. "
-                   "It must be yes, no, true, or false.\n"));
+                T_("Invalid value for accurate.  It must be YES or NO.\n"));
             return false;
           } break;
         }

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1810,12 +1810,22 @@ static bool EstimateCmd(UaContext* ua, const char*)
 
     if (Bstrcasecmp(ua->argk[i], NT_("accurate"))) {
       if (ua->argv[i]) {
-        if (!IsYesno(ua->argv[i], &accurate)) {
-          ua->ErrorMsg(
-              T_("Invalid value for accurate. "
-                 "It must be yes or no.\n"));
+        switch (parse_user_bool(ua->argv[i])) {
+          case parse_bool_result::True: {
+            accurate_set = true;
+            accurate = true;
+          } break;
+          case parse_bool_result::False: {
+            accurate_set = true;
+            accurate = false;
+          } break;
+          case parse_bool_result::Error: {
+            ua->ErrorMsg(
+                T_("Invalid value for accurate. "
+                   "It must be yes, no, true, or false.\n"));
+            return false;
+          } break;
         }
-        accurate_set = true;
         continue;
       } else {
         ua->ErrorMsg(T_("Accurate value missing.\n"));

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1531,13 +1531,17 @@ SetDeviceCommand::ArgumentsList SetDeviceCommand::ScanCommandLine(UaContext* ua)
   }
   if (argument_missing) { return ArgumentsList(); }
 
-  try {
-    BoolString s{arguments["autoselect"].data()};  // throws
-    arguments["autoselect"].clear();
-    arguments["autoselect"] = s.get<bool>() == true ? "1" : "0";
-  } catch (const std::out_of_range& e) {
-    ua->ErrorMsg("Wrong argument: %s\n", arguments["autoselect"].c_str());
-    return ArgumentsList();
+  switch (parse_user_bool(arguments["autoselect"])) {
+    case parse_bool_result::True: {
+      arguments["autoselect"] = "1";
+    } break;
+    case parse_bool_result::False: {
+      arguments["autoselect"] = "0";
+    } break;
+    case parse_bool_result::Error: {
+      ua->ErrorMsg("Wrong argument: %s\n", arguments["autoselect"].c_str());
+      return ArgumentsList();
+    } break;
   }
 
   return arguments;

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1549,8 +1549,10 @@ auto SetDeviceCommand::ScanCommandLine(UaContext* ua)
       arguments->autoselect = false;
     } break;
     case parse_bool_result::Error: {
-      ua->ErrorMsg("Bad value for argument %s: %s\n", argument_name[2],
-                   argument_value[2]);
+      ua->ErrorMsg(
+          "Bad value for argument %s: %s (expect one of YES, NO, TRUE, "
+          "FALSE)\n",
+          argument_name[2], argument_value[2]);
       return std::nullopt;
     } break;
   }

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -1507,40 +1507,51 @@ static bool SetdebugCmd(UaContext* ua, const char* cmd)
   return true;
 }
 
-SetDeviceCommand::ArgumentsList SetDeviceCommand::ScanCommandLine(UaContext* ua)
+auto SetDeviceCommand::ScanCommandLine(UaContext* ua)
+    -> std::optional<ArgumentsList>
 {
-  ArgumentsList arguments{{"storage", ""}, {"device", ""}, {"autoselect", ""}};
+  const char* argument_name[] = {
+      "storage",
+      "device",
+      "autoselect",
+  };
+
+  const char* argument_value[std::size(argument_name)] = {};
 
   for (int i = 1; i < ua->argc; i++) {
-    try {
-      auto& value = arguments.at(ua->argk[i]);
-      int idx = FindArgWithValue(ua, NT_(ua->argk[i]));
-      if (idx >= 0) { value = ua->argv[idx]; }
-    } catch (std::out_of_range& e) {
-      ua->ErrorMsg("Wrong argument: %s\n", ua->argk[i]);
-      return ArgumentsList();
+    for (size_t argument_idx = 0; argument_idx < std::size(argument_name);
+         ++argument_idx) {
+      if (Bstrcasecmp(ua->argk[i], argument_name[argument_idx])) {
+        argument_value[argument_idx] = ua->argv[i];
+      }
     }
   }
 
-  bool argument_missing = false;
-  for (const auto& arg : arguments) {
-    if (arg.second.empty()) {  // value
-      ua->ErrorMsg("Argument missing: %s\n", arg.first.c_str());
-      argument_missing = true;
+  for (size_t argument_idx = 0; argument_idx < std::size(argument_name);
+       ++argument_idx) {
+    if (!argument_value[argument_idx]) {
+      ua->ErrorMsg("Argument missing: %s\n", argument_name[argument_idx]);
+      return std::nullopt;
     }
   }
-  if (argument_missing) { return ArgumentsList(); }
 
-  switch (parse_user_bool(arguments["autoselect"])) {
+  std::optional<ArgumentsList> arguments = {};
+  arguments.emplace();
+
+  arguments->storage = argument_value[0];
+  arguments->device = argument_value[1];
+
+  switch (parse_user_bool(argument_value[2])) {
     case parse_bool_result::True: {
-      arguments["autoselect"] = "1";
+      arguments->autoselect = true;
     } break;
     case parse_bool_result::False: {
-      arguments["autoselect"] = "0";
+      arguments->autoselect = false;
     } break;
     case parse_bool_result::Error: {
-      ua->ErrorMsg("Wrong argument: %s\n", arguments["autoselect"].c_str());
-      return ArgumentsList();
+      ua->ErrorMsg("Bad value for argument %s: %s\n", argument_name[2],
+                   argument_value[2]);
+      return std::nullopt;
     } break;
   }
 
@@ -1576,8 +1587,8 @@ bool SetDeviceCommand::SendToSd(UaContext* ua,
 
   Dmsg0(120, T_("Connected to storage daemon\n"));
   ua->jcr->store_bsock->fsend("setdevice device=%s autoselect=%d",
-                              arguments.at("device").c_str(),
-                              std::stoi(arguments.at("autoselect")));
+                              arguments.device.c_str(),
+                              arguments.autoselect ? 1 : 0);
   if (ua->jcr->store_bsock->recv() >= 0) {
     ua->SendMsg("%s", ua->jcr->store_bsock->msg);
   }
@@ -1594,27 +1605,28 @@ bool SetDeviceCommand::SendToSd(UaContext* ua,
 // setdevice storage=<storage-name> device=<device-name> autoselect=<bool>
 bool SetDeviceCommand::Cmd(UaContext* ua, const char*)
 {
-  auto arguments = ScanCommandLine(ua);
+  auto arguments_opt = ScanCommandLine(ua);
 
-  if (arguments.empty()) {
+  if (!arguments_opt) {
     ua->SendCmdUsage("");
     return false;
   }
 
+  auto& arguments = *arguments_opt;
+
   if (ua->AclHasRestrictions(Storage_ACL)) {
-    if (!ua->AclAccessOk(Storage_ACL, arguments["storage"].c_str())) {
+    if (!ua->AclAccessOk(Storage_ACL, arguments.storage.c_str())) {
       std::string err{"Access to storage "};
-      err += "\"" + arguments["storage"] + "\" forbidden\n";
+      err += "\"" + arguments.storage + "\" forbidden\n";
       ua->ErrorMsg("%s", err.c_str());
       return false;
     }
   }
 
-  StorageResource* sd = ua->GetStoreResWithName(arguments["storage"].c_str());
+  StorageResource* sd = ua->GetStoreResWithName(arguments.storage.c_str());
 
   if (sd == nullptr) {
-    ua->ErrorMsg(T_("Storage \"%s\" not found.\n"),
-                 arguments["storage"].c_str());
+    ua->ErrorMsg(T_("Storage \"%s\" not found.\n"), arguments.storage.c_str());
     return false;
   }
 

--- a/core/src/dird/ua_cmds.h
+++ b/core/src/dird/ua_cmds.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,7 +22,8 @@
 #ifndef BAREOS_DIRD_UA_CMDS_H_
 #define BAREOS_DIRD_UA_CMDS_H_
 
-#include <map>
+#include <string>
+#include <optional>
 
 namespace directordaemon {
 
@@ -33,8 +34,12 @@ bool Do_a_command(UaContext* ua);
 bool DotMessagesCmd(UaContext* ua, const char* cmd);
 
 struct SetDeviceCommand {
-  using ArgumentsList = std::map<std::string, std::string>;
-  static ArgumentsList ScanCommandLine(UaContext* ua);
+  struct ArgumentsList {
+    std::string storage{};
+    std::string device{};
+    bool autoselect{false};
+  };
+  static std::optional<ArgumentsList> ScanCommandLine(UaContext* ua);
   static bool Cmd(UaContext* ua, const char* cmd);
   static bool SendToSd(UaContext* ua,
                        StorageResource* store,

--- a/core/src/dird/ua_dotcmds.cc
+++ b/core/src/dird/ua_dotcmds.cc
@@ -45,6 +45,7 @@
 #include "dird/storage.h"
 #include "include/auth_protocol_types.h"
 #include "lib/attribs.h"
+#include "lib/bool_string.h"
 #include "lib/edit.h"
 #include "lib/parse_conf.h"
 #include "lib/util.h"
@@ -995,10 +996,15 @@ bool DotApiCmd(UaContext* ua, const char*)
       ua->api = API_MODE_JSON;
       ua->batch = true;
       if ((ua->argc == 3) && (FindArgWithValue(ua, "compact") == 2)) {
-        if (Bstrcasecmp(ua->argv[2], "yes")) {
-          ua->send->SetCompact(true);
-        } else {
-          ua->send->SetCompact(false);
+        switch (parse_user_bool(ua->argv[2])) {
+          case parse_bool_result::True: {
+            ua->send->SetCompact(true);
+          } break;
+          case parse_bool_result::False:
+            [[fallthrough]];
+          case parse_bool_result::Error: {
+            ua->send->SetCompact(false);
+          } break;
         }
       }
     } else {

--- a/core/src/dird/ua_input.cc
+++ b/core/src/dird/ua_input.cc
@@ -139,24 +139,27 @@ bool IsYesno(char* val, bool* ret)
  */
 bool GetYesno(UaContext* ua, const char* prompt)
 {
-  int len;
-  bool ret;
-
   ua->pint32_val = 0;
   for (;;) {
     if (ua->api) { ua->UA_sock->signal(BNET_YESNO); }
 
     if (!GetCmd(ua, prompt)) { return false; }
 
-    len = strlen(ua->cmd);
-    if (len < 1 || len > 3) { continue; }
 
-    if (IsYesno(ua->cmd, &ret)) {
-      ua->pint32_val = ret;
-      return true;
+    switch (parse_user_bool(ua->cmd)) {
+      case parse_bool_result::True: {
+        ua->pint32_val = true;
+        return true;
+      } break;
+      case parse_bool_result::False: {
+        ua->pint32_val = false;
+        return true;
+      } break;
+      case parse_bool_result::Error: {
+        ua->WarningMsg(
+            T_("Invalid response. You must answer yes, no, true, or false.\n"));
+      } break;
     }
-
-    ua->WarningMsg(T_("Invalid response. You must answer yes or no.\n"));
   }
 }
 

--- a/core/src/dird/ua_input.cc
+++ b/core/src/dird/ua_input.cc
@@ -156,8 +156,7 @@ bool GetYesno(UaContext* ua, const char* prompt)
         return true;
       } break;
       case parse_bool_result::Error: {
-        ua->WarningMsg(
-            T_("Invalid response. You must answer yes, no, true, or false.\n"));
+        ua->WarningMsg(T_("Invalid response. You must answer YES or NO.\n"));
       } break;
     }
   }
@@ -202,8 +201,7 @@ int GetEnabled(UaContext* ua, const char* val)
         Enabled = VOL_ARCHIVED;
       } else {
         ua->ErrorMsg(
-            T_("Invalid Enabled value, it must be yes, no, true, false, "
-               "archived\n"));
+            T_("Invalid Enabled value, it must be yes, no, or archived\n"));
         return -1;
       }
     } break;

--- a/core/src/dird/ua_input.cc
+++ b/core/src/dird/ua_input.cc
@@ -178,8 +178,8 @@ bool GetConfirmation(UaContext* ua, const char* prompt, bool fallback_value)
 }
 
 /**
- * Gets an Enabled value => 0, 1, 2, yes, no, archived
- * Returns: 0, 1, 2 if OK
+ * Gets an Enabled value => yes, no, true, false, archived
+ * Returns: e_enabled_val if OK
  *          -1 on error
  */
 int GetEnabled(UaContext* ua, const char* val)
@@ -195,12 +195,12 @@ int GetEnabled(UaContext* ua, const char* val)
     } break;
     case parse_bool_result::Error: {
       // in this case we either got some garbage, or archived
-      if (Bstrcasecmp(val, "archived") || strcmp(val, "2") == 0) {
+      if (Bstrcasecmp(val, "archived")) {
         Enabled = VOL_ARCHIVED;
       } else {
         ua->ErrorMsg(
-            T_("Invalid Enabled value, it must be yes, no, archived, 0, 1, or "
-               "2\n"));
+            T_("Invalid Enabled value, it must be yes, no, true, false, "
+               "archived\n"));
         return -1;
       }
     } break;

--- a/core/src/dird/ua_input.cc
+++ b/core/src/dird/ua_input.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2001-2010 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -31,6 +31,7 @@
 #include "dird/ua_cmds.h"
 #include "dird/ua_select.h"
 #include "lib/bnet.h"
+#include "lib/bool_string.h"
 #include "lib/edit.h"
 
 #include <limits>
@@ -113,13 +114,18 @@ bool GetPint(UaContext* ua, const char* prompt)
  */
 bool IsYesno(char* val, bool* ret)
 {
-  *ret = 0;
-  if (Bstrcasecmp(val, T_("yes")) || Bstrcasecmp(val, NT_("yes"))) {
-    *ret = true;
-  } else if (Bstrcasecmp(val, T_("no")) || Bstrcasecmp(val, NT_("no"))) {
-    *ret = false;
-  } else {
-    return false;
+  *ret = false;
+
+  switch (parse_user_bool(val)) {
+    case parse_bool_result::True: {
+      *ret = true;
+    } break;
+    case parse_bool_result::False: {
+      *ret = false;
+    } break;
+    case parse_bool_result::Error: {
+      return false;
+    } break;
   }
 
   return true;
@@ -180,36 +186,24 @@ int GetEnabled(UaContext* ua, const char* val)
 {
   int Enabled = -1;
 
-  if (Bstrcasecmp(val, "yes") || Bstrcasecmp(val, "true")) {
-    Enabled = VOL_ENABLED;
-  } else if (Bstrcasecmp(val, "no") || Bstrcasecmp(val, "false")) {
-    Enabled = VOL_NOT_ENABLED;
-  } else if (Bstrcasecmp(val, "archived")) {
-    Enabled = VOL_ARCHIVED;
-  } else if (*val != '\0') {
-    char* rest = nullptr;
-    errno = 0;
-    auto parsed = std::strtol(val, &rest, 10);
-    if (rest && *rest != '\0') {
-      // something was not parsed correctly
-      Enabled = -1;
-    } else if ((parsed == std::numeric_limits<decltype(parsed)>::min()
-                || parsed == std::numeric_limits<decltype(parsed)>::max())
-               && errno == ERANGE) {
-      // we got an overflow
-      Enabled = -1;
-    } else if (errno == EINVAL) {
-      // some other issue occurred (i.e. base 10 is not supported...)
-      Enabled = -1;
-    } else {
-      Enabled = parsed;
-    }
-  }
-
-  if (Enabled < 0 || Enabled > 2) {
-    ua->ErrorMsg(T_(
-        "Invalid Enabled value, it must be yes, no, archived, 0, 1, or 2\n"));
-    return -1;
+  switch (parse_user_bool(val)) {
+    case parse_bool_result::True: {
+      Enabled = VOL_ENABLED;
+    } break;
+    case parse_bool_result::False: {
+      Enabled = VOL_NOT_ENABLED;
+    } break;
+    case parse_bool_result::Error: {
+      // in this case we either got some garbage, or archived
+      if (Bstrcasecmp(val, "archived") || strcmp(val, "2") == 0) {
+        Enabled = VOL_ARCHIVED;
+      } else {
+        ua->ErrorMsg(
+            T_("Invalid Enabled value, it must be yes, no, archived, 0, 1, or "
+               "2\n"));
+        return -1;
+      }
+    } break;
   }
 
   return Enabled;

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -34,6 +34,7 @@
 #include "dird/ua_input.h"
 #include "dird/ua_select.h"
 #include "dird/ua_run.h"
+#include "lib/bool_string.h"
 #include "lib/breg.h"
 #include "lib/berrno.h"
 #include "lib/edit.h"
@@ -2025,11 +2026,20 @@ static bool ScanCommandLineArguments(UaContext* ua, RunContext& rc)
               ua->SendMsg(T_("Spool flag specified twice.\n"));
               return false;
             }
-            if (IsYesno(ua->argv[i], &rc.spool_data)) {
-              rc.spool_data_set = true;
-              kw_ok = true;
-            } else {
-              ua->SendMsg(T_("Invalid spooldata flag.\n"));
+            switch (parse_user_bool(ua->argv[i])) {
+              case parse_bool_result::True: {
+                rc.spool_data_set = true;
+                rc.spool_data = true;
+                kw_ok = true;
+              } break;
+              case parse_bool_result::False: {
+                rc.spool_data_set = true;
+                rc.spool_data = false;
+                kw_ok = true;
+              } break;
+              case parse_bool_result::Error: {
+                ua->SendMsg(T_("Invalid spooldata flag.\n"));
+              } break;
             }
             break;
           case 28: /* comment */
@@ -2041,11 +2051,20 @@ static bool ScanCommandLineArguments(UaContext* ua, RunContext& rc)
               ua->SendMsg(T_("IgnoreDuplicateCheck flag specified twice.\n"));
               return false;
             }
-            if (IsYesno(ua->argv[i], &rc.ignoreduplicatecheck)) {
-              rc.ignoreduplicatecheck_set = true;
-              kw_ok = true;
-            } else {
-              ua->SendMsg(T_("Invalid ignoreduplicatecheck flag.\n"));
+            switch (parse_user_bool(ua->argv[i])) {
+              case parse_bool_result::True: {
+                rc.ignoreduplicatecheck_set = true;
+                rc.ignoreduplicatecheck = true;
+                kw_ok = true;
+              } break;
+              case parse_bool_result::False: {
+                rc.ignoreduplicatecheck_set = true;
+                rc.ignoreduplicatecheck = false;
+                kw_ok = true;
+              } break;
+              case parse_bool_result::Error: {
+                ua->SendMsg(T_("Invalid ignoreduplicatecheck flag.\n"));
+              } break;
             }
             break;
           case 30: /* accurate */
@@ -2053,11 +2072,20 @@ static bool ScanCommandLineArguments(UaContext* ua, RunContext& rc)
               ua->SendMsg(T_("Accurate flag specified twice.\n"));
               return false;
             }
-            if (IsYesno(ua->argv[i], &rc.accurate)) {
-              rc.accurate_set = true;
-              kw_ok = true;
-            } else {
-              ua->SendMsg(T_("Invalid accurate flag.\n"));
+            switch (parse_user_bool(ua->argv[i])) {
+              case parse_bool_result::True: {
+                rc.accurate_set = true;
+                kw_ok = true;
+                rc.accurate = true;
+              } break;
+              case parse_bool_result::False: {
+                rc.accurate_set = true;
+                kw_ok = true;
+                rc.accurate = false;
+              } break;
+              case parse_bool_result::Error: {
+                ua->SendMsg(T_("Invalid accurate flag.\n"));
+              } break;
             }
             break;
           case 31: /* backupformat */

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,6 +39,7 @@
 #include "dird/ua_db.h"
 #include "dird/ua_input.h"
 #include "dird/ua_select.h"
+#include "lib/bool_string.h"
 #include "lib/edit.h"
 #include "lib/util.h"
 
@@ -245,13 +246,21 @@ static void UpdateVolmaxbytes(UaContext* ua, char* val, MediaDbRecord* mr)
 
 static void UpdateVolrecycle(UaContext* ua, char* val, MediaDbRecord* mr)
 {
-  bool recycle;
+  bool recycle = false;
   char ed1[50];
   PoolMem query(PM_MESSAGE);
 
-  if (!IsYesno(val, &recycle)) {
-    ua->ErrorMsg(T_("Invalid value. It must be yes or no.\n"));
-    return;
+  switch (parse_user_bool(val)) {
+    case parse_bool_result::True: {
+      recycle = true;
+    } break;
+    case parse_bool_result::False: {
+      recycle = false;
+    } break;
+    case parse_bool_result::Error: {
+      ua->ErrorMsg(T_("Invalid value. It must be yes, no, true, or false.\n"));
+      return;
+    } break;
   }
 
   Mmsg(query, "UPDATE Media SET Recycle=%d WHERE MediaId=%s", recycle ? 1 : 0,
@@ -268,12 +277,20 @@ static void UpdateVolrecycle(UaContext* ua, char* val, MediaDbRecord* mr)
 static void UpdateVolinchanger(UaContext* ua, char* val, MediaDbRecord* mr)
 {
   char ed1[50];
-  bool InChanger;
+  bool InChanger = false;
   PoolMem query(PM_MESSAGE);
 
-  if (!IsYesno(val, &InChanger)) {
-    ua->ErrorMsg(T_("Invalid value. It must be yes or no.\n"));
-    return;
+  switch (parse_user_bool(val)) {
+    case parse_bool_result::True: {
+      InChanger = true;
+    } break;
+    case parse_bool_result::False: {
+      InChanger = false;
+    } break;
+    case parse_bool_result::Error: {
+      ua->ErrorMsg(T_("Invalid value. It must be yes, no, true, or false.\n"));
+      return;
+    } break;
   }
 
   Mmsg(query, "UPDATE Media SET InChanger=%d WHERE MediaId=%s",

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -258,7 +258,7 @@ static void UpdateVolrecycle(UaContext* ua, char* val, MediaDbRecord* mr)
       recycle = false;
     } break;
     case parse_bool_result::Error: {
-      ua->ErrorMsg(T_("Invalid value. It must be yes, no, true, or false.\n"));
+      ua->ErrorMsg(T_("Invalid value. It must be YES or NO.\n"));
       return;
     } break;
   }
@@ -288,7 +288,7 @@ static void UpdateVolinchanger(UaContext* ua, char* val, MediaDbRecord* mr)
       InChanger = false;
     } break;
     case parse_bool_result::Error: {
-      ua->ErrorMsg(T_("Invalid value. It must be yes, no, true, or false.\n"));
+      ua->ErrorMsg(T_("Invalid value. It must be YES or NO.\n"));
       return;
     } break;
   }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -245,10 +245,10 @@ static void ConfigReadyCallback(ConfigurationParser&) {}
 ConfigurationParser* InitFdConfig(const char* t_configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      t_configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_NUM, resources, default_config_filename.c_str(),
-      "bareos-fd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
-      DumpResource, FreeResource);
+      t_configfile, InitResourceCb, ParseConfigCb, nullptr, exit_code, R_NUM,
+      resources, default_config_filename.c_str(), "bareos-fd.d",
+      ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
+      FreeResource);
   if (config) { config->r_own_ = R_CLIENT; }
   return config;
 }

--- a/core/src/filed/filed_conf.cc
+++ b/core/src/filed/filed_conf.cc
@@ -179,7 +179,7 @@ static void StoreCipher(lexer* lc, const ResourceItem* item, int index, int)
     }
   }
   if (i != 0) {
-    scan_err1(lc, T_("Expected a Crypto Cipher option, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a Crypto Cipher option, got: %s"), lc->str);
   }
   ScanToEol(lc);
   item->SetPresent();

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,6 +22,49 @@
 #ifndef BAREOS_LIB_BOOL_STRING_H_
 #define BAREOS_LIB_BOOL_STRING_H_
 
+#include <lib/bsys.h>
+#include <string_view>
+#include <span>
+
+/**
+ * Parses a user provided string for a bool.
+ *
+ * This only works for ascii strings.
+ */
+
+enum class parse_bool_result
+{
+  True,
+  False,
+  Error,
+};
+
+static inline parse_bool_result parse_user_bool(std::string_view input)
+{
+  static constexpr std::string_view true_accepted[] = {"yes", "true", "1"};
+
+  static constexpr std::string_view false_accepted[] = {"no", "false", "0"};
+
+  using enum parse_bool_result;
+
+  auto is_in_vec = [](std::span<const std::string_view> candidates,
+                      std::string_view value) -> bool {
+    for (auto candidate : candidates) {
+      if (value.size() == candidate.size()
+          && bstrncasecmp(value.data(), candidate.data(), value.size())) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  if (is_in_vec(true_accepted, input)) { return True; }
+
+  if (is_in_vec(false_accepted, input)) { return False; }
+
+  return Error;
+}
+
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -36,11 +79,7 @@ class BoolString {
       throw std::out_of_range(err + str_value);
     }
   }
-  template <typename T = std::string>
-  T get() const
-  {
-    return str_value;
-  }
+  template <typename T = std::string> T get() const { return str_value; }
 
  private:
   std::string str_value;
@@ -48,8 +87,7 @@ class BoolString {
   const std::set<std::string> false_values{"false", "no", "0"};
 };
 
-template <>
-inline bool BoolString::get<bool>() const
+template <> inline bool BoolString::get<bool>() const
 {
   return true_values.find(str_value) != true_values.end();
 }

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -126,7 +126,8 @@ static inline parse_bool_result parse_conf_bool(
   if (deprecated) {
     (*lc->scan_warning)(
         loc.file_name(), loc.line(), lc,
-        "setting boolean value via true/false/1/0 is deprecated; only yes/no will be supported on newer versions");
+        "setting boolean value via true/false/1/0 is deprecated; only yes/no "
+        "will be supported in newer versions");
   }
 
   return result;

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -65,31 +65,4 @@ static inline parse_bool_result parse_user_bool(std::string_view input)
   return Error;
 }
 
-#include <set>
-#include <stdexcept>
-#include <string>
-
-class BoolString {
- public:
-  explicit BoolString(const std::string& s) : str_value(s)
-  {
-    if (true_values.find(str_value) == true_values.end()
-        && false_values.find(str_value) == false_values.end()) {
-      std::string err = {"Wrong parameter: "};
-      throw std::out_of_range(err + str_value);
-    }
-  }
-  template <typename T = std::string> T get() const { return str_value; }
-
- private:
-  std::string str_value;
-  const std::set<std::string> true_values{"true", "yes", "1"};
-  const std::set<std::string> false_values{"false", "no", "0"};
-};
-
-template <> inline bool BoolString::get<bool>() const
-{
-  return true_values.find(str_value) != true_values.end();
-}
-
 #endif  // BAREOS_LIB_BOOL_STRING_H_

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -124,7 +124,7 @@ static inline parse_bool_result parse_conf_bool(
   auto [result, deprecated] = parse_bool(lc->str, true);
 
   if (deprecated) {
-    (*lc->scan_warning)(
+    scan_warn(
         loc.file_name(), loc.line(), lc,
         "setting boolean value via true/false/1/0 is deprecated; only yes/no "
         "will be supported in newer versions");

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -22,9 +22,13 @@
 #ifndef BAREOS_LIB_BOOL_STRING_H_
 #define BAREOS_LIB_BOOL_STRING_H_
 
-#include <lib/bsys.h>
+#include "include/bareos.h"
+
 #include <string_view>
-#include <span>
+#include <strings.h>
+
+#include "lex.h"
+#include "source_location.h"
 
 /**
  * Parses a user provided string for a bool.
@@ -39,30 +43,93 @@ enum class parse_bool_result
   Error,
 };
 
+namespace bool_parsing::internal {
+template <size_t N>
+inline bool is_in_vec(const std::string_view (&candidates)[N],
+                      std::string_view value)
+{
+  for (auto candidate : candidates) {
+    if (value.size() == candidate.size()
+        && strncasecmp(value.data(), candidate.data(), value.size()) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline std::pair<parse_bool_result, bool> parse_bool(std::string_view input,
+                                                     bool allow_deprecated
+                                                     = false)
+{
+  static constexpr std::string_view true_accepted[] = {"yes"};
+  static constexpr std::string_view true_deprecated[] = {"true", "1"};
+
+  static constexpr std::string_view false_accepted[] = {"no"};
+  static constexpr std::string_view false_deprecated[] = {"false", "0"};
+
+  bool deprecated = false;
+
+  if (is_in_vec(true_accepted, input)) {
+    return {parse_bool_result::True, deprecated};
+  }
+  if (is_in_vec(false_accepted, input)) {
+    return {parse_bool_result::False, deprecated};
+  }
+
+  deprecated = true;
+  if (is_in_vec(true_deprecated, input)) {
+    if (allow_deprecated) {
+      return {parse_bool_result::True, deprecated};
+    } else {
+      return {parse_bool_result::Error, deprecated};
+    }
+  }
+  if (is_in_vec(false_deprecated, input)) {
+    if (allow_deprecated) {
+      return {parse_bool_result::False, deprecated};
+    } else {
+      return {parse_bool_result::Error, deprecated};
+    }
+  }
+
+  return {parse_bool_result::Error, false};
+}
+}  // namespace bool_parsing::internal
+
 static inline parse_bool_result parse_user_bool(std::string_view input)
 {
-  static constexpr std::string_view true_accepted[] = {"yes", "true"};
+  using namespace bool_parsing::internal;
 
-  static constexpr std::string_view false_accepted[] = {"no", "false"};
+  auto [result, deprecated] = parse_bool(input);
 
-  using enum parse_bool_result;
+  if (deprecated) {
+    // we do not accept deprecated options in user contexts
 
-  auto is_in_vec = [](std::span<const std::string_view> candidates,
-                      std::string_view value) -> bool {
-    for (auto candidate : candidates) {
-      if (value.size() == candidate.size()
-          && bstrncasecmp(value.data(), candidate.data(), value.size())) {
-        return true;
-      }
-    }
-    return false;
-  };
+    Dmsg0(100, "User passed deprecated option %.*s\n", (int)input.size(),
+          input.data());
 
-  if (is_in_vec(true_accepted, input)) { return True; }
+    return parse_bool_result::Error;
+  }
+  return result;
+}
 
-  if (is_in_vec(false_accepted, input)) { return False; }
+static inline parse_bool_result parse_conf_bool(
+    lexer* lc,
+    libbareos::source_location loc = libbareos::source_location::current())
+{
+  using namespace bool_parsing::internal;
 
-  return Error;
+  if (!lc->str) { return parse_bool_result::Error; }
+
+  auto [result, deprecated] = parse_bool(lc->str, true);
+
+  if (deprecated) {
+    (*lc->scan_warning)(
+        loc.file_name(), loc.line(), lc,
+        "setting boolean value via true/false/1/0 is deprecated; only yes/no will be supported on newer versions");
+  }
+
+  return result;
 }
 
 #endif  // BAREOS_LIB_BOOL_STRING_H_

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -41,9 +41,9 @@ enum class parse_bool_result
 
 static inline parse_bool_result parse_user_bool(std::string_view input)
 {
-  static constexpr std::string_view true_accepted[] = {"yes", "true", "1"};
+  static constexpr std::string_view true_accepted[] = {"yes", "true"};
 
-  static constexpr std::string_view false_accepted[] = {"no", "false", "0"};
+  static constexpr std::string_view false_accepted[] = {"no", "false"};
 
   using enum parse_bool_result;
 

--- a/core/src/lib/lex.cc
+++ b/core/src/lib/lex.cc
@@ -479,12 +479,12 @@ static uint32_t scan_pint(lexer* lf, char* str)
   int64_t val = 0;
 
   if (!Is_a_number(str)) {
-    scan_err1(lf, T_("expected a positive integer number, got: %s"), str);
+    scan_err(lf, T_("expected a positive integer number, got: %s"), str);
   } else {
     errno = 0;
     val = str_to_int64(str);
     if (errno != 0 || val < 0) {
-      scan_err1(lf, T_("expected a positive integer number, got: %s"), str);
+      scan_err(lf, T_("expected a positive integer number, got: %s"), str);
     }
   }
 
@@ -496,12 +496,12 @@ static uint64_t scan_pint64(lexer* lf, char* str)
   uint64_t val = 0;
 
   if (!Is_a_number(str)) {
-    scan_err1(lf, T_("expected a positive integer number, got: %s"), str);
+    scan_err(lf, T_("expected a positive integer number, got: %s"), str);
   } else {
     errno = 0;
     val = str_to_uint64(str);
     if (errno != 0) {
-      scan_err1(lf, T_("expected a positive integer number, got: %s"), str);
+      scan_err(lf, T_("expected a positive integer number, got: %s"), str);
     }
   }
 
@@ -665,10 +665,9 @@ int LexGetToken(lexer* lf, int expect)
               } else if (ch == 0xFF) {
                 lf->state = lex_utf16_le_bom;
               } else {
-                scan_err0(lf,
-                          T_("This config file appears to be in an "
-                             "unsupported Unicode format (UTF-16be). Please "
-                             "resave as UTF-8\n"));
+                scan_err(lf, T_("This config file appears to be in an "
+                                "unsupported Unicode format (UTF-16be). Please "
+                                "resave as UTF-8\n"));
                 return BCT_ERROR;
               }
             }
@@ -821,8 +820,8 @@ int LexGetToken(lexer* lf, int expect)
           lf = lex_open_file(lf, lf->str, lf->scan_error, lf->print_warning);
           if (lf == NULL) {
             BErrNo be;
-            scan_err2(lfori, T_("Cannot open included config file %s: %s\n"),
-                      lfori->str, be.bstrerror());
+            scan_err(lfori, T_("Cannot open included config file %s: %s\n"),
+                     lfori->str, be.bstrerror());
             return BCT_ERROR;
           }
           break;
@@ -850,8 +849,8 @@ int LexGetToken(lexer* lf, int expect)
           lf = lex_open_file(lf, lf->str, lf->scan_error, lf->print_warning);
           if (lf == NULL) {
             BErrNo be;
-            scan_err2(lfori, T_("Cannot open included config file %s: %s\n"),
-                      lfori->str, be.bstrerror());
+            scan_err(lfori, T_("Cannot open included config file %s: %s\n"),
+                     lfori->str, be.bstrerror());
             return BCT_ERROR;
           }
           break;
@@ -914,8 +913,8 @@ int LexGetToken(lexer* lf, int expect)
       } else {
         char* p = strchr(lf->str, '-');
         if (!p) {
-          scan_err2(lf, T_("expected an integer or a range, got %s: %s"),
-                    lex_tok_to_str(token), lf->str);
+          scan_err(lf, T_("expected an integer or a range, got %s: %s"),
+                   lex_tok_to_str(token), lf->str);
           token = BCT_ERROR;
           break;
         }
@@ -928,16 +927,16 @@ int LexGetToken(lexer* lf, int expect)
 
     case BCT_INT16:
       if (token != BCT_NUMBER || !Is_a_number(lf->str)) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
         break;
       }
       errno = 0;
       lf->u.int16_val = (int16_t)str_to_int64(lf->str);
       if (errno != 0) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
       } else {
         token = BCT_INT16;
@@ -946,16 +945,16 @@ int LexGetToken(lexer* lf, int expect)
 
     case BCT_INT32:
       if (token != BCT_NUMBER || !Is_a_number(lf->str)) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
         break;
       }
       errno = 0;
       lf->u.int32_val = (int32_t)str_to_int64(lf->str);
       if (errno != 0) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
       } else {
         token = BCT_INT32;
@@ -965,16 +964,16 @@ int LexGetToken(lexer* lf, int expect)
     case BCT_INT64:
       Dmsg2(debuglevel, "int64=:%s: %f\n", lf->str, strtod(lf->str, NULL));
       if (token != BCT_NUMBER || !Is_a_number(lf->str)) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
         break;
       }
       errno = 0;
       lf->u.int64_val = str_to_int64(lf->str);
       if (errno != 0) {
-        scan_err2(lf, T_("expected an integer number, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected an integer number, got %s: %s"),
+                 lex_tok_to_str(token), lf->str);
         token = BCT_ERROR;
       } else {
         token = BCT_INT64;
@@ -989,8 +988,8 @@ int LexGetToken(lexer* lf, int expect)
       } else {
         char* p = strchr(lf->str, '-');
         if (!p) {
-          scan_err2(lf, T_("expected an integer or a range, got %s: %s"),
-                    lex_tok_to_str(token), lf->str);
+          scan_err(lf, T_("expected an integer or a range, got %s: %s"),
+                   lex_tok_to_str(token), lf->str);
           token = BCT_ERROR;
           break;
         }
@@ -1004,12 +1003,12 @@ int LexGetToken(lexer* lf, int expect)
     case BCT_NAME:
       if (token != BCT_IDENTIFIER && token != BCT_UNQUOTED_STRING
           && token != BCT_QUOTED_STRING) {
-        scan_err2(lf, T_("expected a name, got %s: %s"), lex_tok_to_str(token),
-                  lf->str);
+        scan_err(lf, T_("expected a name, got %s: %s"), lex_tok_to_str(token),
+                 lf->str);
         token = BCT_ERROR;
       } else if (lf->str_len > MAX_RES_NAME_LENGTH) {
-        scan_err3(lf, T_("name %s length %d too long, max is %d\n"), lf->str,
-                  lf->str_len, MAX_RES_NAME_LENGTH);
+        scan_err(lf, T_("name %s length %d too long, max is %d\n"), lf->str,
+                 lf->str_len, MAX_RES_NAME_LENGTH);
         token = BCT_ERROR;
       }
       break;
@@ -1017,8 +1016,8 @@ int LexGetToken(lexer* lf, int expect)
     case BCT_STRING:
       if (token != BCT_IDENTIFIER && token != BCT_UNQUOTED_STRING
           && token != BCT_QUOTED_STRING) {
-        scan_err2(lf, T_("expected a string, got %s: %s"),
-                  lex_tok_to_str(token), lf->str);
+        scan_err(lf, T_("expected a string, got %s: %s"), lex_tok_to_str(token),
+                 lf->str);
         token = BCT_ERROR;
       } else {
         token = BCT_STRING;

--- a/core/src/lib/lex.cc
+++ b/core/src/lib/lex.cc
@@ -105,7 +105,7 @@ static void s_err(const char* file, int line, lexer* lc, const char* msg, ...)
 
 // Format a scanner warning message
 PRINTF_LIKE(4, 5)
-static void s_warn(const char* file, int line, lexer* lc, const char* msg, ...)
+void scan_warn(const char* file, int line, lexer* lc, const char* msg, ...)
 {
   va_list ap;
   PoolMem buf(PM_NAME), more(PM_NAME);
@@ -121,19 +121,29 @@ static void s_warn(const char* file, int line, lexer* lc, const char* msg, ...)
   }
 
   if (lc->line_no > 0) {
-    p_msg(file, line, 0,
-          T_("Config warning: %s\n"
-             "            : line %d, col %d of file %s\n%s\n%s"),
-          buf.c_str(), lc->line_no, lc->col_no, lc->fname, lc->line,
-          more.c_str());
+    if (lc->print_warning) {
+      lc->print_warning(file, line, lc,
+                        T_("%s;\n"
+                           "See line %d, col %d of file %s\n%s\n%s"),
+                        buf.c_str(), lc->line_no, lc->col_no, lc->fname,
+                        lc->line, more.c_str());
+    } else {
+      p_msg(file, line, 0,
+            T_("Config warning: %s\n"
+               "            : line %d, col %d of file %s\n%s\n%s"),
+            buf.c_str(), lc->line_no, lc->col_no, lc->fname, lc->line,
+            more.c_str());
+    }
   } else {
-    p_msg(file, line, 0, T_("Config warning: %s\n"), buf.c_str());
+    if (lc->print_warning) {
+      lc->print_warning(file, line, lc, T_("%s\n"), buf.c_str());
+    } else {
+      p_msg(file, line, 0, T_("Config warning: %s\n"), buf.c_str());
+    }
   }
 }
 
 void LexSetDefaultErrorHandler(lexer* lf) { lf->scan_error = s_err; }
-
-void LexSetDefaultWarningHandler(lexer* lf) { lf->scan_warning = s_warn; }
 
 // Set err_type used in error_handler
 void LexSetErrorHandlerErrorType(lexer* lf, int err_type)
@@ -219,11 +229,7 @@ static inline lexer* lex_add(lexer* lf,
     LexSetDefaultErrorHandler(lf);
   }
 
-  if (scan_warning) {
-    lf->scan_warning = scan_warning;
-  } else {
-    LexSetDefaultWarningHandler(lf);
-  }
+  lf->print_warning = scan_warning;
 
   lf->fd = fd;
   lf->bpipe = bpipe;
@@ -812,7 +818,7 @@ int LexGetToken(lexer* lf, int expect)
           LexGetChar(lf);
 
           lf->state = lex_none;
-          lf = lex_open_file(lf, lf->str, lf->scan_error, lf->scan_warning);
+          lf = lex_open_file(lf, lf->str, lf->scan_error, lf->print_warning);
           if (lf == NULL) {
             BErrNo be;
             scan_err2(lfori, T_("Cannot open included config file %s: %s\n"),
@@ -841,7 +847,7 @@ int LexGetToken(lexer* lf, int expect)
           lexer* lfori = lf;
 
           lf->state = lex_none;
-          lf = lex_open_file(lf, lf->str, lf->scan_error, lf->scan_warning);
+          lf = lex_open_file(lf, lf->str, lf->scan_error, lf->print_warning);
           if (lf == NULL) {
             BErrNo be;
             scan_err2(lfori, T_("Cannot open included config file %s: %s\n"),

--- a/core/src/lib/lex.cc
+++ b/core/src/lib/lex.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -169,8 +169,14 @@ lexer* LexCloseFile(lexer* lf)
   FreeMemory(lf->str);
   lf->line = NULL;
   if (of) {
+    // this is just an extremely bad idea, but it is kinda entangled
+    // with the rest of the code.
+    // We should try to make this make sense when we touch the lexer
+    // the next time.
+
     of->options = lf->options;              /* preserve options */
     of->error_counter += lf->error_counter; /* summarize the errors */
+    of->caller_ctx = lf->caller_ctx;
     memcpy(lf, of, sizeof(lexer));
     Dmsg1(debuglevel, "Restart scan of cfg file %s\n", of->fname);
   } else {

--- a/core/src/lib/lex.h
+++ b/core/src/lib/lex.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -142,43 +142,47 @@ struct lexer {
                                                  ...);
 
 
-  error_handler* scan_error;
-  warning_handler* scan_warning;
+  error_handler* scan_error = {};
+  warning_handler* print_warning = {};
   int err_type; /* message level for scan_error (M_..) */
   int error_counter;
   void* caller_ctx; /* caller private data */
   Bpipe* bpipe;     /* set if we are piping */
 };
 
+PRINTF_LIKE(4, 5)
+void scan_warn(const char* file, int line, lexer* lc, const char* msg, ...);
+
 // Lexical scanning errors in parsing conf files
-#define scan_err0(lc, msg) (lc)->scan_error(__FILE__, __LINE__, (lc), msg)
-#define scan_err1(lc, msg, a1) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1)
-#define scan_err2(lc, msg, a1, a2) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1, a2)
-#define scan_err3(lc, msg, a1, a2, a3) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1, a2, a3)
-#define scan_err4(lc, msg, a1, a2, a3, a4) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4)
+#define scan_err(lc, msg, ...)                               \
+  do {                                                       \
+    lexer* _temp_lex_ = (lc);                                \
+    _temp_lex_->scan_error(__FILE__, __LINE__, _temp_lex_,   \
+                           (msg)__VA_OPT__(, ) __VA_ARGS__); \
+  } while (0)
+#define scan_err0(lc, msg) scan_err((lc), (msg))
+#define scan_err1(lc, msg, a1) scan_err((lc), (msg), a1)
+#define scan_err2(lc, msg, a1, a2) scan_err((lc), (msg), a1, a2)
+#define scan_err3(lc, msg, a1, a2, a3) scan_err((lc), (msg), a1, a2, a3)
+#define scan_err4(lc, msg, a1, a2, a3, a4) scan_err((lc), (msg), a1, a2, a3, a4)
 #define scan_err5(lc, msg, a1, a2, a3, a4, a5) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5)
+  scan_err((lc), (msg), a1, a2, a3, a4, a5)
 #define scan_err6(lc, msg, a1, a2, a3, a4, a5, a6) \
-  (lc)->scan_error(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5, a6)
+  scan_err((lc), (msg), a1, a2, a3, a4, a5, a6)
 
 // Lexical scanning warnings in parsing conf files
-#define scan_warn0(lc, msg) (lc)->scan_warning(__FILE__, __LINE__, (lc), msg)
-#define scan_warn1(lc, msg, a1) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1)
+#define scan_warn0(lc, msg) scan_warn(__FILE__, __LINE__, (lc), msg)
+#define scan_warn1(lc, msg, a1) scan_warn(__FILE__, __LINE__, (lc), msg, a1)
 #define scan_warn2(lc, msg, a1, a2) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1, a2)
+  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2)
 #define scan_warn3(lc, msg, a1, a2, a3) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1, a2, a3)
+  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3)
 #define scan_warn4(lc, msg, a1, a2, a3, a4) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4)
+  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4)
 #define scan_warn5(lc, msg, a1, a2, a3, a4, a5) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5)
+  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5)
 #define scan_warn6(lc, msg, a1, a2, a3, a4, a5, a6) \
-  (lc)->scan_warning(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5, a6)
+  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5, a6)
 
 void ScanToEol(lexer* lc);
 int ScanToNextNotEol(lexer* lc);
@@ -193,7 +197,6 @@ void LexUngetChar(lexer* lf);
 const char* lex_tok_to_str(int token);
 int LexGetToken(lexer* lf, int expect);
 void LexSetDefaultErrorHandler(lexer* lf);
-void LexSetDefaultWarningHandler(lexer* lf);
 void LexSetErrorHandlerErrorType(lexer* lf, int err_type);
 
 #endif  // BAREOS_LIB_LEX_H_

--- a/core/src/lib/lex.h
+++ b/core/src/lib/lex.h
@@ -160,29 +160,6 @@ void scan_warn(const char* file, int line, lexer* lc, const char* msg, ...);
     _temp_lex_->scan_error(__FILE__, __LINE__, _temp_lex_,   \
                            (msg)__VA_OPT__(, ) __VA_ARGS__); \
   } while (0)
-#define scan_err0(lc, msg) scan_err((lc), (msg))
-#define scan_err1(lc, msg, a1) scan_err((lc), (msg), a1)
-#define scan_err2(lc, msg, a1, a2) scan_err((lc), (msg), a1, a2)
-#define scan_err3(lc, msg, a1, a2, a3) scan_err((lc), (msg), a1, a2, a3)
-#define scan_err4(lc, msg, a1, a2, a3, a4) scan_err((lc), (msg), a1, a2, a3, a4)
-#define scan_err5(lc, msg, a1, a2, a3, a4, a5) \
-  scan_err((lc), (msg), a1, a2, a3, a4, a5)
-#define scan_err6(lc, msg, a1, a2, a3, a4, a5, a6) \
-  scan_err((lc), (msg), a1, a2, a3, a4, a5, a6)
-
-// Lexical scanning warnings in parsing conf files
-#define scan_warn0(lc, msg) scan_warn(__FILE__, __LINE__, (lc), msg)
-#define scan_warn1(lc, msg, a1) scan_warn(__FILE__, __LINE__, (lc), msg, a1)
-#define scan_warn2(lc, msg, a1, a2) \
-  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2)
-#define scan_warn3(lc, msg, a1, a2, a3) \
-  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3)
-#define scan_warn4(lc, msg, a1, a2, a3, a4) \
-  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4)
-#define scan_warn5(lc, msg, a1, a2, a3, a4, a5) \
-  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5)
-#define scan_warn6(lc, msg, a1, a2, a3, a4, a5, a6) \
-  scan_warn(__FILE__, __LINE__, (lc), msg, a1, a2, a3, a4, a5, a6)
 
 void ScanToEol(lexer* lc);
 int ScanToNextNotEol(lexer* lc);

--- a/core/src/lib/parse_bsr.cc
+++ b/core/src/lib/parse_bsr.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -235,7 +235,7 @@ storagedaemon::BootStrapRecord* parse_bsr(JobControlRecord* jcr, char* fname)
         token = LexGetToken(lc, BCT_ALL);
         Dmsg1(300, "in BCT_IDENT got token=%s\n", lex_tok_to_str(token));
         if (token != BCT_EQUALS) {
-          scan_err1(lc, "expected an equals, got: %s", lc->str);
+          scan_err(lc, "expected an equals, got: %s", lc->str);
           bsr = NULL;
           break;
         }
@@ -248,7 +248,7 @@ storagedaemon::BootStrapRecord* parse_bsr(JobControlRecord* jcr, char* fname)
     }
     if (i >= 0) {
       Dmsg1(300, "Keyword = %s\n", lc->str);
-      scan_err1(lc, "Keyword %s not found", lc->str);
+      scan_err(lc, "Keyword %s not found", lc->str);
       bsr = NULL;
       break;
     }

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -224,8 +224,8 @@ void ConfigurationParser::lex_error(const char* cf,
 
   LexSetErrorHandlerErrorType(&lexical_parser_, err_type_);
   BErrNo be;
-  scan_err2(&lexical_parser_, T_("Cannot open config file \"%s\": %s\n"), cf,
-            be.bstrerror());
+  scan_err(&lexical_parser_, T_("Cannot open config file \"%s\": %s\n"), cf,
+           be.bstrerror());
 }
 
 bool ConfigurationParser::ParseConfigFile(const char* config_file_name,
@@ -242,17 +242,17 @@ bool ConfigurationParser::ParseConfigFile(const char* config_file_name,
     if (!state_machine.InitParserPass()) { return false; }
 
     if (!state_machine.ParseAllTokens()) {
-      scan_err0(state_machine.lexical_parser_, T_("ParseAllTokens failed."));
+      scan_err(state_machine.lexical_parser_, T_("ParseAllTokens failed."));
       return false;
     }
 
     switch (state_machine.GetParseError()) {
       case ConfigParserStateMachine::ParserError::kResourceIncomplete:
-        scan_err0(state_machine.lexical_parser_,
-                  T_("End of conf file reached with unclosed resource."));
+        scan_err(state_machine.lexical_parser_,
+                 T_("End of conf file reached with unclosed resource."));
         return false;
       case ConfigParserStateMachine::ParserError::kParserError:
-        scan_err0(state_machine.lexical_parser_, T_("Parser Error occurred."));
+        scan_err(state_machine.lexical_parser_, T_("Parser Error occurred."));
         return false;
       case ConfigParserStateMachine::ParserError::kNoError:
         break;

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -85,8 +85,6 @@ ConfigurationParser::~ConfigurationParser() = default;
 
 ConfigurationParser::ConfigurationParser(
     const char* cf,
-    lexer::error_handler* scan_error,
-    lexer::warning_handler* scan_warning,
     resource_initer* init_res,
     resource_storer* store_res,
     resource_printer* print_res,
@@ -105,8 +103,6 @@ ConfigurationParser::ConfigurationParser(
   cf_ = cf == nullptr ? "" : cf;
   use_config_include_dir_ = false;
   config_include_naming_format_ = "%s/%s/%s.conf";
-  scan_error_ = scan_error;
-  scan_warning_ = scan_warning;
   init_res_ = init_res;
   store_res_ = store_res;
   print_res_ = print_res;
@@ -159,6 +155,29 @@ void ConfigurationParser::ParseConfigOrExit()
   }
 }
 
+void ConfigurationParser_ScanWarning(const char* file,
+                                     int line,
+                                     lexer* lc,
+                                     const char* fmt,
+                                     ...)
+{
+  auto* conf = static_cast<ConfigurationParser*>(lc->caller_ctx);
+
+  ASSERT(conf);
+
+  (void)line;
+  (void)file;
+
+  va_list args;
+  va_start(args, fmt);
+
+  auto warning = vstdprintf(fmt, args);
+
+  va_end(args);
+
+  conf->AddWarning(warning);
+}
+
 bool ConfigurationParser::ParseConfig()
 {
   int errstat;
@@ -179,8 +198,8 @@ bool ConfigurationParser::ParseConfig()
   }
   used_config_path_ = config_path.c_str();
   Dmsg1(100, "config file = %s\n", used_config_path_.c_str());
-  bool success = ParseConfigFile(config_path.c_str(), nullptr, scan_error_,
-                                 scan_warning_);
+  bool success = ParseConfigFile(config_path.c_str(), this, nullptr,
+                                 &ConfigurationParser_ScanWarning);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
 
   config_resources_container_->SetTimestampToNow();

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -155,11 +155,11 @@ void ConfigurationParser::ParseConfigOrExit()
   }
 }
 
-void ConfigurationParser_ScanWarning(const char* file,
-                                     int line,
-                                     lexer* lc,
-                                     const char* fmt,
-                                     ...)
+void ConfigurationParser_PrintWarning(const char* file,
+                                      int line,
+                                      lexer* lc,
+                                      const char* fmt,
+                                      ...)
 {
   auto* conf = static_cast<ConfigurationParser*>(lc->caller_ctx);
 
@@ -199,7 +199,7 @@ bool ConfigurationParser::ParseConfig()
   used_config_path_ = config_path.c_str();
   Dmsg1(100, "config file = %s\n", used_config_path_.c_str());
   bool success = ParseConfigFile(config_path.c_str(), this, nullptr,
-                                 &ConfigurationParser_ScanWarning);
+                                 &ConfigurationParser_PrintWarning);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
 
   config_resources_container_->SetTimestampToNow();
@@ -220,11 +220,7 @@ void ConfigurationParser::lex_error(const char* cf,
     LexSetDefaultErrorHandler(&lexical_parser_);
   }
 
-  if (scan_warning) {
-    lexical_parser_.scan_warning = scan_warning;
-  } else {
-    LexSetDefaultWarningHandler(&lexical_parser_);
-  }
+  lexical_parser_.print_warning = scan_warning;
 
   LexSetErrorHandlerErrorType(&lexical_parser_, err_type_);
   BErrNo be;

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -196,10 +196,7 @@ class ConfigurationParser {
                                 bool inherited,
                                 bool verbose);
 
-  std::string cf_;                            /* Config file parameter */
-  lexer::error_handler* scan_error_{nullptr}; /* Error handler if non-null */
-  lexer::warning_handler* scan_warning_{
-      nullptr}; /* Warning handler if non-null */
+  std::string cf_; /* Config file parameter */
   resource_initer* init_res_{
       nullptr}; /* Init resource handler for non default types if non-null */
   resource_storer* store_res_{
@@ -225,8 +222,6 @@ class ConfigurationParser {
 
   ConfigurationParser();
   ConfigurationParser(const char* cf,
-                      lexer::error_handler* scan_error,
-                      lexer::warning_handler* scan_warning,
                       resource_initer* init_res,
                       resource_storer* store_res,
                       resource_printer* print_res,

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -82,8 +82,8 @@ bool ConfigParserStateMachine::ParseAllTokens()
         }
         break;
       default:
-        scan_err1(lexical_parser_, T_("Unknown parser state %d\n"),
-                  to_underlying(state));
+        scan_err(lexical_parser_, T_("Unknown parser state %d\n"),
+                 to_underlying(state));
         return false;
     }
   }
@@ -115,8 +115,8 @@ ConfigParserStateMachine::ScanResource(int token)
       return ParseInternalReturnCode::kGetNextToken;
     case BCT_IDENTIFIER: {
       if (config_level_ != 1) {
-        scan_err1(lexical_parser_, T_("not in resource definition: %s"),
-                  lexical_parser_->str);
+        scan_err(lexical_parser_, T_("not in resource definition: %s"),
+                 lexical_parser_->str);
         return ParseInternalReturnCode::kError;
       }
 
@@ -130,8 +130,8 @@ ConfigParserStateMachine::ScanResource(int token)
           token = LexGetToken(lexical_parser_, BCT_SKIP_EOL);
           Dmsg1(900, "in BCT_IDENT got token=%s\n", lex_tok_to_str(token));
           if (token != BCT_EQUALS) {
-            scan_err1(lexical_parser_, T_("expected an equals, got: %s"),
-                      lexical_parser_->str);
+            scan_err(lexical_parser_, T_("expected an equals, got: %s"),
+                     lexical_parser_->str);
             return ParseInternalReturnCode::kError;
           }
         }
@@ -159,11 +159,11 @@ ConfigParserStateMachine::ScanResource(int token)
         Dmsg2(900, "config_level_=%d id=%s\n", config_level_,
               lexical_parser_->str);
         Dmsg1(900, "Keyword = %s\n", lexical_parser_->str);
-        scan_err1(lexical_parser_,
-                  T_("Keyword \"%s\" not permitted in this resource.\n"
-                     "Perhaps you left the trailing brace off of the "
-                     "previous resource."),
-                  lexical_parser_->str);
+        scan_err(lexical_parser_,
+                 T_("Keyword \"%s\" not permitted in this resource.\n"
+                    "Perhaps you left the trailing brace off of the "
+                    "previous resource."),
+                 lexical_parser_->str);
         return ParseInternalReturnCode::kError;
       }
       return ParseInternalReturnCode::kGetNextToken;
@@ -173,7 +173,7 @@ ConfigParserStateMachine::ScanResource(int token)
       state = ParseState::kInit;
       Dmsg0(900, "BCT_EOB => define new resource\n");
       if (!currently_parsed_resource_.allocated_resource_->resource_name_) {
-        scan_err0(lexical_parser_, T_("Name not specified for resource"));
+        scan_err(lexical_parser_, T_("Name not specified for resource"));
         return ParseInternalReturnCode::kError;
       }
       /* save resource */
@@ -181,7 +181,7 @@ ConfigParserStateMachine::ScanResource(int token)
               currently_parsed_resource_.rcode_,
               currently_parsed_resource_.resource_items_,
               parser_pass_number_)) {
-        scan_err0(lexical_parser_, T_("SaveResource failed"));
+        scan_err(lexical_parser_, T_("SaveResource failed"));
         return ParseInternalReturnCode::kError;
       }
 
@@ -192,9 +192,9 @@ ConfigParserStateMachine::ScanResource(int token)
       return ParseInternalReturnCode::kGetNextToken;
 
     default:
-      scan_err2(lexical_parser_,
-                T_("unexpected token %d %s in resource definition"), token,
-                lex_tok_to_str(token));
+      scan_err(lexical_parser_,
+               T_("unexpected token %d %s in resource definition"), token,
+               lex_tok_to_str(token));
       return ParseInternalReturnCode::kError;
   }
 }
@@ -209,15 +209,15 @@ ConfigParserStateMachine::ParserInitResource(int token)
     case BCT_UTF8_BOM:
       return ParseInternalReturnCode::kGetNextToken;
     case BCT_UTF16_BOM:
-      scan_err0(lexical_parser_,
-                T_("Currently we cannot handle UTF-16 source files. "
-                   "Please convert the conf file to UTF-8\n"));
+      scan_err(lexical_parser_,
+               T_("Currently we cannot handle UTF-16 source files. "
+                  "Please convert the conf file to UTF-8\n"));
       return ParseInternalReturnCode::kError;
     default:
       if (token != BCT_IDENTIFIER) {
-        scan_err1(lexical_parser_,
-                  T_("Expected a Resource name identifier, got: %s"),
-                  resource_identifier);
+        scan_err(lexical_parser_,
+                 T_("Expected a Resource name identifier, got: %s"),
+                 resource_identifier);
         return ParseInternalReturnCode::kError;
       }
       break;
@@ -226,9 +226,9 @@ ConfigParserStateMachine::ParserInitResource(int token)
   const ResourceTable* resource_table
       = my_config_.GetResourceTable(resource_identifier);
   if (!resource_table) {
-    scan_err1(lexical_parser_,
-              T_("Expected a Resource name identifier, got: %s"),
-              resource_identifier);
+    scan_err(lexical_parser_,
+             T_("Expected a Resource name identifier, got: %s"),
+             resource_identifier);
     return ParseInternalReturnCode::kError;
   }
 
@@ -258,8 +258,8 @@ ConfigParserStateMachine::ParserInitResource(int token)
   }
 
   if (!init_done) {
-    scan_err1(lexical_parser_, T_("expected resource identifier, got: %s"),
-              resource_identifier);
+    scan_err(lexical_parser_, T_("expected resource identifier, got: %s"),
+             resource_identifier);
     return ParseInternalReturnCode::kError;
   }
   return ParseInternalReturnCode::kNextState;

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -232,7 +232,7 @@ void ConfigurationParser::ScanTypes(lexer* lc,
       }
     }
     if (!found) {
-      scan_err1(lc, T_("message type: %s not found"), str);
+      scan_err(lc, T_("message type: %s not found"), str);
       return;
     }
 
@@ -361,7 +361,7 @@ void ConfigurationParser::StoreMsgs(lexer* lc,
           token = LexGetToken(lc, BCT_SKIP_EOL);
           if (token == BCT_COMMA) { continue; /* Get another destination */ }
           if (token != BCT_EQUALS) {
-            scan_err1(lc, T_("expected an =, got: %s"), lc->str);
+            scan_err(lc, T_("expected an =, got: %s"), lc->str);
             return;
           }
           break;
@@ -382,7 +382,7 @@ void ConfigurationParser::StoreMsgs(lexer* lc,
         token = LexGetToken(lc, BCT_SKIP_EOL);
         Dmsg1(900, "StoreMsgs dest=%s:\n", dest_file_path.c_str());
         if (token != BCT_EQUALS) {
-          scan_err1(lc, T_("expected an =, got: %s"), lc->str);
+          scan_err(lc, T_("expected an =, got: %s"), lc->str);
           return;
         }
         ScanTypes(lc, message_resource,
@@ -393,7 +393,7 @@ void ConfigurationParser::StoreMsgs(lexer* lc,
         break;
       }
       default:
-        scan_err1(lc, T_("Unknown item code: %d\n"), item->code);
+        scan_err(lc, T_("Unknown item code: %d\n"), item->code);
         return;
     }
   }
@@ -416,15 +416,14 @@ void ConfigurationParser::StoreName(lexer* lc,
 
   LexGetToken(lc, BCT_NAME);
   if (!IsNameValid(lc->str, msg)) {
-    scan_err1(lc, "%s\n", msg.c_str());
+    scan_err(lc, "%s\n", msg.c_str());
     return;
   }
   // Store the name both in pass 1 and pass 2
   char** p = GetItemVariablePointer<char**>(*item);
 
   if (*p) {
-    scan_err2(lc, T_("Attempt to redefine name \"%s\" to \"%s\"."), *p,
-              lc->str);
+    scan_err(lc, T_("Attempt to redefine name \"%s\" to \"%s\"."), *p, lc->str);
     return;
   }
   *p = strdup(lc->str);
@@ -544,8 +543,8 @@ void ConfigurationParser::StoreMd5Password(lexer* lc,
         if (strncmp(lc->str + 5, empty_password_md5_hash,
                     strlen(empty_password_md5_hash))
             == 0) {
-          scan_err1(lc, "Empty Password not allowed in Resource \"%s\"\n",
-                    (*item->allocated_resource)->resource_name_);
+          scan_err(lc, "Empty Password not allowed in Resource \"%s\"\n",
+                   (*item->allocated_resource)->resource_name_);
           return;
         }
       }
@@ -555,17 +554,17 @@ void ConfigurationParser::StoreMd5Password(lexer* lc,
       constexpr size_t md5len = 32;
 
       if (candidate.size() != md5len) {
-        scan_err2(lc,
-                  "md5 password does not have the right size; expected: %" PRIuz
-                  ", got: %" PRIuz "\n",
-                  md5len, candidate.size());
+        scan_err(lc,
+                 "md5 password does not have the right size; expected: %" PRIuz
+                 ", got: %" PRIuz "\n",
+                 md5len, candidate.size());
         *pwd = {};
         return;
       }
 
       if (auto bad = candidate.find_first_not_of("0123456789ABCDEFabcdef");
           bad != candidate.npos) {
-        scan_err1(
+        scan_err(
             lc, "md5 password contains non hexadecimal characters, e.g. '%c'\n",
             candidate[bad]);
         *pwd = {};
@@ -582,8 +581,8 @@ void ConfigurationParser::StoreMd5Password(lexer* lc,
 
       if (item->is_required) {
         if (strnlen(lc->str, MAX_NAME_LENGTH) == 0) {
-          scan_err1(lc, "Empty Password not allowed in Resource \"%s\"\n",
-                    (*item->allocated_resource)->resource_name_);
+          scan_err(lc, "Empty Password not allowed in Resource \"%s\"\n",
+                   (*item->allocated_resource)->resource_name_);
           return;
         }
       }
@@ -622,9 +621,9 @@ void ConfigurationParser::StoreClearpassword(lexer* lc,
 
     if (item->is_required) {
       if (strnlen(lc->str, MAX_NAME_LENGTH) == 0) {
-        scan_err1(
-            lc, "Empty Password not allowed in Resource \"%s\" not allowed.\n",
-            (*item->allocated_resource)->resource_name_);
+        scan_err(lc,
+                 "Empty Password not allowed in Resource \"%s\" not allowed.\n",
+                 (*item->allocated_resource)->resource_name_);
         return;
       }
     }
@@ -651,7 +650,7 @@ void ConfigurationParser::StoreRes(lexer* lc,
   if (pass == 2) {
     BareosResource* res = GetResWithName(item->code, lc->str);
     if (res == NULL) {
-      scan_err3(
+      scan_err(
           lc,
           T_("Could not find config resource \"%s\" referenced on line %d: %s"),
           lc->str, lc->line_no, lc->line);
@@ -659,7 +658,7 @@ void ConfigurationParser::StoreRes(lexer* lc,
     }
     BareosResource** p = GetItemVariablePointer<BareosResource**>(*item);
     if (*p) {
-      scan_err3(
+      scan_err(
           lc,
           T_("Attempt to redefine resource \"%s\" referenced on line %d: %s"),
           item->name, lc->line_no, lc->line);
@@ -698,10 +697,10 @@ void ConfigurationParser::StoreAlistRes(lexer* lc,
     if (pass == 2) {
       BareosResource* res = GetResWithName(item->code, lc->str);
       if (res == NULL) {
-        scan_err3(lc,
-                  T_("Could not find config Resource \"%s\" referenced on line "
-                     "%d : %s\n"),
-                  item->name, lc->line_no, lc->line);
+        scan_err(lc,
+                 T_("Could not find config Resource \"%s\" referenced on line "
+                    "%d : %s\n"),
+                 item->name, lc->line_no, lc->line);
         return;
       }
       Dmsg5(900, "Append %p (%s) to alist %p size=%d %s\n", res,
@@ -916,7 +915,7 @@ void ConfigurationParser::StoreDefs(lexer* lc,
     Dmsg2(900, "Code=%d name=%s\n", item->code, lc->str);
     res = GetResWithName(item->code, lc->str);
     if (res == NULL) {
-      scan_err3(
+      scan_err(
           lc, T_("Missing config Resource \"%s\" referenced on line %d : %s\n"),
           lc->str, lc->line_no, lc->line);
       return;
@@ -1022,18 +1021,18 @@ void ConfigurationParser::store_int_unit(lexer* lc,
       switch (type) {
         case STORE_SIZE:
           if (!size_to_uint64(bsize, &uvalue)) {
-            scan_err1(lc, T_("expected a size number, got: %s"), lc->str);
+            scan_err(lc, T_("expected a size number, got: %s"), lc->str);
             return;
           }
           break;
         case STORE_SPEED:
           if (!speed_to_uint64(bsize, &uvalue)) {
-            scan_err1(lc, T_("expected a speed number, got: %s"), lc->str);
+            scan_err(lc, T_("expected a speed number, got: %s"), lc->str);
             return;
           }
           break;
         default:
-          scan_err0(lc, T_("unknown unit type encountered"));
+          scan_err(lc, T_("unknown unit type encountered"));
           return;
       }
 
@@ -1051,8 +1050,8 @@ void ConfigurationParser::store_int_unit(lexer* lc,
       }
       break;
     default:
-      scan_err2(lc, T_("expected a %s, got: %s"),
-                (type == STORE_SIZE) ? T_("size") : T_("speed"), lc->str);
+      scan_err(lc, T_("expected a %s, got: %s"),
+               (type == STORE_SIZE) ? T_("size") : T_("speed"), lc->str);
       return;
   }
   if (token != BCT_EOL) { ScanToEol(lc); }
@@ -1116,13 +1115,13 @@ void ConfigurationParser::StoreTime(lexer* lc,
         }
       }
       if (!DurationToUtime(period, &utime)) {
-        scan_err1(lc, T_("expected a time period, got: %s"), period);
+        scan_err(lc, T_("expected a time period, got: %s"), period);
         return;
       }
       SetItemVariable<utime_t>(*item, utime);
       break;
     default:
-      scan_err1(lc, T_("expected a time period, got: %s"), lc->str);
+      scan_err(lc, T_("expected a time period, got: %s"), lc->str);
       return;
   }
   if (token != BCT_EOL) { ScanToEol(lc); }
@@ -1146,8 +1145,8 @@ void ConfigurationParser::StoreBit(lexer* lc,
       ClearBit(item->code, bitvalue);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
-                lc->str); /* YES and NO must not be translated */
+      scan_err(lc, T_("Expect %s, got: %s"), "YES or NO",
+               lc->str); /* YES and NO must not be translated */
       return;
     } break;
   }
@@ -1171,8 +1170,8 @@ void ConfigurationParser::StoreBool(lexer* lc,
       SetItemVariable<bool>(*item, false);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
-                lc->str); /* YES and NO must not be translated */
+      scan_err(lc, T_("Expect %s, got: %s"), "YES or NO",
+               lc->str); /* YES and NO must not be translated */
       return;
     } break;
   }
@@ -1198,7 +1197,7 @@ void ConfigurationParser::StoreLabel(lexer* lc,
     }
   }
   if (i != 0) {
-    scan_err1(lc, T_("Expected a Tape Label keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a Tape Label keyword, got: %s"), lc->str);
     return;
   }
   ScanToEol(lc);
@@ -1256,96 +1255,91 @@ void ConfigurationParser::StoreAddresses(lexer* lc,
 
   token = LexGetToken(lc, BCT_SKIP_EOL);
   if (token != BCT_BOB) {
-    scan_err1(lc, T_("Expected a block begin { , got: %s"), lc->str);
+    scan_err(lc, T_("Expected a block begin { , got: %s"), lc->str);
   }
   token = LexGetToken(lc, BCT_SKIP_EOL);
-  if (token == BCT_EOB) {
-    scan_err0(lc, T_("Empty addr block is not allowed"));
-  }
+  if (token == BCT_EOB) { scan_err(lc, T_("Empty addr block is not allowed")); }
   do {
     if (!(token == BCT_UNQUOTED_STRING || token == BCT_IDENTIFIER)) {
-      scan_err1(lc, T_("Expected a string, got: %s"), lc->str);
+      scan_err(lc, T_("Expected a string, got: %s"), lc->str);
     }
     if (Bstrcasecmp("ip", lc->str) || Bstrcasecmp("ipv4", lc->str)) {
       family = AF_INET;
     } else if (Bstrcasecmp("ipv6", lc->str)) {
       family = AF_INET6;
     } else {
-      scan_err1(lc, T_("Expected a string [ip|ipv4|ipv6], got: %s"), lc->str);
+      scan_err(lc, T_("Expected a string [ip|ipv4|ipv6], got: %s"), lc->str);
     }
     token = LexGetToken(lc, BCT_SKIP_EOL);
     if (token != BCT_EQUALS) {
-      scan_err1(lc, T_("Expected a equal =, got: %s"), lc->str);
+      scan_err(lc, T_("Expected a equal =, got: %s"), lc->str);
     }
     token = LexGetToken(lc, BCT_SKIP_EOL);
     if (token != BCT_BOB) {
-      scan_err1(lc, T_("Expected a block begin { , got: %s"), lc->str);
+      scan_err(lc, T_("Expected a block begin { , got: %s"), lc->str);
     }
     token = LexGetToken(lc, BCT_SKIP_EOL);
     exist = EMPTYLINE;
     port_str[0] = hostname_str[0] = '\0';
     do {
       if (token != BCT_IDENTIFIER) {
-        scan_err1(lc, T_("Expected a identifier [addr|port], got: %s"),
-                  lc->str);
+        scan_err(lc, T_("Expected a identifier [addr|port], got: %s"), lc->str);
       }
       if (Bstrcasecmp("port", lc->str)) {
         next_line = PORTLINE;
         if (exist & PORTLINE) {
-          scan_err0(lc, T_("Only one port per address block"));
+          scan_err(lc, T_("Only one port per address block"));
         }
         exist |= PORTLINE;
       } else if (Bstrcasecmp("addr", lc->str)) {
         next_line = ADDRLINE;
         if (exist & ADDRLINE) {
-          scan_err0(lc, T_("Only one addr per address block"));
+          scan_err(lc, T_("Only one addr per address block"));
         }
         exist |= ADDRLINE;
       } else {
-        scan_err1(lc, T_("Expected a identifier [addr|port], got: %s"),
-                  lc->str);
+        scan_err(lc, T_("Expected a identifier [addr|port], got: %s"), lc->str);
       }
       token = LexGetToken(lc, BCT_SKIP_EOL);
       if (token != BCT_EQUALS) {
-        scan_err1(lc, T_("Expected a equal =, got: %s"), lc->str);
+        scan_err(lc, T_("Expected a equal =, got: %s"), lc->str);
       }
       token = LexGetToken(lc, BCT_SKIP_EOL);
       switch (next_line) {
         case PORTLINE:
           if (!(token == BCT_UNQUOTED_STRING || token == BCT_NUMBER
                 || token == BCT_IDENTIFIER)) {
-            scan_err1(lc, T_("Expected a number or a string, got: %s"),
-                      lc->str);
+            scan_err(lc, T_("Expected a number or a string, got: %s"), lc->str);
           }
           bstrncpy(port_str, lc->str, sizeof(port_str));
           break;
         case ADDRLINE:
           if (!(token == BCT_UNQUOTED_STRING || token == BCT_IDENTIFIER)) {
-            scan_err1(lc, T_("Expected an IP number or a hostname, got: %s"),
-                      lc->str);
+            scan_err(lc, T_("Expected an IP number or a hostname, got: %s"),
+                     lc->str);
           }
           bstrncpy(hostname_str, lc->str, sizeof(hostname_str));
           break;
         case EMPTYLINE:
-          scan_err0(lc, T_("State machine mismatch"));
+          scan_err(lc, T_("State machine mismatch"));
           break;
       }
       token = LexGetToken(lc, BCT_SKIP_EOL);
     } while (token == BCT_IDENTIFIER);
     if (token != BCT_EOB) {
-      scan_err1(lc, T_("Expected a end of block }, got: %s"), lc->str);
+      scan_err(lc, T_("Expected a end of block }, got: %s"), lc->str);
     }
     if (pass == 1
         && !AddAddress(GetItemVariablePointer<dlist<IPADDR>**>(*item),
                        IPADDR::R_MULTIPLE, htons(port), family, hostname_str,
                        port_str, errmsg, sizeof(errmsg))) {
-      scan_err3(lc, T_("Can't add hostname(%s) and port(%s) to addrlist (%s)"),
-                hostname_str, port_str, errmsg);
+      scan_err(lc, T_("Can't add hostname(%s) and port(%s) to addrlist (%s)"),
+               hostname_str, port_str, errmsg);
     }
     token = ScanToNextNotEol(lc);
   } while ((token == BCT_IDENTIFIER || token == BCT_UNQUOTED_STRING));
   if (token != BCT_EOB) {
-    scan_err1(lc, T_("Expected a end of block }, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a end of block }, got: %s"), lc->str);
   }
   item->SetPresent();
   ClearBit(index, (*item->allocated_resource)->inherit_content_);
@@ -1363,7 +1357,7 @@ void ConfigurationParser::StoreAddressesAddress(lexer* lc,
   token = LexGetToken(lc, BCT_SKIP_EOL);
   if (!(token == BCT_UNQUOTED_STRING || token == BCT_NUMBER
         || token == BCT_IDENTIFIER)) {
-    scan_err1(lc, T_("Expected an IP number or a hostname, got: %s"), lc->str);
+    scan_err(lc, T_("Expected an IP number or a hostname, got: %s"), lc->str);
   }
 
   if (pass == 1
@@ -1371,7 +1365,7 @@ void ConfigurationParser::StoreAddressesAddress(lexer* lc,
                      IPADDR::R_SINGLE_ADDR, htons(port),
                      strchr(lc->str, ':') ? AF_INET6 : AF_INET, lc->str, 0,
                      errmsg, sizeof(errmsg))) {
-    scan_err2(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
+    scan_err(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
   }
 }
 
@@ -1387,7 +1381,7 @@ void ConfigurationParser::StoreAddressesPort(lexer* lc,
   token = LexGetToken(lc, BCT_SKIP_EOL);
   if (!(token == BCT_UNQUOTED_STRING || token == BCT_NUMBER
         || token == BCT_IDENTIFIER)) {
-    scan_err1(lc, T_("Expected a port number or string, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a port number or string, got: %s"), lc->str);
   }
 
   bool has_address = false;
@@ -1403,14 +1397,14 @@ void ConfigurationParser::StoreAddressesPort(lexer* lc,
         && !AddAddress(GetItemVariablePointer<dlist<IPADDR>**>(*item),
                        IPADDR::R_SINGLE_PORT, htons(port), AF_INET, 0, lc->str,
                        errmsg, sizeof(errmsg))) {
-      scan_err2(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
+      scan_err(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
     }
   } else {
     if (pass == 1
         && !AddAddress(GetItemVariablePointer<dlist<IPADDR>**>(*item),
                        IPADDR::R_SINGLE, htons(port), 0, 0, lc->str, errmsg,
                        sizeof(errmsg))) {
-      scan_err2(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
+      scan_err(lc, T_("can't add port (%s) to (%s)"), lc->str, errmsg);
     }
   }
 }

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -26,6 +26,7 @@
  * Split from parse_conf.c April MMV
  */
 
+#include "lib/bool_string.h"
 #define NEED_JANSSON_NAMESPACE 1
 #include <openssl/md5.h>
 #include "include/bareos.h"
@@ -1137,14 +1138,18 @@ void ConfigurationParser::StoreBit(lexer* lc,
 {
   LexGetToken(lc, BCT_NAME);
   char* bitvalue = GetItemVariablePointer<char*>(*item);
-  if (Bstrcasecmp(lc->str, "yes") || Bstrcasecmp(lc->str, "true")) {
-    SetBit(item->code, bitvalue);
-  } else if (Bstrcasecmp(lc->str, "no") || Bstrcasecmp(lc->str, "false")) {
-    ClearBit(item->code, bitvalue);
-  } else {
-    scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
-              lc->str); /* YES and NO must not be translated */
-    return;
+  switch (parse_user_bool(lc->str)) {
+    case parse_bool_result::True: {
+      SetBit(item->code, bitvalue);
+    } break;
+    case parse_bool_result::False: {
+      ClearBit(item->code, bitvalue);
+    } break;
+    case parse_bool_result::Error: {
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+                lc->str); /* YES and NO must not be translated */
+      return;
+    } break;
   }
   ScanToEol(lc);
   item->SetPresent();
@@ -1158,14 +1163,18 @@ void ConfigurationParser::StoreBool(lexer* lc,
                                     int)
 {
   LexGetToken(lc, BCT_NAME);
-  if (Bstrcasecmp(lc->str, "yes") || Bstrcasecmp(lc->str, "true")) {
-    SetItemVariable<bool>(*item, true);
-  } else if (Bstrcasecmp(lc->str, "no") || Bstrcasecmp(lc->str, "false")) {
-    SetItemVariable<bool>(*item, false);
-  } else {
-    scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
-              lc->str); /* YES and NO must not be translated */
-    return;
+  switch (parse_user_bool(lc->str)) {
+    case parse_bool_result::True: {
+      SetItemVariable<bool>(*item, true);
+    } break;
+    case parse_bool_result::False: {
+      SetItemVariable<bool>(*item, false);
+    } break;
+    case parse_bool_result::Error: {
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+                lc->str); /* YES and NO must not be translated */
+      return;
+    } break;
   }
   ScanToEol(lc);
   item->SetPresent();

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -1146,7 +1146,7 @@ void ConfigurationParser::StoreBit(lexer* lc,
       ClearBit(item->code, bitvalue);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
                 lc->str); /* YES and NO must not be translated */
       return;
     } break;
@@ -1171,7 +1171,7 @@ void ConfigurationParser::StoreBool(lexer* lc,
       SetItemVariable<bool>(*item, false);
     } break;
     case parse_bool_result::Error: {
-      scan_err2(lc, T_("Expect %s, got: %s"), "YES, NO, TRUE, or FALSE",
+      scan_err2(lc, T_("Expect %s, got: %s"), "YES or NO",
                 lc->str); /* YES and NO must not be translated */
       return;
     } break;

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -1138,7 +1138,7 @@ void ConfigurationParser::StoreBit(lexer* lc,
 {
   LexGetToken(lc, BCT_NAME);
   char* bitvalue = GetItemVariablePointer<char*>(*item);
-  switch (parse_user_bool(lc->str)) {
+  switch (parse_conf_bool(lc)) {
     case parse_bool_result::True: {
       SetBit(item->code, bitvalue);
     } break;
@@ -1163,7 +1163,7 @@ void ConfigurationParser::StoreBool(lexer* lc,
                                     int)
 {
   LexGetToken(lc, BCT_NAME);
-  switch (parse_user_bool(lc->str)) {
+  switch (parse_conf_bool(lc)) {
     case parse_bool_result::True: {
       SetItemVariable<bool>(*item, true);
     } break;

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -232,4 +232,42 @@ static_assert(split_first("abc", ',') == std::nullopt);
 static_assert(split_first("abc", 'b')->first == "a");
 static_assert(split_first("abcbd", 'b')->second == "cbd");
 
+
+inline std::string vstdprintf(const char* fmt, va_list args)
+{
+  va_list copy;
+
+  va_copy(copy, args);
+  auto bytes_required = vsnprintf(nullptr, 0, fmt, copy);
+  va_end(copy);
+
+  if (bytes_required < 0) { return {}; }
+
+  std::string s;
+  s.resize(bytes_required);
+
+  for (;;) {
+    va_copy(copy, args);
+    auto sbytes_written = vsnprintf(s.data(), s.size() + 1, fmt, copy);
+    va_end(copy);
+
+    if (sbytes_written < 0) { return {}; }
+    auto bytes_written
+        = static_cast<std::make_unsigned_t<decltype(sbytes_written)>>(
+            sbytes_written);
+
+    if (bytes_written <= s.size()) {
+      // this is weird, but maybe possible ?
+      s.resize(bytes_written);
+      break;
+    }
+
+    // seems like we ran into some toctou problem, lets try again with a
+    // bigger buffer
+    s.resize(bytes_written);
+  }
+
+  return s;
+}
+
 #endif  // BAREOS_LIB_UTIL_H_

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -269,35 +269,50 @@ struct plugin_arguments {
       std::string_view value = {};
       switch (next_option(str, keywords, &value)) {
         case index_of(keywords, save_unreferenced_disks): {
-          try {
-            args.save_unknown_disks
-                = BoolString(std::string{value}).get<bool>();
-          } catch (std::out_of_range& e) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_disks);
-            return std::nullopt;
+          switch (parse_user_bool(value)) {
+            case parse_bool_result::True: {
+              args.save_unknown_disks = true;
+            } break;
+            case parse_bool_result::False: {
+              args.save_unknown_disks = false;
+            } break;
+            case parse_bool_result::Error: {
+              fatal_msg(ctx, "unexpected value {} for {} flag", value,
+                        save_unreferenced_disks);
+              return std::nullopt;
+            } break;
           }
         } break;
 
         case index_of(keywords, save_unreferenced_partitions): {
-          try {
-            args.save_unknown_partitions
-                = BoolString(std::string{value}).get<bool>();
-          } catch (std::out_of_range& e) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_partitions);
-            return std::nullopt;
+          switch (parse_user_bool(value)) {
+            case parse_bool_result::True: {
+              args.save_unknown_partitions = true;
+            } break;
+            case parse_bool_result::False: {
+              args.save_unknown_partitions = false;
+            } break;
+            case parse_bool_result::Error: {
+              fatal_msg(ctx, "unexpected value {} for {} flag", value,
+                        save_unreferenced_partitions);
+              return std::nullopt;
+            } break;
           }
         } break;
 
         case index_of(keywords, save_unreferenced_extents): {
-          try {
-            args.save_unknown_extents
-                = BoolString(std::string{value}).get<bool>();
-          } catch (std::out_of_range& e) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_extents);
-            return std::nullopt;
+          switch (parse_user_bool(value)) {
+            case parse_bool_result::True: {
+              args.save_unknown_extents = true;
+            } break;
+            case parse_bool_result::False: {
+              args.save_unknown_extents = false;
+            } break;
+            case parse_bool_result::Error: {
+              fatal_msg(ctx, "unexpected value {} for {} flag", value,
+                        save_unreferenced_extents);
+              return std::nullopt;
+            } break;
           }
         } break;
 
@@ -314,8 +329,7 @@ struct plugin_arguments {
           }
         } break;
         default: {
-          fatal_msg(ctx, "could not parse plugin options string '{}'", str,
-                    str.size());
+          fatal_msg(ctx, "could not parse plugin options string '{}'", str);
 
           return std::nullopt;
         } break;

--- a/core/src/qt-tray-monitor/tray_conf.cc
+++ b/core/src/qt-tray-monitor/tray_conf.cc
@@ -377,7 +377,7 @@ static void ConfigReadyCallback(ConfigurationParser&) {}
 ConfigurationParser* InitTmonConfig(const char* configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      configfile, nullptr, nullptr, nullptr, nullptr, nullptr, exit_code, R_NUM,
+      configfile, nullptr, nullptr, nullptr, exit_code, R_NUM,
       resource_definitions, default_config_filename.c_str(), "tray-monitor.d",
       ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
       FreeResource);

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -276,8 +276,8 @@ static void StoreAuthenticationType(lexer* lc,
     }
   }
   if (i != 0) {
-    scan_err1(lc, T_("Expected a Authentication Type keyword, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Authentication Type keyword, got: %s"),
+             lc->str);
   }
   ScanToEol(lc);
   item->SetPresent();
@@ -322,10 +322,10 @@ static void StoreMaxblocksize(lexer* lc,
 {
   my_config->StoreResource(CFG_TYPE_SIZE32, lc, item, index, pass);
   if (GetItemVariable<uint32_t>(*item) > MAX_BLOCK_LENGTH) {
-    scan_err2(lc,
-              T_("Maximum Block Size configured value %u is greater than "
-                 "allowed maximum: %u"),
-              GetItemVariable<uint32_t>(*item), MAX_BLOCK_LENGTH);
+    scan_err(lc,
+             T_("Maximum Block Size configured value %u is greater than "
+                "allowed maximum: %u"),
+             GetItemVariable<uint32_t>(*item), MAX_BLOCK_LENGTH);
   }
 }
 
@@ -346,7 +346,7 @@ static void StoreIoDirection(lexer* lc,
     }
   }
   if (i != 0) {
-    scan_err1(lc, T_("Expected a IO direction keyword, got: %s"), lc->str);
+    scan_err(lc, T_("Expected a IO direction keyword, got: %s"), lc->str);
   }
   ScanToEol(lc);
   item->SetPresent();
@@ -371,8 +371,8 @@ static void StoreCompressionalgorithm(lexer* lc,
     }
   }
   if (i != 0) {
-    scan_err1(lc, T_("Expected a Compression algorithm keyword, got: %s"),
-              lc->str);
+    scan_err(lc, T_("Expected a Compression algorithm keyword, got: %s"),
+             lc->str);
   }
   ScanToEol(lc);
   item->SetPresent();

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -607,10 +607,10 @@ static void ConfigReadyCallback(ConfigurationParser& config)
 ConfigurationParser* InitSdConfig(const char* t_configfile, int exit_code)
 {
   ConfigurationParser* config = new ConfigurationParser(
-      t_configfile, nullptr, nullptr, InitResourceCb, ParseConfigCb, nullptr,
-      exit_code, R_NUM, resources, default_config_filename.c_str(),
-      "bareos-sd.d", ConfigBeforeCallback, ConfigReadyCallback, SaveResource,
-      DumpResource, FreeResource);
+      t_configfile, InitResourceCb, ParseConfigCb, nullptr, exit_code, R_NUM,
+      resources, default_config_filename.c_str(), "bareos-sd.d",
+      ConfigBeforeCallback, ConfigReadyCallback, SaveResource, DumpResource,
+      FreeResource);
   if (config) { config->r_own_ = R_STORAGE; }
   return config;
 }

--- a/core/src/tests/bool_string.cc
+++ b/core/src/tests/bool_string.cc
@@ -1,7 +1,7 @@
 /**
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -28,41 +28,41 @@
 
 #include "lib/bool_string.h"
 
-#include <iostream>
-#include <map>
-#include <string>
-
-TEST(BoolString, convert_supported_bool_strings)
+TEST(ParseBool, simple_yes)
 {
-  const std::map<std::string, bool> test_pattern{
-      {"true", true},   {"yes", true}, {"1", true},
-      {"false", false}, {"no", false}, {"0", false}};
-
-  for (const auto& t : test_pattern) {
-    bool value = false;
-    try {
-      BoolString s{t.first};
-      value = s.get<bool>();
-    } catch (const std::out_of_range& e) {
-      // abort the test
-      ASSERT_TRUE(false) << "Failed to create BoolString: " << e.what();
-    }
-    EXPECT_EQ(value, t.second) << "test pattern: '" << t.first << "'";
-  }
+  EXPECT_EQ(parse_user_bool("yes"), parse_bool_result::True);
+  EXPECT_EQ(parse_user_bool("true"), parse_bool_result::True);
+  EXPECT_EQ(parse_user_bool("1"), parse_bool_result::True);
 }
 
-TEST(BoolString, try_to_convert_not_supported_bool_strings)
+TEST(ParseBool, simple_no)
 {
-  const std::set<std::string> test_pattern{
-      {"o"}, {"tru"}, {"ye"}, {"12"}, {"offf"}, {"ffalse"}, {"0-no"}};
+  EXPECT_EQ(parse_user_bool("no"), parse_bool_result::False);
+  EXPECT_EQ(parse_user_bool("false"), parse_bool_result::False);
+  EXPECT_EQ(parse_user_bool("0"), parse_bool_result::False);
+}
 
-  for (const auto& t : test_pattern) {
-    bool can_be_converted = true;
-    try {
-      BoolString s{t};
-    } catch (const std::out_of_range& e) {
-      can_be_converted = false;
-    }
-    EXPECT_FALSE(can_be_converted) << "test pattern: '" << t << "'";
-  }
+TEST(ParseBool, random_capitalisation)
+{
+  EXPECT_EQ(parse_user_bool("YeS"), parse_bool_result::True);
+  EXPECT_EQ(parse_user_bool("fAlSe"), parse_bool_result::False);
+}
+
+TEST(ParseBool, bad_numbers)
+{
+  EXPECT_EQ(parse_user_bool("2"), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool("01"), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool("10"), parse_bool_result::Error);
+}
+
+TEST(ParseBool, whitespace)
+{
+  // parse_user_bool does _not_ handle trimming
+  EXPECT_EQ(parse_user_bool(" yes"), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool("yes "), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool("false "), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool(" false"), parse_bool_result::Error);
+
+  EXPECT_EQ(parse_user_bool(""), parse_bool_result::Error);
+  EXPECT_EQ(parse_user_bool(" "), parse_bool_result::Error);
 }

--- a/core/src/tests/bool_string.cc
+++ b/core/src/tests/bool_string.cc
@@ -28,41 +28,71 @@
 
 #include "lib/bool_string.h"
 
+using namespace bool_parsing::internal;
+
+
+static inline std::pair<parse_bool_result, bool> deprecated(parse_bool_result x)
+{
+  return {x, true};
+}
+
+static inline std::pair<parse_bool_result, bool> allowed(parse_bool_result x)
+{
+  return {x, false};
+}
+
 TEST(ParseBool, simple_yes)
 {
-  EXPECT_EQ(parse_user_bool("yes"), parse_bool_result::True);
-  EXPECT_EQ(parse_user_bool("true"), parse_bool_result::True);
-  EXPECT_EQ(parse_user_bool("1"), parse_bool_result::True);
+  EXPECT_EQ(parse_bool("yes", true), allowed(parse_bool_result::True));
+  EXPECT_EQ(parse_bool("true", true), deprecated(parse_bool_result::True));
+  EXPECT_EQ(parse_bool("1", true), deprecated(parse_bool_result::True));
+}
+
+TEST(ParseBool, deprecation_true)
+{
+  EXPECT_EQ(parse_bool("yes"), allowed(parse_bool_result::True));
+  EXPECT_EQ(parse_bool("true"), deprecated(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("1"), deprecated(parse_bool_result::Error));
 }
 
 TEST(ParseBool, simple_no)
 {
-  EXPECT_EQ(parse_user_bool("no"), parse_bool_result::False);
-  EXPECT_EQ(parse_user_bool("false"), parse_bool_result::False);
-  EXPECT_EQ(parse_user_bool("0"), parse_bool_result::False);
+  EXPECT_EQ(parse_bool("no", true), allowed(parse_bool_result::False));
+  EXPECT_EQ(parse_bool("false", true), deprecated(parse_bool_result::False));
+  EXPECT_EQ(parse_bool("0", true), deprecated(parse_bool_result::False));
+}
+
+TEST(ParseBool, deprecation_false)
+{
+  EXPECT_EQ(parse_bool("no"), allowed(parse_bool_result::False));
+  EXPECT_EQ(parse_bool("false"), deprecated(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("0"), deprecated(parse_bool_result::Error));
 }
 
 TEST(ParseBool, random_capitalisation)
 {
-  EXPECT_EQ(parse_user_bool("YeS"), parse_bool_result::True);
-  EXPECT_EQ(parse_user_bool("fAlSe"), parse_bool_result::False);
+  EXPECT_EQ(parse_bool("YeS", true), allowed(parse_bool_result::True));
+  EXPECT_EQ(parse_bool("nO", true), allowed(parse_bool_result::False));
+
+  EXPECT_EQ(parse_bool("TrUe", true), deprecated(parse_bool_result::True));
+  EXPECT_EQ(parse_bool("fAlSe", true), deprecated(parse_bool_result::False));
 }
 
 TEST(ParseBool, bad_numbers)
 {
-  EXPECT_EQ(parse_user_bool("2"), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool("01"), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool("10"), parse_bool_result::Error);
+  EXPECT_EQ(parse_bool("2"), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("01"), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("10"), allowed(parse_bool_result::Error));
 }
 
 TEST(ParseBool, whitespace)
 {
-  // parse_user_bool does _not_ handle trimming
-  EXPECT_EQ(parse_user_bool(" yes"), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool("yes "), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool("false "), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool(" false"), parse_bool_result::Error);
+  // parse_bool does _not_ handle trimming
+  EXPECT_EQ(parse_bool(" yes"), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("yes "), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool("false "), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool(" false"), allowed(parse_bool_result::Error));
 
-  EXPECT_EQ(parse_user_bool(""), parse_bool_result::Error);
-  EXPECT_EQ(parse_user_bool(" "), parse_bool_result::Error);
+  EXPECT_EQ(parse_bool(""), allowed(parse_bool_result::Error));
+  EXPECT_EQ(parse_bool(" "), allowed(parse_bool_result::Error));
 }

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -1,7 +1,7 @@
 /**
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -83,8 +83,8 @@ TEST(setdevice, scan_command_line)
   ParseArgs(command_line.c_str(), ua->args, &ua->argc, ua->argk, ua->argv,
             MAX_CMD_ARGS);
 
-  auto result = SetDeviceCommand::ScanCommandLine(ua.get());
-  EXPECT_TRUE(!result.empty());
+  std::optional result = SetDeviceCommand::ScanCommandLine(ua.get());
+  EXPECT_TRUE(result.has_value());
 
   std::array<std::string, 5> wrong_command_lines{
       "setdevice device=Any autoselect=yes",
@@ -95,7 +95,7 @@ TEST(setdevice, scan_command_line)
 
   for (const auto& c : wrong_command_lines) {
     ParseArgs(c.c_str(), ua->args, &ua->argc, ua->argk, ua->argv, MAX_CMD_ARGS);
-    auto res = SetDeviceCommand::ScanCommandLine(ua.get());
-    EXPECT_TRUE(res.empty());
+    std::optional res = SetDeviceCommand::ScanCommandLine(ua.get());
+    EXPECT_FALSE(res.has_value());
   }
 }

--- a/core/src/win32/plugins/filed/hyper-v.cc
+++ b/core/src/win32/plugins/filed/hyper-v.cc
@@ -730,7 +730,7 @@ struct variant_type {
 struct cim_type {
 #define DEFINE_CIM_TYPE(name, vtype, ctype)        \
   struct name {                                    \
-    using v_type = variant_type::##vtype;          \
+    using v_type = variant_type::vtype;            \
     static constexpr CIMTYPE c_type = CIM_##ctype; \
   }
 

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -260,8 +260,7 @@ directory
 
 enabled
    This keyword can appear on the :bcommand:`update volume` as well as the :bcommand:`update slots`
-   commands, and can allows one of the following arguments: yes, true, no, false, archived, 0, 1, 2.
-   Where 0 corresponds to no or false, 1 corresponds to yes or true, and 2 corresponds to archived.
+   commands, and can allows one of the following arguments: yes, true, no, false, archived.
    Archived volumes will not be used, nor will the Media record in the catalog be pruned.
    Volumes that are not enabled, will not be used for backup or restore.
 


### PR DESCRIPTION
We have lots of places that manually try to parse strings into bools in often times slightly different ways.
This PR aims to unify all of them into the same logic:

* yes, true, 1 => true
* no, false, 0 => false
* everything else => error

This should make it slightly easier for people to configure bareos.


Also included in this pr, is a small refactor that turns a somewhat "stringly typed" struct into an actual struct.

- [x] Remove 0/1 as possibilities ? (=> were deprecated in config, removed in command line)

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- [x] Correct milestone is set

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault