### PR TITLE
Skip database dialog when Director is not selected

### DIFF
--- a/core/platforms/win32/winbareos-native.nsi
+++ b/core/platforms/win32/winbareos-native.nsi
@@ -1952,8 +1952,6 @@ FunctionEnd
 # Database Configuration Dialog
 #
 Function getDatabaseParameters
-  Push $R0
-
   strcmp $Upgrading "yes" skip
   strcmp $InstallDirector "no" skip
 
@@ -1965,9 +1963,10 @@ Function getDatabaseParameters
   WriteINIStr "$PLUGINSDIR\databasedialog.ini" "Field 7" "state" $DbName
   WriteINIStr "$PLUGINSDIR\databasedialog.ini" "Field 8" "state" $DbPort
   InstallOptions::dialog $PLUGINSDIR\databasedialog.ini
+  Return
 
 skip:
-  Pop $R0
+  Abort  # skip this page entirely
 FunctionEnd
 
 Function getDatabaseParametersLeave

--- a/core/platforms/win32/winbareos.nsi
+++ b/core/platforms/win32/winbareos.nsi
@@ -1787,8 +1787,6 @@ FunctionEnd
 # Database Configuration Dialog
 #
 Function getDatabaseParameters
-  Push $R0
-
   strcmp $Upgrading "yes" skip
   strcmp $InstallDirector "no" skip
 
@@ -1800,9 +1798,10 @@ Function getDatabaseParameters
   WriteINIStr "$PLUGINSDIR\databasedialog.ini" "Field 7" "state" $DbName
   WriteINIStr "$PLUGINSDIR\databasedialog.ini" "Field 8" "state" $DbPort
   InstallOptions::dialog $PLUGINSDIR\databasedialog.ini
+  Return
 
 skip:
-  Pop $R0
+  Abort  # skip this page entirely
 FunctionEnd
 
 Function getDatabaseParametersLeave


### PR DESCRIPTION
## Summary
- When Director component is deselected in the Windows installer, the database configuration dialog was still shown
- Use NSIS `Abort` in the page callback to skip the page entirely instead of just skipping the dialog call
- Fixes both `winbareos.nsi` and `winbareos-native.nsi`

## Test plan
- [x] Verified with test NSIS installer on Windows 11 VM (VS 2026)
- [x] Director selected → DB dialog appears (confirmed)
- [x] Director deselected → DB dialog skipped, jumps to install (confirmed)
- [ ] WebUI selected → Director auto-selected → DB dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
