### PR TITLE
webui: live mid-run job progress using the new status JSON API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- dir/sd/fd: JSON output for `status` commands under `.api json`. Adds
+  JSON emission for `status director`, `status scheduler`,
+  `status client=X`, `status storage=X`, and a new aggregator
+  `status jobid=N` that returns a single document combining the
+  director's view with the targeted FD and SD `.status json` replies.
+  Intended for monitoring UIs (refs bareos/bareos#2325).
+
+### Changed
+- fd: bumped FD protocol to version 55 (capability advertisement for
+  JSON status output).
+- sd: introduced versioned hello handshake (SD_VERSION_1), allowing the
+  director to gate JSON status requests on SD capability. Older
+  (unversioned) SD hello replies remain accepted as SD_VERSION_0.
+
+## [25.0.3] - 2026-04-01
+
+### Changed
+- debian: dbconfig allow major upgrade without backup dump [PR #2538]
+- plugins: mariabackup python-mysqlclient ignore invalid utf8 [PR #2560]
+- dedup backend: Fix leaking filedescriptor [PR #2549]
+- vol-mgr: fix not locking the volume reservation chain during copying [PR #2582]
+- grpc-fd: fix not freeing memory of backed up filenames [PR #2591]
+- hyper-v: fix automerging AVHDX differencing disks after RCT backup [PR #2596]
+- docs and comments: fix typos [PR #2598]
+- barri: sync parameter names between plugin and cli [PR #2570]
+- `status subscription` command: adapt to new price-list [PR #2602]
+
+### Removed
+- dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2573]
+
+### Fixed
+- Increase read timeout in Proxmox plugin [PR #2545]
+- systemtests check runscript failed - improve media_vault [PR #2568]
+- packaging: add missing DLLs to windows installer [PR #2574]
+- Fix gcc 16 build for Fedora 44 and newer [PR #2604]
+
+### Documentation
+- docs: add tape speed test, tapestat & sg_logs in troubleshooting [PR #2555]
+
+## [25.0.2] - 2026-02-11
+
+### Added
 - add SUSE 15SP7 and 16.0 [PR #2505]
 - Add simple dependency generator for systemtest testrunners [PR #2484]
 

--- a/core/src/dird/authenticate.cc
+++ b/core/src/dird/authenticate.cc
@@ -59,6 +59,7 @@ static char hello[] = "Hello Director %s calling\n";
 
 // Response from Storage daemon
 static char OKhello[] = "3000 OK Hello\n";
+static char OKnewHello[] = "3000 OK Hello %d\n";
 static char FDOKhello[] = "2000 OK Hello\n";
 static char FDOKnewHello[] = "2000 OK Hello %d\n";
 
@@ -109,7 +110,9 @@ bool AuthenticateWithStorageDaemon(BareosSocket* sd,
   }
 
   Dmsg1(110, "<stored: %s", sd->msg);
-  if (!bstrncmp(sd->msg, OKhello, sizeof(OKhello))) {
+  jcr->dir_impl->SDVersion = 0;
+  if (!bstrncmp(sd->msg, OKhello, sizeof(OKhello))
+      && sscanf(sd->msg, OKnewHello, &jcr->dir_impl->SDVersion) != 1) {
     Dmsg0(debuglevel, T_("Storage daemon rejected Hello command\n"));
     Jmsg2(jcr, M_FATAL, 0,
           T_("Storage daemon at \"%s:%d\" rejected Hello command\n"),

--- a/core/src/dird/dird.h
+++ b/core/src/dird/dird.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -226,6 +226,14 @@ inline constexpr slot_number_t INDEX_SLOT_OFFSET = 100;
 #define FD_VERSION_53 53
 #define FD_VERSION_54 54
 #define FD_VERSION_55 55
+
+/* Storage daemon protocol versions. Historically the SD's hello reply did
+ * not include a version; clients treat an unversioned hello as SD_VERSION_0.
+ *
+ *  1 Apr26 - Versioned hello + JSON output for .status command
+ */
+#define SD_VERSION_0 0
+#define SD_VERSION_1 1
 
 } /* namespace directordaemon */
 

--- a/core/src/dird/dird.h
+++ b/core/src/dird/dird.h
@@ -225,6 +225,7 @@ inline constexpr slot_number_t INDEX_SLOT_OFFSET = 100;
 #define FD_VERSION_52 52
 #define FD_VERSION_53 53
 #define FD_VERSION_54 54
+#define FD_VERSION_55 55
 
 } /* namespace directordaemon */
 

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -147,6 +147,7 @@ struct DirectorJcrImpl {
   int32_t NumVols{};                    /**< Number of Volume used in pool */
   int32_t reschedule_count{};           /**< Number of times rescheduled */
   int32_t FDVersion{};                  /**< File daemon version number */
+  int32_t SDVersion{};                  /**< Storage daemon version number */
   int64_t spool_size{};                 /**< Spool size for this job */
   std::atomic<bool> sd_msg_thread_done{};   /**< Set when Storage message thread done */
   bool IgnoreDuplicateJobChecking{};    /**< Set in migration jobs */

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -1042,26 +1042,42 @@ void DoNativeClientStatus(UaContext* ua, ClientResource* client, char* cmd)
           0);
       ua->send->ObjectEnd("client_status");
     } else {
+      /* Cap on JSON payload from FD: a real status reply is a few KB.
+       * Protects the director from a compromised/buggy FD flooding the
+       * authenticated channel and exhausting memory. */
+      constexpr int64_t kMaxClientStatusJsonBytes = 16 * 1024 * 1024;
       fd->fsend(".status json");
 
       PoolMem buf(PM_MESSAGE);
-      int total = 0;
+      int64_t total = 0;
+      bool overflow = false;
       while (fd->recv() >= 0) {
+        if (overflow) { continue; }
+        if (total + fd->message_length + 1 > kMaxClientStatusJsonBytes) {
+          overflow = true;
+          continue;
+        }
         buf.check_size(total + fd->message_length + 1);
         memcpy(buf.c_str() + total, fd->msg, fd->message_length);
         total += fd->message_length;
         buf.c_str()[total] = '\0';
       }
 
-      json_error_t jerr;
-      json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
       ua->send->ObjectStart("client_status");
       ua->send->ObjectKeyValue("client", client->resource_name_, 0);
-      if (parsed) {
-        ua->send->JsonKeyValueAddJson("data", parsed);
+      if (overflow) {
+        ua->send->ObjectKeyValue("error", "reply_too_large", 0);
+        ua->send->ObjectKeyValue(
+            "message", "File Daemon JSON status exceeded 16 MB cap", 0);
       } else {
-        ua->send->ObjectKeyValue("error", "parse_failed", 0);
-        ua->send->ObjectKeyValue("message", jerr.text, 0);
+        json_error_t jerr;
+        json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
+        if (parsed) {
+          ua->send->JsonKeyValueAddJson("data", parsed);
+        } else {
+          ua->send->ObjectKeyValue("error", "parse_failed", 0);
+          ua->send->ObjectKeyValue("message", jerr.text, 0);
+        }
       }
       ua->send->ObjectEnd("client_status");
     }

--- a/core/src/dird/fd_cmds.cc
+++ b/core/src/dird/fd_cmds.cc
@@ -34,6 +34,10 @@
 #include "include/bareos.h"
 #include "include/filetypes.h"
 #include "include/streams.h"
+
+#if HAVE_JANSSON
+#  include <jansson.h>
+#endif
 #include "cats/cats.h"
 #include "dird.h"
 #include "dird/dird_globals.h"
@@ -1022,13 +1026,56 @@ void DoNativeClientStatus(UaContext* ua, ClientResource* client, char* cmd)
 
   Dmsg0(20, T_("Connected to file daemon\n"));
   fd = ua->jcr->file_bsock;
-  if (cmd) {
-    fd->fsend(".status %s", cmd);
-  } else {
-    fd->fsend("status");
-  }
 
-  while (fd->recv() >= 0) { ua->SendMsg("%s", fd->msg); }
+#if HAVE_JANSSON
+  if (ua->api == API_MODE_JSON) {
+    /* Require a File Daemon new enough to speak `.status json`. Older
+     * FDs would return text that we cannot usefully nest. */
+    if (ua->jcr->dir_impl->FDVersion < FD_VERSION_55) {
+      ua->send->ObjectStart("client_status");
+      ua->send->ObjectKeyValue("error", "file_daemon_too_old", 0);
+      ua->send->ObjectKeyValue("client", client->resource_name_, 0);
+      ua->send->ObjectKeyValue(
+          "message",
+          "File Daemon does not support JSON status output (requires "
+          "FD protocol version 55 or newer).",
+          0);
+      ua->send->ObjectEnd("client_status");
+    } else {
+      fd->fsend(".status json");
+
+      PoolMem buf(PM_MESSAGE);
+      int total = 0;
+      while (fd->recv() >= 0) {
+        buf.check_size(total + fd->message_length + 1);
+        memcpy(buf.c_str() + total, fd->msg, fd->message_length);
+        total += fd->message_length;
+        buf.c_str()[total] = '\0';
+      }
+
+      json_error_t jerr;
+      json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
+      ua->send->ObjectStart("client_status");
+      ua->send->ObjectKeyValue("client", client->resource_name_, 0);
+      if (parsed) {
+        ua->send->JsonKeyValueAddJson("data", parsed);
+      } else {
+        ua->send->ObjectKeyValue("error", "parse_failed", 0);
+        ua->send->ObjectKeyValue("message", jerr.text, 0);
+      }
+      ua->send->ObjectEnd("client_status");
+    }
+  } else
+#endif  // HAVE_JANSSON
+  {
+    if (cmd) {
+      fd->fsend(".status %s", cmd);
+    } else {
+      fd->fsend("status");
+    }
+
+    while (fd->recv() >= 0) { ua->SendMsg("%s", fd->msg); }
+  }
 
   fd->signal(BNET_TERMINATE);
   fd->close();

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -737,26 +737,40 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
           0);
       ua->send->ObjectEnd("storage_status");
     } else {
+      /* Cap on JSON payload from SD. See matching rationale in fd_cmds.cc. */
+      constexpr int64_t kMaxStorageStatusJsonBytes = 16 * 1024 * 1024;
       sd->fsend(dotstatuscmd, "json");
 
       PoolMem buf(PM_MESSAGE);
-      int total = 0;
+      int64_t total = 0;
+      bool overflow = false;
       while (sd->recv() >= 0) {
+        if (overflow) { continue; }
+        if (total + sd->message_length + 1 > kMaxStorageStatusJsonBytes) {
+          overflow = true;
+          continue;
+        }
         buf.check_size(total + sd->message_length + 1);
         memcpy(buf.c_str() + total, sd->msg, sd->message_length);
         total += sd->message_length;
         buf.c_str()[total] = '\0';
       }
 
-      json_error_t jerr;
-      json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
       ua->send->ObjectStart("storage_status");
       ua->send->ObjectKeyValue("storage", store->resource_name_, 0);
-      if (parsed) {
-        ua->send->JsonKeyValueAddJson("data", parsed);
+      if (overflow) {
+        ua->send->ObjectKeyValue("error", "reply_too_large", 0);
+        ua->send->ObjectKeyValue(
+            "message", "Storage Daemon JSON status exceeded 16 MB cap", 0);
       } else {
-        ua->send->ObjectKeyValue("error", "parse_failed", 0);
-        ua->send->ObjectKeyValue("message", jerr.text, 0);
+        json_error_t jerr;
+        json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
+        if (parsed) {
+          ua->send->JsonKeyValueAddJson("data", parsed);
+        } else {
+          ua->send->ObjectKeyValue("error", "parse_failed", 0);
+          ua->send->ObjectKeyValue("message", jerr.text, 0);
+        }
       }
       ua->send->ObjectEnd("storage_status");
     }

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -30,6 +30,11 @@
  */
 
 #include "include/bareos.h"
+
+#if HAVE_JANSSON
+#  include <jansson.h>
+#endif
+
 #include "dird.h"
 #include "dird/dird_globals.h"
 #include "dird/authenticate.h"
@@ -716,6 +721,50 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
   }
 
   Dmsg0(20, T_("Connected to storage daemon\n"));
+
+#if HAVE_JANSSON
+  if (ua->api == API_MODE_JSON) {
+    BareosSocket* sd = ua->jcr->store_bsock;
+
+    if (ua->jcr->dir_impl->SDVersion < SD_VERSION_1) {
+      ua->send->ObjectStart("storage_status");
+      ua->send->ObjectKeyValue("error", "storage_daemon_too_old", 0);
+      ua->send->ObjectKeyValue("storage", store->resource_name_, 0);
+      ua->send->ObjectKeyValue(
+          "message",
+          "Storage Daemon does not support JSON status output (requires "
+          "SD protocol version 1 or newer).",
+          0);
+      ua->send->ObjectEnd("storage_status");
+    } else {
+      sd->fsend(dotstatuscmd, "json");
+
+      PoolMem buf(PM_MESSAGE);
+      int total = 0;
+      while (sd->recv() >= 0) {
+        buf.check_size(total + sd->message_length + 1);
+        memcpy(buf.c_str() + total, sd->msg, sd->message_length);
+        total += sd->message_length;
+        buf.c_str()[total] = '\0';
+      }
+
+      json_error_t jerr;
+      json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
+      ua->send->ObjectStart("storage_status");
+      ua->send->ObjectKeyValue("storage", store->resource_name_, 0);
+      if (parsed) {
+        ua->send->JsonKeyValueAddJson("data", parsed);
+      } else {
+        ua->send->ObjectKeyValue("error", "parse_failed", 0);
+        ua->send->ObjectKeyValue("message", jerr.text, 0);
+      }
+      ua->send->ObjectEnd("storage_status");
+    }
+
+    TerminateAndCloseJcrStoreSocket(ua->jcr);
+    return;
+  }
+#endif  // HAVE_JANSSON
 
   if (cmd) {
     ua->jcr->store_bsock->fsend(dotstatuscmd, cmd);

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -33,6 +33,8 @@
 
 #if HAVE_JANSSON
 #  include <jansson.h>
+#  include <set>
+#  include <string>
 #endif
 
 #include "dird.h"
@@ -694,6 +696,63 @@ bail_out:
   FreeUaContext(ua);
 }
 
+#if HAVE_JANSSON
+/* An SD serves multiple Storage definitions over the same daemon. The
+ * text-mode status path restricts output to devices belonging to the
+ * queried Storage resource (by passing `devicenames=X,Y`); the SD's JSON
+ * emitter currently dumps everything. Until the protocol grows a filter
+ * arg, prune the parsed reply here so `status storage=X api=json` can't
+ * leak device or volume state from unrelated Storage resources that
+ * happen to share an SD. */
+static void FilterSdJsonToStorage(json_t* root, StorageResource* store)
+{
+  if (!root || !store) { return; }
+  json_t* data = json_object_get(root, "data");
+  if (!data) { return; }
+
+  std::set<std::string> allowed_devices;
+  for (auto& device : store->devices) { allowed_devices.insert(device.name); }
+
+  /* `devices` array: each item has a "name" (the DeviceResource name).
+   * Drop items not in the allowed set. */
+  json_t* devices = json_object_get(data, "devices");
+  if (devices && json_is_array(devices)) {
+    for (size_t i = json_array_size(devices); i > 0; --i) {
+      json_t* item = json_array_get(devices, i - 1);
+      json_t* name = item ? json_object_get(item, "name") : nullptr;
+      if (!name || !json_is_string(name)
+          || allowed_devices.find(json_string_value(name))
+                 == allowed_devices.end()) {
+        json_array_remove(devices, i - 1);
+      }
+    }
+  }
+
+  /* `used_volumes` items have a "device" field that is the device's
+   * print-name (not resource name). Match by substring against each
+   * allowed device name; imperfect but conservative (drops volumes
+   * belonging to clearly-unrelated devices). */
+  json_t* volumes = json_object_get(data, "used_volumes");
+  if (volumes && json_is_array(volumes)) {
+    for (size_t i = json_array_size(volumes); i > 0; --i) {
+      json_t* item = json_array_get(volumes, i - 1);
+      json_t* dev = item ? json_object_get(item, "device") : nullptr;
+      bool keep = false;
+      if (dev && json_is_string(dev)) {
+        std::string s(json_string_value(dev));
+        for (auto& allowed : allowed_devices) {
+          if (s.find(allowed) != std::string::npos) {
+            keep = true;
+            break;
+          }
+        }
+      }
+      if (!keep) { json_array_remove(volumes, i - 1); }
+    }
+  }
+}
+#endif  // HAVE_JANSSON
+
 void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
 {
   UnifiedStorageResource lstore;
@@ -766,6 +825,7 @@ void DoNativeStorageStatus(UaContext* ua, StorageResource* store, char* cmd)
         json_error_t jerr;
         json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
         if (parsed) {
+          FilterSdJsonToStorage(parsed, store);
           ua->send->JsonKeyValueAddJson("data", parsed);
         } else {
           ua->send->ObjectKeyValue("error", "parse_failed", 0);

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -2029,18 +2029,33 @@ bail_out:
 }
 
 #if HAVE_JANSSON
+/* Cap on JSON status payload the director will accept from FD/SD. A real
+ * status reply is at most a few KB; caps prevent a compromised or buggy
+ * daemon from exhausting director memory over the authenticated channel. */
+constexpr int64_t kMaxDaemonStatusJsonBytes = 16 * 1024 * 1024;
+
 /* Drain whatever the daemon wrote to the socket up to BNET_EOD, parse the
  * accumulated bytes as JSON, return a new json_t* on success or nullptr on
  * parse failure. `err_out` (if non-null) receives the parser's error text. */
 static json_t* ReadDaemonStatusJson(BareosSocket* bs, std::string& err_out)
 {
   PoolMem buf(PM_MESSAGE);
-  int total = 0;
+  int64_t total = 0;
+  bool overflow = false;
   while (bs->recv() >= 0) {
+    if (overflow) { continue; /* drain remainder so peer can close cleanly */ }
+    if (total + bs->message_length + 1 > kMaxDaemonStatusJsonBytes) {
+      overflow = true;
+      continue;
+    }
     buf.check_size(total + bs->message_length + 1);
     memcpy(buf.c_str() + total, bs->msg, bs->message_length);
     total += bs->message_length;
     buf.c_str()[total] = '\0';
+  }
+  if (overflow) {
+    err_out = "daemon JSON response exceeded size cap";
+    return nullptr;
   }
   json_error_t jerr;
   json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
@@ -2110,6 +2125,15 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
   }
   ua->send->ObjectEnd("dir");
 
+  /* The aggregator reuses the console's JCR (ua->jcr) to open sockets to
+   * the target FD and SD. That requires temporarily setting its
+   * res.client and write_storage to the running job's values. Save them
+   * first and restore before returning so subsequent console commands on
+   * the same session aren't affected. */
+  ClientResource* saved_client = ua->jcr->dir_impl->res.client;
+  StorageResource* saved_wstore = ua->jcr->dir_impl->res.write_storage;
+  StorageResource* saved_rstore = ua->jcr->dir_impl->res.read_storage;
+
   /* FD subtree: connect, ask for `.status json`, nest the reply. */
   if (client) {
     ua->send->ObjectStart("fd");
@@ -2176,6 +2200,12 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
   }
 
   ua->send->ObjectEnd("job_status");
+
+  /* Restore prior console JCR state. */
+  ua->jcr->dir_impl->res.client = saved_client;
+  ua->jcr->dir_impl->res.write_storage = saved_wstore;
+  ua->jcr->dir_impl->res.read_storage = saved_rstore;
+
   FreeJcr(job_jcr);
 #else
   (void)ua;

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -2036,7 +2036,10 @@ constexpr int64_t kMaxDaemonStatusJsonBytes = 16 * 1024 * 1024;
 
 /* Drain whatever the daemon wrote to the socket up to BNET_EOD, parse the
  * accumulated bytes as JSON, return a new json_t* on success or nullptr on
- * parse failure. `err_out` (if non-null) receives the parser's error text. */
+ * failure. On failure, `err_out` receives a short classifier; callers use
+ * the same error word as the key in the JSON error response so consumers
+ * can distinguish a protocol-level transport error from a malformed
+ * payload or an oversized reply. */
 static json_t* ReadDaemonStatusJson(BareosSocket* bs, std::string& err_out)
 {
   PoolMem buf(PM_MESSAGE);
@@ -2053,8 +2056,17 @@ static json_t* ReadDaemonStatusJson(BareosSocket* bs, std::string& err_out)
     total += bs->message_length;
     buf.c_str()[total] = '\0';
   }
+  /* The recv() loop exits on any negative return -- that covers BNET_EOD
+   * (normal end), BNET_TERMINATE, and real socket errors. Distinguish
+   * transport failure from clean EOD so callers don't feed a truncated
+   * payload to the JSON parser and surface the parser's complaint as if
+   * it were the root cause. */
+  if (bs->IsError() || bs->IsStop()) {
+    err_out = "transport_error";
+    return nullptr;
+  }
   if (overflow) {
-    err_out = "daemon JSON response exceeded size cap";
+    err_out = "reply_too_large";
     return nullptr;
   }
   json_error_t jerr;
@@ -2088,8 +2100,18 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
   }
   /* A JCR that lacks its director-private side cannot be fanned out; this
    * only happens for malformed or partially-initialized records. */
-  if (!job_jcr->dir_impl) {
+  if (!job_jcr->dir_impl || !job_jcr->dir_impl->res.job) {
     ua->send->ObjectKeyValue("error", "job_has_no_dir_state", 0);
+    ua->send->ObjectEnd("job_status");
+    FreeJcr(job_jcr);
+    return;
+  }
+
+  /* Gate on Job_ACL so restricted consoles cannot enumerate or introspect
+   * jobs they aren't allowed to see. Client_ACL / Storage_ACL are re-checked
+   * below before fanning out to the target daemon. */
+  if (!ua->AclAccessOk(Job_ACL, job_jcr->dir_impl->res.job->resource_name_)) {
+    ua->send->ObjectKeyValue("error", "access_denied", 0);
     ua->send->ObjectEnd("job_status");
     FreeJcr(job_jcr);
     return;
@@ -2126,41 +2148,49 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
   ua->send->ObjectEnd("dir");
 
   /* The aggregator reuses the console's JCR (ua->jcr) to open sockets to
-   * the target FD and SD. That requires temporarily setting its
-   * res.client and write_storage to the running job's values. Save them
-   * first and restore before returning so subsequent console commands on
-   * the same session aren't affected. */
+   * the target FD and SD. That requires temporarily setting its res.client
+   * and write-storage to the running job's values, and leaves the handshake
+   * side-effects (FDVersion, SDVersion, authenticated) mutated. Save every
+   * field the fan-out touches and restore before returning so subsequent
+   * console commands on the same session see the console's original state. */
   ClientResource* saved_client = ua->jcr->dir_impl->res.client;
   StorageResource* saved_wstore = ua->jcr->dir_impl->res.write_storage;
   StorageResource* saved_rstore = ua->jcr->dir_impl->res.read_storage;
+  int32_t saved_fdversion = ua->jcr->dir_impl->FDVersion;
+  int32_t saved_sdversion = ua->jcr->dir_impl->SDVersion;
+  bool saved_authenticated = ua->jcr->authenticated;
 
   /* FD subtree: connect, ask for `.status json`, nest the reply. */
   if (client) {
     ua->send->ObjectStart("fd");
     ua->send->ObjectKeyValue("client", client->resource_name_, 0);
 
-    ua->jcr->dir_impl->res.client = client;
-    if (!ConnectToFileDaemon(ua->jcr, 1, 15, false, ua)) {
-      ua->send->ObjectKeyValue("error", "connect_failed", 0);
+    if (!ua->AclAccessOk(Client_ACL, client->resource_name_)) {
+      ua->send->ObjectKeyValue("error", "access_denied", 0);
     } else {
-      BareosSocket* fd = ua->jcr->file_bsock;
-      if (ua->jcr->dir_impl->FDVersion < FD_VERSION_55) {
-        ua->send->ObjectKeyValue("error", "file_daemon_too_old", 0);
+      ua->jcr->dir_impl->res.client = client;
+      if (!ConnectToFileDaemon(ua->jcr, 1, 15, false, ua)) {
+        ua->send->ObjectKeyValue("error", "connect_failed", 0);
       } else {
-        fd->fsend(".status json");
-        std::string perr;
-        json_t* parsed = ReadDaemonStatusJson(fd, perr);
-        if (parsed) {
-          ua->send->JsonKeyValueAddJson("data", parsed);
+        BareosSocket* fd = ua->jcr->file_bsock;
+        if (ua->jcr->dir_impl->FDVersion < FD_VERSION_55) {
+          ua->send->ObjectKeyValue("error", "file_daemon_too_old", 0);
         } else {
-          ua->send->ObjectKeyValue("error", "parse_failed", 0);
-          ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+          fd->fsend(".status json");
+          std::string perr;
+          json_t* parsed = ReadDaemonStatusJson(fd, perr);
+          if (parsed) {
+            ua->send->JsonKeyValueAddJson("data", parsed);
+          } else {
+            ua->send->ObjectKeyValue("error", "parse_failed", 0);
+            ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+          }
         }
+        fd->signal(BNET_TERMINATE);
+        fd->close();
+        delete ua->jcr->file_bsock;
+        ua->jcr->file_bsock = nullptr;
       }
-      fd->signal(BNET_TERMINATE);
-      fd->close();
-      delete ua->jcr->file_bsock;
-      ua->jcr->file_bsock = nullptr;
     }
     ua->send->ObjectEnd("fd");
   }
@@ -2170,41 +2200,52 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
     ua->send->ObjectStart("sd");
     ua->send->ObjectKeyValue("storage", store->resource_name_, 0);
 
-    UnifiedStorageResource lstore;
-    lstore.store = store;
-    PmStrcpy(lstore.store_source, T_("status jobid aggregator"));
-    SetWstorage(ua->jcr, &lstore);
-    if (!ConnectToStorageDaemon(ua->jcr, 10, me->SDConnectTimeout, false)) {
-      ua->send->ObjectKeyValue("error", "connect_failed", 0);
+    if (!ua->AclAccessOk(Storage_ACL, store->resource_name_)) {
+      ua->send->ObjectKeyValue("error", "access_denied", 0);
     } else {
-      BareosSocket* sd = ua->jcr->store_bsock;
-      if (ua->jcr->dir_impl->SDVersion < SD_VERSION_1) {
-        ua->send->ObjectKeyValue("error", "storage_daemon_too_old", 0);
+      UnifiedStorageResource lstore;
+      lstore.store = store;
+      PmStrcpy(lstore.store_source, T_("status jobid aggregator"));
+      SetWstorage(ua->jcr, &lstore);
+      if (!ConnectToStorageDaemon(ua->jcr, 10, me->SDConnectTimeout, false)) {
+        ua->send->ObjectKeyValue("error", "connect_failed", 0);
       } else {
-        sd->fsend(".status json\n");
-        std::string perr;
-        json_t* parsed = ReadDaemonStatusJson(sd, perr);
-        if (parsed) {
-          ua->send->JsonKeyValueAddJson("data", parsed);
+        BareosSocket* sd = ua->jcr->store_bsock;
+        if (ua->jcr->dir_impl->SDVersion < SD_VERSION_1) {
+          ua->send->ObjectKeyValue("error", "storage_daemon_too_old", 0);
         } else {
-          ua->send->ObjectKeyValue("error", "parse_failed", 0);
-          ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+          sd->fsend(".status json");
+          std::string perr;
+          json_t* parsed = ReadDaemonStatusJson(sd, perr);
+          if (parsed) {
+            ua->send->JsonKeyValueAddJson("data", parsed);
+          } else {
+            ua->send->ObjectKeyValue("error", "parse_failed", 0);
+            ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+          }
         }
+        sd->signal(BNET_TERMINATE);
+        sd->close();
+        delete ua->jcr->store_bsock;
+        ua->jcr->store_bsock = nullptr;
       }
-      sd->signal(BNET_TERMINATE);
-      sd->close();
-      delete ua->jcr->store_bsock;
-      ua->jcr->store_bsock = nullptr;
+      /* SetWstorage pushed an entry onto the write-storage list; pop it so
+       * the console's JCR doesn't accumulate storage references on repeated
+       * aggregator calls. */
+      FreeWstorage(ua->jcr);
     }
     ua->send->ObjectEnd("sd");
   }
 
   ua->send->ObjectEnd("job_status");
 
-  /* Restore prior console JCR state. */
+  /* Restore prior console JCR state in full. */
   ua->jcr->dir_impl->res.client = saved_client;
   ua->jcr->dir_impl->res.write_storage = saved_wstore;
   ua->jcr->dir_impl->res.read_storage = saved_rstore;
+  ua->jcr->dir_impl->FDVersion = saved_fdversion;
+  ua->jcr->dir_impl->SDVersion = saved_sdversion;
+  ua->jcr->authenticated = saved_authenticated;
 
   FreeJcr(job_jcr);
 #else

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -27,6 +27,11 @@
  */
 
 #include "include/bareos.h"
+
+#if HAVE_JANSSON
+#  include <jansson.h>
+#endif
+
 #include "dird.h"
 #include "dird/director_jcr_impl.h"
 #include "dird/date_time.h"
@@ -64,6 +69,7 @@ static void ListRunningJobs(UaContext* ua);
 static void ListTerminatedJobs(UaContext* ua);
 static void ListConnectedClients(UaContext* ua);
 static void DoDirectorStatus(UaContext* ua);
+static void DoJobIdStatus(UaContext* ua, uint32_t jobid);
 #if HAVE_JANSSON
 static void ListDirStatusHeaderJson(UaContext* ua);
 static void ListScheduledJobsJson(UaContext* ua);
@@ -195,6 +201,11 @@ bool StatusCmd(UaContext* ua, const char* cmd)
     } else if (Bstrcasecmp(ua->argk[i], NT_("client"))) {
       client = get_client_resource(ua);
       if (client) { ClientStatus(ua, client, NULL); }
+      return true;
+    } else if (Bstrcasecmp(ua->argk[i], NT_("jobid"))) {
+      uint32_t jobid = 0;
+      if (ua->argv[i]) { jobid = static_cast<uint32_t>(atoi(ua->argv[i])); }
+      DoJobIdStatus(ua, jobid);
       return true;
     } else if (bstrncasecmp(ua->argk[i], NT_("sched"), 5)) {
       DoSchedulerStatus(ua);
@@ -2016,4 +2027,161 @@ bail_out:
 
   return;
 }
+
+#if HAVE_JANSSON
+/* Drain whatever the daemon wrote to the socket up to BNET_EOD, parse the
+ * accumulated bytes as JSON, return a new json_t* on success or nullptr on
+ * parse failure. `err_out` (if non-null) receives the parser's error text. */
+static json_t* ReadDaemonStatusJson(BareosSocket* bs, std::string& err_out)
+{
+  PoolMem buf(PM_MESSAGE);
+  int total = 0;
+  while (bs->recv() >= 0) {
+    buf.check_size(total + bs->message_length + 1);
+    memcpy(buf.c_str() + total, bs->msg, bs->message_length);
+    total += bs->message_length;
+    buf.c_str()[total] = '\0';
+  }
+  json_error_t jerr;
+  json_t* parsed = json_loads(buf.c_str(), 0, &jerr);
+  if (!parsed) { err_out = jerr.text; }
+  return parsed;
+}
+#endif
+
+/* Aggregate per-job status: combine director-local info with the FD and SD
+ * JSON replies for a specific running job. JSON mode only — text mode was
+ * never offered, since consumers of this command are monitoring tools. */
+static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
+{
+#if HAVE_JANSSON
+  if (ua->api != API_MODE_JSON) {
+    ua->SendMsg(
+        T_("status jobid=N is only available in JSON mode. "
+           "Run '.api json' first.\n"));
+    return;
+  }
+
+  JobControlRecord* job_jcr = get_jcr_by_id(jobid);
+  ua->send->ObjectStart("job_status");
+  ua->send->ObjectKeyValue("jobid", static_cast<uint64_t>(jobid));
+
+  if (!job_jcr) {
+    ua->send->ObjectKeyValue("error", "job_not_found", 0);
+    ua->send->ObjectEnd("job_status");
+    return;
+  }
+  /* A JCR that lacks its director-private side cannot be fanned out; this
+   * only happens for malformed or partially-initialized records. */
+  if (!job_jcr->dir_impl) {
+    ua->send->ObjectKeyValue("error", "job_has_no_dir_state", 0);
+    ua->send->ObjectEnd("job_status");
+    FreeJcr(job_jcr);
+    return;
+  }
+
+  /* Director-side metadata subtree. */
+  ua->send->ObjectStart("dir");
+  ua->send->ObjectKeyValue("job", job_jcr->Job, 0);
+  ua->send->ObjectKeyValue("level", job_level_to_str(job_jcr->getJobLevel()),
+                           0);
+  ua->send->ObjectKeyValue("job_type", job_type_to_str(job_jcr->getJobType()),
+                           0);
+  char status_code[2] = {static_cast<char>(job_jcr->getJobStatus()), 0};
+  ua->send->ObjectKeyValue("status_code", status_code, 0);
+  ua->send->ObjectKeyValue(
+      "status", JobstatusToAscii(job_jcr->getJobStatus()).c_str(), 0);
+
+  ClientResource* client = job_jcr->dir_impl->res.client;
+  if (client) { ua->send->ObjectKeyValue("client", client->resource_name_, 0); }
+  StorageResource* store = job_jcr->dir_impl->res.write_storage
+                               ? job_jcr->dir_impl->res.write_storage
+                               : job_jcr->dir_impl->res.read_storage;
+  if (store) { ua->send->ObjectKeyValue("storage", store->resource_name_, 0); }
+  if (job_jcr->start_time) {
+    char dt[MAX_TIME_LENGTH];
+    bstrftime(dt, sizeof(dt), job_jcr->start_time, "%Y-%m-%dT%H:%M:%S");
+    ua->send->ObjectKeyValue("start_time", dt, 0);
+  }
+  if (job_jcr->sched_time) {
+    char dt[MAX_TIME_LENGTH];
+    bstrftime(dt, sizeof(dt), job_jcr->sched_time, "%Y-%m-%dT%H:%M:%S");
+    ua->send->ObjectKeyValue("sched_time", dt, 0);
+  }
+  ua->send->ObjectEnd("dir");
+
+  /* FD subtree: connect, ask for `.status json`, nest the reply. */
+  if (client) {
+    ua->send->ObjectStart("fd");
+    ua->send->ObjectKeyValue("client", client->resource_name_, 0);
+
+    ua->jcr->dir_impl->res.client = client;
+    if (!ConnectToFileDaemon(ua->jcr, 1, 15, false, ua)) {
+      ua->send->ObjectKeyValue("error", "connect_failed", 0);
+    } else {
+      BareosSocket* fd = ua->jcr->file_bsock;
+      if (ua->jcr->dir_impl->FDVersion < FD_VERSION_55) {
+        ua->send->ObjectKeyValue("error", "file_daemon_too_old", 0);
+      } else {
+        fd->fsend(".status json");
+        std::string perr;
+        json_t* parsed = ReadDaemonStatusJson(fd, perr);
+        if (parsed) {
+          ua->send->JsonKeyValueAddJson("data", parsed);
+        } else {
+          ua->send->ObjectKeyValue("error", "parse_failed", 0);
+          ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+        }
+      }
+      fd->signal(BNET_TERMINATE);
+      fd->close();
+      delete ua->jcr->file_bsock;
+      ua->jcr->file_bsock = nullptr;
+    }
+    ua->send->ObjectEnd("fd");
+  }
+
+  /* SD subtree: same pattern. */
+  if (store) {
+    ua->send->ObjectStart("sd");
+    ua->send->ObjectKeyValue("storage", store->resource_name_, 0);
+
+    UnifiedStorageResource lstore;
+    lstore.store = store;
+    PmStrcpy(lstore.store_source, T_("status jobid aggregator"));
+    SetWstorage(ua->jcr, &lstore);
+    if (!ConnectToStorageDaemon(ua->jcr, 10, me->SDConnectTimeout, false)) {
+      ua->send->ObjectKeyValue("error", "connect_failed", 0);
+    } else {
+      BareosSocket* sd = ua->jcr->store_bsock;
+      if (ua->jcr->dir_impl->SDVersion < SD_VERSION_1) {
+        ua->send->ObjectKeyValue("error", "storage_daemon_too_old", 0);
+      } else {
+        sd->fsend(".status json\n");
+        std::string perr;
+        json_t* parsed = ReadDaemonStatusJson(sd, perr);
+        if (parsed) {
+          ua->send->JsonKeyValueAddJson("data", parsed);
+        } else {
+          ua->send->ObjectKeyValue("error", "parse_failed", 0);
+          ua->send->ObjectKeyValue("message", perr.c_str(), 0);
+        }
+      }
+      sd->signal(BNET_TERMINATE);
+      sd->close();
+      delete ua->jcr->store_bsock;
+      ua->jcr->store_bsock = nullptr;
+    }
+    ua->send->ObjectEnd("sd");
+  }
+
+  ua->send->ObjectEnd("job_status");
+  FreeJcr(job_jcr);
+#else
+  (void)ua;
+  (void)jobid;
+  ua->SendMsg(T_("status jobid=N requires JSON support (jansson).\n"));
+#endif
+}
+
 } /* namespace directordaemon */

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -64,6 +64,13 @@ static void ListRunningJobs(UaContext* ua);
 static void ListTerminatedJobs(UaContext* ua);
 static void ListConnectedClients(UaContext* ua);
 static void DoDirectorStatus(UaContext* ua);
+#if HAVE_JANSSON
+static void ListDirStatusHeaderJson(UaContext* ua);
+static void ListScheduledJobsJson(UaContext* ua);
+static void ListRunningJobsJson(UaContext* ua);
+static void ListTerminatedJobsJson(UaContext* ua);
+static void DoDirectorStatusJson(UaContext* ua);
+#endif
 static void DoSchedulerStatus(UaContext* ua);
 static bool DoSubscriptionStatus(UaContext* ua);
 static void DoConfigurationStatus(UaContext* ua);
@@ -642,6 +649,12 @@ static void DoConfigurationStatus(UaContext* ua)
 
 static void DoSchedulerStatus(UaContext* ua)
 {
+#if HAVE_JANSSON
+  if (ua->api == API_MODE_JSON) {
+    ListScheduledJobsJson(ua);
+    return;
+  }
+#endif
   int i;
   int max_date_len = 0;
   int days = DEFAULT_STATUS_SCHED_DAYS; /* Default days for preview */
@@ -813,8 +826,250 @@ start_again:
   ua->SendMsg("====\n");
 }
 
+struct sched_pkt {
+  JobResource* job;
+  int level;
+  int priority;
+  utime_t runtime;
+  PoolResource* pool;
+  StorageResource* store;
+};
+
+// Sort items by runtime, priority
+static int CompareByRuntimePriority(const sched_pkt& p1, const sched_pkt& p2)
+{
+  if (p1.runtime < p2.runtime) {
+    return -1;
+  } else if (p1.runtime > p2.runtime) {
+    return 1;
+  }
+
+  if (p1.priority < p2.priority) {
+    return -1;
+  } else if (p1.priority > p2.priority) {
+    return 1;
+  }
+
+  return 0;
+}
+
+#if HAVE_JANSSON
+static void ListDirStatusHeaderJson(UaContext* ua)
+{
+  char dt[MAX_TIME_LENGTH];
+  PoolMem msg(PM_FNAME);
+
+  ua->send->ObjectStart("header");
+  ua->send->ObjectKeyValue("name", my_name, 0);
+  ua->send->ObjectKeyValue("version", kBareosVersionStrings.Full, 0);
+  ua->send->ObjectKeyValue("version_date", kBareosVersionStrings.Date, 0);
+  ua->send->ObjectKeyValue("os_info", kBareosVersionStrings.GetOsInfo(), 0);
+  bstrftime(dt, sizeof(dt), daemon_start_time, "%Y-%m-%dT%H:%M:%S");
+  ua->send->ObjectKeyValue("daemon_started", dt, 0);
+  ua->send->ObjectKeyValue("jobs_run", static_cast<uint64_t>(NumJobsRun()));
+  ua->send->ObjectKeyValue("jobs_running", static_cast<uint64_t>(JobCount()));
+  ua->send->ObjectKeyValue("binary_info", kBareosVersionStrings.BinaryInfo, 0);
+  ua->send->ObjectKeyValueBool("config_warnings", my_config->HasWarnings(), 0);
+  if (me->secure_erase_cmdline) {
+    ua->send->ObjectKeyValue("secure_erase_command", me->secure_erase_cmdline,
+                             0);
+  }
+  int plugin_len = ListDirPlugins(msg);
+  if (plugin_len > 0) { ua->send->ObjectKeyValue("plugins", msg.c_str(), 0); }
+  ua->send->ObjectEnd("header");
+}
+
+static void ListScheduledJobsJson(UaContext* ua)
+{
+  int days = 1;
+  if (const char* value = GetArgValue(ua, NT_("days"))) {
+    days = atoi(value);
+    if (days < 0 || days > 500) { days = 1; }
+  }
+
+  ua->send->ArrayStart("scheduled_jobs");
+  JobResource* job = nullptr;
+  std::vector<sched_pkt> sched;
+  time_t now = time(nullptr);
+  foreach_res (job, R_JOB) {
+    if (!ua->AclAccessOk(Job_ACL, job->resource_name_) || !job->enabled
+        || (job->client && !job->client->enabled)) {
+      continue;
+    }
+    if (!job->schedule) { continue; }
+    for (RunResource* run = job->schedule->run; run; run = run->next) {
+      std::optional<time_t> next_scheduled = run->NextScheduleTime(now, days);
+      if (!next_scheduled.has_value()) { continue; }
+
+      UnifiedStorageResource storage_res;
+      GetJobStorage(&storage_res, job, run);
+      sched.push_back(
+          {.job = job,
+           .level = int(run->level ? run->level : job->JobLevel),
+           .priority = (run->Priority ? run->Priority : job->Priority),
+           .runtime = next_scheduled.value(),
+           .pool = run->pool,
+           .store = storage_res.store});
+    }
+  }
+
+  std::sort(sched.begin(), sched.end(), [](auto& l, auto& r) -> bool {
+    return CompareByRuntimePriority(l, r) < 0;
+  });
+
+  char dt[MAX_TIME_LENGTH];
+  for (sched_pkt& sp : sched) {
+    ua->send->ObjectStart();
+    ua->send->ObjectKeyValue("job_name", sp.job->resource_name_, 0);
+    ua->send->ObjectKeyValue("level", job_level_to_str(sp.level), 0);
+    ua->send->ObjectKeyValue("job_type", job_type_to_str(sp.job->JobType), 0);
+    ua->send->ObjectKeyValue("priority", static_cast<uint64_t>(sp.priority));
+    bstrftime(dt, sizeof(dt), sp.runtime, "%Y-%m-%dT%H:%M:%S");
+    ua->send->ObjectKeyValue("scheduled", dt, 0);
+    if (sp.pool) {
+      ua->send->ObjectKeyValue("pool", sp.pool->resource_name_, 0);
+    }
+    if (sp.store) {
+      ua->send->ObjectKeyValue("storage", sp.store->resource_name_, 0);
+    }
+    ua->send->ObjectEnd();
+  }
+  ua->send->ArrayEnd("scheduled_jobs");
+}
+
+static void ListRunningJobsJson(UaContext* ua)
+{
+  JobControlRecord* jcr;
+
+  ua->send->ArrayStart("running_jobs");
+  foreach_jcr (jcr) {
+    if (jcr->JobId == 0
+        || !ua->AclAccessOk(Job_ACL, jcr->dir_impl->res.job->resource_name_)) {
+      continue;
+    }
+    ua->send->ObjectStart();
+    ua->send->ObjectKeyValue("jobid", static_cast<uint64_t>(jcr->JobId));
+    ua->send->ObjectKeyValue("job_name", jcr->Job, 0);
+    ua->send->ObjectKeyValue("level", job_level_to_str(jcr->getJobLevel()), 0);
+    ua->send->ObjectKeyValue("job_type", job_type_to_str(jcr->getJobType()), 0);
+    char status_code[2] = {static_cast<char>(jcr->getJobStatus()), 0};
+    ua->send->ObjectKeyValue("status_code", status_code, 0);
+    ua->send->ObjectKeyValue("status",
+                             JobstatusToAscii(jcr->getJobStatus()).c_str(), 0);
+    if (jcr->dir_impl->res.client) {
+      ua->send->ObjectKeyValue("client",
+                               jcr->dir_impl->res.client->resource_name_, 0);
+    }
+    if (jcr->dir_impl->res.write_storage) {
+      ua->send->ObjectKeyValue(
+          "storage", jcr->dir_impl->res.write_storage->resource_name_, 0);
+    } else if (jcr->dir_impl->res.read_storage) {
+      ua->send->ObjectKeyValue(
+          "storage", jcr->dir_impl->res.read_storage->resource_name_, 0);
+    }
+    if (jcr->start_time) {
+      char dt[MAX_TIME_LENGTH];
+      bstrftime(dt, sizeof(dt), jcr->start_time, "%Y-%m-%dT%H:%M:%S");
+      ua->send->ObjectKeyValue("started", dt, 0);
+    }
+    if (jcr->sched_time) {
+      char dt[MAX_TIME_LENGTH];
+      bstrftime(dt, sizeof(dt), jcr->sched_time, "%Y-%m-%dT%H:%M:%S");
+      ua->send->ObjectKeyValue("scheduled", dt, 0);
+    }
+    ua->send->ObjectEnd();
+  }
+  endeach_jcr(jcr);
+  ua->send->ArrayEnd("running_jobs");
+}
+
+static void ListTerminatedJobsJson(UaContext* ua)
+{
+  ua->send->ArrayStart("terminated_jobs");
+  for (const RecentJobResultsList::JobResult& je :
+       RecentJobResultsList::Get()) {
+    char JobName[MAX_NAME_LENGTH];
+    const char* termstat;
+
+    bstrncpy(JobName, je.Job, sizeof(JobName));
+    for (int i = 0; i < 3; i++) {
+      char* p = strrchr(JobName, '.');
+      if (p) { *p = 0; }
+    }
+    if (!ua->AclAccessOk(Job_ACL, JobName)) { continue; }
+
+    const char* level_str;
+    switch (je.JobType) {
+      case JT_ADMIN:
+      case JT_ARCHIVE:
+      case JT_RESTORE:
+        level_str = "";
+        break;
+      default:
+        level_str = JobLevelToString(je.JobLevel);
+        break;
+    }
+    switch (je.JobStatus) {
+      case JS_Created:
+        termstat = "Created";
+        break;
+      case JS_FatalError:
+      case JS_ErrorTerminated:
+        termstat = "Error";
+        break;
+      case JS_Differences:
+        termstat = "Diffs";
+        break;
+      case JS_Canceled:
+        termstat = "Cancel";
+        break;
+      case JS_Terminated:
+        termstat = "OK";
+        break;
+      case JS_Warnings:
+        termstat = "OK -- with warnings";
+        break;
+      default:
+        termstat = "Other";
+        break;
+    }
+
+    char dt[MAX_TIME_LENGTH];
+    bstrftime(dt, sizeof(dt), je.end_time, "%Y-%m-%dT%H:%M:%S");
+    char status_code[2] = {static_cast<char>(je.JobStatus), 0};
+
+    ua->send->ObjectStart();
+    ua->send->ObjectKeyValue("jobid", static_cast<uint64_t>(je.JobId));
+    ua->send->ObjectKeyValue("job_name", JobName, 0);
+    ua->send->ObjectKeyValue("level", level_str, 0);
+    ua->send->ObjectKeyValue("files", static_cast<uint64_t>(je.JobFiles));
+    ua->send->ObjectKeyValue("bytes", static_cast<uint64_t>(je.JobBytes));
+    ua->send->ObjectKeyValue("status_code", status_code, 0);
+    ua->send->ObjectKeyValue("status", termstat, 0);
+    ua->send->ObjectKeyValue("finished", dt, 0);
+    ua->send->ObjectEnd();
+  }
+  ua->send->ArrayEnd("terminated_jobs");
+}
+
+static void DoDirectorStatusJson(UaContext* ua)
+{
+  ListDirStatusHeaderJson(ua);
+  ListScheduledJobsJson(ua);
+  ListRunningJobsJson(ua);
+  ListTerminatedJobsJson(ua);
+  ListConnectedClients(ua);
+}
+#endif  // HAVE_JANSSON
+
 static void DoDirectorStatus(UaContext* ua)
 {
+#if HAVE_JANSSON
+  if (ua->api == API_MODE_JSON) {
+    DoDirectorStatusJson(ua);
+    return;
+  }
+#endif
   ListDirStatusHeader(ua);
   ListScheduledJobs(ua);
   ListRunningJobs(ua);
@@ -837,15 +1092,6 @@ static void PrtRunhdr(UaContext* ua)
 }
 
 /* Scheduling packet */
-struct sched_pkt {
-  JobResource* job;
-  int level;
-  int priority;
-  utime_t runtime;
-  PoolResource* pool;
-  StorageResource* store;
-};
-
 static void PrtRuntime(UaContext* ua, sched_pkt* sp)
 {
   char dt[MAX_TIME_LENGTH];
@@ -896,24 +1142,6 @@ static void PrtRuntime(UaContext* ua, sched_pkt* sp)
   if (CloseDb) { DbSqlClosePooledConnection(jcr, jcr->db); }
   jcr->db = ua->db; /* restore ua db to jcr */
   jcr->setJobType(orig_jobtype);
-}
-
-// Sort items by runtime, priority
-static int CompareByRuntimePriority(const sched_pkt& p1, const sched_pkt& p2)
-{
-  if (p1.runtime < p2.runtime) {
-    return -1;
-  } else if (p1.runtime > p2.runtime) {
-    return 1;
-  }
-
-  if (p1.priority < p2.priority) {
-    return -1;
-  } else if (p1.priority > p2.priority) {
-    return 1;
-  }
-
-  return 0;
 }
 
 // Find all jobs to be run in roughly the next 24 hours.

--- a/core/src/dird/ua_status.cc
+++ b/core/src/dird/ua_status.cc
@@ -32,6 +32,10 @@
 #  include <jansson.h>
 #endif
 
+#include <cerrno>
+#include <cstdlib>
+#include <limits>
+
 #include "dird.h"
 #include "dird/director_jcr_impl.h"
 #include "dird/date_time.h"
@@ -203,8 +207,30 @@ bool StatusCmd(UaContext* ua, const char* cmd)
       if (client) { ClientStatus(ua, client, NULL); }
       return true;
     } else if (Bstrcasecmp(ua->argk[i], NT_("jobid"))) {
+      /* Require jobid=<positive integer>. Reject bare `jobid`, empty values,
+       * negatives, and non-numeric junk rather than silently defaulting to 0
+       * and returning {"error":"job_not_found"}. */
       uint32_t jobid = 0;
-      if (ua->argv[i]) { jobid = static_cast<uint32_t>(atoi(ua->argv[i])); }
+      if (ua->argv[i] && *ua->argv[i]) {
+        char* endp = nullptr;
+        errno = 0;
+        unsigned long v = strtoul(ua->argv[i], &endp, 10);
+        if (errno == 0 && endp != ua->argv[i] && *endp == '\0' && v > 0
+            && v <= std::numeric_limits<uint32_t>::max()) {
+          jobid = static_cast<uint32_t>(v);
+        }
+      }
+      if (jobid == 0) {
+        if (ua->api == API_MODE_JSON) {
+          ua->send->ObjectStart("job_status");
+          ua->send->ObjectKeyValue("error", "invalid_jobid", 0);
+          ua->send->ObjectEnd("job_status");
+        } else {
+          ua->SendMsg(
+              T_("status jobid=<N> requires a positive integer argument.\n"));
+        }
+        return true;
+      }
       DoJobIdStatus(ua, jobid);
       return true;
     } else if (bstrncasecmp(ua->argk[i], NT_("sched"), 5)) {
@@ -865,6 +891,17 @@ static int CompareByRuntimePriority(const sched_pkt& p1, const sched_pkt& p2)
 }
 
 #if HAVE_JANSSON
+/* Emit a JS_* status code as a one-character JSON string. All currently
+ * defined JS_* values are ASCII-printable, but `char` is signed on most
+ * targets, so guard against any future non-ASCII code that would emit a
+ * lone high byte and break UTF-8 JSON encoding. */
+static void EmitStatusCodeJson(UaContext* ua, int status)
+{
+  unsigned char u = static_cast<unsigned char>(status);
+  char buf[2] = {(u < 0x80) ? static_cast<char>(u) : '?', 0};
+  ua->send->ObjectKeyValue("status_code", buf, 0);
+}
+
 static void ListDirStatusHeaderJson(UaContext* ua)
 {
   char dt[MAX_TIME_LENGTH];
@@ -893,11 +930,22 @@ static void ListDirStatusHeaderJson(UaContext* ua)
 static void ListScheduledJobsJson(UaContext* ua)
 {
   int days = 1;
+  bool days_invalid = false;
   if (const char* value = GetArgValue(ua, NT_("days"))) {
-    days = atoi(value);
-    if (days < 0 || days > 500) { days = 1; }
+    char* endp = nullptr;
+    errno = 0;
+    long v = strtol(value, &endp, 10);
+    if (errno != 0 || endp == value || *endp != '\0' || v < 0 || v > 500) {
+      days_invalid = true;
+    } else {
+      days = static_cast<int>(v);
+    }
   }
 
+  if (days_invalid) {
+    ua->send->ObjectKeyValue("days_warning",
+                             "invalid_or_out_of_range_reset_to_1", 0);
+  }
   ua->send->ArrayStart("scheduled_jobs");
   JobResource* job = nullptr;
   std::vector<sched_pkt> sched;
@@ -963,8 +1011,7 @@ static void ListRunningJobsJson(UaContext* ua)
     ua->send->ObjectKeyValue("job_name", jcr->Job, 0);
     ua->send->ObjectKeyValue("level", job_level_to_str(jcr->getJobLevel()), 0);
     ua->send->ObjectKeyValue("job_type", job_type_to_str(jcr->getJobType()), 0);
-    char status_code[2] = {static_cast<char>(jcr->getJobStatus()), 0};
-    ua->send->ObjectKeyValue("status_code", status_code, 0);
+    EmitStatusCodeJson(ua, jcr->getJobStatus());
     ua->send->ObjectKeyValue("status",
                              JobstatusToAscii(jcr->getJobStatus()).c_str(), 0);
     if (jcr->dir_impl->res.client) {
@@ -1047,7 +1094,6 @@ static void ListTerminatedJobsJson(UaContext* ua)
 
     char dt[MAX_TIME_LENGTH];
     bstrftime(dt, sizeof(dt), je.end_time, "%Y-%m-%dT%H:%M:%S");
-    char status_code[2] = {static_cast<char>(je.JobStatus), 0};
 
     ua->send->ObjectStart();
     ua->send->ObjectKeyValue("jobid", static_cast<uint64_t>(je.JobId));
@@ -1055,7 +1101,7 @@ static void ListTerminatedJobsJson(UaContext* ua)
     ua->send->ObjectKeyValue("level", level_str, 0);
     ua->send->ObjectKeyValue("files", static_cast<uint64_t>(je.JobFiles));
     ua->send->ObjectKeyValue("bytes", static_cast<uint64_t>(je.JobBytes));
-    ua->send->ObjectKeyValue("status_code", status_code, 0);
+    EmitStatusCodeJson(ua, je.JobStatus);
     ua->send->ObjectKeyValue("status", termstat, 0);
     ua->send->ObjectKeyValue("finished", dt, 0);
     ua->send->ObjectEnd();
@@ -2124,8 +2170,7 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
                            0);
   ua->send->ObjectKeyValue("job_type", job_type_to_str(job_jcr->getJobType()),
                            0);
-  char status_code[2] = {static_cast<char>(job_jcr->getJobStatus()), 0};
-  ua->send->ObjectKeyValue("status_code", status_code, 0);
+  EmitStatusCodeJson(ua, job_jcr->getJobStatus());
   ua->send->ObjectKeyValue(
       "status", JobstatusToAscii(job_jcr->getJobStatus()).c_str(), 0);
 
@@ -2249,7 +2294,6 @@ static void DoJobIdStatus(UaContext* ua, uint32_t jobid)
 
   FreeJcr(job_jcr);
 #else
-  (void)ua;
   (void)jobid;
   ua->SendMsg(T_("status jobid=N requires JSON support (jansson).\n"));
 #endif

--- a/core/src/filed/authenticate.cc
+++ b/core/src/filed/authenticate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,7 +54,13 @@ const int debuglevel = 50;
  *  54 29Oct15 - Added getSecureEraseCmd
  *  55          - Added JSON output for .status command
  */
+#if HAVE_JANSSON
 inline constexpr const char OK_hello[] = "2000 OK Hello 55\n";
+#else
+/* Without jansson the .status json handler is absent -- don't advertise
+ * the capability or the director would send a command we cannot answer. */
+inline constexpr const char OK_hello[] = "2000 OK Hello 54\n";
+#endif
 
 inline constexpr const char Dir_sorry[] = "2999 Authentication failed.\n";
 

--- a/core/src/filed/authenticate.cc
+++ b/core/src/filed/authenticate.cc
@@ -52,8 +52,9 @@ const int debuglevel = 50;
  *  52 13Jul13 - Added plugin options
  *  53 02Apr15 - Added setdebug timestamp
  *  54 29Oct15 - Added getSecureEraseCmd
+ *  55          - Added JSON output for .status command
  */
-inline constexpr const char OK_hello[] = "2000 OK Hello 54\n";
+inline constexpr const char OK_hello[] = "2000 OK Hello 55\n";
 
 inline constexpr const char Dir_sorry[] = "2999 Authentication failed.\n";
 

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -415,6 +415,28 @@ static void ListTerminatedJobs(StatusPacket* sp)
 
 #if HAVE_JANSSON
 
+/* json_string() returns NULL when the input isn't valid UTF-8, which would
+ * leave the resulting JSON object in a broken state. Filesystem paths can
+ * contain arbitrary non-UTF-8 bytes, so fall back to a sanitized copy where
+ * invalid continuation bytes are replaced with '?'. */
+static json_t* SafeJsonString(const char* s)
+{
+  if (!s) { return json_null(); }
+  json_t* j = json_string(s);
+  if (j) { return j; }
+
+  size_t len = strlen(s);
+  PoolMem clean(PM_FNAME);
+  clean.check_size(len + 1);
+  char* out = clean.c_str();
+  for (size_t i = 0; i < len; i++) {
+    unsigned char c = static_cast<unsigned char>(s[i]);
+    out[i] = (c < 0x80) ? s[i] : '?';
+  }
+  out[len] = '\0';
+  return json_string(out);
+}
+
 /* Long-form status string for a terminated job, mirroring the text emitter
  * in ListTerminatedJobs(). */
 static const char* TerminatedStatusToLongString(int js)
@@ -493,7 +515,7 @@ static json_t* BuildRunningJobsJson()
     json_t* j = json_object();
     json_object_set_new(j, "jobid",
                         json_integer(static_cast<json_int_t>(njcr->JobId)));
-    json_object_set_new(j, "job", json_string(njcr->Job));
+    json_object_set_new(j, "job", SafeJsonString(njcr->Job));
     json_object_set_new(j, "started", TimeAsIsoJson(njcr->start_time));
     json_object_set_new(j, "level", CharAsStringJson(njcr->getJobLevel()));
     json_object_set_new(j, "job_type", CharAsStringJson(njcr->getJobType()));
@@ -526,7 +548,7 @@ static json_t* BuildRunningJobsJson()
       std::unique_lock l(njcr->mutex_guard());
       json_object_set_new(j, "processing_file",
                           njcr->fd_impl->last_fname
-                              ? json_string(njcr->fd_impl->last_fname)
+                              ? SafeJsonString(njcr->fd_impl->last_fname)
                               : json_null());
     } else {
       json_object_set_new(j, "processing_file", json_null());
@@ -557,8 +579,8 @@ static json_t* BuildDirectorsConnectedJson()
   foreach_jcr (njcr) {
     if (njcr->JobId == 0 && njcr->fd_impl && njcr->fd_impl->director) {
       json_t* o = json_object();
-      json_object_set_new(o, "name",
-                          json_string(njcr->fd_impl->director->resource_name_));
+      json_object_set_new(
+          o, "name", SafeJsonString(njcr->fd_impl->director->resource_name_));
       json_object_set_new(o, "connected_at", TimeAsIsoJson(njcr->start_time));
       json_array_append_new(arr, o);
     }
@@ -606,7 +628,7 @@ static json_t* BuildTerminatedJobsJson()
       char* p = strrchr(JobName, '.');
       if (p) { *p = 0; }
     }
-    json_object_set_new(j, "job_name", json_string(JobName));
+    json_object_set_new(j, "job_name", SafeJsonString(JobName));
 
     json_array_append_new(arr, j);
   }

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
 
    This program is Free Software; you can redistribute it and/or
@@ -466,11 +466,11 @@ static json_t* BuildStatusHeaderJson()
                       json_integer(static_cast<json_int_t>(JobCount())));
   json_object_set_new(obj, "binary_info",
                       json_string(kBareosVersionStrings.BinaryInfo));
-#ifdef WIN32_VSS
+#  ifdef WIN32_VSS
   json_object_set_new(obj, "vss_supported", json_true());
-#else
+#  else
   json_object_set_new(obj, "vss_supported", json_false());
-#endif
+#  endif
   json_object_set_new(obj, "secure_erase_command",
                       me->secure_erase_cmdline
                           ? json_string(me->secure_erase_cmdline)
@@ -495,18 +495,16 @@ static json_t* BuildRunningJobsJson()
                         json_integer(static_cast<json_int_t>(njcr->JobId)));
     json_object_set_new(j, "job", json_string(njcr->Job));
     json_object_set_new(j, "started", TimeAsIsoJson(njcr->start_time));
-    json_object_set_new(j, "level",
-                        CharAsStringJson(njcr->getJobLevel()));
-    json_object_set_new(j, "job_type",
-                        CharAsStringJson(njcr->getJobType()));
-#ifdef WIN32_VSS
+    json_object_set_new(j, "level", CharAsStringJson(njcr->getJobLevel()));
+    json_object_set_new(j, "job_type", CharAsStringJson(njcr->getJobType()));
+#  ifdef WIN32_VSS
     json_object_set_new(
         j, "vss",
         json_boolean(njcr->fd_impl->pVSSClient
                      && njcr->fd_impl->pVSSClient->IsInitialized()));
-#else
+#  else
     json_object_set_new(j, "vss", json_false());
-#endif
+#  endif
     int sec = time(NULL) - njcr->start_time;
     if (sec <= 0) { sec = 1; }
     uint64_t bps = njcr->JobBytes / sec;
@@ -521,10 +519,9 @@ static json_t* BuildRunningJobsJson()
     json_object_set_new(
         j, "bwlimit",
         json_integer(static_cast<json_int_t>(njcr->max_bandwidth)));
-    json_object_set_new(
-        j, "files_examined",
-        json_integer(
-            static_cast<json_int_t>(njcr->fd_impl->num_files_examined)));
+    json_object_set_new(j, "files_examined",
+                        json_integer(static_cast<json_int_t>(
+                            njcr->fd_impl->num_files_examined)));
     if (njcr->JobFiles > 0) {
       std::unique_lock l(njcr->mutex_guard());
       json_object_set_new(j, "processing_file",
@@ -538,8 +535,7 @@ static json_t* BuildRunningJobsJson()
       json_t* sdsock = json_object();
       json_object_set_new(
           sdsock, "read_seqno",
-          json_integer(
-              static_cast<json_int_t>(njcr->store_bsock->read_seqno)));
+          json_integer(static_cast<json_int_t>(njcr->store_bsock->read_seqno)));
       json_object_set_new(
           sdsock, "fd",
           json_integer(static_cast<json_int_t>(njcr->store_bsock->fd_)));
@@ -561,9 +557,8 @@ static json_t* BuildDirectorsConnectedJson()
   foreach_jcr (njcr) {
     if (njcr->JobId == 0 && njcr->fd_impl && njcr->fd_impl->director) {
       json_t* o = json_object();
-      json_object_set_new(
-          o, "name",
-          json_string(njcr->fd_impl->director->resource_name_));
+      json_object_set_new(o, "name",
+                          json_string(njcr->fd_impl->director->resource_name_));
       json_object_set_new(o, "connected_at", TimeAsIsoJson(njcr->start_time));
       json_array_append_new(arr, o);
     }
@@ -599,8 +594,8 @@ static json_t* BuildTerminatedJobsJson()
                         json_integer(static_cast<json_int_t>(je.JobBytes)));
     json_object_set_new(j, "status_code",
                         CharAsStringJson(static_cast<char>(je.JobStatus)));
-    json_object_set_new(j, "status",
-                        json_string(TerminatedStatusToLongString(je.JobStatus)));
+    json_object_set_new(
+        j, "status", json_string(TerminatedStatusToLongString(je.JobStatus)));
     json_object_set_new(j, "finished", TimeAsIsoJson(je.end_time));
 
     /* Strip the three trailing ".<timestamp>.<seq>" pieces from the Job

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -39,6 +39,10 @@
 #include "findlib/enable_priv.h"
 #include "lib/util.h"
 
+#if HAVE_JANSSON
+#  include <jansson.h>
+#endif
+
 namespace filedaemon {
 
 /* Forward referenced functions */
@@ -46,6 +50,9 @@ static void ListTerminatedJobs(StatusPacket* sp);
 static void ListRunningJobs(StatusPacket* sp);
 static void ListStatusHeader(StatusPacket* sp);
 static const char* JobLevelToString(int level);
+#if HAVE_JANSSON
+static void OutputStatusJson(StatusPacket* sp);
+#endif
 
 /* Static variables */
 inline constexpr const char qstatus[] = ".status %s\n";
@@ -406,6 +413,241 @@ static void ListTerminatedJobs(StatusPacket* sp)
   }
 }
 
+#if HAVE_JANSSON
+
+/* Long-form status string for a terminated job, mirroring the text emitter
+ * in ListTerminatedJobs(). */
+static const char* TerminatedStatusToLongString(int js)
+{
+  switch (js) {
+    case JS_Created:
+      return "Created";
+    case JS_FatalError:
+    case JS_ErrorTerminated:
+      return "Error";
+    case JS_Differences:
+      return "Diffs";
+    case JS_Canceled:
+      return "Cancel";
+    case JS_Terminated:
+      return "OK";
+    default:
+      return "Other";
+  }
+}
+
+static json_t* TimeAsIsoJson(utime_t t)
+{
+  if (t == 0) { return json_null(); }
+  char dt[MAX_TIME_LENGTH];
+  bstrftime(dt, sizeof(dt), t, "%Y-%m-%dT%H:%M:%S");
+  return json_string(dt);
+}
+
+static json_t* CharAsStringJson(char c)
+{
+  char buf[2] = {c, 0};
+  return json_string(buf);
+}
+
+static json_t* BuildStatusHeaderJson()
+{
+  json_t* obj = json_object();
+  json_object_set_new(obj, "name", json_string(my_name));
+  json_object_set_new(obj, "version", json_string(kBareosVersionStrings.Full));
+  json_object_set_new(obj, "version_date",
+                      json_string(kBareosVersionStrings.Date));
+  json_object_set_new(obj, "os_info",
+                      json_string(kBareosVersionStrings.GetOsInfo()));
+  json_object_set_new(obj, "daemon_started", TimeAsIsoJson(daemon_start_time));
+  json_object_set_new(obj, "jobs_run",
+                      json_integer(static_cast<json_int_t>(NumJobsRun())));
+  json_object_set_new(obj, "jobs_running",
+                      json_integer(static_cast<json_int_t>(JobCount())));
+  json_object_set_new(obj, "binary_info",
+                      json_string(kBareosVersionStrings.BinaryInfo));
+#ifdef WIN32_VSS
+  json_object_set_new(obj, "vss_supported", json_true());
+#else
+  json_object_set_new(obj, "vss_supported", json_false());
+#endif
+  json_object_set_new(obj, "secure_erase_command",
+                      me->secure_erase_cmdline
+                          ? json_string(me->secure_erase_cmdline)
+                          : json_null());
+  json_object_set_new(obj, "config_warnings",
+                      json_boolean(my_config->HasWarnings()));
+  return obj;
+}
+
+static json_t* BuildRunningJobsJson()
+{
+  json_t* arr = json_array();
+  JobControlRecord* njcr;
+
+  foreach_jcr (njcr) {
+    if (njcr->JobId == 0) {
+      /* Director control connections are emitted separately. */
+      continue;
+    }
+    json_t* j = json_object();
+    json_object_set_new(j, "jobid",
+                        json_integer(static_cast<json_int_t>(njcr->JobId)));
+    json_object_set_new(j, "job", json_string(njcr->Job));
+    json_object_set_new(j, "started", TimeAsIsoJson(njcr->start_time));
+    json_object_set_new(j, "level",
+                        CharAsStringJson(njcr->getJobLevel()));
+    json_object_set_new(j, "job_type",
+                        CharAsStringJson(njcr->getJobType()));
+#ifdef WIN32_VSS
+    json_object_set_new(
+        j, "vss",
+        json_boolean(njcr->fd_impl->pVSSClient
+                     && njcr->fd_impl->pVSSClient->IsInitialized()));
+#else
+    json_object_set_new(j, "vss", json_false());
+#endif
+    int sec = time(NULL) - njcr->start_time;
+    if (sec <= 0) { sec = 1; }
+    uint64_t bps = njcr->JobBytes / sec;
+    json_object_set_new(j, "files",
+                        json_integer(static_cast<json_int_t>(njcr->JobFiles)));
+    json_object_set_new(j, "bytes",
+                        json_integer(static_cast<json_int_t>(njcr->JobBytes)));
+    json_object_set_new(j, "bytes_per_sec",
+                        json_integer(static_cast<json_int_t>(bps)));
+    json_object_set_new(j, "errors",
+                        json_integer(static_cast<json_int_t>(njcr->JobErrors)));
+    json_object_set_new(
+        j, "bwlimit",
+        json_integer(static_cast<json_int_t>(njcr->max_bandwidth)));
+    json_object_set_new(
+        j, "files_examined",
+        json_integer(
+            static_cast<json_int_t>(njcr->fd_impl->num_files_examined)));
+    if (njcr->JobFiles > 0) {
+      std::unique_lock l(njcr->mutex_guard());
+      json_object_set_new(j, "processing_file",
+                          njcr->fd_impl->last_fname
+                              ? json_string(njcr->fd_impl->last_fname)
+                              : json_null());
+    } else {
+      json_object_set_new(j, "processing_file", json_null());
+    }
+    if (njcr->store_bsock) {
+      json_t* sdsock = json_object();
+      json_object_set_new(
+          sdsock, "read_seqno",
+          json_integer(
+              static_cast<json_int_t>(njcr->store_bsock->read_seqno)));
+      json_object_set_new(
+          sdsock, "fd",
+          json_integer(static_cast<json_int_t>(njcr->store_bsock->fd_)));
+      json_object_set_new(j, "sd_socket", sdsock);
+    } else {
+      json_object_set_new(j, "sd_socket", json_null());
+    }
+    json_array_append_new(arr, j);
+  }
+  endeach_jcr(njcr);
+  return arr;
+}
+
+static json_t* BuildDirectorsConnectedJson()
+{
+  json_t* arr = json_array();
+  JobControlRecord* njcr;
+
+  foreach_jcr (njcr) {
+    if (njcr->JobId == 0 && njcr->fd_impl && njcr->fd_impl->director) {
+      json_t* o = json_object();
+      json_object_set_new(
+          o, "name",
+          json_string(njcr->fd_impl->director->resource_name_));
+      json_object_set_new(o, "connected_at", TimeAsIsoJson(njcr->start_time));
+      json_array_append_new(arr, o);
+    }
+  }
+  endeach_jcr(njcr);
+  return arr;
+}
+
+static json_t* BuildTerminatedJobsJson()
+{
+  json_t* arr = json_array();
+
+  for (const RecentJobResultsList::JobResult& je :
+       RecentJobResultsList::Get()) {
+    json_t* j = json_object();
+    json_object_set_new(j, "jobid",
+                        json_integer(static_cast<json_int_t>(je.JobId)));
+
+    const char* level_str;
+    switch (je.JobType) {
+      case JT_ADMIN:
+      case JT_RESTORE:
+        level_str = "";
+        break;
+      default:
+        level_str = JobLevelToString(je.JobLevel);
+        break;
+    }
+    json_object_set_new(j, "level", json_string(level_str));
+    json_object_set_new(j, "files",
+                        json_integer(static_cast<json_int_t>(je.JobFiles)));
+    json_object_set_new(j, "bytes",
+                        json_integer(static_cast<json_int_t>(je.JobBytes)));
+    json_object_set_new(j, "status_code",
+                        CharAsStringJson(static_cast<char>(je.JobStatus)));
+    json_object_set_new(j, "status",
+                        json_string(TerminatedStatusToLongString(je.JobStatus)));
+    json_object_set_new(j, "finished", TimeAsIsoJson(je.end_time));
+
+    /* Strip the three trailing ".<timestamp>.<seq>" pieces from the Job
+     * name, matching the text emitter's behavior. */
+    char JobName[MAX_NAME_LENGTH];
+    bstrncpy(JobName, je.Job, sizeof(JobName));
+    for (int i = 0; i < 3; i++) {
+      char* p = strrchr(JobName, '.');
+      if (p) { *p = 0; }
+    }
+    json_object_set_new(j, "job_name", json_string(JobName));
+
+    json_array_append_new(arr, j);
+  }
+  return arr;
+}
+
+static void OutputStatusJson(StatusPacket* sp)
+{
+  json_t* root = json_object();
+  json_object_set_new(root, "header", BuildStatusHeaderJson());
+  json_object_set_new(root, "directors_connected",
+                      BuildDirectorsConnectedJson());
+  json_object_set_new(root, "running_jobs", BuildRunningJobsJson());
+  json_object_set_new(root, "terminated_jobs", BuildTerminatedJobsJson());
+
+  char* serialized = json_dumps(root, JSON_INDENT(2));
+  if (serialized) {
+    int len = strlen(serialized);
+    if (sp->bs) {
+      /* StatusPacket::send() assumes bs->msg is already large enough; JSON
+       * payloads can exceed the default PM_MESSAGE buffer, so grow it
+       * explicitly before sending. */
+      sp->bs->msg = CheckPoolMemorySize(sp->bs->msg, len + 1);
+      memcpy(sp->bs->msg, serialized, len + 1);
+      sp->bs->message_length = len + 1;
+      sp->bs->send();
+    } else if (sp->callback) {
+      sp->callback(serialized, len, sp->context);
+    }
+    free(serialized);
+  }
+  json_decref(root);
+}
+
+#endif  // HAVE_JANSSON
+
 // Status command from Director
 bool StatusCmd(JobControlRecord* jcr)
 {
@@ -467,6 +709,10 @@ bool QstatusCmd(JobControlRecord* jcr)
   } else if (Bstrcasecmp(cmd, "terminated")) {
     sp.api = true;
     ListTerminatedJobs(&sp);
+#if HAVE_JANSSON
+  } else if (Bstrcasecmp(cmd, "json")) {
+    OutputStatusJson(&sp);
+#endif
   } else {
     PmStrcpy(jcr->errmsg, dir->msg);
     Jmsg1(jcr, M_FATAL, 0, T_("Bad .status command: %s\n"), jcr->errmsg);

--- a/core/src/filed/status.cc
+++ b/core/src/filed/status.cc
@@ -453,6 +453,8 @@ static const char* TerminatedStatusToLongString(int js)
       return "Cancel";
     case JS_Terminated:
       return "OK";
+    case JS_Warnings:
+      return "OK -- with warnings";
     default:
       return "Other";
   }

--- a/core/src/lib/output_formatter.cc
+++ b/core/src/lib/output_formatter.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2015-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -347,16 +347,12 @@ void OutputFormatter::ArrayItem(const char* value,
 }
 
 void OutputFormatter::ObjectKeyValueBool(const char* key, bool value)
-{
-  ObjectKeyValueBool(key, NULL, value, NULL);
-}
+{ ObjectKeyValueBool(key, NULL, value, NULL); }
 
 void OutputFormatter::ObjectKeyValueBool(const char* key,
                                          bool value,
                                          const char* value_fmt)
-{
-  ObjectKeyValueBool(key, NULL, value, value_fmt);
-}
+{ ObjectKeyValueBool(key, NULL, value, value_fmt); }
 
 void OutputFormatter::ObjectKeyValueBool(const char* key,
                                          const char* key_fmt,
@@ -389,16 +385,12 @@ void OutputFormatter::ObjectKeyValueBool(const char* key,
 }
 
 void OutputFormatter::ObjectKeyValue(const char* key, uint64_t value)
-{
-  ObjectKeyValue(key, NULL, value, NULL);
-}
+{ ObjectKeyValue(key, NULL, value, NULL); }
 
 void OutputFormatter::ObjectKeyValue(const char* key,
                                      uint64_t value,
                                      const char* value_fmt)
-{
-  ObjectKeyValue(key, NULL, value, value_fmt);
-}
+{ ObjectKeyValue(key, NULL, value, value_fmt); }
 
 void OutputFormatter::ObjectKeyValue(const char* key,
                                      const char* key_fmt,
@@ -427,16 +419,12 @@ void OutputFormatter::ObjectKeyValue(const char* key,
 }
 
 void OutputFormatter::ObjectKeyValueSignedInt(const char* key, int64_t value)
-{
-  ObjectKeyValueSignedInt(key, NULL, value, NULL);
-}
+{ ObjectKeyValueSignedInt(key, NULL, value, NULL); }
 
 void OutputFormatter::ObjectKeyValueSignedInt(const char* key,
                                               int64_t value,
                                               const char* value_fmt)
-{
-  ObjectKeyValueSignedInt(key, NULL, value, value_fmt);
-}
+{ ObjectKeyValueSignedInt(key, NULL, value, value_fmt); }
 
 void OutputFormatter::ObjectKeyValueSignedInt(const char* key,
                                               const char* key_fmt,
@@ -468,17 +456,13 @@ void OutputFormatter::ObjectKeyValueSignedInt(const char* key,
 void OutputFormatter::ObjectKeyValue(const char* key,
                                      const char* value,
                                      int wrap)
-{
-  ObjectKeyValue(key, NULL, value, NULL, wrap);
-}
+{ ObjectKeyValue(key, NULL, value, NULL, wrap); }
 
 void OutputFormatter::ObjectKeyValue(const char* key,
                                      const char* value,
                                      const char* value_fmt,
                                      int wrap)
-{
-  ObjectKeyValue(key, NULL, value, value_fmt, wrap);
-}
+{ ObjectKeyValue(key, NULL, value, value_fmt, wrap); }
 
 void OutputFormatter::ObjectKeyValue(const char* key,
                                      const char* key_fmt,
@@ -638,19 +622,13 @@ void OutputFormatter::AddAclFilterTuple(int column, int acltype)
 }
 
 void OutputFormatter::AddResFilterTuple(int column, int restype)
-{
-  CreateNewResFilter(OF_FILTER_RESOURCE, column, restype);
-}
+{ CreateNewResFilter(OF_FILTER_RESOURCE, column, restype); }
 
 void OutputFormatter::AddEnabledFilterTuple(int column, int restype)
-{
-  CreateNewResFilter(OF_FILTER_ENABLED, column, restype);
-}
+{ CreateNewResFilter(OF_FILTER_ENABLED, column, restype); }
 
 void OutputFormatter::AddDisabledFilterTuple(int column, int restype)
-{
-  CreateNewResFilter(OF_FILTER_DISABLED, column, restype);
-}
+{ CreateNewResFilter(OF_FILTER_DISABLED, column, restype); }
 
 void OutputFormatter::ClearFilters()
 {
@@ -920,6 +898,26 @@ bool OutputFormatter::JsonKeyValueAdd(const char* key, const char* value)
   int rc = json_object_set_new(json_obj, lkey.c_str(), value_as_json_string);
   assert(rc == 0);
 
+  return (rc == 0);
+}
+
+bool OutputFormatter::JsonKeyValueAddJson(const char* key, json_t* value)
+{
+  PoolMem lkey(key);
+
+  lkey.toLower();
+  json_t* json_obj = (json_t*)result_stack_json->last();
+  if (json_obj == NULL || !json_is_object(json_obj)) {
+    Emsg1(M_ERROR, 0, "No json object on stack to add subtree for key '%s'\n",
+          key);
+    if (value) { json_decref(value); }
+    return false;
+  }
+  if (value == NULL) {
+    Emsg1(M_ERROR, 0, "Refusing to add NULL subtree for key '%s'\n", key);
+    return false;
+  }
+  int rc = json_object_set_new(json_obj, lkey.c_str(), value);
   return (rc == 0);
 }
 

--- a/core/src/lib/output_formatter.h
+++ b/core/src/lib/output_formatter.h
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2015-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2015-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -256,6 +256,9 @@ class OutputFormatter {
   bool JsonKeyValueAddBool(const char* key, bool value);
   bool JsonKeyValueAdd(const char* key, uint64_t value);
   bool JsonKeyValueAdd(const char* key, const char* value);
+  /* Insert an already-built json_t subtree under `key` at the top of the
+   * stack. Takes ownership of `value` (does not call json_incref). */
+  bool JsonKeyValueAddJson(const char* key, json_t* value);
   void JsonAddMessage(const char* type, PoolMem& message);
   bool JsonHasErrorMessage();
   void JsonFinalizeResult(bool result);

--- a/core/src/qt-tray-monitor/authenticate.cc
+++ b/core/src/qt-tray-monitor/authenticate.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2004-2008 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -47,6 +47,7 @@ inline constexpr const char SDFDhello[] = "Hello Director %s calling\n";
 
 /* Response from SD */
 inline constexpr const char SDOKhello[] = "3000 OK Hello\n";
+inline constexpr const char SDOKnewHello[] = "3000 OK Hello %d\n";
 /* Response from FD */
 inline constexpr const char FDOKhello[] = "2000 OK Hello";
 
@@ -182,7 +183,9 @@ static AuthenticationResult AuthenticateWithStorageDaemon(
   }
 
   Dmsg1(110, "<stored: %s", sd->msg);
-  if (!bstrncmp(sd->msg, SDOKhello, sizeof(SDOKhello))) {
+  int sd_version = 0;
+  if (!bstrncmp(sd->msg, SDOKhello, sizeof(SDOKhello))
+      && sscanf(sd->msg, SDOKnewHello, &sd_version) != 1) {
     Dmsg0(debuglevel, T_("Storage daemon rejected Hello command\n"));
     Jmsg2(jcr, M_FATAL, 0,
           T_("Storage daemon at \"%s:%d\" rejected Hello command\n"),

--- a/core/src/stored/authenticate.cc
+++ b/core/src/stored/authenticate.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,7 +39,12 @@ namespace storagedaemon {
 const int debuglevel = 50;
 
 constexpr const char Dir_sorry[] = "3999 No go\n";
-constexpr const char OK_hello[] = "3000 OK Hello\n";
+/* Version history:
+ *
+ *  0          - Implicit version: hello had no version field
+ *  1          - Added JSON output for .status command
+ */
+constexpr const char OK_hello[] = "3000 OK Hello 1\n";
 
 /**
  * Initiate the message channel with the Director.

--- a/core/src/stored/authenticate.cc
+++ b/core/src/stored/authenticate.cc
@@ -44,7 +44,13 @@ constexpr const char Dir_sorry[] = "3999 No go\n";
  *  0          - Implicit version: hello had no version field
  *  1          - Added JSON output for .status command
  */
+#if HAVE_JANSSON
 constexpr const char OK_hello[] = "3000 OK Hello 1\n";
+#else
+/* Without jansson the .status json handler is absent -- don't advertise
+ * the capability or the director would send a command we cannot answer. */
+constexpr const char OK_hello[] = "3000 OK Hello\n";
+#endif
 
 /**
  * Initiate the message channel with the Director.

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -34,6 +34,7 @@
 #include "stored/stored_jcr_impl.h"
 #include "stored/spool.h"
 #include "stored/status.h"
+#include "stored/vol_mgr.h"
 #include "lib/status_packet.h"
 #include "lib/edit.h"
 #include "include/jcr.h"
@@ -42,6 +43,10 @@
 #include "lib/recent_job_results_list.h"
 #include "lib/util.h"
 #include "lib/version.h"
+
+#if HAVE_JANSSON
+#  include <jansson.h>
+#endif
 
 namespace storagedaemon {
 
@@ -903,6 +908,402 @@ static const char* JobLevelToString(int level)
   return str;
 }
 
+#if HAVE_JANSSON
+
+static json_t* TimeAsIsoJson(utime_t t)
+{
+  if (t == 0) { return json_null(); }
+  char dt[MAX_TIME_LENGTH];
+  bstrftime(dt, sizeof(dt), t, "%Y-%m-%dT%H:%M:%S");
+  return json_string(dt);
+}
+
+static json_t* CharAsStringJson(char c)
+{
+  char buf[2] = {c, 0};
+  return json_string(buf);
+}
+
+static const char* TerminatedStatusToLongString(int js)
+{
+  switch (js) {
+    case JS_Created:
+      return "Created";
+    case JS_FatalError:
+    case JS_ErrorTerminated:
+      return "Error";
+    case JS_Differences:
+      return "Diffs";
+    case JS_Canceled:
+      return "Cancel";
+    case JS_Terminated:
+      return "OK";
+    default:
+      return "Other";
+  }
+}
+
+static const char* BlockedStateToString(int state)
+{
+  switch (state) {
+    case BST_NOT_BLOCKED:
+      return "not_blocked";
+    case BST_UNMOUNTED:
+      return "unmounted";
+    case BST_WAITING_FOR_SYSOP:
+      return "waiting_for_sysop";
+    case BST_DOING_ACQUIRE:
+      return "doing_acquire";
+    case BST_WRITING_LABEL:
+      return "writing_label";
+    case BST_UNMOUNTED_WAITING_FOR_SYSOP:
+      return "unmounted_waiting_for_sysop";
+    case BST_MOUNT:
+      return "mount";
+    case BST_DESPOOLING:
+      return "despooling";
+    case BST_RELEASING:
+      return "releasing";
+    default:
+      return "unknown";
+  }
+}
+
+static json_t* BuildStatusHeaderJson()
+{
+  json_t* obj = json_object();
+  json_object_set_new(obj, "name", json_string(my_name));
+  json_object_set_new(obj, "version", json_string(kBareosVersionStrings.Full));
+  json_object_set_new(obj, "version_date",
+                      json_string(kBareosVersionStrings.Date));
+  json_object_set_new(obj, "os_info",
+                      json_string(kBareosVersionStrings.GetOsInfo()));
+  json_object_set_new(obj, "daemon_started", TimeAsIsoJson(daemon_start_time));
+  json_object_set_new(obj, "jobs_run",
+                      json_integer(static_cast<json_int_t>(NumJobsRun())));
+  json_object_set_new(obj, "jobs_running",
+                      json_integer(static_cast<json_int_t>(JobCount())));
+  json_object_set_new(obj, "binary_info",
+                      json_string(kBareosVersionStrings.BinaryInfo));
+  json_object_set_new(obj, "config_warnings",
+                      json_boolean(my_config->HasWarnings()));
+  return obj;
+}
+
+static json_t* BuildDcrJson(DeviceControlRecord* dcr)
+{
+  json_t* o = json_object();
+  json_object_set_new(o, "volume", json_string(dcr->VolumeName));
+  json_object_set_new(o, "pool", json_string(dcr->pool_name));
+  json_object_set_new(
+      o, "device",
+      json_string(dcr->dev ? dcr->dev->print_name()
+                           : dcr->device_resource->archive_device_string));
+  return o;
+}
+
+static json_t* BuildRunningJobsJson()
+{
+  json_t* arr = json_array();
+  JobControlRecord* jcr;
+
+  foreach_jcr (jcr) {
+    DeviceControlRecord* dcr = jcr->sd_impl->dcr;
+    DeviceControlRecord* rdcr = jcr->sd_impl->read_dcr;
+
+    if (!(dcr && dcr->device_resource) && !(rdcr && rdcr->device_resource)
+        && jcr->getJobStatus() != JS_WaitFD) {
+      continue;
+    }
+
+    json_t* j = json_object();
+    json_object_set_new(j, "jobid",
+                        json_integer(static_cast<json_int_t>(jcr->JobId)));
+
+    /* Strip the three trailing ".<timestamp>.<seq>" pieces from the Job
+     * name to match the text emitter. */
+    char JobName[MAX_NAME_LENGTH];
+    bstrncpy(JobName, jcr->Job, sizeof(JobName));
+    for (int i = 0; i < 3; i++) {
+      char* p = strrchr(JobName, '.');
+      if (p) { *p = 0; }
+    }
+    json_object_set_new(j, "job_name", json_string(JobName));
+    json_object_set_new(j, "level",
+                        json_string(job_level_to_str(jcr->getJobLevel())));
+    json_object_set_new(j, "job_type",
+                        json_string(job_type_to_str(jcr->getJobType())));
+    json_object_set_new(
+        j, "status_code",
+        CharAsStringJson(static_cast<char>(jcr->getJobStatus())));
+    json_object_set_new(
+        j, "status",
+        json_string(JobstatusToAscii(jcr->getJobStatus()).c_str()));
+
+    if (rdcr && rdcr->device_resource) {
+      json_object_set_new(j, "reading", BuildDcrJson(rdcr));
+    } else {
+      json_object_set_new(j, "reading", json_null());
+    }
+    if (dcr && dcr->device_resource) {
+      json_t* w = BuildDcrJson(dcr);
+      json_object_set_new(w, "spooling", json_boolean(dcr->spooling));
+      json_object_set_new(w, "despooling", json_boolean(dcr->despooling));
+      json_object_set_new(w, "despool_wait", json_boolean(dcr->despool_wait));
+      json_object_set_new(j, "writing", w);
+    } else {
+      json_object_set_new(j, "writing", json_null());
+    }
+
+    jcr->UpdateJobStats();
+    json_object_set_new(j, "files",
+                        json_integer(static_cast<json_int_t>(jcr->JobFiles)));
+    json_object_set_new(j, "bytes",
+                        json_integer(static_cast<json_int_t>(jcr->JobBytes)));
+    json_object_set_new(
+        j, "avg_bytes_per_sec",
+        json_integer(static_cast<json_int_t>(jcr->AverageRate)));
+    json_object_set_new(j, "last_bytes_per_sec",
+                        json_integer(static_cast<json_int_t>(jcr->LastRate)));
+
+    if (jcr->file_bsock) {
+      json_t* fd_sock = json_object();
+      json_object_set_new(
+          fd_sock, "read_seqno",
+          json_integer(static_cast<json_int_t>(jcr->file_bsock->read_seqno)));
+      json_object_set_new(
+          fd_sock, "in_msg",
+          json_integer(static_cast<json_int_t>(jcr->file_bsock->in_msg_no)));
+      json_object_set_new(
+          fd_sock, "out_msg",
+          json_integer(static_cast<json_int_t>(jcr->file_bsock->out_msg_no)));
+      json_object_set_new(
+          fd_sock, "fd",
+          json_integer(static_cast<json_int_t>(jcr->file_bsock->fd_)));
+      json_object_set_new(j, "fd_socket", fd_sock);
+    } else {
+      json_object_set_new(j, "fd_socket", json_null());
+    }
+
+    json_array_append_new(arr, j);
+  }
+  endeach_jcr(jcr);
+  return arr;
+}
+
+static json_t* BuildWaitingJobsJson()
+{
+  json_t* arr = json_array();
+  JobControlRecord* jcr;
+
+  foreach_jcr (jcr) {
+    if (!jcr->sd_impl->reserve_msgs.size()) { continue; }
+    json_t* j = json_object();
+    json_object_set_new(j, "jobid",
+                        json_integer(static_cast<json_int_t>(jcr->JobId)));
+    json_t* msgs = json_array();
+    {
+      std::unique_lock lock(jcr->mutex_guard());
+      for (auto& m : jcr->sd_impl->reserve_msgs) {
+        json_array_append_new(msgs, json_string(m.c_str()));
+      }
+    }
+    json_object_set_new(j, "reserve_messages", msgs);
+    json_array_append_new(arr, j);
+  }
+  endeach_jcr(jcr);
+  return arr;
+}
+
+static json_t* BuildTerminatedJobsJson()
+{
+  json_t* arr = json_array();
+
+  for (const RecentJobResultsList::JobResult& je :
+       RecentJobResultsList::Get()) {
+    json_t* j = json_object();
+    json_object_set_new(j, "jobid",
+                        json_integer(static_cast<json_int_t>(je.JobId)));
+
+    const char* level_str;
+    switch (je.JobType) {
+      case JT_ADMIN:
+      case JT_RESTORE:
+        level_str = "";
+        break;
+      default:
+        level_str = JobLevelToString(je.JobLevel);
+        break;
+    }
+    json_object_set_new(j, "level", json_string(level_str));
+    json_object_set_new(j, "files",
+                        json_integer(static_cast<json_int_t>(je.JobFiles)));
+    json_object_set_new(j, "bytes",
+                        json_integer(static_cast<json_int_t>(je.JobBytes)));
+    json_object_set_new(j, "status_code",
+                        CharAsStringJson(static_cast<char>(je.JobStatus)));
+    json_object_set_new(
+        j, "status", json_string(TerminatedStatusToLongString(je.JobStatus)));
+    json_object_set_new(j, "finished", TimeAsIsoJson(je.end_time));
+
+    char JobName[MAX_NAME_LENGTH];
+    bstrncpy(JobName, je.Job, sizeof(JobName));
+    for (int i = 0; i < 3; i++) {
+      char* p = strrchr(JobName, '.');
+      if (p) { *p = 0; }
+    }
+    json_object_set_new(j, "job_name", json_string(JobName));
+
+    json_array_append_new(arr, j);
+  }
+  return arr;
+}
+
+static json_t* BuildDeviceJson(DeviceResource* device_resource)
+{
+  json_t* o = json_object();
+  Device* dev = device_resource->dev;
+
+  json_object_set_new(o, "name", json_string(device_resource->resource_name_));
+  json_object_set_new(
+      o, "device_path",
+      json_string(dev ? dev->print_name()
+                      : device_resource->archive_device_string));
+  json_object_set_new(o, "media_type",
+                      json_string(device_resource->media_type));
+  json_object_set_new(
+      o, "autochanger",
+      device_resource->changer_res
+          ? json_string(device_resource->changer_res->resource_name_)
+          : json_null());
+
+  if (dev && dev->IsOpen()) {
+    json_object_set_new(o, "open", json_true());
+    json_object_set_new(o, "labeled", json_boolean(dev->IsLabeled()));
+    json_object_set_new(o, "blocked_state",
+                        json_string(BlockedStateToString(dev->blocked())));
+    if (dev->IsLabeled()) {
+      json_object_set_new(o, "mounted_volume",
+                          json_string(dev->VolHdr.VolumeName));
+      json_object_set_new(o, "pool",
+                          json_string(dev->pool_name[0] ? dev->pool_name : ""));
+      if (dev->CanAppend()) {
+        json_t* pos = json_object();
+        int64_t blocks = dev->VolCatInfo.VolCatBlocks;
+        int64_t bpb = blocks > 0 ? dev->VolCatInfo.VolCatBytes / blocks : 0;
+        json_object_set_new(
+            pos, "total_bytes",
+            json_integer(static_cast<json_int_t>(dev->VolCatInfo.VolCatBytes)));
+        json_object_set_new(pos, "blocks",
+                            json_integer(static_cast<json_int_t>(blocks)));
+        json_object_set_new(pos, "bytes_per_block",
+                            json_integer(static_cast<json_int_t>(bpb)));
+        json_object_set_new(o, "write_position", pos);
+      }
+    } else {
+      json_object_set_new(o, "mounted_volume", json_null());
+      json_object_set_new(o, "pool", json_null());
+    }
+    json_object_set_new(
+        o, "num_writers",
+        json_integer(static_cast<json_int_t>(dev->num_writers)));
+    json_object_set_new(
+        o, "reserved",
+        json_integer(static_cast<json_int_t>(dev->NumReserved())));
+    json_object_set_new(o, "can_read", json_boolean(dev->CanRead()));
+    json_object_set_new(o, "can_append", json_boolean(dev->CanAppend()));
+  } else {
+    json_object_set_new(o, "open", json_false());
+  }
+  return o;
+}
+
+static json_t* BuildDevicesJson()
+{
+  json_t* arr = json_array();
+  DeviceResource* device_resource = nullptr;
+
+  foreach_res (device_resource, R_DEVICE) {
+    if (device_resource->count > 1) { continue; }
+    json_array_append_new(arr, BuildDeviceJson(device_resource));
+  }
+  return arr;
+}
+
+static json_t* BuildUsedVolumesJson()
+{
+  json_t* arr = json_array();
+
+  foreach_vol ([&](auto* vol) {
+    json_t* v = json_object();
+    Device* dev = vol->dev;
+    json_object_set_new(v, "volume", json_string(vol->vol_name));
+    json_object_set_new(v, "device",
+                        dev ? json_string(dev->print_name()) : json_null());
+    json_object_set_new(v, "direction", json_string("write"));
+    json_object_set_new(v, "readers",
+                        json_integer(dev && dev->CanRead() ? 1 : 0));
+    json_object_set_new(
+        v, "writers",
+        json_integer(static_cast<json_int_t>(dev ? dev->num_writers : 0)));
+    json_object_set_new(
+        v, "reserves",
+        json_integer(static_cast<json_int_t>(dev ? dev->NumReserved() : 0)));
+    json_object_set_new(v, "in_use", json_boolean(vol->IsInUse()));
+    json_array_append_new(arr, v);
+  });
+
+  foreach_read_vol([&](auto* vol) {
+    json_t* v = json_object();
+    Device* dev = vol->dev;
+    json_object_set_new(v, "volume", json_string(vol->vol_name));
+    json_object_set_new(v, "device",
+                        dev ? json_string(dev->print_name()) : json_null());
+    json_object_set_new(v, "direction", json_string("read"));
+    json_object_set_new(v, "readers",
+                        json_integer(dev && dev->CanRead() ? 1 : 0));
+    json_object_set_new(
+        v, "writers",
+        json_integer(static_cast<json_int_t>(dev ? dev->num_writers : 0)));
+    json_object_set_new(
+        v, "reserves",
+        json_integer(static_cast<json_int_t>(dev ? dev->NumReserved() : 0)));
+    json_object_set_new(v, "in_use", json_boolean(vol->IsInUse()));
+    json_object_set_new(v, "jobid",
+                        json_integer(static_cast<json_int_t>(vol->GetJobid())));
+    json_array_append_new(arr, v);
+  });
+  return arr;
+}
+
+static void OutputStatusJson(StatusPacket* sp)
+{
+  json_t* root = json_object();
+  json_object_set_new(root, "header", BuildStatusHeaderJson());
+  json_object_set_new(root, "running_jobs", BuildRunningJobsJson());
+  json_object_set_new(root, "waiting_jobs", BuildWaitingJobsJson());
+  json_object_set_new(root, "terminated_jobs", BuildTerminatedJobsJson());
+  json_object_set_new(root, "devices", BuildDevicesJson());
+  json_object_set_new(root, "used_volumes", BuildUsedVolumesJson());
+
+  char* serialized = json_dumps(root, JSON_INDENT(2));
+  if (serialized) {
+    int len = strlen(serialized);
+    if (sp->bs) {
+      sp->bs->msg = CheckPoolMemorySize(sp->bs->msg, len + 1);
+      memcpy(sp->bs->msg, serialized, len + 1);
+      sp->bs->message_length = len + 1;
+      sp->bs->send();
+    } else if (sp->callback) {
+      sp->callback(serialized, len, sp->context);
+    }
+    free(serialized);
+  }
+  json_decref(root);
+}
+
+#endif  // HAVE_JANSSON
+
 // Status command from Director
 bool StatusCmd(JobControlRecord* jcr)
 {
@@ -986,6 +1387,10 @@ bool DotstatusCmd(JobControlRecord* jcr)
   } else if (Bstrcasecmp(cmd.c_str(), "terminated")) {
     sp.api = true;
     ListTerminatedJobs(&sp);
+#if HAVE_JANSSON
+  } else if (Bstrcasecmp(cmd.c_str(), "json")) {
+    OutputStatusJson(&sp);
+#endif
   } else {
     PmStrcpy(jcr->errmsg, dir->msg);
     dir->fsend(T_("3900 Unknown arg in .status command: %s\n"), jcr->errmsg);

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -910,6 +910,28 @@ static const char* JobLevelToString(int level)
 
 #if HAVE_JANSSON
 
+/* json_string() returns NULL when input isn't valid UTF-8, which breaks the
+ * surrounding JSON object. Filesystem paths and pool/volume names can carry
+ * arbitrary bytes, so fall back to a sanitized copy where non-ASCII bytes
+ * are replaced with '?'. Mirrors the helper in filed/status.cc. */
+static json_t* SafeJsonString(const char* s)
+{
+  if (!s) { return json_null(); }
+  json_t* j = json_string(s);
+  if (j) { return j; }
+
+  size_t len = strlen(s);
+  PoolMem clean(PM_FNAME);
+  clean.check_size(len + 1);
+  char* out = clean.c_str();
+  for (size_t i = 0; i < len; i++) {
+    unsigned char c = static_cast<unsigned char>(s[i]);
+    out[i] = (c < 0x80) ? s[i] : '?';
+  }
+  out[len] = '\0';
+  return json_string(out);
+}
+
 static json_t* TimeAsIsoJson(utime_t t)
 {
   if (t == 0) { return json_null(); }
@@ -993,12 +1015,12 @@ static json_t* BuildStatusHeaderJson()
 static json_t* BuildDcrJson(DeviceControlRecord* dcr)
 {
   json_t* o = json_object();
-  json_object_set_new(o, "volume", json_string(dcr->VolumeName));
-  json_object_set_new(o, "pool", json_string(dcr->pool_name));
+  json_object_set_new(o, "volume", SafeJsonString(dcr->VolumeName));
+  json_object_set_new(o, "pool", SafeJsonString(dcr->pool_name));
   json_object_set_new(
       o, "device",
-      json_string(dcr->dev ? dcr->dev->print_name()
-                           : dcr->device_resource->archive_device_string));
+      SafeJsonString(dcr->dev ? dcr->dev->print_name()
+                              : dcr->device_resource->archive_device_string));
   return o;
 }
 
@@ -1028,7 +1050,7 @@ static json_t* BuildRunningJobsJson()
       char* p = strrchr(JobName, '.');
       if (p) { *p = 0; }
     }
-    json_object_set_new(j, "job_name", json_string(JobName));
+    json_object_set_new(j, "job_name", SafeJsonString(JobName));
     json_object_set_new(j, "level",
                         json_string(job_level_to_str(jcr->getJobLevel())));
     json_object_set_new(j, "job_type",
@@ -1105,7 +1127,7 @@ static json_t* BuildWaitingJobsJson()
     {
       std::unique_lock lock(jcr->mutex_guard());
       for (auto& m : jcr->sd_impl->reserve_msgs) {
-        json_array_append_new(msgs, json_string(m.c_str()));
+        json_array_append_new(msgs, SafeJsonString(m.c_str()));
       }
     }
     json_object_set_new(j, "reserve_messages", msgs);
@@ -1152,7 +1174,7 @@ static json_t* BuildTerminatedJobsJson()
       char* p = strrchr(JobName, '.');
       if (p) { *p = 0; }
     }
-    json_object_set_new(j, "job_name", json_string(JobName));
+    json_object_set_new(j, "job_name", SafeJsonString(JobName));
 
     json_array_append_new(arr, j);
   }
@@ -1164,17 +1186,18 @@ static json_t* BuildDeviceJson(DeviceResource* device_resource)
   json_t* o = json_object();
   Device* dev = device_resource->dev;
 
-  json_object_set_new(o, "name", json_string(device_resource->resource_name_));
+  json_object_set_new(o, "name",
+                      SafeJsonString(device_resource->resource_name_));
   json_object_set_new(
       o, "device_path",
-      json_string(dev ? dev->print_name()
-                      : device_resource->archive_device_string));
+      SafeJsonString(dev ? dev->print_name()
+                         : device_resource->archive_device_string));
   json_object_set_new(o, "media_type",
-                      json_string(device_resource->media_type));
+                      SafeJsonString(device_resource->media_type));
   json_object_set_new(
       o, "autochanger",
       device_resource->changer_res
-          ? json_string(device_resource->changer_res->resource_name_)
+          ? SafeJsonString(device_resource->changer_res->resource_name_)
           : json_null());
 
   if (dev && dev->IsOpen()) {
@@ -1184,9 +1207,9 @@ static json_t* BuildDeviceJson(DeviceResource* device_resource)
                         json_string(BlockedStateToString(dev->blocked())));
     if (dev->IsLabeled()) {
       json_object_set_new(o, "mounted_volume",
-                          json_string(dev->VolHdr.VolumeName));
-      json_object_set_new(o, "pool",
-                          json_string(dev->pool_name[0] ? dev->pool_name : ""));
+                          SafeJsonString(dev->VolHdr.VolumeName));
+      json_object_set_new(
+          o, "pool", SafeJsonString(dev->pool_name[0] ? dev->pool_name : ""));
       if (dev->CanAppend()) {
         json_t* pos = json_object();
         int64_t blocks = dev->VolCatInfo.VolCatBlocks;
@@ -1237,9 +1260,9 @@ static json_t* BuildUsedVolumesJson()
   foreach_vol ([&](auto* vol) {
     json_t* v = json_object();
     Device* dev = vol->dev;
-    json_object_set_new(v, "volume", json_string(vol->vol_name));
+    json_object_set_new(v, "volume", SafeJsonString(vol->vol_name));
     json_object_set_new(v, "device",
-                        dev ? json_string(dev->print_name()) : json_null());
+                        dev ? SafeJsonString(dev->print_name()) : json_null());
     json_object_set_new(v, "direction", json_string("write"));
     json_object_set_new(v, "readers",
                         json_integer(dev && dev->CanRead() ? 1 : 0));
@@ -1256,9 +1279,9 @@ static json_t* BuildUsedVolumesJson()
   foreach_read_vol([&](auto* vol) {
     json_t* v = json_object();
     Device* dev = vol->dev;
-    json_object_set_new(v, "volume", json_string(vol->vol_name));
+    json_object_set_new(v, "volume", SafeJsonString(vol->vol_name));
     json_object_set_new(v, "device",
-                        dev ? json_string(dev->print_name()) : json_null());
+                        dev ? SafeJsonString(dev->print_name()) : json_null());
     json_object_set_new(v, "direction", json_string("read"));
     json_object_set_new(v, "readers",
                         json_integer(dev && dev->CanRead() ? 1 : 0));

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -960,6 +960,8 @@ static const char* TerminatedStatusToLongString(int js)
       return "Cancel";
     case JS_Terminated:
       return "OK";
+    case JS_Warnings:
+      return "OK -- with warnings";
     default:
       return "Other";
   }

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -1237,6 +1237,12 @@ static json_t* BuildDeviceJson(DeviceResource* device_resource)
     json_object_set_new(o, "can_append", json_boolean(dev->CanAppend()));
   } else {
     json_object_set_new(o, "open", json_false());
+    /* Closed devices still carry a blocked_state -- unmounted /
+     * waiting-for-sysop are common operational causes worth surfacing
+     * even when the device isn't currently open. */
+    json_object_set_new(
+        o, "blocked_state",
+        dev ? json_string(BlockedStateToString(dev->blocked())) : json_null());
   }
   return o;
 }

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1537,7 +1537,7 @@ status
    available in previous releases.
 
    For clients, the director requires |fd| protocol version 55 or newer
-   (:config:option:`dir/director/*`) to obtain the JSON status; older
+   to obtain the JSON status; older
    |fd|'s return a structured
    ``{"error": "file_daemon_too_old"}`` response instead. The equivalent
    gate for |sd| is protocol version 1 -- older |sd|'s return

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1521,8 +1521,40 @@ status
 
       status [all | dir=<dir-name> | director | scheduler | schedule=<schedule-name> |
               client=<client-name> | storage=<storage-name> slots |
+              jobid=<jobid> |
               subscriptions [clients] [plugins] [all] [anonymize] [client=<client-name>] |
               configuration]
+
+   .. _section-StatusJsonOutput:
+
+   **JSON output**
+
+   When the console is in JSON api mode (activate with :bcommand:`.api json`),
+   :bcommand:`status director`, :bcommand:`status scheduler`,
+   :bcommand:`status client=<name>` and :bcommand:`status storage=<name>`
+   return a JSON document inside the standard JSON-RPC response envelope,
+   in addition to the :bcommand:`status slots` JSON output that has been
+   available in previous releases.
+
+   For clients, the director requires |fd| protocol version 55 or newer
+   (:config:option:`dir/director/*`) to obtain the JSON status; older
+   |fd|'s return a structured
+   ``{"error": "file_daemon_too_old"}`` response instead. The equivalent
+   gate for |sd| is protocol version 1 -- older |sd|'s return
+   ``{"error": "storage_daemon_too_old"}``.
+
+   The :bcommand:`status jobid=<jobid>` form is a JSON-only aggregator
+   intended for monitoring tools. It returns a single response containing:
+
+   - a ``dir`` subtree with director-local job metadata (name, level,
+     client, storage, status, start time)
+   - an ``fd`` subtree with the |fd|'s complete ``.status json`` reply
+     nested under ``fd.data``
+   - an ``sd`` subtree with the |sd|'s complete ``.status json`` reply
+     nested under ``sd.data``
+
+   In text mode (``.api off``) the aggregator prints an instructive
+   message and does nothing; switch to JSON first.
 
    If you do a status dir, the console will list any currently running jobs, a summary of all jobs
    scheduled to be run in the next 24 hours, and a listing of the last ten terminated jobs with

--- a/webui/module/Api/config/module.config.php
+++ b/webui/module/Api/config/module.config.php
@@ -36,6 +36,7 @@ return array(
             'Api\Controller\Fileset' => 'Api\Controller\FilesetController',
             'Api\Controller\Job' => 'Api\Controller\JobController',
             'Api\Controller\JobLog' => 'Api\Controller\JobLogController',
+            'Api\Controller\JobStatus' => 'Api\Controller\JobStatusController',
             'Api\Controller\JobTotals' => 'Api\Controller\JobTotalsController',
             'Api\Controller\Media' => 'Api\Controller\MediaController',
             'Api\Controller\Pool' => 'Api\Controller\PoolController',
@@ -82,6 +83,18 @@ return array(
                             ),
                             'defaults' => array(
                                 'controller' => 'Api\Controller\JobLog',
+                            ),
+                        ),
+                    ),
+                    'jobstatus' => array(
+                        'type' => Segment::class,
+                        'options' => array(
+                            'route' => '/jobstatus[/][:id]',
+                            'constraints' => array(
+                                'id' => '[a-zA-Z0-9][a-zA-Z0-9\._-]*',
+                            ),
+                            'defaults' => array(
+                                'controller' => 'Api\Controller\JobStatus',
                             ),
                         ),
                     ),

--- a/webui/module/Api/src/Api/Controller/JobStatusController.php
+++ b/webui/module/Api/src/Api/Controller/JobStatusController.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ *
+ * bareos-webui - Bareos Web-Frontend
+ *
+ * @link      https://github.com/bareos/bareos for the canonical source repository
+ * @copyright Copyright (C) 2013-2026 Bareos GmbH & Co. KG (http://www.bareos.org/)
+ * @license   GNU Affero General Public License (http://www.gnu.org/licenses/)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Api\Controller;
+
+use Laminas\Mvc\Controller\AbstractRestfulController;
+use Laminas\View\Model\JsonModel;
+use Exception;
+
+/**
+ * Live status of a currently-running job. Consumes the director's
+ * `status jobid=N` aggregator (available under `.api json` in Bareos
+ * with the JSON-status feature). The director fans out to the FD and
+ * SD and returns a single document combining dir/fd/sd views.
+ *
+ * Response matches the aggregator output verbatim:
+ *   {
+ *     "job_status": {
+ *       "jobid": N,
+ *       "dir": {...},          # only if the job is currently known
+ *       "fd":  { "data": {...} | "error": "..." },
+ *       "sd":  { "data": {...} | "error": "..." }
+ *     }
+ *   }
+ * or:
+ *   { "job_status": { "jobid": N, "error": "job_not_found" } }
+ */
+class JobStatusController extends AbstractRestfulController
+{
+    protected $bsock = null;
+    protected $jobModel = null;
+    protected $result = null;
+
+    public function getList()
+    {
+        $this->RequestURIPlugin()->setRequestURI();
+
+        if (!$this->SessionTimeoutPlugin()->isValid()) {
+            return $this->redirect()->toRoute(
+                'auth',
+                array(
+                    'action' => 'login'
+                ),
+                array(
+                    'query' => array(
+                        'req' => $this->RequestURIPlugin()->getRequestURI(),
+                        'dird' => $_SESSION['bareos']['director']
+                    )
+                )
+            );
+        }
+
+        return new JsonModel();
+    }
+
+    public function get($id)
+    {
+        $this->RequestURIPlugin()->setRequestURI();
+
+        if (!$this->SessionTimeoutPlugin()->isValid()) {
+            return $this->redirect()->toRoute(
+                'auth',
+                array(
+                    'action' => 'login'
+                ),
+                array(
+                    'query' => array(
+                        'req' => $this->RequestURIPlugin()->getRequestURI(),
+                        'dird' => $_SESSION['bareos']['director']
+                    )
+                )
+            );
+        }
+
+        $this->bsock = $this->getServiceLocator()->get('director');
+        $jobid = $this->params()->fromRoute('id');
+
+        try {
+            $this->result = $this->getJobModel()->getLiveJobStatus($this->bsock, $jobid);
+        } catch (Exception $e) {
+            $this->getResponse()->setStatusCode(500);
+            error_log($e);
+        }
+
+        return new JsonModel($this->result);
+    }
+
+    public function getJobModel()
+    {
+        if (!$this->jobModel) {
+            $sm = $this->getServiceLocator();
+            $this->jobModel = $sm->get('Job\Model\JobModel');
+        }
+        return $this->jobModel;
+    }
+}

--- a/webui/module/Api/src/Api/Controller/JobStatusController.php
+++ b/webui/module/Api/src/Api/Controller/JobStatusController.php
@@ -53,6 +53,14 @@ class JobStatusController extends AbstractRestfulController
     protected $jobModel = null;
     protected $result = null;
 
+    /**
+     * Handle `GET /api/jobstatus` (collection). Not used — clients must
+     * request a specific jobid via `GET /api/jobstatus/<id>`. Redirects
+     * to the login page if the session has timed out; otherwise returns
+     * an empty JSON object.
+     *
+     * @return JsonModel|\Laminas\Http\Response
+     */
     public function getList()
     {
         $this->RequestURIPlugin()->setRequestURI();
@@ -75,6 +83,16 @@ class JobStatusController extends AbstractRestfulController
         return new JsonModel();
     }
 
+    /**
+     * Handle `GET /api/jobstatus/<id>`. Forwards to
+     * JobModel::getLiveJobStatus(), which invokes the director's
+     * aggregating `status jobid=<id>` command under `.api json`.
+     * Redirects to login on session timeout. Returns HTTP 500 if the
+     * director call throws.
+     *
+     * @param int|string $id jobid to query.
+     * @return JsonModel|\Laminas\Http\Response
+     */
     public function get($id)
     {
         $this->RequestURIPlugin()->setRequestURI();
@@ -107,6 +125,11 @@ class JobStatusController extends AbstractRestfulController
         return new JsonModel($this->result);
     }
 
+    /**
+     * Lazily resolve and memoize the Job model from the service locator.
+     *
+     * @return \Job\Model\JobModel
+     */
     public function getJobModel()
     {
         if (!$this->jobModel) {

--- a/webui/module/Api/src/Api/Controller/JobStatusController.php
+++ b/webui/module/Api/src/Api/Controller/JobStatusController.php
@@ -112,14 +112,29 @@ class JobStatusController extends AbstractRestfulController
             );
         }
 
+        /* The route constraint permits non-numeric ids; reject them up
+         * front rather than letting JobModel silently cast to `(int)0`
+         * and issue `status jobid=0`. */
+        if (!ctype_digit((string)$id)) {
+            $this->getResponse()->setStatusCode(400);
+            return new JsonModel(array('error' => 'invalid_jobid'));
+        }
+
         $this->bsock = $this->getServiceLocator()->get('director');
-        $jobid = $this->params()->fromRoute('id');
 
         try {
-            $this->result = $this->getJobModel()->getLiveJobStatus($this->bsock, $jobid);
+            $this->result = $this->getJobModel()->getLiveJobStatus($this->bsock, $id);
         } catch (Exception $e) {
             $this->getResponse()->setStatusCode(500);
-            error_log($e);
+            /* Log only the message so file paths / stack frames don't
+             * land in the server error log on every transient director
+             * hiccup. */
+            error_log(sprintf(
+                'JobStatusController: director error for jobid=%s: %s',
+                $id,
+                $e->getMessage()
+            ));
+            $this->result = array('error' => 'director_error');
         }
 
         return new JsonModel($this->result);

--- a/webui/module/Application/config/commands.csv
+++ b/webui/module/Application/config/commands.csv
@@ -32,7 +32,7 @@ reload,--,optional,--,--,--,--,--,--,--,--,--,--
 rerun,--,optional,--,--,--,optional,--,--,--,--,--,--
 resolve,--,optional,--,--,--,--,--,--,--,--,--,--
 run,--,optional,--,--,--,optional,--,--,--,--,--,--
-status,optional,optional,--,optional,--,--,--,--,--,optional,optional,--
+status,optional,optional,--,optional,--,optional,--,--,--,optional,optional,--
 setbandwidth,--,optional,--,--,--,--,--,--,--,--,--,--
 setdebug,--,optional,--,--,--,--,--,--,--,--,--,--
 setip,--,optional,--,--,--,--,--,--,--,--,--,--

--- a/webui/module/Dashboard/view/dashboard/dashboard/index.phtml
+++ b/webui/module/Dashboard/view/dashboard/dashboard/index.phtml
@@ -222,7 +222,15 @@ $this->headTitle($title);
             {
                field: 'jobbytes',
                sortable: true,
-               formatter: function(value) {
+               formatter: function(value, row) {
+                  // For running jobs the catalog's jobbytes isn't populated
+                  // until the job completes. Queue a live-status fetch that
+                  // fills in the real byte count asynchronously.
+                  if (row && row.jobstatus === 'R' && row.jobid) {
+                     queueTableLiveBytes(row.jobid);
+                     return '<span class="lp-table-bytes-' + row.jobid
+                        + '"><em class="text-muted">&mdash;</em></span>';
+                  }
                   return formatBytes(value);
                }
             },
@@ -268,8 +276,15 @@ $this->headTitle($title);
                      //$('.rjc-panel-'+i).append('<div class="progress" id="progress" data-toggle="tooltip" data-placement="top"><div class="progress-bar progress-bar-striped active" role="progressbar" aria-valuenow="100" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: 100%"></div></div>');
                      //$('.rjc-panel-'+i).append('<span class="text-muted"><i>(<?php echo $this->translate("Not enough data to estimate progress or statistics collection is disabled."); ?>)</i></span>');
                   }
+                  // Live-progress slot (populated asynchronously per-job below).
+                  // Works even without a prior successful run to estimate against.
+                  $('.rjc-panel-'+i).append('<div class="lp-live-dashboard" id="lp-live-' + data[id].jobid + '" style="margin-top:6px; font-size:90%; color:#333;"></div>');
                   $('.rjc-panel-'+i).append('</div></div>');
                   i++;
+               });
+               // Fetch per-job live status (backend aggregator -> FD + SD).
+               $(Object.keys(data)).each(function(key, id) {
+                  fetchDashboardLiveProgress(data[id].jobid);
                });
             }
             else {
@@ -288,6 +303,83 @@ $this->headTitle($title);
          parsererror: function() {
             $('.running-jobs-container').empty();
             $('.running-jobs-container').append('Error parsing data.');
+         }
+      });
+   }
+
+   // Fetch live mid-run progress for one running job and inject it into the
+   // dashboard card. Uses the director's `status jobid=N api=json` aggregator
+   // which returns the FD and SD views combined. Fails silently on error --
+   // the existing card (with Bareos's own bytes/progress fields) stays visible.
+   function fetchDashboardLiveProgress(jobid) {
+      var basePath = '<?php echo $this->basePath(); ?>';
+      // API returns jobid as a JSON number. The id coming in from the outer
+      // getRunningJobs payload can be a string -- coerce once so the
+      // .find() strict comparison below matches.
+      var jobidNum = Number(jobid);
+      $.ajax({
+         url: basePath + '/api/jobstatus/' + jobidNum,
+         dataType: 'json',
+         timeout: 8000,
+         success: function(data) {
+            // The endpoint returns the job_status object directly (Laminas
+            // JsonModel serializes the inner subtree, not the wrapper).
+            if (!data || !data.jobid || data.error) return;
+            var js = data;
+            var fj = (js.fd && js.fd.data && js.fd.data.running_jobs)
+               ? js.fd.data.running_jobs.find(function(j){return j.jobid===jobidNum;}) : null;
+            var sj = (js.sd && js.sd.data && js.sd.data.running_jobs)
+               ? js.sd.data.running_jobs.find(function(j){return j.jobid===jobidNum;}) : null;
+            var parts = [];
+            if (fj) {
+               if (fj.bytes !== undefined)   parts.push('<strong>FD:</strong> ' + formatBytes(fj.bytes));
+               if (fj.files !== undefined)   parts.push(fj.files.toLocaleString() + ' files');
+               if (fj.processing_file)       parts.push('<span style="word-break:break-all">' + $('<div>').text(fj.processing_file).html() + '</span>');
+            }
+            if (sj) {
+               if (sj.bytes !== undefined)            parts.push('<strong>SD:</strong> ' + formatBytes(sj.bytes));
+               if (sj.avg_bytes_per_sec !== undefined) parts.push(formatBytes(sj.avg_bytes_per_sec) + '/s avg');
+               if (sj.last_bytes_per_sec !== undefined)parts.push(formatBytes(sj.last_bytes_per_sec) + '/s now');
+               if (sj.writing && sj.writing.volume)    parts.push('vol ' + $('<div>').text(sj.writing.volume).html());
+            }
+            if (parts.length) {
+               $('#lp-live-' + jobid).html(parts.join(' &middot; '));
+            }
+         }
+      });
+   }
+
+   // Fills the bytes cell of a running row in the "Most recent job status"
+   // table with live FD/SD bytes. Reuses the same `status jobid=N api=json`
+   // endpoint. The table formatter emits `<span class="lp-table-bytes-N">`
+   // placeholders; this function updates them after the AJAX returns.
+   // Dedups in-flight requests so rapid re-renders don't pile up.
+   var lpTableInflight = {};
+   function queueTableLiveBytes(jobid) {
+      var key = Number(jobid);
+      if (lpTableInflight[key]) return;
+      lpTableInflight[key] = true;
+      var basePath = '<?php echo $this->basePath(); ?>';
+      $.ajax({
+         url: basePath + '/api/jobstatus/' + key,
+         dataType: 'json',
+         timeout: 8000
+      }).always(function() {
+         delete lpTableInflight[key];
+      }).done(function(data) {
+         if (!data || data.error || !data.sd || !data.sd.data) return;
+         var sj = (data.sd.data.running_jobs || []).find(function(j){
+            return j.jobid === key;
+         });
+         var fj = ((data.fd && data.fd.data) ? data.fd.data.running_jobs : [] || [])
+            .find(function(j){ return j.jobid === key; });
+         // Prefer SD bytes (closer to what actually landed on storage);
+         // fall back to FD bytes if the SD hasn't started writing yet.
+         var bytes = null;
+         if (sj && sj.bytes) bytes = sj.bytes;
+         else if (fj && fj.bytes) bytes = fj.bytes;
+         if (bytes !== null) {
+            $('.lp-table-bytes-' + key).html(formatBytes(bytes));
          }
       });
    }

--- a/webui/module/Job/src/Job/Model/JobModel.php
+++ b/webui/module/Job/src/Job/Model/JobModel.php
@@ -209,6 +209,38 @@ class JobModel
     }
 
     /**
+     * Live status for a currently-running job. Calls the director's
+     * `status jobid=N` aggregator under api=json and returns the
+     * nested job_status subtree (dir + fd + sd views combined), or
+     * an empty array if the director did not return a result.
+     *
+     * Requires a bareos-dir that implements the JSON status feature
+     * (bareos/bareos#2325). Callers should tolerate:
+     *   - {"error": "job_not_found"}             (job already finished)
+     *   - fd/sd with {"error": "..._too_old"}    (backward-compat gating)
+     *   - fd/sd with {"error": "reply_too_large"} (defensive cap)
+     *
+     * @param $bsock
+     * @param $id
+     *
+     * @return array
+     */
+    public function getLiveJobStatus(&$bsock = null, $id = null)
+    {
+        if (isset($bsock, $id)) {
+            $cmd = 'status jobid=' . (int)$id;
+            $result = $bsock->send_command($cmd, 2);
+            $decoded = \Laminas\Json\Json::decode($result, \Laminas\Json\Json::TYPE_ARRAY);
+            if (empty($decoded['result']['job_status'])) {
+                return array();
+            }
+            return $decoded['result']['job_status'];
+        } else {
+            throw new \Exception('Missing argument.');
+        }
+    }
+
+    /**
      * Get Job Log
      *
      * @param $bsock

--- a/webui/module/Job/view/job/job/details.phtml
+++ b/webui/module/Job/view/job/job/details.phtml
@@ -40,6 +40,53 @@ $this->headTitle($title);
 
 <?php if($this->acl_alert) : echo $this->ACLAlert($this->invalid_commands); elseif(!$this->acl_alert) : ?>
 
+<!-- Live progress (hidden unless the job is currently running) -->
+<div class="row" id="live-progress-row" style="display: none;">
+   <div class="col-md-12">
+      <div class="panel panel-primary">
+         <div class="panel-heading">
+            <h3 class="panel-title">
+               <span class="glyphicon glyphicon-refresh" style="animation: spin 1.6s linear infinite;"></span>
+               <?php echo $this->translate("Live progress"); ?>
+               <span id="live-progress-status" class="badge" style="margin-left: 8px;"></span>
+            </h3>
+         </div>
+         <div class="panel-body">
+            <div class="row">
+               <div class="col-md-6">
+                  <dl class="dl-horizontal">
+                     <dt><?php echo $this->translate("Client bytes"); ?></dt>
+                     <dd id="lp-fd-bytes">&mdash;</dd>
+                     <dt><?php echo $this->translate("Client files"); ?></dt>
+                     <dd id="lp-fd-files">&mdash;</dd>
+                     <dt><?php echo $this->translate("Files examined"); ?></dt>
+                     <dd id="lp-fd-examined">&mdash;</dd>
+                     <dt><?php echo $this->translate("Processing file"); ?></dt>
+                     <dd id="lp-fd-processing" style="word-break: break-all;">&mdash;</dd>
+                  </dl>
+               </div>
+               <div class="col-md-6">
+                  <dl class="dl-horizontal">
+                     <dt><?php echo $this->translate("Storage bytes"); ?></dt>
+                     <dd id="lp-sd-bytes">&mdash;</dd>
+                     <dt><?php echo $this->translate("Average rate"); ?></dt>
+                     <dd id="lp-sd-avgrate">&mdash;</dd>
+                     <dt><?php echo $this->translate("Current rate"); ?></dt>
+                     <dd id="lp-sd-lastrate">&mdash;</dd>
+                     <dt><?php echo $this->translate("Volume"); ?></dt>
+                     <dd id="lp-sd-volume">&mdash;</dd>
+                     <dt><?php echo $this->translate("Device"); ?></dt>
+                     <dd id="lp-sd-device" style="word-break: break-all;">&mdash;</dd>
+                  </dl>
+               </div>
+            </div>
+            <div id="live-progress-warning" class="alert alert-warning" style="display: none;"></div>
+         </div>
+      </div>
+   </div>
+</div>
+<style>@keyframes spin { from{transform:rotate(0);} to{transform:rotate(360deg);} }</style>
+
 <!-- Job -->
 <div class="row">
 
@@ -302,6 +349,108 @@ $this->headTitle($title);
       });
    }
 
+   // Live progress panel: polls /api/jobstatus/<id> every 5s while the
+   // job is running, hides the panel (and stops polling) once the job
+   // is no longer in the director's live JCR list. Fail-soft: if the
+   // director or either daemon returns a structured error (too-old,
+   // oversize reply, parse failure) the panel stays visible with a
+   // warning banner but continues polling -- the error may be transient.
+   var liveProgressTimer = null;
+   var liveProgressJobid = <?php echo (int)$this->jobid; ?>;
+
+   function fmtBytes(n) {
+      if (n === null || n === undefined) return '\u2014';
+      var u = ['B','KB','MB','GB','TB','PB'];
+      var i = 0; n = Number(n);
+      while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+      return n.toFixed(i === 0 ? 0 : 2) + ' ' + u[i];
+   }
+
+   function fmtRate(bps) {
+      if (!bps) return '\u2014';
+      return fmtBytes(bps) + '/s';
+   }
+
+   function renderLiveProgress(data) {
+      // The endpoint returns the job_status object directly (Laminas
+      // JsonModel serializes $this->result, which is the inner subtree).
+      var warn = $('#live-progress-warning');
+      if (!data || !data.jobid) { return false; }
+      var js = data;
+
+      if (js.error === 'job_not_found') {
+         // Job is no longer running. Hide panel and stop polling.
+         $('#live-progress-row').hide();
+         return false;
+      }
+
+      var fdData = (js.fd && js.fd.data) ? js.fd.data : null;
+      var sdData = (js.sd && js.sd.data) ? js.sd.data : null;
+      var fdErr = (js.fd && js.fd.error) ? js.fd.error : null;
+      var sdErr = (js.sd && js.sd.error) ? js.sd.error : null;
+
+      $('#live-progress-row').show();
+      if (js.dir && js.dir.status) {
+         $('#live-progress-status').text(js.dir.status);
+      }
+
+      var fdJob = (fdData && fdData.running_jobs)
+         ? fdData.running_jobs.find(function(j) { return j.jobid === liveProgressJobid; })
+         : null;
+      if (fdJob) {
+         $('#lp-fd-bytes').text(fmtBytes(fdJob.bytes));
+         $('#lp-fd-files').text((fdJob.files || 0).toLocaleString());
+         $('#lp-fd-examined').text((fdJob.files_examined || 0).toLocaleString());
+         $('#lp-fd-processing').text(fdJob.processing_file || '\u2014');
+      }
+
+      var sdJob = (sdData && sdData.running_jobs)
+         ? sdData.running_jobs.find(function(j) { return j.jobid === liveProgressJobid; })
+         : null;
+      if (sdJob) {
+         $('#lp-sd-bytes').text(fmtBytes(sdJob.bytes));
+         $('#lp-sd-avgrate').text(fmtRate(sdJob.avg_bytes_per_sec));
+         $('#lp-sd-lastrate').text(fmtRate(sdJob.last_bytes_per_sec));
+         if (sdJob.writing) {
+            $('#lp-sd-volume').text(sdJob.writing.volume || '\u2014');
+            $('#lp-sd-device').text(sdJob.writing.device || '\u2014');
+         }
+      }
+
+      var warnings = [];
+      if (fdErr) { warnings.push('<?php echo $this->translate("File Daemon JSON status unavailable"); ?>: ' + fdErr); }
+      if (sdErr) { warnings.push('<?php echo $this->translate("Storage Daemon JSON status unavailable"); ?>: ' + sdErr); }
+      if (warnings.length) {
+         warn.html(warnings.join('<br>')).show();
+      } else {
+         warn.hide();
+      }
+
+      return true;
+   }
+
+   function pollLiveProgress() {
+      $.ajax({
+         url: '<?php echo $this->url('api/jobstatus', array('id' => $this->jobid)); ?>',
+         method: 'GET',
+         dataType: 'json',
+         timeout: 10000
+      }).done(function(data) {
+         var stillRunning = renderLiveProgress(data);
+         if (!stillRunning) {
+            clearInterval(liveProgressTimer);
+            liveProgressTimer = null;
+         }
+      }).fail(function() {
+         // Transient -- leave panel in its current state, keep polling.
+      });
+   }
+
+   function attachLiveProgress() {
+      pollLiveProgress();
+      liveProgressTimer = setInterval(pollLiveProgress, 5000);
+   }
+
    $(document).ready(function() {
 
       setDtTextDomain('<?php echo $this->basePath() . '/js/locale'; ?>');
@@ -310,6 +459,7 @@ $this->headTitle($title);
       attachJobDetailsTable();
       attachJobLogTable();
       attachJobMediaTable();
+      attachLiveProgress();
 
    });
 


### PR DESCRIPTION
## Summary

Adds a live-progress UI for currently-running jobs, powered by the new
\`status jobid=N api=json\` aggregator command in the director (introduced
in companion PR #2626, required for this to work end-to-end).

**Where it appears:**
- **Per-job details page** (\`/job/details/<id>\`) — a dedicated \"Live
  progress\" panel showing client-side files examined / bytes /
  processing-file path, and storage-side bytes / volume / device /
  average and instantaneous rates. Auto-hides once the job is no longer
  in the director's live JCR list.
- **Dashboard → Running Jobs cards** — a compact inline summary line
  (FD bytes · files · current file · SD bytes · avg rate · current rate ·
  volume) appears below each card, filling the gap where Bareos's own
  \`jobbytes\` shows 0 until job completion.
- **Dashboard → \"Most recent job status\" table** — the \`Bytes\` column
  hydrates asynchronously for rows whose \`jobstatus === 'R'\`, so a row
  for a running job shows the live SD byte count rather than \`0.00 B\`.

## Implementation

- New REST endpoint: \`GET /api/jobstatus/<id>\`, handled by a new
  \`Api\\Controller\\JobStatusController\` that mirrors the existing
  \`JobLogController\` pattern.
- New model method \`Job\\Model\\JobModel::getLiveJobStatus()\` invoking
  the director aggregator through \`BareosBSock::send_command(cmd, 2)\`.
- \`console_commands\` / \`commands.csv\`: added \`status\` to the Job
  module so webui admin profiles can invoke \`status jobid=N\`.
- Polls every 5 s on the details page; hydrates on-demand on the
  dashboard table + running-jobs cards. Fail-soft: transient AJAX
  errors leave existing UI intact; session timeout redirects to auth.

## Dependency

**Requires the backend PR #2626 to be merged** (director needs to understand
\`status jobid=N\` under \`.api json\`). Against an older director, the
endpoint returns structured \`file_daemon_too_old\` /
\`storage_daemon_too_old\` errors which the UI renders as a warning banner
instead of populating the fields.

## Test plan

- [x] Deployed end-to-end against a live director running the backend
      patches and exercised during a real ~130 GB tape backup: dashboard
      live line, per-job panel, and jobs-table byte-column hydration all
      populate correctly and clear when the job terminates.
- [x] \`GET /api/jobstatus/<id>\` returns structured \`job_not_found\` when
      the jobid isn't in the live JCR list.
- [x] Session-timeout path redirects to \`/auth/login\`.
- [ ] No webui systemtests added; existing tests unaffected.