### PR TITLE
stored: unblock status during device init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - dirconfig: add subscription setting with comment [PR #2468]
-- stored: document `MaximumFileSizeImmediateFilemark = no` as upgrade fallback [PR #2634]
+- stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
+  rollover filemarks; set `MaximumFileSizeImmediateFilemark = no` after upgrade
+  to keep the previous blocking behavior [PR #2634]
 - hyper-v: fix restores with portable data [PR #2469]
 - table-formatter.js: Fix icon selection logic [PR #2479]
 - systemtests: tune for execution on Windows [PR #2501]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - dirconfig: add subscription setting with comment [PR #2468]
+- stored: document `MaximumFileSizeImmediateFilemark = no` as upgrade fallback [PR #2634]
 - hyper-v: fix restores with portable data [PR #2469]
 - table-formatter.js: Fix icon selection logic [PR #2479]
 - systemtests: tune for execution on Windows [PR #2501]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 - stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
-  rollover filemarks for `MaximumFileSize`. Tape backends overriding
-  `weof_immediate()` now see that behavior on upgrade unless
+  rollover filemarks for `MaximumFileSize`, changing tape backends that
+  override `weof_immediate()` from `weof(1)` to `weof_immediate(1)` on upgrade unless
   `MaximumFileSizeImmediateFilemark = no` is set to keep the previous blocking
   behavior [PR #2634]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Breaking Changes
 - stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
-  rollover filemarks for `MaximumFileSize`; set
-  `MaximumFileSizeImmediateFilemark = no` after upgrade to keep the previous
-  blocking behavior [PR #2634]
+  rollover filemarks for `MaximumFileSize`. Tape backends overriding
+  `weof_immediate()` now see that behavior on upgrade unless
+  `MaximumFileSizeImmediateFilemark = no` is set to keep the previous blocking
+  behavior [PR #2634]
 
 ### Changed
 - dirconfig: add subscription setting with comment [PR #2468]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 - stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
   rollover filemarks for `MaximumFileSize`, changing tape backends that
-  override `weof_immediate()` from `weof(1)` to `weof_immediate(1)` on upgrade unless
-  `MaximumFileSizeImmediateFilemark = no` is set to keep the previous blocking
-  behavior [PR #2634]
+  override `weof_immediate()` from `weof(1)` to `weof_immediate(1)` on upgrade
+  unless `sd/device/MaximumFileSizeImmediateFilemark = no` is set to keep the
+  previous blocking behavior [PR #2634]
 
 ### Changed
 - dirconfig: add subscription setting with comment [PR #2468]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - add SUSE 15SP7 and 16.0 [PR #2505]
 - Add simple dependency generator for systemtest testrunners [PR #2484]
 
+### Breaking Changes
+- stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
+  rollover filemarks for `MaximumFileSize`; set
+  `MaximumFileSizeImmediateFilemark = no` after upgrade to keep the previous
+  blocking behavior [PR #2634]
+
 ### Changed
 - dirconfig: add subscription setting with comment [PR #2468]
-- stored: `MaximumFileSizeImmediateFilemark` now defaults to non-blocking
-  rollover filemarks; set `MaximumFileSizeImmediateFilemark = no` after upgrade
-  to keep the previous blocking behavior [PR #2634]
 - hyper-v: fix restores with portable data [PR #2469]
 - table-formatter.js: Fix icon selection logic [PR #2479]
 - systemtests: tune for execution on Windows [PR #2501]

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -341,14 +341,8 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
           field5 = nullptr;
         }
       } else {
-        field3 = strchr(field2, ':');
-        if (field3) {
-          *field3++ = '\0';
-          nr_fields = 3;
-        } else {
-          nr_fields = 2;
-          field3 = nullptr;
-        }
+        nr_fields = 2;
+        field3 = nullptr;
         field4 = nullptr;
         field5 = nullptr;
       }

--- a/core/src/dird/sd_cmds.cc
+++ b/core/src/dird/sd_cmds.cc
@@ -298,12 +298,12 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
       continue;
     }
 
-    /* Parse the message. list gives max 2 fields listall max 5.
+    /* Parse the message. list gives max 3 fields, listall max 5.
      * We always make sure all fields are initialized to either
      * a value or nullptr.
      *
      * For autochanger list the following mapping is used:
-     * - field1 == slotnr
+     * - field1 == slotnr or D<drive>
      * - field2 == volumename
      *
      * For autochanger listall the following mapping is used:
@@ -341,8 +341,14 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
           field5 = nullptr;
         }
       } else {
-        nr_fields = 2;
-        field3 = nullptr;
+        field3 = strchr(field2, ':');
+        if (field3) {
+          *field3++ = '\0';
+          nr_fields = 3;
+        } else {
+          nr_fields = 2;
+          field3 = nullptr;
+        }
         field4 = nullptr;
         field5 = nullptr;
       }
@@ -363,6 +369,10 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
 
     if (scan && !listall) {
       // Scanning -- require only valid slot
+      if (!IsAnInteger(field1)) {
+        free(vl);
+        continue;
+      }
       vl->bareos_slot_number = atoi(field1);
       if (vl->bareos_slot_number <= 0) {
         ua->ErrorMsg(T_("Invalid Slot number: %s\n"), sd->msg);
@@ -380,16 +390,27 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
       vl->element_address = INDEX_SLOT_OFFSET + vl->bareos_slot_number;
     } else if (!listall) {
       // Not scanning and not listall.
-      if (strlen(field2) == 0) {
+      const bool drive_entry = field1[0] == 'D' && IsAnInteger(field1 + 1);
+
+      if (!drive_entry && strlen(field2) == 0) {
         free(vl);
         continue;
       }
 
-      if (!IsAnInteger(field1)
-          || (vl->bareos_slot_number = atoi(field1)) <= 0) {
+      if (drive_entry) {
+        vl->slot_type = slot_type_t::kSlotTypeDrive;
+        vl->slot_status = slot_status_t::kSlotStatusFull;
+        vl->bareos_slot_number = static_cast<slot_number_t>(atoi(field1 + 1));
+        vl->element_address = INDEX_DRIVE_OFFSET + vl->bareos_slot_number;
+      } else if (!IsAnInteger(field1)
+                 || (vl->bareos_slot_number = atoi(field1)) <= 0) {
         ua->ErrorMsg(T_("Invalid Slot number: %s\n"), field1);
         free(vl);
         continue;
+      } else {
+        vl->slot_type = slot_type_t::kSlotTypeStorage;
+        vl->slot_status = slot_status_t::kSlotStatusFull;
+        vl->element_address = INDEX_SLOT_OFFSET + vl->bareos_slot_number;
       }
 
       if (!IsVolumeNameLegal(ua, field2)) {
@@ -398,10 +419,7 @@ dlist<vol_list_t>* native_get_vol_list(UaContext* ua,
         continue;
       }
 
-      vl->slot_type = slot_type_t::kSlotTypeStorage;
-      vl->slot_status = slot_status_t::kSlotStatusFull;
       vl->VolName = strdup(field2);
-      vl->element_address = INDEX_SLOT_OFFSET + vl->bareos_slot_number;
     } else {
       // Listall.
       if (!field3) { goto parse_error; }

--- a/core/src/dird/ua_label.cc
+++ b/core/src/dird/ua_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -351,7 +351,8 @@ static void label_from_barcodes(UaContext* ua,
          "Slot  Volume\n"
          "==============\n"));
   foreach_dlist (vl, vol_list->contents) {
-    if (!vl->VolName || !BitIsSet(vl->bareos_slot_number - 1, slot_list)) {
+    if (vl->slot_type != slot_type_t::kSlotTypeStorage || !vl->VolName
+        || !BitIsSet(vl->bareos_slot_number - 1, slot_list)) {
       continue;
     }
     ua->SendMsg("%4d  %s\n", vl->bareos_slot_number, vl->VolName);
@@ -368,6 +369,7 @@ static void label_from_barcodes(UaContext* ua,
 
   // Fire off the label requests
   foreach_dlist (vl, vol_list->contents) {
+    if (vl->slot_type != slot_type_t::kSlotTypeStorage) { continue; }
     if (!vl->VolName || !BitIsSet(vl->bareos_slot_number - 1, slot_list)) {
       continue;
     }

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -1046,6 +1046,7 @@ static void UpdateSlots(UaContext* ua)
 
   // Walk through the list updating the media records
   foreach_dlist (vl, vol_list->contents) {
+    if (vl->slot_type != slot_type_t::kSlotTypeStorage) { continue; }
     if (vl->bareos_slot_number > max_slots) {
       ua->WarningMsg(T_("Slot %d greater than max %d ignored.\n"),
                      vl->bareos_slot_number, max_slots);

--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -82,6 +82,7 @@ target_sources(
           scan.cc
           scsi_crypto.cc
           scsi_lli.cc
+          scsi_tapealert.cc
           serial.cc
           signal.cc
           status_packet.cc
@@ -113,7 +114,6 @@ if(HAVE_WIN32)
   target_link_libraries(bareos PUBLIC PCRE2::POSIX)
 else()
   target_sources(bareos PRIVATE bpipe_unix.cc)
-  target_sources(bareos PRIVATE scsi_tapealert.cc)
   target_sources(bareos PRIVATE osinfo_unix.cc)
 endif()
 

--- a/core/src/lib/scsi_lli.cc
+++ b/core/src/lib/scsi_lli.cc
@@ -130,6 +130,15 @@ bool RecvScsiCmdPage(int fd,
                           SG_DXFER_FROM_DEV);
 }
 
+bool DoScsiCmd(int fd,
+               const char* device_name,
+               void* cdb,
+               unsigned int cdb_len)
+{
+  return do_scsi_cmd_page(fd, device_name, cdb, cdb_len, nullptr, 0,
+                          SG_DXFER_NONE);
+}
+
 /*
  * Send a lowlevel SCSI cmd to a SCSI device using the Linux SG_IO ioctl
  * interface.
@@ -241,6 +250,15 @@ bool RecvScsiCmdPage(int fd,
 {
   return do_scsi_cmd_page(fd, device_name, cdb, cdb_len, cmd_page, cmd_page_len,
                           (USCSI_READ | USCSI_SILENT | USCSI_RQENABLE));
+}
+
+bool DoScsiCmd(int fd,
+               const char* device_name,
+               void* cdb,
+               unsigned int cdb_len)
+{
+  return do_scsi_cmd_page(fd, device_name, cdb, cdb_len, nullptr, 0,
+                          (USCSI_SILENT | USCSI_RQENABLE));
 }
 
 /*
@@ -372,6 +390,15 @@ bool RecvScsiCmdPage(int fd,
                           CAM_DIR_IN);
 }
 
+bool DoScsiCmd(int fd,
+               const char* device_name,
+               void* cdb,
+               unsigned int cdb_len)
+{
+  return do_scsi_cmd_page(fd, device_name, cdb, cdb_len, nullptr, 0,
+                          CAM_DIR_NONE);
+}
+
 /*
  * Send a lowlevel SCSI cmd to a SCSI device using the FreeBSD SCSI CAM
  * interface.
@@ -395,6 +422,8 @@ bool RecvScsiCmdPage(int, const char*, void*, unsigned int, void*, unsigned int)
 {
   return false;
 }
+
+bool DoScsiCmd(int, const char*, void*, unsigned int) { return false; }
 
 bool send_scsi_cmd_page(int,
                         const char*,

--- a/core/src/lib/scsi_lli.h
+++ b/core/src/lib/scsi_lli.h
@@ -166,6 +166,10 @@ bool RecvScsiCmdPage(int fd,
                      unsigned int cdb_len,
                      void* cmd_page,
                      unsigned int cmd_page_len);
+bool DoScsiCmd(int fd,
+               const char* device_name,
+               void* cdb,
+               unsigned int cdb_len);
 bool send_scsi_cmd_page(int fd,
                         const char* device_name,
                         void* cdb,

--- a/core/src/lib/scsi_tapealert.cc
+++ b/core/src/lib/scsi_tapealert.cc
@@ -146,11 +146,22 @@ bool GetTapealertFlags(int fd, const char* device_name, uint64_t* flags)
 
   // Walk over all tape alert parameters.
   cnt = 0;
-  while (cnt < tapealert_length) {
+  if (tapealert_length > static_cast<int>(sizeof(cmd_page.log_parameters))) {
+    tapealert_length = sizeof(cmd_page.log_parameters);
+  }
+
+  while (cnt + static_cast<int>(sizeof(TAPEALERT_PARAMETER) - 1)
+         <= tapealert_length) {
     uint16_t result_index;
     TAPEALERT_PARAMETER* ta_param;
+    int parameter_size;
 
     ta_param = (TAPEALERT_PARAMETER*)&cmd_page.log_parameters[cnt];
+    parameter_size
+        = static_cast<int>(sizeof(TAPEALERT_PARAMETER) - 1 + ta_param->parameter_length);
+    if (parameter_size <= 0 || cnt + parameter_size > tapealert_length) {
+      break;
+    }
     result_index
         = (ta_param->parameter_code[0] << 8) + ta_param->parameter_code[1];
     if (result_index > 0 && result_index < MAX_TAPE_ALERTS) {
@@ -166,10 +177,10 @@ bool GetTapealertFlags(int fd, const char* device_name, uint64_t* flags)
       }
     }
 
-    cnt += ((sizeof(TAPEALERT_PARAMETER) - 1) + ta_param->parameter_length);
+    cnt += parameter_size;
   }
 
-  return false;
+  return true;
 }
 #else
 bool GetTapealertFlags(int, const char*, uint64_t* flags)

--- a/core/src/lib/scsi_tapealert_flags.h
+++ b/core/src/lib/scsi_tapealert_flags.h
@@ -1,0 +1,334 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_LIB_SCSI_TAPEALERT_FLAGS_H_
+#define BAREOS_LIB_SCSI_TAPEALERT_FLAGS_H_
+
+#include <array>
+#include <cstdint>
+
+#include "lib/message_severity.h"
+
+namespace scsitapealert {
+
+struct flag {
+  unsigned int no;
+  std::int32_t type;
+  const char* name;
+  const char* message;
+  const char* cause;
+
+  bool present_in(uint64_t flags) const { return flags & (UINT64_C(1) << no); }
+};
+
+/* The following information is taken from the Tape Alert Specification v3.0
+ * provided by Hewlett-Packard to NCITS for standardization activities.
+ * see https://www.t10.org/ftp/t10/document.02/02-142r0.pdf */
+constexpr std::array flags{
+    flag{1, M_WARNING, "Read Warning",
+         "The tape drive is having problems reading data. No data has been "
+         "lost, "
+         "but there has been a reduction in the performance of the tape.",
+         "The drive is having severe trouble reading"},
+    flag{2, M_WARNING, "Write Warning",
+         "The tape drive is having problems writing data. No data has been "
+         "lost, "
+         "but there has been a reduction in the capacity of the tape.",
+         "The drive is having severe trouble writing"},
+    flag{
+        3, M_WARNING, "Hard Error",
+        "The operation has stopped because an error has occurred while reading "
+        "or writing data which the drive cannot correct.",
+        "The drive had a hard read or write error"},
+    flag{4, M_ERROR, "Media",
+         "Your data is at risk:\n"
+         "1. Copy any data you require from this tape.\n"
+         "2. Do not use this tape again.\n"
+         "3. Restart the operation with a different tape.",
+         "Media can no longer be written/read, or performance is severely "
+         "degraded"},
+    flag{5, M_ERROR, "Read Failure",
+         "The tape is damaged or the drive is faulty. Call the tape drive "
+         "supplier helpline.",
+         "The drive can no longer read data from the tape"},
+    flag{6, M_ERROR, "Write Failure",
+         "The tape is from a faulty batch or the tape drive is faulty:\n"
+         "1. Use a good tape to test the drive.\n"
+         "2. If the problem persists, call the tape drive supplier helpline.",
+         "The drive can no longer write data to the tape"},
+    flag{7, M_WARNING, "Media Life",
+         "The tape cartridge has reached the end of its calculated useful "
+         "life:\n"
+         "1. Copy any data you need to another tape\n"
+         "2. Discard the old tape.",
+         "The media has exceeded its specified life"},
+    flag{8, M_WARNING, "Not Data Grade",
+         "The tape cartridge is not data-grade. Any data you back up to the "
+         "tape "
+         "is at risk. Replace the cartridge with a data-grade tape.",
+         "The drive has not been able to read the MRS stripes"},
+    flag{9, M_ERROR, "Write Protect",
+         "You are trying to write to a write-protected cartridge. Remove the "
+         "write-protection or use another tape.",
+         "Write command is attempted to a write protected tape"},
+    flag{
+        10, M_INFO, "No Removal",
+        "You cannot eject the cartridge because the tape drive is in use. Wait "
+        "until the operation is complete before ejecting the cartridge.",
+        "Manual or s/w unload attempted when prevent media removal on"},
+    flag{11, M_INFO, "Cleaning Media",
+         "The tape in the drive is a cleaning cartridge.",
+         "Cleaning tape loaded into drive"},
+    flag{
+        12, M_INFO, "Unsupported Format",
+        "You have tried to load a cartridge of a type which is not supported "
+        "by "
+        "this drive.",
+        "Attempted loaded of unsupported tape format, e.g. DDS2 in DDS1 drive"},
+    flag{13, M_ERROR, "Recoverable Snapped Tape",
+         "The operation has failed because the tape in the drive has snapped:\n"
+         "1. Discard the old tape.\n"
+         "2. Restart the operation with a different tape.",
+         "Tape snapped/cut in the drive where media can be ejected"},
+    flag{14, M_ERROR, "Unrecoverable Snapped Tape",
+         "The operation has failed because the tape in the drive has snapped:\n"
+         "1. Do not attempt to extract the tape cartridge.\n"
+         "2. Call the tape drive supplier helpline.",
+         "Tape snapped/cut in the drive where media cannot be ejected"},
+    flag{15, M_WARNING, "Memory Chip in Cartridge Failure",
+         "The memory in the tape cartridge has failed, which reduces "
+         "performance. "
+         "Do not use the cartridge for further backup operations.",
+         "Memory chip failed in cartridge"},
+    flag{16, M_ERROR, "Forced Eject",
+         "The operation has failed because the tape cartridge was manually "
+         "ejected while the tape drive was actively writing or reading.",
+         "Manual or forced eject while drive actively writing or reading"},
+    flag{17, M_WARNING, "Read Only Format",
+         "You have loaded a cartridge of a type that is read-only in this "
+         "drive. "
+         "The cartridge will appear as write-protected.",
+         "Media loaded that is read-only format"},
+    flag{18, M_WARNING, "Tape Directory Corrupted on Load",
+         "The directory on the tape cartridge has been corrupted. File search "
+         "performance will be degraded. The tape directory can be rebuilt by "
+         "reading all the data on the cartridge.",
+         "Tape drive powered down with tape loaded, or permanent error "
+         "prevented "
+         "the tape directory being updated"},
+    flag{19, M_INFO, "Nearing Media Life",
+         "The tape cartridge is nearing the end of its calculated life. It is "
+         "recommended that you:\n"
+         "1. Use another tape cartridge for your next backup.\n"
+         "2. Store this tape cartridge in a safe place in case you need to "
+         "restore data from it.",
+         "Media may have exceeded its specified number of passes"},
+    flag{20, M_ERROR, "Clean Now",
+         "The tape drive needs cleaning:\n"
+         "1. If the operation has stopped, eject the tape and clean the drive\n"
+         "2. If the operation has not stopped, wait for it to finish and then "
+         "clean the drive.\n"
+         "Check the tape drive users manual for device specific cleaning "
+         "instructions.",
+         "The drive thinks it has a head clog, or needs cleaning"},
+    flag{21, M_WARNING, "Clean Periodic",
+         "The tape drive is due for routine cleaning:\n"
+         "1. Wait for the current operation to finish.\n"
+         "2. Then use a cleaning cartridge.\n"
+         "Check the tape drive users manual for device specific cleaning "
+         "instructions.",
+         "The drive is ready for a periodic clean"},
+    flag{22, M_ERROR, "Expired Cleaning Media",
+         "The last cleaning cartridge used in the tape drive has worn out:\n"
+         "1. Discard the worn out cleaning cartridge.\n"
+         "2. Wait for the current operation to finish.\n"
+         "3. Then use a new cleaning cartridge.",
+         "The cleaning tape has expired"},
+    flag{23, M_ERROR, "Invalid Cleaning Tape",
+         "The last cleaning cartridge used in the tape drive was an invalid "
+         "type:\n"
+         "1. Do not use this cleaning cartridge in this drive.\n"
+         "2. Wait for the current operation to finish.\n"
+         "3. Then use a valid cleaning cartridge.\n"
+         "",
+         "Invalid cleaning tape type used"},
+    flag{24, M_WARNING, "Retention Requested",
+         "The tape drive has requested a retention operation.",
+         "The drive is having severe trouble reading or writing, which will be "
+         "resolved by a retention cycle"},
+    flag{25, M_WARNING, "Dual-Port Interface Error",
+         "A redundant interface port on the tape drive has failed.",
+         "Failure of one interface port in a dual-port configuration, e.g. "
+         "Fibrechannel"},
+    flag{26, M_WARNING, "Cooling Fan Failure",
+         "A tape drive cooling fan has failed.",
+         "Fan failure inside tape drive mechanism or tape drive enclosure"},
+    flag{27, M_WARNING, "Power Supply",
+         "A redundant power supply has failed inside the tape drive enclosure. "
+         "Check the enclosure users manual for instructions on replacing the "
+         "failed power supply.",
+         "Redundant PSU failure inside the tape drive enclosure or rack "
+         "subsystem"},
+    flag{28, M_WARNING, "Power Consumption",
+         "The tape drive power consumption is outside the specified range.",
+         "Power consumption of the tape drive is outside specified range"},
+    flag{29, M_WARNING, "Drive Maintenance",
+         "Preventive maintenance of the tape drive is required. Check the tape "
+         "drive users manual for device specific preventive maintenance tasks "
+         "or "
+         "call the tape drive supplier helpline.",
+         "The drive requires preventative maintenance (not cleaning)."},
+    flag{30, M_ERROR, "Hardware A",
+         "The tape drive has a hardware fault:\n"
+         "1. Eject the tape or magazine.\n"
+         "2. Reset the drive.\n"
+         "3. Restart the operation.",
+         "The drive has a hardware fault that requires reset to recover."},
+    flag{
+        31, M_ERROR, "Hardware B",
+        "The tape drive has a hardware fault:\n"
+        "1. Turn the tape drive off and then on again.\n"
+        "2. Restart the operation.\n"
+        "3. If the problem persists, call the tape drive supplier helpline.\n"
+        "Check the tape drive users manual for device specific instructions on "
+        "turning the device power on and off.",
+        "The drive has a hardware fault which is not read/write related or "
+        "requires a power cycle to recover."},
+    flag{32, M_WARNING, "Interface",
+         "The tape drive has a problem with the host interface:\n"
+         "1. Check the cables and cable connections.\n"
+         "2. Restart the operation.",
+         "The drive has identified an interfacing fault"},
+    flag{33, M_ERROR, "Eject Media",
+         "The operation has failed:\n"
+         "1. Eject the tape or magazine.\n"
+         "2. Insert the tape or magazine again.\n"
+         "3. Restart the operation.",
+         "Error recovery action"},
+    flag{34, M_WARNING, "Download Fail",
+         "The firmware download has failed because you have tried to use the "
+         "incorrect firmware for this tape drive. Obtain the correct firmware "
+         "and "
+         "try again.",
+         "Firmware download failed"},
+    flag{35, M_WARNING, "Drive Humidity",
+         "Environmental conditions inside the tape drive are outside the "
+         "specified humidity range",
+         "Drive humidity limits exceeded"},
+    flag{36, M_WARNING, "Drive Temperature",
+         "Environmental conditions inside the tape drive are outside the "
+         "specified temperature range",
+         "Drive temperature limits exceeded"},
+    flag{37, M_WARNING, "Drive Voltage",
+         "The voltage supply to the tape drive is outside the specified range",
+         "Drive voltage limits exceeded"},
+    flag{38, M_ERROR, "Predictive Failure",
+         "A hardware failure of the tape drive is predicted. Call the tape "
+         "drive "
+         "supplier helpline.",
+         "Predictive failure of drive hardware"},
+    flag{
+        39, M_WARNING, "Diagnostics Required",
+        "The tape drive may have a fault. Check for availability of diagnostic "
+        "information and run extended diagnostics if applicable. Check the "
+        "tape "
+        "drive users manual for instructions on running extended diagnostic "
+        "tests and retrieving diagnostic data.",
+        "The drive may have had a failure which may be identified by stored "
+        "diagnostic information or by running extended diagnostics (eg Send "
+        "Diagnostic)"},
+    flag{
+        40, M_ERROR, "Loader Hardware A",
+        "The changer mechanism is having difficulty communicating with the "
+        "tape "
+        "drive:\n"
+        "1. Turn the autoloader off then on.\n"
+        "2. Restart the operation.\n"
+        "3. If problem persists, call the tape drive supplier helpline.",
+        "Loader mechanism is having trouble communicating with the tape drive"},
+    flag{
+        41, M_ERROR, "Loader Stray Tape",
+        "A tape has been left in the autoloader by a previous hardware fault:\n"
+        "1. Insert an empty magazine to clear the fault.\n"
+        "2. If the fault does not clear, turn the autoloader off and then on "
+        "again.\n"
+        "3. If the problem persists, call the tape drive supplier helpline.",
+        "Stray tape left in loader after previous error recovery"},
+    flag{42, M_WARNING, "Loader Hardware B",
+         "There is a problem with the autoloader mechanism.",
+         "Loader mechanism has a hardware fault"},
+    flag{43, M_ERROR, "Loader Door",
+         "The operation has failed because the autoloader door is open:\n"
+         "1. Clear any obstructions from the autoloader door.\n"
+         "2. Eject the magazine and then insert it again.\n"
+         "3. If the fault does not clear, turn the autoloader off and then on "
+         "again\n"
+         "4. If the problem persists, call the tape drive supplier helpline.",
+         "Tape changer door open"},
+    flag{
+        44, M_ERROR, "Loader Hardware C",
+        "The autoloader has a hardware fault:\n"
+        "1. Turn the autoloader off and then on again.\n"
+        "2. Restart the operation.\n"
+        "3. If the problem persists, call the tape drive supplier helpline.\n"
+        "Check the autoloader users manual for device specific instructions on "
+        "turning the device power on and off.",
+        "The loader mechanism has a hardware fault that is not mechanically "
+        "related."},
+    flag{45, M_ERROR, "Loader Magazine",
+         "The autoloader cannot operate without the magazine.\n"
+         "1. Insert the magazine into the autoloader\n"
+         "2. Restart the operation.",
+         "Loader magazine not present"},
+    flag{46, M_WARNING, "Loader Predictive Failure",
+         "A hardware failure of the changer mechanism is predicted. Call the "
+         "tape "
+         "drive supplier helpline.",
+         "Predictive failure of loader mechanism hardware"},
+    flag{50, M_WARNING, "Lost Statistics",
+         "Media statistics have been lost at some time in the past.",
+         "Drive or library powered down with tape loaded"},
+    flag{51, M_WARNING, "Tape directory invalid at unload",
+         "The tape directory on the tape cartridge just unloaded has been "
+         "corrupted. File search performance will be degraded The tape "
+         "directory "
+         "can be rebuilt by reading all the data.",
+         "Error prevented the tape directory being updated on unload."},
+    flag{
+        52, M_ERROR, "Tape system area write failure",
+        "The tape just unloaded could not write its system area successfully:\n"
+        "1. Copy data to another tape cartridge\n"
+        "2. Discard the old cartridge",
+        "Write errors while writing the system log on unload"},
+    flag{53, M_ERROR, "Tape system area read failure",
+         "The tape system area could not be read successfully at load time:\n"
+         "1. Copy data to another tape cartridge\n"
+         "2. Discard the old cartridge",
+         "Read errors while reading the system area on load"},
+    flag{54, M_ERROR, "No start of data",
+         "The start of data could not be found on the tape:\n"
+         "1. Check you are using the correct format tape\n"
+         "2. Discard the tape or return the tape to your supplier.",
+         "Tape damaged, bulk erased, or incorrect format"}};
+
+}  // namespace scsitapealert
+
+#endif  // BAREOS_LIB_SCSI_TAPEALERT_FLAGS_H_

--- a/core/src/plugins/filed/spam/spam.cc
+++ b/core/src/plugins/filed/spam/spam.cc
@@ -21,8 +21,10 @@
 
 #define BUILD_PLUGIN
 
+#include <chrono>
 #include <cinttypes>
 #include <ctime>
+#include <thread>
 #include "include/bareos.h"
 #include "filed/fd_plugins.h"
 
@@ -36,6 +38,8 @@ namespace filedaemon {
 namespace {
 CoreFunctions* bareos = NULL;
 thread_local std::size_t num_messages = 0;
+constexpr std::size_t kMaxMessages = 300;
+constexpr auto kMessageDelay = std::chrono::milliseconds(100);
 
 #define Jmsg(ctx, type, fmt, ...)                                           \
   bareos->JobMessage((ctx), __FILE__, __LINE__, (type), std::time(nullptr), \
@@ -58,8 +62,9 @@ bRC setPluginValue(PluginContext*, pVariable, void*) { return bRC_OK; }
 bRC handlePluginEvent(PluginContext*, bEvent*, void*) { return bRC_OK; }
 bRC startBackupFile(PluginContext* ctx, save_pkt*)
 {
-  if (num_messages < 50'000) {
+  if (num_messages < kMaxMessages) {
     Jmsg(ctx, M_INFO, "I am spamming (%" PRIuz ")\n", num_messages++);
+    std::this_thread::sleep_for(kMessageDelay);
     return bRC_Skip;
   }
 

--- a/core/src/plugins/stored/scsitapealert/scsitapealert-sd.cc
+++ b/core/src/plugins/stored/scsitapealert/scsitapealert-sd.cc
@@ -25,10 +25,7 @@
  * SCSI Tape Alert Storage daemon Plugin
  */
 #include "include/bareos.h"
-#include "stored/device_control_record.h"
 #include "stored/stored.h"
-#include "lib/scsi_tapealert.h"
-#include "scsitapealert-sd.h"
 
 using namespace storagedaemon;
 
@@ -36,47 +33,8 @@ using namespace storagedaemon;
 #define PLUGIN_AUTHOR "Marco van Wieringen"
 #define PLUGIN_DATE "November 2013"
 #define PLUGIN_VERSION "1"
-#define PLUGIN_DESCRIPTION "SCSI Tape Alert Storage Daemon Plugin"
+#define PLUGIN_DESCRIPTION "SCSI Tape Alert Storage Daemon Compatibility Plugin"
 #define PLUGIN_USAGE "(No usage yet)"
-
-namespace {
-
-void dispatch_messages(JobControlRecord* jcr,
-                       const char* device,
-                       const char* volume,
-                       uint64_t flags)
-{
-  constexpr const char* job_msg
-      = "TapeAlert on device \"%s\" with volume \"%s\": [%d] %s\n%s\n"
-        "Possible cause: %s\n";
-  constexpr const char* job_msg_novol
-      = "TapeAlert on device \"%s\": [%d] %s\n%s\n"
-        "Possible cause: %s\n";
-
-  constexpr const char* print_msg
-      = "TapeAlert on device \"%s\" with volume \"%s\" from jobid %lu: "
-        "[%d] %s\n";
-  constexpr const char* print_msg_novol
-      = "TapeAlert on device \"%s\" from jobid %lu: [%d] %s\n";
-
-  const uint64_t jobid{jcr ? jcr->JobId : 0};
-
-  for (auto& flag : scsitapealert::flags) {
-    if (flag.present_in(flags)) {
-      if (volume && volume[0] != '\0') {
-        Jmsg(jcr, flag.type, 0, job_msg, device, volume, flag.no, flag.name,
-             flag.message, flag.cause);
-        Pmsg0(-1, print_msg, device, volume, jobid, flag.no, flag.name);
-      } else {
-        Jmsg(jcr, flag.type, 0, job_msg_novol, device, flag.no, flag.name,
-             flag.message, flag.cause);
-        Pmsg0(-1, print_msg_novol, device, jobid, flag.no, flag.name);
-      }
-    }
-  }
-}
-
-}  // namespace
 
 // Forward referenced functions
 static bRC newPlugin(PluginContext* ctx);
@@ -84,7 +42,6 @@ static bRC freePlugin(PluginContext* ctx);
 static bRC getPluginValue(PluginContext* ctx, pVariable var, void* value);
 static bRC setPluginValue(PluginContext* ctx, pVariable var, void* value);
 static bRC handlePluginEvent(PluginContext* ctx, bSdEvent* event, void* value);
-static bRC handle_tapealert_readout(void* value);
 
 // Pointers to Bareos functions
 static CoreFunctions* bareos_core_functions = NULL;
@@ -156,13 +113,6 @@ static bRC newPlugin(PluginContext* ctx)
   bareos_core_functions->getBareosValue(ctx, bsdVarJobId, (void*)&JobId);
   Dmsg1(debuglevel, "scsitapealert-sd: newPlugin JobId=%d\n", JobId);
 
-  // Only register plugin events we are interested in.
-  bareos_core_functions->registerBareosEvents(
-      ctx, 10, bSdEventDeviceInit, bSdEventVolumeLoad, bSdEventLabelVerified,
-      bSdEventLabelWrite, bSdEventReadError, bSdEventWriteError,
-      bSdEventVolumeUnload, bSdEventDeviceRelease, bSdEventDeviceOpen,
-      bSdEventDeviceClose);
-
   return bRC_OK;
 }
 
@@ -194,74 +144,10 @@ static bRC setPluginValue(PluginContext*, pVariable var, void*)
 }
 
 // Handle an event that was generated in Bareos
-static bRC handlePluginEvent(PluginContext*, bSdEvent* event, void* value)
+static bRC handlePluginEvent(PluginContext*, bSdEvent* event, void*)
 {
-  switch (event->eventType) {
-    case bSdEventDeviceClose:
-    case bSdEventDeviceInit:
-    case bSdEventDeviceOpen:
-    case bSdEventDeviceRelease:
-    case bSdEventLabelVerified:
-    case bSdEventLabelWrite:
-    case bSdEventReadError:
-    case bSdEventVolumeLoad:
-    case bSdEventVolumeUnload:
-    case bSdEventWriteError:
-      return handle_tapealert_readout(value);
-    default:
-      Dmsg1(debuglevel, "scsitapealert-sd: Unknown event %d\n",
-            event->eventType);
-      return bRC_Error;
-  }
-
-  return bRC_OK;
-}
-
-static pthread_mutex_t tapealert_operation_mutex = PTHREAD_MUTEX_INITIALIZER;
-
-static bRC handle_tapealert_readout(void* value)
-{
-  DeviceControlRecord* dcr;
-  Device* dev;
-  DeviceResource* device_resource;
-  uint64_t flags;
-
-  // Unpack the arguments passed in.
-  dcr = (DeviceControlRecord*)value;
-  if (!dcr) { return bRC_Error; }
-  dev = dcr->dev;
-  if (!dev) { return bRC_Error; }
-  device_resource = dev->device_resource;
-  if (!device_resource) { return bRC_Error; }
-
-  // See if drive tapealert is enabled.
-  if (!device_resource->drive_tapealert_enabled) {
-    Dmsg1(debuglevel,
-          "scsitapealert-sd: tapealert is not enabled on device %s\n",
-          dev->archive_device_string);
-    return bRC_OK;
-  }
-
-  Dmsg1(debuglevel, "scsitapealert-sd: checking for tapealerts on device %s\n",
-        dev->archive_device_string);
-  lock_mutex(tapealert_operation_mutex);
-  GetTapealertFlags(dev->fd, dev->archive_device_string, &flags);
-  unlock_mutex(tapealert_operation_mutex);
-
   Dmsg1(debuglevel,
-        "scsitapealert-sd: checking for tapealerts on device %s DONE\n",
-        dev->archive_device_string);
-  Dmsg1(debuglevel, "scsitapealert-sd: flags: %ld \n", flags);
-
-  if (flags) {
-    Dmsg1(
-        debuglevel,
-        "scsitapealert-sd: tapealerts on device %s, calling UpdateTapeAlerts\n",
-        dev->archive_device_string);
-    bareos_core_functions->UpdateTapeAlert(dcr, flags);
-    dispatch_messages(dcr->jcr, device_resource->resource_name_,
-                      dev->getVolCatName(), flags);
-  }
-
+        "scsitapealert-sd: core monitoring active, ignoring event %d\n",
+        event->eventType);
   return bRC_OK;
 }

--- a/core/src/stored/CMakeLists.txt
+++ b/core/src/stored/CMakeLists.txt
@@ -48,33 +48,35 @@ endif()
 
 add_library(bareossd SHARED)
 add_library(Bareos::LibSD ALIAS bareossd)
-target_sources(
+  target_sources(
   bareossd
   PRIVATE acquire.cc
-          ansi_label.cc
-          askdir.cc
-          autochanger.cc
-          autochanger_resource.cc
-          block.cc
-          bsr.cc
-          butil.cc
-          crc32/crc32.cc
-          dev.cc
-          device.cc
-          device_control_record.cc
-          device_resource.cc
-          ebcdic.cc
-          label.cc
-          lock.cc
-          mount.cc
-          read_record.cc
-          record.cc
-          reserve.cc
-          scan.cc
-          sd_device_control_record.cc
-          sd_plugins.cc
-          sd_stats.cc
-          spool.cc
+           ansi_label.cc
+           askdir.cc
+           autochanger.cc
+           autochanger_resource.cc
+           block.cc
+           bsr.cc
+           butil.cc
+           crc32/crc32.cc
+           dev.cc
+           device.cc
+           device_control_record.cc
+           device_resource.cc
+           drive_tapealert_monitor.cc
+           ebcdic.cc
+           label.cc
+           lock.cc
+           mount.cc
+           read_record.cc
+           record.cc
+           reserve.cc
+           scsi_changer.cc
+           scan.cc
+           sd_device_control_record.cc
+           sd_plugins.cc
+           sd_stats.cc
+           spool.cc
           stored_globals.cc
           stored_conf.cc
           vol_mgr.cc

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -186,7 +186,7 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
     rtn_stat = 0;
   } else {
     uint32_t timeout = dcr->device_resource->max_changer_wait;
-    int status;
+    int status = -1;
     slot_number_t loaded_slot;
     bool native_scsi
         = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
@@ -218,11 +218,21 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
             dcr->dev->print_name());
       Jmsg(jcr, M_INFO, 0,
            T_("3304 Issuing autochanger \"load slot %hd, drive %hd\" "
-               "command.\n"),
+              "command.\n"),
            wanted_slot, drive);
       dcr->VolCatInfo.Slot = wanted_slot; /* slot to be loaded */
       if (native_scsi) {
-        status = NativeScsiLoadSlot(dcr, wanted_slot) ? 0 : -1;
+        switch (NativeScsiLoadSlot(dcr, wanted_slot)) {
+          case NativeScsiLoadResult::kSuccess:
+            status = 0;
+            break;
+          case NativeScsiLoadResult::kSlotEmpty:
+            status = -3;
+            break;
+          case NativeScsiLoadResult::kError:
+            status = -1;
+            break;
+        }
       } else {
         changer = edit_device_codes(
             dcr, changer, dcr->device_resource->changer_command, "load");
@@ -246,13 +256,18 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
         BErrNo be;
         be.SetErrno(status);
         std::string tmp(results.c_str());
-        if (!native_scsi && tmp.find("Source Element Address") != std::string::npos
+        if (!native_scsi
+            && tmp.find("Source Element Address") != std::string::npos
             && tmp.find("is Empty") != std::string::npos) {
+          rtn_stat = -3; /* medium not found in slot */
+        } else if (status == -3) {
           rtn_stat = -3; /* medium not found in slot */
         } else {
           rtn_stat = -1; /* hard error */
         }
-        if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
+        if (native_scsi && rtn_stat != -3) {
+          ReportNativeScsiChangerDiagnostics(dcr);
+        }
         Dmsg3(100, "load slot %hd, drive %hd, bad stats=%s.\n", wanted_slot,
               drive, be.bstrerror());
         Jmsg(jcr, rtn_stat == -3 ? M_ERROR : M_FATAL, 0,
@@ -308,7 +323,8 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
 
   // Virtual disk autochanger
   if (dcr->device_resource->changer_command[0] == 0) { return 1; }
-  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
+  native_scsi
+      = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   /* Only lock the changer if the lock_set is false e.g. changer not locked by
    * calling function. */
@@ -329,8 +345,8 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
     loaded_slot = NativeScsiGetLoadedSlot(dcr);
     status = (loaded_slot == kInvalidSlotNumber) ? -1 : 0;
   } else {
-    changer = edit_device_codes(dcr, changer,
-                                dcr->device_resource->changer_command, "loaded");
+    changer = edit_device_codes(
+        dcr, changer, dcr->device_resource->changer_command, "loaded");
     Dmsg1(100, "Run program=%s\n", changer);
     status = RunProgramFullOutput(changer, timeout, results.addr());
     Dmsg3(100, "run_prog: %s stat=%d result=%s\n", changer, status,
@@ -451,7 +467,8 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
     dev->ClearUnload();
     return true;
   }
-  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
+  native_scsi
+      = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   /* Only lock the changer if the lock_set is false e.g. changer not locked by
    * calling function. */
@@ -604,7 +621,8 @@ bool UnloadDev(DeviceControlRecord* dcr, Device* dev, bool lock_set)
   AutochangerResource* changer = dcr->dev->device_resource->changer_res;
 
   if (!changer) { return false; }
-  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
+  native_scsi
+      = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   save_dev = dcr->dev; /* save dcr device */
   dcr->SetDev(dev);    /* temporarily point dcr at other device */
@@ -720,7 +738,8 @@ bool AutochangerCmd(DeviceControlRecord* dcr,
     Dmsg1(100, "drives=%d\n", drives);
     return true;
   }
-  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
+  native_scsi
+      = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   // If listing, reprobe changer
   if (bstrcmp(cmd, "list") || bstrcmp(cmd, "listall")) {
@@ -815,13 +834,13 @@ bool AutochangerTransferCmd(DeviceControlRecord* dcr,
                dev->print_name());
     return false;
   }
-  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
+  native_scsi
+      = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   changer = GetPoolMemory(PM_FNAME);
   LockChanger(dcr);
   if (native_scsi) {
-    auto ok
-        = NativeScsiAutochangerTransferCmd(dcr, dir, src_slot, dst_slot);
+    auto ok = NativeScsiAutochangerTransferCmd(dcr, dir, src_slot, dst_slot);
     if (!ok) { ReportNativeScsiChangerDiagnostics(dcr); }
     goto bail_out;
   }

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -193,6 +193,15 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
 
     // Attempt to load the Volume
     loaded_slot = GetAutochangerLoadedSlot(dcr);
+    if (loaded_slot == kLoadedSlotUnknown && loaded_slot != wanted_slot) {
+      if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
+      Jmsg(jcr, M_FATAL, 0,
+           T_("3992 Cannot load slot %hd into drive %hd because the drive "
+              "already contains media with an unknown source slot.\n"),
+           wanted_slot, drive);
+      rtn_stat = -1;
+      goto bail_out;
+    }
     if (loaded_slot != wanted_slot) {
       PoolMem results(PM_MESSAGE);
 
@@ -298,6 +307,8 @@ bail_out:
 
 /**
  * Returns: -1 if error from changer command
+ *          0 if drive is empty
+ *          kLoadedSlotUnknown if media is loaded but the source slot is unknown
  *          slot otherwise
  *
  * Note, this is safe to do without releasing the drive since it does not
@@ -365,6 +376,14 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
             drive, loaded_slot);
       }
       dev->SetSlotNumber(loaded_slot);
+    } else if (loaded_slot == kLoadedSlotUnknown) {
+      if (!dev->poll && debug_level >= 1) {
+        Jmsg(jcr, M_INFO, 0,
+             T_("3302 Autochanger \"loaded? drive %hd\", result: media loaded "
+                "with unknown source slot.\n"),
+             drive);
+      }
+      dev->InvalidateSlotNumber();
     } else {
       // Suppress info when polling
       if (!dev->poll && debug_level >= 1) {

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -224,6 +224,7 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
       if (native_scsi) {
         switch (NativeScsiLoadSlot(dcr, wanted_slot)) {
           case NativeScsiLoadResult::kSuccess:
+          case NativeScsiLoadResult::kLoadedNotReady:
             status = 0;
             break;
           case NativeScsiLoadResult::kSlotEmpty:
@@ -839,6 +840,7 @@ bool AutochangerTransferCmd(DeviceControlRecord* dcr,
 
   changer = GetPoolMemory(PM_FNAME);
   LockChanger(dcr);
+  dir->fsend(T_("3306 Issuing autochanger transfer command.\n"));
   if (native_scsi) {
     auto ok = NativeScsiAutochangerTransferCmd(dcr, dir, src_slot, dst_slot);
     if (!ok) { ReportNativeScsiChangerDiagnostics(dcr); }
@@ -847,7 +849,6 @@ bool AutochangerTransferCmd(DeviceControlRecord* dcr,
   changer = transfer_edit_device_codes(dcr, changer,
                                        dcr->device_resource->changer_command,
                                        "transfer", src_slot, dst_slot);
-  dir->fsend(T_("3306 Issuing autochanger transfer command.\n"));
 
   // Now issue the command
   bpipe = OpenBpipe(changer, timeout, "r");

--- a/core/src/stored/autochanger.cc
+++ b/core/src/stored/autochanger.cc
@@ -31,6 +31,7 @@
 #include "stored/stored_globals.h"
 #include "stored/autochanger.h"
 #include "stored/device_control_record.h"
+#include "stored/scsi_changer.h"
 #include "stored/wait.h"
 #include "lib/berrno.h"
 #include "lib/bnet.h"
@@ -187,6 +188,8 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
     uint32_t timeout = dcr->device_resource->max_changer_wait;
     int status;
     slot_number_t loaded_slot;
+    bool native_scsi
+        = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
     // Attempt to load the Volume
     loaded_slot = GetAutochangerLoadedSlot(dcr);
@@ -215,14 +218,18 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
             dcr->dev->print_name());
       Jmsg(jcr, M_INFO, 0,
            T_("3304 Issuing autochanger \"load slot %hd, drive %hd\" "
-              "command.\n"),
+               "command.\n"),
            wanted_slot, drive);
       dcr->VolCatInfo.Slot = wanted_slot; /* slot to be loaded */
-      changer = edit_device_codes(
-          dcr, changer, dcr->device_resource->changer_command, "load");
-      dcr->dev->close(dcr);
-      Dmsg1(200, "Run program=%s\n", changer);
-      status = RunProgramFullOutput(changer, timeout, results.addr());
+      if (native_scsi) {
+        status = NativeScsiLoadSlot(dcr, wanted_slot) ? 0 : -1;
+      } else {
+        changer = edit_device_codes(
+            dcr, changer, dcr->device_resource->changer_command, "load");
+        dcr->dev->close(dcr);
+        Dmsg1(200, "Run program=%s\n", changer);
+        status = RunProgramFullOutput(changer, timeout, results.addr());
+      }
       if (status == 0) {
         Jmsg(jcr, M_INFO, 0,
              T_("3305 Autochanger \"load slot %hd, drive %hd\", status is "
@@ -239,12 +246,13 @@ int AutoloadDevice(DeviceControlRecord* dcr, int writing, BareosSocket* dir)
         BErrNo be;
         be.SetErrno(status);
         std::string tmp(results.c_str());
-        if (tmp.find("Source Element Address") != std::string::npos
+        if (!native_scsi && tmp.find("Source Element Address") != std::string::npos
             && tmp.find("is Empty") != std::string::npos) {
           rtn_stat = -3; /* medium not found in slot */
         } else {
           rtn_stat = -1; /* hard error */
         }
+        if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
         Dmsg3(100, "load slot %hd, drive %hd, bad stats=%s.\n", wanted_slot,
               drive, be.bstrerror());
         Jmsg(jcr, rtn_stat == -3 ? M_ERROR : M_FATAL, 0,
@@ -281,6 +289,7 @@ bail_out:
  */
 slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
 {
+  bool native_scsi;
   int status;
   POOLMEM* changer;
   JobControlRecord* jcr = dcr->jcr;
@@ -299,6 +308,7 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
 
   // Virtual disk autochanger
   if (dcr->device_resource->changer_command[0] == 0) { return 1; }
+  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   /* Only lock the changer if the lock_set is false e.g. changer not locked by
    * calling function. */
@@ -315,15 +325,20 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
   }
 
   changer = GetPoolMemory(PM_FNAME);
-  changer = edit_device_codes(dcr, changer,
-                              dcr->device_resource->changer_command, "loaded");
-  Dmsg1(100, "Run program=%s\n", changer);
-  status = RunProgramFullOutput(changer, timeout, results.addr());
-  Dmsg3(100, "run_prog: %s stat=%d result=%s\n", changer, status,
-        results.c_str());
+  if (native_scsi) {
+    loaded_slot = NativeScsiGetLoadedSlot(dcr);
+    status = (loaded_slot == kInvalidSlotNumber) ? -1 : 0;
+  } else {
+    changer = edit_device_codes(dcr, changer,
+                                dcr->device_resource->changer_command, "loaded");
+    Dmsg1(100, "Run program=%s\n", changer);
+    status = RunProgramFullOutput(changer, timeout, results.addr());
+    Dmsg3(100, "run_prog: %s stat=%d result=%s\n", changer, status,
+          results.c_str());
+    if (status == 0) { loaded_slot = str_to_uint16(results.c_str()); }
+  }
 
   if (status == 0) {
-    loaded_slot = str_to_uint16(results.c_str());
     if (IsSlotNumberValid(loaded_slot)) {
       // Suppress info when polling
       if (!dev->poll && debug_level >= 1) {
@@ -346,6 +361,7 @@ slot_number_t GetAutochangerLoadedSlot(DeviceControlRecord* dcr, bool lock_set)
   } else {
     BErrNo be;
     be.SetErrno(status);
+    if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
     Jmsg(jcr, M_INFO, 0,
          T_("3991 Bad autochanger \"loaded? drive %hd\" command: "
             "ERR=%s.\nResults=%s\n"),
@@ -418,6 +434,7 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
 {
   Device* dev = dcr->dev;
   JobControlRecord* jcr = dcr->jcr;
+  bool native_scsi;
   slot_number_t slot;
   uint32_t timeout = dcr->device_resource->max_changer_wait;
   bool retval = true;
@@ -434,6 +451,7 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
     dev->ClearUnload();
     return true;
   }
+  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   /* Only lock the changer if the lock_set is false e.g. changer not locked by
    * calling function. */
@@ -456,16 +474,21 @@ bool UnloadAutochanger(DeviceControlRecord* dcr,
          loaded_slot, dev->drive);
     slot = dcr->VolCatInfo.Slot;
     dcr->VolCatInfo.Slot = loaded_slot;
-    changer = edit_device_codes(
-        dcr, changer, dcr->device_resource->changer_command, "unload");
-    dev->close(dcr);
-    Dmsg1(100, "Run program=%s\n", changer);
-    status = RunProgramFullOutput(changer, timeout, results.addr());
+    if (native_scsi) {
+      status = NativeScsiUnloadSlot(dcr, loaded_slot) ? 0 : -1;
+    } else {
+      changer = edit_device_codes(
+          dcr, changer, dcr->device_resource->changer_command, "unload");
+      dev->close(dcr);
+      Dmsg1(100, "Run program=%s\n", changer);
+      status = RunProgramFullOutput(changer, timeout, results.addr());
+    }
     dcr->VolCatInfo.Slot = slot;
     if (status != 0) {
       BErrNo be;
 
       be.SetErrno(status);
+      if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
       Jmsg(jcr, M_INFO, 0,
            T_("3995 Bad autochanger \"unload slot %hd, drive %hd\": "
               "ERR=%s\nResults=%s\n"),
@@ -571,6 +594,7 @@ static bool UnloadOtherDrive(DeviceControlRecord* dcr,
 // Unconditionally unload a specified drive
 bool UnloadDev(DeviceControlRecord* dcr, Device* dev, bool lock_set)
 {
+  bool native_scsi;
   int status;
   Device* save_dev;
   bool retval = true;
@@ -580,6 +604,7 @@ bool UnloadDev(DeviceControlRecord* dcr, Device* dev, bool lock_set)
   AutochangerResource* changer = dcr->dev->device_resource->changer_res;
 
   if (!changer) { return false; }
+  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   save_dev = dcr->dev; /* save dcr device */
   dcr->SetDev(dev);    /* temporarily point dcr at other device */
@@ -619,20 +644,25 @@ bool UnloadDev(DeviceControlRecord* dcr, Device* dev, bool lock_set)
   Dmsg2(100, "Issuing autochanger \"unload slot %hd, drive %hd\" command.\n",
         dev->GetSlot(), dev->drive);
 
-  ChangerCmd = edit_device_codes(
-      dcr, ChangerCmd, dcr->device_resource->changer_command, "unload");
-  dev->close(dcr);
+  if (native_scsi) {
+    status = NativeScsiUnloadDrive(dcr, dev) ? 0 : -1;
+  } else {
+    ChangerCmd = edit_device_codes(
+        dcr, ChangerCmd, dcr->device_resource->changer_command, "unload");
+    dev->close(dcr);
 
-  Dmsg2(200, "close dev=%s reserve=%d\n", dev->print_name(),
-        dev->NumReserved());
-  Dmsg1(100, "Run program=%s\n", ChangerCmd);
+    Dmsg2(200, "close dev=%s reserve=%d\n", dev->print_name(),
+          dev->NumReserved());
+    Dmsg1(100, "Run program=%s\n", ChangerCmd);
 
-  status = RunProgramFullOutput(ChangerCmd, timeout, results.addr());
+    status = RunProgramFullOutput(ChangerCmd, timeout, results.addr());
+  }
   dcr->VolCatInfo.Slot = save_slot;
   dcr->SetDev(save_dev);
   if (status != 0) {
     BErrNo be;
     be.SetErrno(status);
+    if (native_scsi) { ReportNativeScsiChangerDiagnostics(dcr); }
     Jmsg(jcr, M_INFO, 0,
          T_("3997 Bad autochanger \"unload slot %hd, drive %hd\": ERR=%s.\n"),
          dev->GetSlot(), dev->drive, be.bstrerror());
@@ -666,6 +696,7 @@ bool AutochangerCmd(DeviceControlRecord* dcr,
                     const char* cmd)
 {
   Device* dev = dcr->dev;
+  bool native_scsi;
   uint32_t timeout = dcr->device_resource->max_changer_wait;
   POOLMEM* changer;
   Bpipe* bpipe;
@@ -689,6 +720,7 @@ bool AutochangerCmd(DeviceControlRecord* dcr,
     Dmsg1(100, "drives=%d\n", drives);
     return true;
   }
+  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   // If listing, reprobe changer
   if (bstrcmp(cmd, "list") || bstrcmp(cmd, "listall")) {
@@ -698,9 +730,16 @@ bool AutochangerCmd(DeviceControlRecord* dcr,
 
   changer = GetPoolMemory(PM_FNAME);
   LockChanger(dcr);
+  dir->fsend(T_("3306 Issuing autochanger \"%s\" command.\n"), cmd);
+
+  if (native_scsi) {
+    auto ok = NativeScsiAutochangerCmd(dcr, dir, cmd);
+    if (!ok) { ReportNativeScsiChangerDiagnostics(dcr); }
+    goto bail_out;
+  }
+
   changer = edit_device_codes(dcr, changer,
                               dcr->device_resource->changer_command, cmd);
-  dir->fsend(T_("3306 Issuing autochanger \"%s\" command.\n"), cmd);
 
   // Now issue the command
 retry_changercmd:
@@ -763,6 +802,7 @@ bool AutochangerTransferCmd(DeviceControlRecord* dcr,
                             slot_number_t dst_slot)
 {
   Device* dev = dcr->dev;
+  bool native_scsi;
   uint32_t timeout = dcr->device_resource->max_changer_wait;
   POOLMEM* changer;
   Bpipe* bpipe;
@@ -775,9 +815,16 @@ bool AutochangerTransferCmd(DeviceControlRecord* dcr,
                dev->print_name());
     return false;
   }
+  native_scsi = IsNativeScsiChangerCommand(dcr->device_resource->changer_command);
 
   changer = GetPoolMemory(PM_FNAME);
   LockChanger(dcr);
+  if (native_scsi) {
+    auto ok
+        = NativeScsiAutochangerTransferCmd(dcr, dir, src_slot, dst_slot);
+    if (!ok) { ReportNativeScsiChangerDiagnostics(dcr); }
+    goto bail_out;
+  }
   changer = transfer_edit_device_codes(dcr, changer,
                                        dcr->device_resource->changer_command,
                                        "transfer", src_slot, dst_slot);

--- a/core/src/stored/backends/generic_tape_device.cc
+++ b/core/src/stored/backends/generic_tape_device.cc
@@ -334,6 +334,16 @@ bool generic_tape_device::offline()
  */
 bool generic_tape_device::weof(int num)
 {
+  return DoWeof(num, false);
+}
+
+bool generic_tape_device::weof_immediate(int num)
+{
+  return DoWeof(num, true);
+}
+
+bool generic_tape_device::DoWeof(int num, bool immediate)
+{
   mtop mt_com{};
   int status;
   Dmsg1(129, "=== weof_dev=%s\n", prt_name);
@@ -354,7 +364,12 @@ bool generic_tape_device::weof(int num)
 
   ClearEof();
   ClearEot();
+#if defined(MTWEOFI)
+  mt_com.mt_op = UseImmediateWriteFilemarkOperation(immediate) ? MTWEOFI : MTWEOF;
+#else
+  static_cast<void>(immediate);
   mt_com.mt_op = MTWEOF;
+#endif
   mt_com.mt_count = num;
   status = d_ioctl(fd, MTIOCTOP, (char*)&mt_com);
   if (status == 0) {

--- a/core/src/stored/backends/generic_tape_device.h
+++ b/core/src/stored/backends/generic_tape_device.h
@@ -32,6 +32,16 @@
 
 namespace storagedaemon {
 
+inline bool UseImmediateWriteFilemarkOperation(bool immediate_requested)
+{
+#if defined(MTWEOFI)
+  return immediate_requested;
+#else
+  static_cast<void>(immediate_requested);
+  return false;
+#endif
+}
+
 class generic_tape_device : public Device {
  public:
   generic_tape_device() = default;
@@ -47,6 +57,7 @@ class generic_tape_device : public Device {
   virtual void SetAteot() override;
   virtual bool offline() override;
   virtual bool weof(int num) override;
+  virtual bool weof_immediate(int num) override;
   virtual bool fsf(int num) override;
   virtual bool bsf(int num) override;
   virtual bool fsr(int num) override;
@@ -75,6 +86,7 @@ class generic_tape_device : public Device {
   virtual bool d_truncate(DeviceControlRecord* dcr) override;
 
  private:
+  bool DoWeof(int num, bool immediate);
   bool do_mount(DeviceControlRecord* dcr, int mount, int dotimeout);
   void OsClrError();
   void HandleError(int func);

--- a/core/src/stored/backends/win32_tape_device.cc
+++ b/core/src/stored/backends/win32_tape_device.cc
@@ -508,6 +508,17 @@ int win32_tape_device::TapeOp(struct mtop* mt_com)
         pHandleInfo->ullFileStart = 0;
       }
       break;
+    case MTWEOFI:
+      result = WriteTapemark(pHandleInfo->OSHandle, TAPE_FILEMARKS,
+                             mt_com->mt_count, TRUE);
+      if (result == NO_ERROR) {
+        pHandleInfo->bEOF = true;
+        pHandleInfo->bEOT = false;
+        pHandleInfo->ulFile += mt_com->mt_count;
+        pHandleInfo->bBlockValid = true;
+        pHandleInfo->ullFileStart = 0;
+      }
+      break;
     case MTREW:
       result
           = SetTapePosition(pHandleInfo->OSHandle, TAPE_REWIND, 0, 0, 0, FALSE);

--- a/core/src/stored/block.cc
+++ b/core/src/stored/block.cc
@@ -678,7 +678,11 @@ bool DeviceControlRecord::WriteBlockToDev()
       && (dev->file_size + block->binbuf) >= dev->max_file_size) {
     dev->file_size = 0; /* reset file size */
 
-    if (!dev->weof(1)) { /* write eof */
+    bool wrote_filemark
+        = dev->device_resource->max_file_size_immediate_filemark
+              ? dev->weof_immediate(1)
+              : dev->weof(1);
+    if (!wrote_filemark) { /* write eof */
       Dmsg0(50, "WEOF error in max file size.\n");
       Jmsg(jcr, M_FATAL, 0, T_("Unable to write EOF. ERR=%s\n"),
            dev->bstrerror());

--- a/core/src/stored/dev.h
+++ b/core/src/stored/dev.h
@@ -440,6 +440,7 @@ public:
   // Tape specific operations.
   virtual bool offline() { return true; }
   virtual bool weof(int) { return true; }
+  virtual bool weof_immediate(int num) { return weof(num); }
   virtual bool fsf(int) { return true; }
   virtual bool bsf(int) { return false; }
   virtual bool fsr(int) { return false; }

--- a/core/src/stored/device_resource.cc
+++ b/core/src/stored/device_resource.cc
@@ -63,6 +63,7 @@ DeviceResource::DeviceResource(const DeviceResource& other)
   access_mode = other.access_mode;
   autoselect = other.autoselect;
   norewindonclose = other.norewindonclose;
+  max_file_size_immediate_filemark = other.max_file_size_immediate_filemark;
   drive_tapealert_enabled = other.drive_tapealert_enabled;
   drive_crypto_enabled = other.drive_crypto_enabled;
   query_crypto_status = other.query_crypto_status;
@@ -117,6 +118,7 @@ DeviceResource& DeviceResource::operator=(const DeviceResource& rhs)
   access_mode = rhs.access_mode;
   autoselect = rhs.autoselect;
   norewindonclose = rhs.norewindonclose;
+  max_file_size_immediate_filemark = rhs.max_file_size_immediate_filemark;
   drive_tapealert_enabled = rhs.drive_tapealert_enabled;
   drive_crypto_enabled = rhs.drive_crypto_enabled;
   query_crypto_status = rhs.query_crypto_status;

--- a/core/src/stored/device_resource.h
+++ b/core/src/stored/device_resource.h
@@ -52,6 +52,8 @@ class DeviceResource : public BareosResource {
       IODirection::READ_WRITE}; /**< Allowed access mode(s) for reservation */
   bool autoselect{true};        /**< Automatically select from AutoChanger */
   bool norewindonclose{true};   /**< Don't rewind tape drive on close */
+  bool max_file_size_immediate_filemark{
+      true}; /**< Use immediate mode for MaximumFileSize rollover filemarks */
   bool drive_tapealert_enabled{false}; /**< Enable Tape Alert monitoring */
   bool drive_crypto_enabled{false};    /**< Enable hardware crypto */
   bool query_crypto_status{false};     /**< Query device for crypto status */

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -192,7 +192,7 @@ static struct s_sd_dir_cmds cmds[] = {
     // { "action_on_purge",  ActionOnPurgeCmd, false },
     {"autochanger", ChangerCmd, false, true},
     {"bootstrap", BootstrapCmd, false, true},
-    {"cancel", CancelCmd, false, true},
+    {"cancel", CancelCmd, false, false}, /**< Does not require devices */
     {"finish", FinishCmd, false, true}, /**< End of backup */
     {"JobId=", job_cmd, false, true},   /**< Start Job */
     {"label", LabelCmd, false, true},   /**< Label a tape */
@@ -211,7 +211,8 @@ static struct s_sd_dir_cmds cmds[] = {
      true},                       /**< Replicate data to an external SD */
     {"run", RunCmd, false, true}, /**< Start of Job */
     {"getSecureEraseCmd", SecureerasereqCmd, false, false},
-    {"setbandwidth=", SetbandwidthCmd, false, true},
+    {"setbandwidth=", SetbandwidthCmd, false,
+     false}, /**< Does not require devices */
     {"setdebug=", SetdebugCmd, false, false}, /**< Set debug level */
     {"setdevice", SetdeviceCmd, false, true}, /**< Set device parameter */
     {"stats", StatsCmd, false, false},

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -196,22 +196,24 @@ static struct s_sd_dir_cmds cmds[] = {
     {"finish", FinishCmd, false, true}, /**< End of backup */
     {"JobId=", job_cmd, false, true},   /**< Start Job */
     {"label", LabelCmd, false, true},   /**< Label a tape */
-    {"listen", ListenCmd, false, true}, /**< Listen for an incoming Storage Job */
+    {"listen", ListenCmd, false,
+     true}, /**< Listen for an incoming Storage Job */
     {"mount", MountCmd, false, true},
-    {"nextrun", nextRunCmd,
-     false, true}, /**< Prepare for next backup/restore part of same Job */
+    {"nextrun", nextRunCmd, false,
+     true}, /**< Prepare for next backup/restore part of same Job */
     {"passive", PassiveCmd, false, true},
     {"pluginoptions", PluginoptionsCmd, false, true},
     {"readlabel", ReadlabelCmd, false, true},
     {"relabel", RelabelCmd, false, true}, /**< Relabel a tape */
     {"release", ReleaseCmd, false, true},
     {"resolve", ResolveCmd, false, false},
-    {"replicate", ReplicateCmd, false, true}, /**< Replicate data to an external SD */
-    {"run", RunCmd, false, true},             /**< Start of Job */
+    {"replicate", ReplicateCmd, false,
+     true},                       /**< Replicate data to an external SD */
+    {"run", RunCmd, false, true}, /**< Start of Job */
     {"getSecureEraseCmd", SecureerasereqCmd, false, false},
     {"setbandwidth=", SetbandwidthCmd, false, true},
-    {"setdebug=", SetdebugCmd, false, false},  /**< Set debug level */
-    {"setdevice", SetdeviceCmd, false, true},  /**< Set device parameter */
+    {"setdebug=", SetdebugCmd, false, false}, /**< Set debug level */
+    {"setdevice", SetdeviceCmd, false, true}, /**< Set device parameter */
     {"stats", StatsCmd, false, false},
     {"status", StatusCmd, true, false},
     {".status", DotstatusCmd, true, false},
@@ -300,9 +302,7 @@ void* HandleDirectorConnection(BareosSocket* dir)
           break;
         }
         if (cmds[i].wait_for_device_initialization) {
-          while (!init_done.load(std::memory_order_acquire)) {
-            Bmicrosleep(1, 0);
-          }
+          WaitForDeviceInitialization();
         }
         Dmsg1(200, "Do command: %s\n", cmds[i].cmd);
         if (!cmds[i].func(jcr)) { /* do command */

--- a/core/src/stored/dir_cmd.cc
+++ b/core/src/stored/dir_cmd.cc
@@ -179,6 +179,7 @@ struct s_sd_dir_cmds {
   const char* cmd;
   bool (*func)(JobControlRecord* jcr);
   bool monitoraccess; /* set if monitors can access this cmd */
+  bool wait_for_device_initialization;
 };
 
 /**
@@ -189,34 +190,34 @@ struct s_sd_dir_cmds {
  */
 static struct s_sd_dir_cmds cmds[] = {
     // { "action_on_purge",  ActionOnPurgeCmd, false },
-    {"autochanger", ChangerCmd, false},
-    {"bootstrap", BootstrapCmd, false},
-    {"cancel", CancelCmd, false},
-    {"finish", FinishCmd, false}, /**< End of backup */
-    {"JobId=", job_cmd, false},   /**< Start Job */
-    {"label", LabelCmd, false},   /**< Label a tape */
-    {"listen", ListenCmd, false}, /**< Listen for an incoming Storage Job */
-    {"mount", MountCmd, false},
+    {"autochanger", ChangerCmd, false, true},
+    {"bootstrap", BootstrapCmd, false, true},
+    {"cancel", CancelCmd, false, true},
+    {"finish", FinishCmd, false, true}, /**< End of backup */
+    {"JobId=", job_cmd, false, true},   /**< Start Job */
+    {"label", LabelCmd, false, true},   /**< Label a tape */
+    {"listen", ListenCmd, false, true}, /**< Listen for an incoming Storage Job */
+    {"mount", MountCmd, false, true},
     {"nextrun", nextRunCmd,
-     false}, /**< Prepare for next backup/restore part of same Job */
-    {"passive", PassiveCmd, false},
-    {"pluginoptions", PluginoptionsCmd, false},
-    {"readlabel", ReadlabelCmd, false},
-    {"relabel", RelabelCmd, false}, /**< Relabel a tape */
-    {"release", ReleaseCmd, false},
-    {"resolve", ResolveCmd, false},
-    {"replicate", ReplicateCmd, false}, /**< Replicate data to an external SD */
-    {"run", RunCmd, false},             /**< Start of Job */
-    {"getSecureEraseCmd", SecureerasereqCmd, false},
-    {"setbandwidth=", SetbandwidthCmd, false},
-    {"setdebug=", SetdebugCmd, false},  /**< Set debug level */
-    {"setdevice", SetdeviceCmd, false}, /**< Set device parameter */
-    {"stats", StatsCmd, false},
-    {"status", StatusCmd, true},
-    {".status", DotstatusCmd, true},
-    {"unmount", UnmountCmd, false},
-    {"use storage=", use_cmd, false},
-    {NULL, NULL, false} /**< list terminator */
+     false, true}, /**< Prepare for next backup/restore part of same Job */
+    {"passive", PassiveCmd, false, true},
+    {"pluginoptions", PluginoptionsCmd, false, true},
+    {"readlabel", ReadlabelCmd, false, true},
+    {"relabel", RelabelCmd, false, true}, /**< Relabel a tape */
+    {"release", ReleaseCmd, false, true},
+    {"resolve", ResolveCmd, false, false},
+    {"replicate", ReplicateCmd, false, true}, /**< Replicate data to an external SD */
+    {"run", RunCmd, false, true},             /**< Start of Job */
+    {"getSecureEraseCmd", SecureerasereqCmd, false, false},
+    {"setbandwidth=", SetbandwidthCmd, false, true},
+    {"setdebug=", SetdebugCmd, false, false},  /**< Set debug level */
+    {"setdevice", SetdeviceCmd, false, true},  /**< Set device parameter */
+    {"stats", StatsCmd, false, false},
+    {"status", StatusCmd, true, false},
+    {".status", DotstatusCmd, true, false},
+    {"unmount", UnmountCmd, false, true},
+    {"use storage=", use_cmd, false, true},
+    {NULL, NULL, false, false} /**< list terminator */
 };
 
 static inline bool AreMaxConcurrentJobsExceeded()
@@ -289,9 +290,6 @@ void* HandleDirectorConnection(BareosSocket* dir)
 
     Dmsg1(199, "<dird: %s", dir->msg);
 
-    // Ensure that device initialization is complete
-    while (!init_done) { Bmicrosleep(1, 0); }
-
     found = false;
     for (i = 0; cmds[i].cmd; i++) {
       if (bstrncmp(cmds[i].cmd, dir->msg, strlen(cmds[i].cmd))) {
@@ -300,6 +298,11 @@ void* HandleDirectorConnection(BareosSocket* dir)
           dir->fsend(invalid_cmd);
           dir->signal(BNET_EOD);
           break;
+        }
+        if (cmds[i].wait_for_device_initialization) {
+          while (!init_done.load(std::memory_order_acquire)) {
+            Bmicrosleep(1, 0);
+          }
         }
         Dmsg1(200, "Do command: %s\n", cmds[i].cmd);
         if (!cmds[i].func(jcr)) { /* do command */

--- a/core/src/stored/drive_tapealert_monitor.cc
+++ b/core/src/stored/drive_tapealert_monitor.cc
@@ -23,6 +23,7 @@
 
 #include "stored/drive_tapealert_monitor.h"
 
+#include <cinttypes>
 #include <ctime>
 
 #include "lib/scsi_tapealert.h"
@@ -51,10 +52,11 @@ void DispatchDriveTapealertMessages(::JobControlRecord* jcr,
         "Possible cause: %s\n";
 
   constexpr const char* print_msg
-      = "TapeAlert on device \"%s\" with volume \"%s\" from jobid %lu: "
+      = "TapeAlert on device \"%s\" with volume \"%s\" from jobid %" PRIu64
+        ": "
         "[%d] %s\n";
   constexpr const char* print_msg_novol
-      = "TapeAlert on device \"%s\" from jobid %lu: [%d] %s\n";
+      = "TapeAlert on device \"%s\" from jobid %" PRIu64 ": [%d] %s\n";
 
   const uint64_t jobid{jcr ? jcr->JobId : 0};
 
@@ -115,7 +117,6 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
   const char* resource_name = nullptr;
   std::string device_name;
   std::string volume_name;
-  int fd = -1;
 
   lock_mutex(dcr->mutex_);
   device_resource = GetTapealertDeviceResource(dcr);
@@ -126,7 +127,6 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
   }
 
   resource_name = device_resource->resource_name_;
-  fd = dcr->dev->fd;
   if (dcr->dev->archive_device_string
       && dcr->dev->archive_device_string[0] != '\0') {
     device_name = dcr->dev->archive_device_string;
@@ -146,7 +146,7 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
 
   Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name.c_str());
   lock_mutex(tapealert_operation_mutex);
-  bool success = GetTapealertFlags(fd, device_name.c_str(), &flags);
+  bool success = GetTapealertFlags(-1, device_name.c_str(), &flags);
   unlock_mutex(tapealert_operation_mutex);
   Dmsg1(200, "sd: tapealert check on device %s done\n", device_name.c_str());
 

--- a/core/src/stored/drive_tapealert_monitor.cc
+++ b/core/src/stored/drive_tapealert_monitor.cc
@@ -30,6 +30,7 @@
 #include "lib/scsi_tapealert_flags.h"
 #include "stored/device_control_record.h"
 #include "stored/device_resource.h"
+#include "stored/scsi_changer.h"
 #include "stored/sd_stats.h"
 #include "stored/stored.h"
 
@@ -115,7 +116,8 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
 
   DeviceResource* device_resource = nullptr;
   const char* resource_name = nullptr;
-  std::string device_name;
+  std::string archive_device_name;
+  std::string diag_device_name;
   std::string volume_name;
 
   lock_mutex(dcr->mutex_);
@@ -129,10 +131,14 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
   resource_name = device_resource->resource_name_;
   if (dcr->dev->archive_device_string
       && dcr->dev->archive_device_string[0] != '\0') {
-    device_name = dcr->dev->archive_device_string;
+    archive_device_name = dcr->dev->archive_device_string;
   } else if (device_resource->archive_device_string
              && device_resource->archive_device_string[0] != '\0') {
-    device_name = device_resource->archive_device_string;
+    archive_device_name = device_resource->archive_device_string;
+  }
+  if (device_resource->diag_device_name
+      && device_resource->diag_device_name[0] != '\0') {
+    diag_device_name = device_resource->diag_device_name;
   }
   if (const char* volume = dcr->dev->getVolCatName();
       volume && volume[0] != '\0') {
@@ -140,15 +146,21 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
   }
   unlock_mutex(dcr->mutex_);
 
-  if (device_name.empty()) { return; }
+  auto devices = GetDriveDiagnosticDeviceCandidates(
+      diag_device_name.c_str(), archive_device_name.c_str());
+  if (devices.empty()) { return; }
 
   uint64_t flags = 0;
+  bool success = false;
 
-  Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name.c_str());
-  lock_mutex(tapealert_operation_mutex);
-  bool success = GetTapealertFlags(-1, device_name.c_str(), &flags);
-  unlock_mutex(tapealert_operation_mutex);
-  Dmsg1(200, "sd: tapealert check on device %s done\n", device_name.c_str());
+  for (const auto& device_name : devices) {
+    Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name.c_str());
+    lock_mutex(tapealert_operation_mutex);
+    success = GetTapealertFlags(-1, device_name.c_str(), &flags);
+    unlock_mutex(tapealert_operation_mutex);
+    Dmsg1(200, "sd: tapealert check on device %s done\n", device_name.c_str());
+    if (success && flags != 0) { break; }
+  }
 
   if (!success || flags == 0) { return; }
 

--- a/core/src/stored/drive_tapealert_monitor.cc
+++ b/core/src/stored/drive_tapealert_monitor.cc
@@ -109,31 +109,53 @@ void HandleDriveTapealertEvent(::JobControlRecord* jcr,
   if (!jcr || !value || !IsDriveTapealertPollingEvent(event_type)) { return; }
 
   auto* dcr = static_cast<DeviceControlRecord*>(value);
-  if (!dcr || !dcr->dev) { return; }
+  if (!dcr) { return; }
 
-  auto* device_resource = GetTapealertDeviceResource(dcr);
-  if (!device_resource || !device_resource->drive_tapealert_enabled) { return; }
+  DeviceResource* device_resource = nullptr;
+  const char* resource_name = nullptr;
+  std::string device_name;
+  std::string volume_name;
+  int fd = -1;
 
-  const char* device_name = dcr->dev->archive_device_string;
-  if (!device_name || device_name[0] == '\0') {
+  lock_mutex(dcr->mutex_);
+  device_resource = GetTapealertDeviceResource(dcr);
+  if (!dcr->dev || !device_resource
+      || !device_resource->drive_tapealert_enabled) {
+    unlock_mutex(dcr->mutex_);
+    return;
+  }
+
+  resource_name = device_resource->resource_name_;
+  fd = dcr->dev->fd;
+  if (dcr->dev->archive_device_string
+      && dcr->dev->archive_device_string[0] != '\0') {
+    device_name = dcr->dev->archive_device_string;
+  } else if (device_resource->archive_device_string
+             && device_resource->archive_device_string[0] != '\0') {
     device_name = device_resource->archive_device_string;
   }
-  if (!device_name || device_name[0] == '\0') { return; }
+  if (const char* volume = dcr->dev->getVolCatName();
+      volume && volume[0] != '\0') {
+    volume_name = volume;
+  }
+  unlock_mutex(dcr->mutex_);
+
+  if (device_name.empty()) { return; }
 
   uint64_t flags = 0;
 
-  Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name);
+  Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name.c_str());
   lock_mutex(tapealert_operation_mutex);
-  bool success = GetTapealertFlags(dcr->dev->fd, device_name, &flags);
+  bool success = GetTapealertFlags(fd, device_name.c_str(), &flags);
   unlock_mutex(tapealert_operation_mutex);
-  Dmsg1(200, "sd: tapealert check on device %s done\n", device_name);
+  Dmsg1(200, "sd: tapealert check on device %s done\n", device_name.c_str());
 
   if (!success || flags == 0) { return; }
 
-  UpdateDeviceTapealert(device_resource->resource_name_, flags,
-                        static_cast<utime_t>(time(NULL)));
-  DispatchDriveTapealertMessages(jcr, device_resource->resource_name_,
-                                 dcr->dev->getVolCatName(), flags);
+  UpdateDeviceTapealert(resource_name, flags, static_cast<utime_t>(time(NULL)));
+  DispatchDriveTapealertMessages(
+      jcr, resource_name, volume_name.empty() ? nullptr : volume_name.c_str(),
+      flags);
 }
 
 }  // namespace storagedaemon

--- a/core/src/stored/drive_tapealert_monitor.cc
+++ b/core/src/stored/drive_tapealert_monitor.cc
@@ -1,0 +1,139 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "include/bareos.h"
+
+#include "stored/drive_tapealert_monitor.h"
+
+#include <ctime>
+
+#include "lib/scsi_tapealert.h"
+#include "lib/scsi_tapealert_flags.h"
+#include "stored/device_control_record.h"
+#include "stored/device_resource.h"
+#include "stored/sd_stats.h"
+#include "stored/stored.h"
+
+namespace storagedaemon {
+
+namespace {
+
+static pthread_mutex_t tapealert_operation_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void DispatchDriveTapealertMessages(::JobControlRecord* jcr,
+                                    const char* device,
+                                    const char* volume,
+                                    uint64_t flags)
+{
+  constexpr const char* job_msg
+      = "TapeAlert on device \"%s\" with volume \"%s\": [%d] %s\n%s\n"
+        "Possible cause: %s\n";
+  constexpr const char* job_msg_novol
+      = "TapeAlert on device \"%s\": [%d] %s\n%s\n"
+        "Possible cause: %s\n";
+
+  constexpr const char* print_msg
+      = "TapeAlert on device \"%s\" with volume \"%s\" from jobid %lu: "
+        "[%d] %s\n";
+  constexpr const char* print_msg_novol
+      = "TapeAlert on device \"%s\" from jobid %lu: [%d] %s\n";
+
+  const uint64_t jobid{jcr ? jcr->JobId : 0};
+
+  for (auto& flag : scsitapealert::flags) {
+    if (!flag.present_in(flags)) { continue; }
+
+    if (volume && volume[0] != '\0') {
+      Jmsg(jcr, flag.type, 0, job_msg, device, volume, flag.no, flag.name,
+           flag.message, flag.cause);
+      Pmsg0(-1, print_msg, device, volume, jobid, flag.no, flag.name);
+    } else {
+      Jmsg(jcr, flag.type, 0, job_msg_novol, device, flag.no, flag.name,
+           flag.message, flag.cause);
+      Pmsg0(-1, print_msg_novol, device, jobid, flag.no, flag.name);
+    }
+  }
+}
+
+DeviceResource* GetTapealertDeviceResource(DeviceControlRecord* dcr)
+{
+  if (!dcr) { return nullptr; }
+  if (dcr->device_resource) { return dcr->device_resource; }
+  if (dcr->dev) { return dcr->dev->device_resource; }
+  return nullptr;
+}
+
+}  // namespace
+
+bool IsDriveTapealertPollingEvent(bSdEventType event_type)
+{
+  switch (event_type) {
+    case bSdEventDeviceInit:
+    case bSdEventVolumeLoad:
+    case bSdEventLabelVerified:
+    case bSdEventLabelWrite:
+    case bSdEventReadError:
+    case bSdEventWriteError:
+    case bSdEventVolumeUnload:
+    case bSdEventDeviceRelease:
+    case bSdEventDeviceOpen:
+    case bSdEventDeviceClose:
+      return true;
+    default:
+      return false;
+  }
+}
+
+void HandleDriveTapealertEvent(::JobControlRecord* jcr,
+                               bSdEventType event_type,
+                               void* value)
+{
+  if (!jcr || !value || !IsDriveTapealertPollingEvent(event_type)) { return; }
+
+  auto* dcr = static_cast<DeviceControlRecord*>(value);
+  if (!dcr || !dcr->dev) { return; }
+
+  auto* device_resource = GetTapealertDeviceResource(dcr);
+  if (!device_resource || !device_resource->drive_tapealert_enabled) { return; }
+
+  const char* device_name = dcr->dev->archive_device_string;
+  if (!device_name || device_name[0] == '\0') {
+    device_name = device_resource->archive_device_string;
+  }
+  if (!device_name || device_name[0] == '\0') { return; }
+
+  uint64_t flags = 0;
+
+  Dmsg1(200, "sd: checking for tapealerts on device %s\n", device_name);
+  lock_mutex(tapealert_operation_mutex);
+  bool success = GetTapealertFlags(dcr->dev->fd, device_name, &flags);
+  unlock_mutex(tapealert_operation_mutex);
+  Dmsg1(200, "sd: tapealert check on device %s done\n", device_name);
+
+  if (!success || flags == 0) { return; }
+
+  UpdateDeviceTapealert(device_resource->resource_name_, flags,
+                        static_cast<utime_t>(time(NULL)));
+  DispatchDriveTapealertMessages(jcr, device_resource->resource_name_,
+                                 dcr->dev->getVolCatName(), flags);
+}
+
+}  // namespace storagedaemon

--- a/core/src/stored/drive_tapealert_monitor.h
+++ b/core/src/stored/drive_tapealert_monitor.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2025-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -18,9 +18,21 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
-#ifndef BAREOS_PLUGINS_STORED_SCSITAPEALERT_SCSITAPEALERT_SD_H_
-#define BAREOS_PLUGINS_STORED_SCSITAPEALERT_SCSITAPEALERT_SD_H_
 
-#include "lib/scsi_tapealert_flags.h"
+#ifndef BAREOS_STORED_DRIVE_TAPEALERT_MONITOR_H_
+#define BAREOS_STORED_DRIVE_TAPEALERT_MONITOR_H_
 
-#endif  // BAREOS_PLUGINS_STORED_SCSITAPEALERT_SCSITAPEALERT_SD_H_
+#include "stored/sd_plugins.h"
+
+class JobControlRecord;
+
+namespace storagedaemon {
+
+bool IsDriveTapealertPollingEvent(bSdEventType event_type);
+void HandleDriveTapealertEvent(::JobControlRecord* jcr,
+                               bSdEventType event_type,
+                               void* value);
+
+}  // namespace storagedaemon
+
+#endif  // BAREOS_STORED_DRIVE_TAPEALERT_MONITOR_H_

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -1,0 +1,850 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+ */
+
+#include "stored/scsi_changer.h"
+
+#include "include/bareos.h"
+#include "lib/bsock.h"
+#include "lib/scsi_lli.h"
+#include "lib/scsi_tapealert.h"
+#include "stored/device_control_record.h"
+#include "stored/sd_stats.h"
+#include "stored/stored.h"
+
+#include <algorithm>
+#include <array>
+#include <optional>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+namespace storagedaemon {
+namespace {
+
+constexpr char kNativeScsiChangerCommand[] = "builtin:scsi";
+constexpr uint8_t kScsiInquiry = 0x12;
+constexpr uint8_t kScsiLogSense = 0x4D;
+constexpr uint8_t kScsiModeSense6 = 0x1A;
+constexpr uint8_t kScsiReadElementStatus = 0xB8;
+constexpr uint8_t kScsiMoveMedium = 0xA5;
+constexpr uint8_t kScsiTestUnitReady = 0x00;
+constexpr uint8_t kLogSenseSupportedPages = 0x00;
+constexpr uint8_t kLogSenseTapeAlert = 0x2E;
+
+constexpr uint8_t kElementTypeAll = 0;
+constexpr uint8_t kElementTypeStorage = 2;
+constexpr uint8_t kElementTypeImportExport = 3;
+constexpr uint8_t kElementTypeDrive = 4;
+
+constexpr std::size_t kVolumeTagLength = 36;
+
+uint16_t Get2(const uint8_t* data)
+{
+  return static_cast<uint16_t>((data[0] << 8) | data[1]);
+}
+
+uint32_t Get3(const uint8_t* data)
+{
+  return (static_cast<uint32_t>(data[0]) << 16)
+         | (static_cast<uint32_t>(data[1]) << 8) | data[2];
+}
+
+void Put2(uint8_t* data, uint16_t value)
+{
+  data[0] = static_cast<uint8_t>(value >> 8);
+  data[1] = static_cast<uint8_t>(value & 0xff);
+}
+
+void Put3(uint8_t* data, uint32_t value)
+{
+  data[0] = static_cast<uint8_t>((value >> 16) & 0xff);
+  data[1] = static_cast<uint8_t>((value >> 8) & 0xff);
+  data[2] = static_cast<uint8_t>(value & 0xff);
+}
+
+std::string TrimAscii(const uint8_t* data, std::size_t size)
+{
+  std::string result(reinterpret_cast<const char*>(data), size);
+  auto first = result.find_first_not_of(' ');
+  if (first == std::string::npos) { return {}; }
+  auto last = result.find_last_not_of(' ');
+  return result.substr(first, last - first + 1);
+}
+
+const char* GetDriveDiagnosticDevice(const DeviceControlRecord* dcr)
+{
+  if (dcr->device_resource->diag_device_name
+      && dcr->device_resource->diag_device_name[0] != '\0') {
+    return dcr->device_resource->diag_device_name;
+  }
+
+  return dcr->dev->archive_device_string;
+}
+
+bool TestUnitReady(const char* device_name)
+{
+  std::array<uint8_t, 6> cdb{};
+
+  cdb[0] = kScsiTestUnitReady;
+  return DoScsiCmd(-1, device_name, cdb.data(), cdb.size());
+}
+
+bool WaitForDriveReady(DeviceControlRecord* dcr)
+{
+  const char* device_name = GetDriveDiagnosticDevice(dcr);
+  if (!device_name || device_name[0] == '\0') { return true; }
+
+  auto timeout = std::max<utime_t>(1, dcr->device_resource->max_changer_wait);
+  for (utime_t second = 0; second < timeout; ++second) {
+    if (TestUnitReady(device_name)) { return true; }
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  Jmsg(dcr->jcr, M_WARNING, 0,
+       T_("Native SCSI changer: drive %s did not become ready within %u seconds "
+          "after media move.\n"),
+       device_name, static_cast<unsigned>(timeout));
+  return false;
+}
+
+bool ReadInquiry(const char* device_name, std::array<uint8_t, 96>& data)
+{
+  std::array<uint8_t, 6> cdb{};
+  cdb[0] = kScsiInquiry;
+  cdb[4] = static_cast<uint8_t>(data.size());
+
+  data.fill(0);
+  return RecvScsiCmdPage(-1, device_name, cdb.data(), cdb.size(), data.data(),
+                         data.size());
+}
+
+bool ReadElementAddressAssignmentPage(
+    const char* device_name, std::array<uint8_t, 255>& data)
+{
+  std::array<uint8_t, 6> cdb{};
+  cdb[0] = kScsiModeSense6;
+  cdb[1] = 0x08; /* DBD */
+  cdb[2] = 0x1D;
+  cdb[4] = static_cast<uint8_t>(data.size());
+
+  data.fill(0);
+  return RecvScsiCmdPage(-1, device_name, cdb.data(), cdb.size(), data.data(),
+                         data.size());
+}
+
+bool ReadElementStatus(const char* device_name,
+                       uint8_t element_type,
+                       uint16_t number_of_elements,
+                       bool with_volume_tags,
+                       std::vector<uint8_t>& data)
+{
+  std::array<uint8_t, 12> cdb{};
+  cdb[0] = kScsiReadElementStatus;
+  cdb[1] = static_cast<uint8_t>((with_volume_tags ? 0x10 : 0x00)
+                                | (element_type & 0x0f));
+  Put2(&cdb[4], number_of_elements);
+  Put3(&cdb[7], static_cast<uint32_t>(data.size()));
+
+  std::fill(data.begin(), data.end(), 0);
+  if (!RecvScsiCmdPage(-1, device_name, cdb.data(), cdb.size(), data.data(),
+                       data.size())) {
+    if (with_volume_tags) {
+      cdb[1] = static_cast<uint8_t>(element_type & 0x0f);
+      std::fill(data.begin(), data.end(), 0);
+      return RecvScsiCmdPage(-1, device_name, cdb.data(), cdb.size(),
+                             data.data(), data.size());
+    }
+
+    return false;
+  }
+
+  return true;
+}
+
+bool ReadLogSensePage(const char* device_name,
+                      uint8_t page_code,
+                      std::vector<uint8_t>& data)
+{
+  std::array<uint8_t, 10> cdb{};
+  cdb[0] = kScsiLogSense;
+  cdb[2] = page_code & 0x3f;
+  Put2(&cdb[7], static_cast<uint16_t>(data.size()));
+
+  std::fill(data.begin(), data.end(), 0);
+  return RecvScsiCmdPage(-1, device_name, cdb.data(), cdb.size(), data.data(),
+                         data.size());
+}
+
+bool MoveMedium(const char* device_name,
+                uint16_t medium_transport_element,
+                uint16_t source,
+                uint16_t destination)
+{
+  std::array<uint8_t, 12> cdb{};
+  cdb[0] = kScsiMoveMedium;
+  Put2(&cdb[2], medium_transport_element);
+  Put2(&cdb[4], source);
+  Put2(&cdb[6], destination);
+
+  return DoScsiCmd(-1, device_name, cdb.data(), cdb.size());
+}
+
+bool PrepareDriveForMediumMove(DeviceControlRecord* dcr)
+{
+  auto* dev = dcr->dev;
+  if (!dev->IsOpen()) { return true; }
+
+  bool ok = false;
+  if (dev->HasCap(CAP_OFFLINEUNMOUNT)) {
+    ok = dev->offline();
+    if (!ok) {
+      Jmsg(dcr->jcr, M_WARNING, 0,
+           T_("Native SCSI changer: failed to offline drive %s before media "
+              "move: %s"),
+           dev->print_name(), NPRT(dev->print_errmsg()));
+    }
+  } else {
+    ok = dev->close(dcr);
+    if (!ok) {
+      Jmsg(dcr->jcr, M_WARNING, 0,
+           T_("Native SCSI changer: failed to close drive %s before media move: "
+              "%s"),
+           dev->print_name(), NPRT(dev->print_errmsg()));
+    }
+  }
+
+  return ok;
+}
+
+void ReportNativeScsiDriveDiagnostics(DeviceControlRecord* dcr)
+{
+  auto devices = GetDriveDiagnosticDeviceCandidates(
+      dcr->device_resource->diag_device_name, dcr->dev->archive_device_string);
+
+  for (const auto& device_name : devices) {
+    std::array<uint8_t, 96> inquiry{};
+    if (ReadInquiry(device_name.c_str(), inquiry)) {
+      Dmsg4(100, "Native SCSI drive inquiry: vendor=%s product=%s revision=%s "
+                 "device=%s\n",
+            TrimAscii(inquiry.data() + 8, 8).c_str(),
+            TrimAscii(inquiry.data() + 16, 16).c_str(),
+            TrimAscii(inquiry.data() + 32, 4).c_str(), device_name.c_str());
+    }
+
+    if (!TestUnitReady(device_name.c_str())) {
+      Jmsg(dcr->jcr, M_WARNING, 0,
+           T_("Native SCSI drive diagnostic: TEST UNIT READY failed on %s\n"),
+           device_name.c_str());
+    }
+  }
+
+  if (!dcr->device_resource->drive_tapealert_enabled) { return; }
+
+  uint64_t flags = 0;
+  for (const auto& device_name : devices) {
+    if (GetTapealertFlags(-1, device_name.c_str(), &flags) && flags != 0) {
+      UpdateDeviceTapealert(dcr->device_resource->resource_name_, flags,
+                            static_cast<utime_t>(time(nullptr)));
+      Jmsg(dcr->jcr, M_WARNING, 0,
+           T_("Native SCSI drive diagnostic: TapeAlert flags=0x%llx on %s\n"),
+           static_cast<unsigned long long>(flags), device_name.c_str());
+      break;
+    }
+  }
+}
+
+std::optional<ScsiChangerElementAddressAssignment> ReadAssignment(
+    const char* device_name)
+{
+  std::array<uint8_t, 255> data{};
+  ScsiChangerElementAddressAssignment assignment;
+
+  if (!ReadElementAddressAssignmentPage(device_name, data)
+      || !ParseScsiChangerElementAddressAssignment(data.data(), data.size(),
+                                                  assignment)) {
+    return std::nullopt;
+  }
+
+  return assignment;
+}
+
+std::optional<std::vector<ScsiChangerElementStatus>> ReadStatuses(
+    const char* device_name,
+    uint8_t element_type,
+    uint16_t number_of_elements,
+    bool with_volume_tags)
+{
+  std::vector<uint8_t> data(32768);
+  std::vector<ScsiChangerElementStatus> elements;
+
+  if (!ReadElementStatus(device_name, element_type, number_of_elements,
+                         with_volume_tags, data)
+      || !ParseScsiChangerElementStatusData(data.data(), data.size(), elements)) {
+    return std::nullopt;
+  }
+
+  return elements;
+}
+
+std::optional<std::vector<uint8_t>> ReadSupportedLogPages(const char* device_name)
+{
+  std::vector<uint8_t> data(256);
+  std::vector<uint8_t> pages;
+
+  if (!ReadLogSensePage(device_name, kLogSenseSupportedPages, data)
+      || !ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages)) {
+    return std::nullopt;
+  }
+
+  return pages;
+}
+
+slot_number_t ElementAddressToSlot(
+    const ScsiChangerElementAddressAssignment& assignment,
+    uint16_t element_address,
+    uint8_t element_type_code)
+{
+  switch (element_type_code) {
+    case kElementTypeStorage:
+      if (element_address >= assignment.se_addr) {
+        return static_cast<slot_number_t>(element_address - assignment.se_addr
+                                          + 1);
+      }
+      break;
+    case kElementTypeImportExport:
+      if (element_address >= assignment.iee_addr) {
+        return static_cast<slot_number_t>(
+            assignment.se_count + (element_address - assignment.iee_addr) + 1);
+      }
+      break;
+    default:
+      break;
+  }
+
+  return kInvalidSlotNumber;
+}
+
+uint16_t SlotToElementAddress(const ScsiChangerElementAddressAssignment& assignment,
+                              slot_number_t slot)
+{
+  if (!IsSlotNumberValid(slot)) { return 0; }
+
+  if (slot <= assignment.se_count) {
+    return static_cast<uint16_t>(assignment.se_addr + slot - 1);
+  }
+
+  auto import_slot
+      = static_cast<uint16_t>(slot - assignment.se_count);
+  if (import_slot >= 1 && import_slot <= assignment.iee_count) {
+    return static_cast<uint16_t>(assignment.iee_addr + import_slot - 1);
+  }
+
+  return 0;
+}
+
+uint16_t DriveToElementAddress(const ScsiChangerElementAddressAssignment& assignment,
+                               const Device* dev)
+{
+  return static_cast<uint16_t>(assignment.dte_addr + dev->drive_index);
+}
+
+std::string FormatBarcode(const std::string& barcode)
+{
+  return barcode.empty() ? std::string{"E"} : std::string{"F:"} + barcode;
+}
+
+bool MoveMediumWithRetry(DeviceControlRecord* dcr,
+                         const ScsiChangerElementAddressAssignment& assignment,
+                         uint16_t source,
+                         uint16_t destination)
+{
+  auto transports = GetScsiChangerTransportElementAddresses(assignment);
+  for (const auto transport : transports) {
+    if (MoveMedium(dcr->device_resource->changer_name, transport, source,
+                   destination)) {
+      return true;
+    }
+
+    Dmsg4(100,
+          "Native SCSI changer: MOVE MEDIUM with transport %u failed from %u to "
+          "%u on %s\n",
+          transport, source, destination, dcr->device_resource->changer_name);
+  }
+
+  return false;
+}
+
+void SendListLine(BareosSocket* dir, const std::string& line)
+{
+  dir->fsend("%s\n", line.c_str());
+}
+
+void ReportElementExceptions(JobControlRecord* jcr,
+                             const std::vector<ScsiChangerElementStatus>& elements)
+{
+  for (const auto& element : elements) {
+    if (!element.except) { continue; }
+
+    Jmsg(jcr, M_WARNING, 0,
+         T_("Native SCSI changer diagnostic: element type=%u address=%u "
+            "reports ASC=0x%02x ASCQ=0x%02x\n"),
+         element.element_type_code, element.element_address, element.asc,
+         element.ascq);
+  }
+}
+
+bool HasLogPage(const std::vector<uint8_t>& pages, uint8_t page)
+{
+  return std::find(pages.begin(), pages.end(), page) != pages.end();
+}
+
+std::string FormatLogPages(const std::vector<uint8_t>& pages)
+{
+  std::string formatted;
+  char page[8];
+
+  for (std::size_t i = 0; i < pages.size(); ++i) {
+    if (!formatted.empty()) { formatted += ' '; }
+    Bsnprintf(page, sizeof(page), "0x%02x", pages[i]);
+    formatted += page;
+  }
+
+  return formatted;
+}
+
+}  // namespace
+
+bool IsNativeScsiChangerCommand(const char* changer_command)
+{
+  return changer_command != nullptr
+         && bstrcmp(changer_command, kNativeScsiChangerCommand);
+}
+
+bool ParseScsiChangerElementAddressAssignment(
+    const uint8_t* data,
+    std::size_t size,
+    ScsiChangerElementAddressAssignment& assignment)
+{
+  if (size < 22 || data[0] < 0x12) { return false; }
+
+  const auto* page = data + 4;
+  assignment.mte_addr = Get2(page + 2);
+  assignment.mte_count = Get2(page + 4);
+  assignment.se_addr = Get2(page + 6);
+  assignment.se_count = Get2(page + 8);
+  assignment.iee_addr = Get2(page + 10);
+  assignment.iee_count = Get2(page + 12);
+  assignment.dte_addr = Get2(page + 14);
+  assignment.dte_count = Get2(page + 16);
+  return true;
+}
+
+bool ParseScsiChangerElementStatusData(
+    const uint8_t* data,
+    std::size_t size,
+    std::vector<ScsiChangerElementStatus>& elements)
+{
+  if (size < 8) { return false; }
+
+  auto byte_count = Get3(data + 5);
+  auto effective_size = std::min<std::size_t>(size, byte_count + 8);
+  std::size_t offset = 8;
+  elements.clear();
+
+  while (offset + 8 <= effective_size) {
+    const auto* page = data + offset;
+    auto element_type = page[0];
+    auto descriptor_length = Get2(page + 2);
+    auto page_byte_count = Get3(page + 5);
+    auto page_end = std::min<std::size_t>(effective_size, offset + 8
+                                                              + page_byte_count);
+    bool primary_volume_tag = (page[1] & 0x80) != 0;
+    offset += 8;
+
+    while (offset + descriptor_length <= page_end && descriptor_length >= 12) {
+      const auto* descriptor = data + offset;
+      ScsiChangerElementStatus status;
+      status.element_type_code = element_type;
+      status.element_address = Get2(descriptor);
+      status.full = (descriptor[2] & 0x01) != 0;
+      status.import_export = (descriptor[2] & 0x02) != 0;
+      status.except = (descriptor[2] & 0x04) != 0;
+      status.access = (descriptor[2] & 0x08) != 0;
+      status.export_enabled = (descriptor[2] & 0x10) != 0;
+      status.import_enabled = (descriptor[2] & 0x20) != 0;
+      status.asc = descriptor[4];
+      status.ascq = descriptor[5];
+      status.scsi_lun = static_cast<uint8_t>(descriptor[6] & 0x07);
+      status.lun_valid = (descriptor[6] & 0x10) != 0;
+      status.id_valid = (descriptor[6] & 0x20) != 0;
+      status.not_bus = (descriptor[6] & 0x80) != 0;
+      status.scsi_id = descriptor[7];
+      status.invert = (descriptor[9] & 0x40) != 0;
+      status.source_valid = (descriptor[9] & 0x80) != 0;
+      status.src_se_addr = Get2(descriptor + 10);
+
+      if (primary_volume_tag && descriptor_length >= 12 + kVolumeTagLength) {
+        status.primary_volume_tag
+            = TrimAscii(descriptor + 12, kVolumeTagLength - 4);
+      }
+
+      elements.emplace_back(std::move(status));
+      offset += descriptor_length;
+    }
+
+    offset = page_end;
+  }
+
+  return !elements.empty() || effective_size == 8;
+}
+
+bool ParseScsiLogSenseSupportedPages(const uint8_t* data,
+                                     std::size_t size,
+                                     std::vector<uint8_t>& pages)
+{
+  if (size < 4 || (data[0] & 0x3f) != kLogSenseSupportedPages) { return false; }
+
+  auto page_length = static_cast<std::size_t>(Get2(data + 2));
+  if (size < page_length + 4) { return false; }
+  auto effective_size = page_length + 4;
+
+  pages.clear();
+  for (std::size_t offset = 4; offset < effective_size; ++offset) {
+    pages.push_back(static_cast<uint8_t>(data[offset] & 0x3f));
+  }
+
+  return true;
+}
+
+std::vector<uint16_t> GetScsiChangerTransportElementAddresses(
+    const ScsiChangerElementAddressAssignment& assignment)
+{
+  std::vector<uint16_t> transports;
+  transports.reserve(assignment.mte_count);
+
+  for (uint16_t index = 0; index < assignment.mte_count; ++index) {
+    transports.push_back(static_cast<uint16_t>(assignment.mte_addr + index));
+  }
+
+  return transports;
+}
+
+std::vector<std::string> GetDriveDiagnosticDeviceCandidates(
+    const char* diag_device_name,
+    const char* archive_device_name)
+{
+  std::vector<std::string> devices;
+
+  if (diag_device_name && diag_device_name[0] != '\0') {
+    devices.emplace_back(diag_device_name);
+  }
+
+  if (archive_device_name && archive_device_name[0] != '\0'
+      && (devices.empty() || devices.front() != archive_device_name)) {
+    devices.emplace_back(archive_device_name);
+  }
+
+  return devices;
+}
+
+std::string FormatNativeScsiDiagnosticStatus(const char* changer_command,
+                                             const char* changer_name,
+                                             const char* diag_device_name,
+                                             const char* archive_device_name,
+                                             bool drive_tapealert_enabled)
+{
+  std::string status;
+  char line[512];
+  auto native_changer = IsNativeScsiChangerCommand(changer_command);
+  auto drive_devices = GetDriveDiagnosticDeviceCandidates(diag_device_name,
+                                                          archive_device_name);
+
+  if (!native_changer && !drive_tapealert_enabled && drive_devices.empty()) {
+    return status;
+  }
+
+  if (native_changer) {
+    status += T_("    Changer backend: native SCSI\n");
+    if (changer_name && changer_name[0] != '\0') {
+      Bsnprintf(line, sizeof(line), T_("    Changer device: %s\n"), changer_name);
+      status += line;
+    }
+  }
+
+  if (!drive_devices.empty()) {
+    status += T_("    Drive diagnostics via: ");
+    for (std::size_t i = 0; i < drive_devices.size(); ++i) {
+      if (i != 0) { status += ", "; }
+      status += drive_devices[i];
+    }
+    status += '\n';
+  }
+
+  if (drive_tapealert_enabled) {
+    status += T_("    Drive TapeAlert monitoring: enabled\n");
+  }
+
+  return status;
+}
+
+slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr)
+{
+  auto assignment = ReadAssignment(dcr->device_resource->changer_name);
+  if (!assignment) { return kInvalidSlotNumber; }
+
+  auto statuses = ReadStatuses(dcr->device_resource->changer_name, kElementTypeDrive,
+                               assignment->dte_count, true);
+  if (!statuses) { return kInvalidSlotNumber; }
+
+  auto drive_element_address = DriveToElementAddress(*assignment, dcr->dev);
+  for (const auto& element : *statuses) {
+    if (element.element_address != drive_element_address) { continue; }
+    if (!element.full) { return 0; }
+    if (!element.source_valid) { return kInvalidSlotNumber; }
+    return ElementAddressToSlot(*assignment, element.src_se_addr,
+                                kElementTypeStorage);
+  }
+
+  return kInvalidSlotNumber;
+}
+
+bool NativeScsiLoadSlot(DeviceControlRecord* dcr, slot_number_t slot)
+{
+  auto assignment = ReadAssignment(dcr->device_resource->changer_name);
+  if (!assignment) { return false; }
+
+  auto source = SlotToElementAddress(*assignment, slot);
+  auto destination = DriveToElementAddress(*assignment, dcr->dev);
+  if (source == 0 || destination == 0) { return false; }
+
+  if (!PrepareDriveForMediumMove(dcr)) { return false; }
+
+  auto moved = MoveMediumWithRetry(dcr, *assignment, source, destination);
+  if (moved) {
+    moved = WaitForDriveReady(dcr);
+    if (!moved) {
+      ReportNativeScsiDriveDiagnostics(dcr);
+      ReportNativeScsiChangerDiagnostics(dcr);
+    }
+  }
+
+  return moved;
+}
+
+bool NativeScsiUnloadSlot(DeviceControlRecord* dcr, slot_number_t slot)
+{
+  auto assignment = ReadAssignment(dcr->device_resource->changer_name);
+  if (!assignment) { return false; }
+
+  auto source = DriveToElementAddress(*assignment, dcr->dev);
+  auto destination = SlotToElementAddress(*assignment, slot);
+  if (source == 0 || destination == 0) { return false; }
+
+  if (!PrepareDriveForMediumMove(dcr)) { return false; }
+
+  return MoveMediumWithRetry(dcr, *assignment, source, destination);
+}
+
+bool NativeScsiUnloadDrive(DeviceControlRecord* dcr, Device* dev)
+{
+  auto save_dev = dcr->dev;
+  auto save_slot = dcr->VolCatInfo.Slot;
+  dcr->SetDev(dev);
+  dcr->VolCatInfo.Slot = dev->GetSlot();
+
+  auto unloaded = NativeScsiUnloadSlot(dcr, dev->GetSlot());
+  dcr->VolCatInfo.Slot = save_slot;
+  dcr->SetDev(save_dev);
+  return unloaded;
+}
+
+bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
+                              BareosSocket* dir,
+                              const char* cmd)
+{
+  auto assignment = ReadAssignment(dcr->device_resource->changer_name);
+  if (!assignment) {
+    dir->fsend(T_("3998 Native SCSI autochanger error: could not read element "
+                  "address assignment.\n"));
+    return false;
+  }
+
+  auto statuses
+      = ReadStatuses(dcr->device_resource->changer_name, kElementTypeAll,
+                     static_cast<uint16_t>(assignment->mte_count
+                                           + assignment->se_count
+                                           + assignment->iee_count
+                                           + assignment->dte_count),
+                     true);
+  if (!statuses) {
+    dir->fsend(
+        T_("3998 Native SCSI autochanger error: could not read element status.\n"));
+    return false;
+  }
+
+  ReportElementExceptions(dcr->jcr, *statuses);
+
+  if (bstrcmp(cmd, "slots")) {
+    dir->fsend("slots=%hd", assignment->se_count + assignment->iee_count);
+    return true;
+  }
+
+  if (bstrcmp(cmd, "list")) {
+    for (const auto& element : *statuses) {
+      if (!element.full) { continue; }
+      if (element.element_type_code == kElementTypeStorage) {
+        auto slot = ElementAddressToSlot(*assignment, element.element_address,
+                                         element.element_type_code);
+        SendListLine(dir, std::to_string(slot) + ":" + element.primary_volume_tag);
+      } else if (element.element_type_code == kElementTypeDrive
+                 && element.source_valid) {
+        auto slot = ElementAddressToSlot(*assignment, element.src_se_addr,
+                                         kElementTypeStorage);
+        if (IsSlotNumberValid(slot)) {
+          SendListLine(dir,
+                       std::to_string(slot) + ":" + element.primary_volume_tag);
+        }
+      }
+    }
+    return true;
+  }
+
+  if (bstrcmp(cmd, "listall")) {
+    for (const auto& element : *statuses) {
+      switch (element.element_type_code) {
+        case kElementTypeDrive: {
+          auto drive = element.element_address - assignment->dte_addr;
+          if (element.full && element.source_valid) {
+            auto slot = ElementAddressToSlot(*assignment, element.src_se_addr,
+                                             kElementTypeStorage);
+            SendListLine(dir, "D:" + std::to_string(drive) + ":F:"
+                                  + std::to_string(slot) + ":"
+                                  + element.primary_volume_tag);
+          } else {
+            SendListLine(dir, "D:" + std::to_string(drive) + ":E");
+          }
+          break;
+        }
+        case kElementTypeStorage: {
+          auto slot = ElementAddressToSlot(*assignment, element.element_address,
+                                           element.element_type_code);
+          SendListLine(dir, "S:" + std::to_string(slot) + ":"
+                                + FormatBarcode(element.primary_volume_tag));
+          break;
+        }
+        case kElementTypeImportExport: {
+          auto slot = ElementAddressToSlot(*assignment, element.element_address,
+                                           element.element_type_code);
+          SendListLine(dir, "I:" + std::to_string(slot) + ":"
+                                + FormatBarcode(element.primary_volume_tag));
+          break;
+        }
+        default:
+          break;
+      }
+    }
+    return true;
+  }
+
+  return false;
+}
+
+bool NativeScsiAutochangerTransferCmd(DeviceControlRecord* dcr,
+                                      BareosSocket* dir,
+                                      slot_number_t src_slot,
+                                      slot_number_t dst_slot)
+{
+  auto assignment = ReadAssignment(dcr->device_resource->changer_name);
+  if (!assignment) {
+    dir->fsend(T_("3998 Native SCSI autochanger error: could not read element "
+                  "address assignment.\n"));
+    return false;
+  }
+
+  auto source = SlotToElementAddress(*assignment, src_slot);
+  auto destination = SlotToElementAddress(*assignment, dst_slot);
+  if (source == 0 || destination == 0) {
+    dir->fsend(T_("3998 Native SCSI autochanger error: invalid slot for "
+                  "transfer.\n"));
+    return false;
+  }
+
+  if (!MoveMediumWithRetry(dcr, *assignment, source, destination)) {
+    dir->fsend(T_("3998 Native SCSI autochanger error: transfer failed.\n"));
+    return false;
+  }
+
+  dir->fsend(T_("3308 Successfully transferred volume from slot %hd to %hd.\n"),
+             src_slot, dst_slot);
+  return true;
+}
+
+void ReportNativeScsiChangerDiagnostics(DeviceControlRecord* dcr)
+{
+  const char* device_name = dcr->device_resource->changer_name;
+  if (!device_name || device_name[0] == '\0') { return; }
+
+  std::array<uint8_t, 96> inquiry{};
+  if (ReadInquiry(device_name, inquiry)) {
+    Dmsg4(100, "Native SCSI changer inquiry: vendor=%s product=%s revision=%s "
+               "device=%s\n",
+          TrimAscii(inquiry.data() + 8, 8).c_str(),
+          TrimAscii(inquiry.data() + 16, 16).c_str(),
+          TrimAscii(inquiry.data() + 32, 4).c_str(), device_name);
+  }
+
+  if (!TestUnitReady(device_name)) {
+    Jmsg(dcr->jcr, M_WARNING, 0,
+         T_("Native SCSI changer diagnostic: TEST UNIT READY failed on %s\n"),
+         device_name);
+  }
+
+  auto supported_log_pages = ReadSupportedLogPages(device_name);
+  if (supported_log_pages) {
+    Dmsg2(100, "Native SCSI changer diagnostic: supported LOG SENSE pages on %s: "
+               "%s\n",
+          device_name, FormatLogPages(*supported_log_pages).c_str());
+  }
+
+  uint64_t flags = 0;
+  if ((!supported_log_pages || HasLogPage(*supported_log_pages, kLogSenseTapeAlert))
+      && GetTapealertFlags(-1, device_name, &flags) && flags != 0) {
+    Jmsg(dcr->jcr, M_WARNING, 0,
+         T_("Native SCSI changer diagnostic: TapeAlert flags=0x%llx on %s\n"),
+         static_cast<unsigned long long>(flags), device_name);
+  }
+
+  auto assignment = ReadAssignment(device_name);
+  if (!assignment) { return; }
+
+  auto statuses
+      = ReadStatuses(device_name, kElementTypeAll,
+                     static_cast<uint16_t>(assignment->mte_count
+                                           + assignment->se_count
+                                           + assignment->iee_count
+                                           + assignment->dte_count),
+                     false);
+  if (!statuses) { return; }
+
+  ReportElementExceptions(dcr->jcr, *statuses);
+}
+
+} /* namespace storagedaemon */

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -55,6 +55,11 @@ constexpr uint8_t kElementTypeImportExport = 3;
 constexpr uint8_t kElementTypeDrive = 4;
 
 constexpr std::size_t kVolumeTagLength = 36;
+constexpr std::size_t kElementStatusDescriptorLength = 12;
+constexpr std::size_t kElementStatusDescriptorLengthWithVolumeTag
+    = kElementStatusDescriptorLength + kVolumeTagLength;
+constexpr std::size_t kReadElementStatusSafetyMargin = 1024;
+constexpr std::size_t kScsiReadElementStatusMaxAllocation = 0x00ffffff;
 
 uint16_t Get2(const uint8_t* data)
 {
@@ -118,10 +123,11 @@ bool WaitForDriveReady(DeviceControlRecord* dcr)
     std::this_thread::sleep_for(std::chrono::seconds(1));
   }
 
-  Jmsg(dcr->jcr, M_WARNING, 0,
-       T_("Native SCSI changer: drive %s did not become ready within %u seconds "
-          "after media move.\n"),
-       device_name, static_cast<unsigned>(timeout));
+  Jmsg(
+      dcr->jcr, M_WARNING, 0,
+      T_("Native SCSI changer: drive %s did not become ready within %u seconds "
+         "after media move.\n"),
+      device_name, static_cast<unsigned>(timeout));
   return false;
 }
 
@@ -136,8 +142,8 @@ bool ReadInquiry(const char* device_name, std::array<uint8_t, 96>& data)
                          data.size());
 }
 
-bool ReadElementAddressAssignmentPage(
-    const char* device_name, std::array<uint8_t, 255>& data)
+bool ReadElementAddressAssignmentPage(const char* device_name,
+                                      std::array<uint8_t, 255>& data)
 {
   std::array<uint8_t, 6> cdb{};
   cdb[0] = kScsiModeSense6;
@@ -217,16 +223,16 @@ bool PrepareDriveForMediumMove(DeviceControlRecord* dcr)
     ok = dev->offline();
     if (!ok) {
       Jmsg(dcr->jcr, M_WARNING, 0,
-           T_("Native SCSI changer: failed to offline drive %s before media "
-              "move: %s"),
+           T_("Native SCSI changer: failed to offline drive %s while preparing "
+              "for media move: %s"),
            dev->print_name(), NPRT(dev->print_errmsg()));
     }
   } else {
     ok = dev->close(dcr);
     if (!ok) {
       Jmsg(dcr->jcr, M_WARNING, 0,
-           T_("Native SCSI changer: failed to close drive %s before media move: "
-              "%s"),
+           T_("Native SCSI changer: failed to close drive %s while preparing "
+              "for media move: %s"),
            dev->print_name(), NPRT(dev->print_errmsg()));
     }
   }
@@ -242,8 +248,9 @@ void ReportNativeScsiDriveDiagnostics(DeviceControlRecord* dcr)
   for (const auto& device_name : devices) {
     std::array<uint8_t, 96> inquiry{};
     if (ReadInquiry(device_name.c_str(), inquiry)) {
-      Dmsg4(100, "Native SCSI drive inquiry: vendor=%s product=%s revision=%s "
-                 "device=%s\n",
+      Dmsg4(100,
+            "Native SCSI drive inquiry: vendor=%s product=%s revision=%s "
+            "device=%s\n",
             TrimAscii(inquiry.data() + 8, 8).c_str(),
             TrimAscii(inquiry.data() + 16, 16).c_str(),
             TrimAscii(inquiry.data() + 32, 4).c_str(), device_name.c_str());
@@ -279,7 +286,7 @@ std::optional<ScsiChangerElementAddressAssignment> ReadAssignment(
 
   if (!ReadElementAddressAssignmentPage(device_name, data)
       || !ParseScsiChangerElementAddressAssignment(data.data(), data.size(),
-                                                  assignment)) {
+                                                   assignment)) {
     return std::nullopt;
   }
 
@@ -292,19 +299,30 @@ std::optional<std::vector<ScsiChangerElementStatus>> ReadStatuses(
     uint16_t number_of_elements,
     bool with_volume_tags)
 {
-  std::vector<uint8_t> data(32768);
+  auto descriptor_length = with_volume_tags
+                               ? kElementStatusDescriptorLengthWithVolumeTag
+                               : kElementStatusDescriptorLength;
+  auto desired_size = std::min<std::size_t>(
+      kReadElementStatusSafetyMargin
+          + static_cast<std::size_t>(number_of_elements) * descriptor_length,
+      kScsiReadElementStatusMaxAllocation);
+  std::vector<uint8_t> data(desired_size);
   std::vector<ScsiChangerElementStatus> elements;
 
   if (!ReadElementStatus(device_name, element_type, number_of_elements,
                          with_volume_tags, data)
-      || !ParseScsiChangerElementStatusData(data.data(), data.size(), elements)) {
+      || !ParseScsiChangerElementStatusData(data.data(), data.size(),
+                                            elements)) {
     return std::nullopt;
   }
+
+  if (elements.size() < number_of_elements) { return std::nullopt; }
 
   return elements;
 }
 
-std::optional<std::vector<uint8_t>> ReadSupportedLogPages(const char* device_name)
+std::optional<std::vector<uint8_t>> ReadSupportedLogPages(
+    const char* device_name)
 {
   std::vector<uint8_t> data(256);
   std::vector<uint8_t> pages;
@@ -324,13 +342,17 @@ slot_number_t ElementAddressToSlot(
 {
   switch (element_type_code) {
     case kElementTypeStorage:
-      if (element_address >= assignment.se_addr) {
+      if (element_address >= assignment.se_addr
+          && element_address < static_cast<uint32_t>(assignment.se_addr)
+                                   + assignment.se_count) {
         return static_cast<slot_number_t>(element_address - assignment.se_addr
                                           + 1);
       }
       break;
     case kElementTypeImportExport:
-      if (element_address >= assignment.iee_addr) {
+      if (element_address >= assignment.iee_addr
+          && element_address < static_cast<uint32_t>(assignment.iee_addr)
+                                   + assignment.iee_count) {
         return static_cast<slot_number_t>(
             assignment.se_count + (element_address - assignment.iee_addr) + 1);
       }
@@ -342,8 +364,9 @@ slot_number_t ElementAddressToSlot(
   return kInvalidSlotNumber;
 }
 
-uint16_t SlotToElementAddress(const ScsiChangerElementAddressAssignment& assignment,
-                              slot_number_t slot)
+uint16_t SlotToElementAddress(
+    const ScsiChangerElementAddressAssignment& assignment,
+    slot_number_t slot)
 {
   if (!IsSlotNumberValid(slot)) { return 0; }
 
@@ -351,8 +374,7 @@ uint16_t SlotToElementAddress(const ScsiChangerElementAddressAssignment& assignm
     return static_cast<uint16_t>(assignment.se_addr + slot - 1);
   }
 
-  auto import_slot
-      = static_cast<uint16_t>(slot - assignment.se_count);
+  auto import_slot = static_cast<uint16_t>(slot - assignment.se_count);
   if (import_slot >= 1 && import_slot <= assignment.iee_count) {
     return static_cast<uint16_t>(assignment.iee_addr + import_slot - 1);
   }
@@ -360,8 +382,9 @@ uint16_t SlotToElementAddress(const ScsiChangerElementAddressAssignment& assignm
   return 0;
 }
 
-uint16_t DriveToElementAddress(const ScsiChangerElementAddressAssignment& assignment,
-                               const Device* dev)
+uint16_t DriveToElementAddress(
+    const ScsiChangerElementAddressAssignment& assignment,
+    const Device* dev)
 {
   return static_cast<uint16_t>(assignment.dte_addr + dev->drive_index);
 }
@@ -383,10 +406,11 @@ bool MoveMediumWithRetry(DeviceControlRecord* dcr,
       return true;
     }
 
-    Dmsg4(100,
-          "Native SCSI changer: MOVE MEDIUM with transport %u failed from %u to "
-          "%u on %s\n",
-          transport, source, destination, dcr->device_resource->changer_name);
+    Dmsg4(
+        100,
+        "Native SCSI changer: MOVE MEDIUM with transport %u failed from %u to "
+        "%u on %s\n",
+        transport, source, destination, dcr->device_resource->changer_name);
   }
 
   return false;
@@ -397,8 +421,9 @@ void SendListLine(BareosSocket* dir, const std::string& line)
   dir->fsend("%s\n", line.c_str());
 }
 
-void ReportElementExceptions(JobControlRecord* jcr,
-                             const std::vector<ScsiChangerElementStatus>& elements)
+void ReportElementExceptions(
+    JobControlRecord* jcr,
+    const std::vector<ScsiChangerElementStatus>& elements)
 {
   for (const auto& element : elements) {
     if (!element.except) { continue; }
@@ -443,7 +468,7 @@ bool ParseScsiChangerElementAddressAssignment(
     std::size_t size,
     ScsiChangerElementAddressAssignment& assignment)
 {
-  if (size < 22 || data[0] < 0x12) { return false; }
+  if (size < 22 || data[0] < 0x17) { return false; }
 
   const auto* page = data + 4;
   assignment.mte_addr = Get2(page + 2);
@@ -474,8 +499,8 @@ bool ParseScsiChangerElementStatusData(
     auto element_type = page[0];
     auto descriptor_length = Get2(page + 2);
     auto page_byte_count = Get3(page + 5);
-    auto page_end = std::min<std::size_t>(effective_size, offset + 8
-                                                              + page_byte_count);
+    auto page_end
+        = std::min<std::size_t>(effective_size, offset + 8 + page_byte_count);
     bool primary_volume_tag = (page[1] & 0x80) != 0;
     offset += 8;
 
@@ -584,7 +609,8 @@ std::string FormatNativeScsiDiagnosticStatus(const char* changer_command,
   if (native_changer) {
     status += T_("    Changer backend: native SCSI\n");
     if (changer_name && changer_name[0] != '\0') {
-      Bsnprintf(line, sizeof(line), T_("    Changer device: %s\n"), changer_name);
+      Bsnprintf(line, sizeof(line), T_("    Changer device: %s\n"),
+                changer_name);
       status += line;
     }
   }
@@ -610,8 +636,8 @@ slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr)
   auto assignment = ReadAssignment(dcr->device_resource->changer_name);
   if (!assignment) { return kInvalidSlotNumber; }
 
-  auto statuses = ReadStatuses(dcr->device_resource->changer_name, kElementTypeDrive,
-                               assignment->dte_count, true);
+  auto statuses = ReadStatuses(dcr->device_resource->changer_name,
+                               kElementTypeDrive, assignment->dte_count, true);
   if (!statuses) { return kInvalidSlotNumber; }
 
   auto drive_element_address = DriveToElementAddress(*assignment, dcr->dev);
@@ -626,16 +652,32 @@ slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr)
   return kInvalidSlotNumber;
 }
 
-bool NativeScsiLoadSlot(DeviceControlRecord* dcr, slot_number_t slot)
+NativeScsiLoadResult NativeScsiLoadSlot(DeviceControlRecord* dcr,
+                                        slot_number_t slot)
 {
   auto assignment = ReadAssignment(dcr->device_resource->changer_name);
-  if (!assignment) { return false; }
+  if (!assignment) { return NativeScsiLoadResult::kError; }
 
   auto source = SlotToElementAddress(*assignment, slot);
   auto destination = DriveToElementAddress(*assignment, dcr->dev);
-  if (source == 0 || destination == 0) { return false; }
+  if (source == 0 || destination == 0) { return NativeScsiLoadResult::kError; }
 
-  if (!PrepareDriveForMediumMove(dcr)) { return false; }
+  auto statuses = ReadStatuses(
+      dcr->device_resource->changer_name, kElementTypeAll,
+      static_cast<uint16_t>(assignment->mte_count + assignment->se_count
+                            + assignment->iee_count + assignment->dte_count),
+      true);
+  if (statuses) {
+    auto it = std::find_if(statuses->begin(), statuses->end(),
+                           [source](const auto& element) {
+                             return element.element_address == source;
+                           });
+    if (it != statuses->end() && !it->full) {
+      return NativeScsiLoadResult::kSlotEmpty;
+    }
+  }
+
+  if (!PrepareDriveForMediumMove(dcr)) { return NativeScsiLoadResult::kError; }
 
   auto moved = MoveMediumWithRetry(dcr, *assignment, source, destination);
   if (moved) {
@@ -646,7 +688,7 @@ bool NativeScsiLoadSlot(DeviceControlRecord* dcr, slot_number_t slot)
     }
   }
 
-  return moved;
+  return moved ? NativeScsiLoadResult::kSuccess : NativeScsiLoadResult::kError;
 }
 
 bool NativeScsiUnloadSlot(DeviceControlRecord* dcr, slot_number_t slot)
@@ -682,28 +724,28 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
 {
   auto assignment = ReadAssignment(dcr->device_resource->changer_name);
   if (!assignment) {
-    dir->fsend(T_("3998 Native SCSI autochanger error: could not read element "
-                  "address assignment.\n"));
+    dir->fsend(
+        T_("3998 Native SCSI autochanger error: could not read element "
+           "address assignment.\n"));
     return false;
   }
 
-  auto statuses
-      = ReadStatuses(dcr->device_resource->changer_name, kElementTypeAll,
-                     static_cast<uint16_t>(assignment->mte_count
-                                           + assignment->se_count
-                                           + assignment->iee_count
-                                           + assignment->dte_count),
-                     true);
+  auto statuses = ReadStatuses(
+      dcr->device_resource->changer_name, kElementTypeAll,
+      static_cast<uint16_t>(assignment->mte_count + assignment->se_count
+                            + assignment->iee_count + assignment->dte_count),
+      true);
   if (!statuses) {
     dir->fsend(
-        T_("3998 Native SCSI autochanger error: could not read element status.\n"));
+        T_("3998 Native SCSI autochanger error: could not read element "
+           "status.\n"));
     return false;
   }
 
   ReportElementExceptions(dcr->jcr, *statuses);
 
   if (bstrcmp(cmd, "slots")) {
-    dir->fsend("slots=%hd", assignment->se_count + assignment->iee_count);
+    dir->fsend("slots=%hd\n", assignment->se_count + assignment->iee_count);
     return true;
   }
 
@@ -713,7 +755,8 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
       if (element.element_type_code == kElementTypeStorage) {
         auto slot = ElementAddressToSlot(*assignment, element.element_address,
                                          element.element_type_code);
-        SendListLine(dir, std::to_string(slot) + ":" + element.primary_volume_tag);
+        SendListLine(dir,
+                     std::to_string(slot) + ":" + element.primary_volume_tag);
       } else if (element.element_type_code == kElementTypeDrive
                  && element.source_valid) {
         auto slot = ElementAddressToSlot(*assignment, element.src_se_addr,
@@ -735,9 +778,12 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
           if (element.full && element.source_valid) {
             auto slot = ElementAddressToSlot(*assignment, element.src_se_addr,
                                              kElementTypeStorage);
-            SendListLine(dir, "D:" + std::to_string(drive) + ":F:"
-                                  + std::to_string(slot) + ":"
+            SendListLine(dir, "D:" + std::to_string(drive)
+                                  + ":F:" + std::to_string(slot) + ":"
                                   + element.primary_volume_tag);
+          } else if (element.full) {
+            SendListLine(dir, "D:" + std::to_string(drive) + ":F::"
+                                  + FormatBarcode(element.primary_volume_tag));
           } else {
             SendListLine(dir, "D:" + std::to_string(drive) + ":E");
           }
@@ -774,16 +820,18 @@ bool NativeScsiAutochangerTransferCmd(DeviceControlRecord* dcr,
 {
   auto assignment = ReadAssignment(dcr->device_resource->changer_name);
   if (!assignment) {
-    dir->fsend(T_("3998 Native SCSI autochanger error: could not read element "
-                  "address assignment.\n"));
+    dir->fsend(
+        T_("3998 Native SCSI autochanger error: could not read element "
+           "address assignment.\n"));
     return false;
   }
 
   auto source = SlotToElementAddress(*assignment, src_slot);
   auto destination = SlotToElementAddress(*assignment, dst_slot);
   if (source == 0 || destination == 0) {
-    dir->fsend(T_("3998 Native SCSI autochanger error: invalid slot for "
-                  "transfer.\n"));
+    dir->fsend(
+        T_("3998 Native SCSI autochanger error: invalid slot for "
+           "transfer.\n"));
     return false;
   }
 
@@ -804,8 +852,9 @@ void ReportNativeScsiChangerDiagnostics(DeviceControlRecord* dcr)
 
   std::array<uint8_t, 96> inquiry{};
   if (ReadInquiry(device_name, inquiry)) {
-    Dmsg4(100, "Native SCSI changer inquiry: vendor=%s product=%s revision=%s "
-               "device=%s\n",
+    Dmsg4(100,
+          "Native SCSI changer inquiry: vendor=%s product=%s revision=%s "
+          "device=%s\n",
           TrimAscii(inquiry.data() + 8, 8).c_str(),
           TrimAscii(inquiry.data() + 16, 16).c_str(),
           TrimAscii(inquiry.data() + 32, 4).c_str(), device_name);
@@ -819,13 +868,15 @@ void ReportNativeScsiChangerDiagnostics(DeviceControlRecord* dcr)
 
   auto supported_log_pages = ReadSupportedLogPages(device_name);
   if (supported_log_pages) {
-    Dmsg2(100, "Native SCSI changer diagnostic: supported LOG SENSE pages on %s: "
-               "%s\n",
+    Dmsg2(100,
+          "Native SCSI changer diagnostic: supported LOG SENSE pages on %s: "
+          "%s\n",
           device_name, FormatLogPages(*supported_log_pages).c_str());
   }
 
   uint64_t flags = 0;
-  if ((!supported_log_pages || HasLogPage(*supported_log_pages, kLogSenseTapeAlert))
+  if ((!supported_log_pages
+       || HasLogPage(*supported_log_pages, kLogSenseTapeAlert))
       && GetTapealertFlags(-1, device_name, &flags) && flags != 0) {
     Jmsg(dcr->jcr, M_WARNING, 0,
          T_("Native SCSI changer diagnostic: TapeAlert flags=0x%llx on %s\n"),
@@ -835,13 +886,11 @@ void ReportNativeScsiChangerDiagnostics(DeviceControlRecord* dcr)
   auto assignment = ReadAssignment(device_name);
   if (!assignment) { return; }
 
-  auto statuses
-      = ReadStatuses(device_name, kElementTypeAll,
-                     static_cast<uint16_t>(assignment->mte_count
-                                           + assignment->se_count
-                                           + assignment->iee_count
-                                           + assignment->dte_count),
-                     false);
+  auto statuses = ReadStatuses(
+      device_name, kElementTypeAll,
+      static_cast<uint16_t>(assignment->mte_count + assignment->se_count
+                            + assignment->iee_count + assignment->dte_count),
+      false);
   if (!statuses) { return; }
 
   ReportElementExceptions(dcr->jcr, *statuses);

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -651,7 +651,7 @@ slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr)
   for (const auto& element : *statuses) {
     if (element.element_address != drive_element_address) { continue; }
     if (!element.full) { return 0; }
-    if (!element.source_valid) { return kInvalidSlotNumber; }
+    if (!element.source_valid) { return kLoadedSlotUnknown; }
     return ElementAddressToSlot(*assignment, element.src_se_addr,
                                 kElementTypeStorage);
   }

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -386,6 +386,7 @@ uint16_t DriveToElementAddress(
     const ScsiChangerElementAddressAssignment& assignment,
     const Device* dev)
 {
+  if (!dev || dev->drive_index >= assignment.dte_count) { return 0; }
   return static_cast<uint16_t>(assignment.dte_addr + dev->drive_index);
 }
 
@@ -681,10 +682,10 @@ NativeScsiLoadResult NativeScsiLoadSlot(DeviceControlRecord* dcr,
 
   auto moved = MoveMediumWithRetry(dcr, *assignment, source, destination);
   if (moved) {
-    moved = WaitForDriveReady(dcr);
-    if (!moved) {
+    if (!WaitForDriveReady(dcr)) {
       ReportNativeScsiDriveDiagnostics(dcr);
       ReportNativeScsiChangerDiagnostics(dcr);
+      return NativeScsiLoadResult::kLoadedNotReady;
     }
   }
 
@@ -765,6 +766,11 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
           SendListLine(dir,
                        std::to_string(slot) + ":" + element.primary_volume_tag);
         }
+      } else if (element.element_type_code == kElementTypeDrive) {
+        if (element.primary_volume_tag.empty()) { continue; }
+        auto drive = element.element_address - assignment->dte_addr;
+        SendListLine(dir, "D" + std::to_string(drive) + ":"
+                              + element.primary_volume_tag);
       }
     }
     return true;

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -795,7 +795,7 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
                                   + element.primary_volume_tag);
           } else if (element.full) {
             SendListLine(dir, "D:" + std::to_string(drive) + ":F::"
-                                  + FormatBarcode(element.primary_volume_tag));
+                                  + element.primary_volume_tag);
           } else {
             SendListLine(dir, "D:" + std::to_string(drive) + ":E");
           }

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -396,11 +396,6 @@ uint16_t DriveToElementAddress(
   return static_cast<uint16_t>(assignment.dte_addr + dev->drive_index);
 }
 
-std::string FormatBarcode(const std::string& barcode)
-{
-  return barcode.empty() ? std::string{"E"} : std::string{"F:"} + barcode;
-}
-
 bool MoveMediumWithRetry(DeviceControlRecord* dcr,
                          const ScsiChangerElementAddressAssignment& assignment,
                          uint16_t source,
@@ -804,15 +799,17 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
         case kElementTypeStorage: {
           auto slot = ElementAddressToSlot(*assignment, element.element_address,
                                            element.element_type_code);
-          SendListLine(dir, "S:" + std::to_string(slot) + ":"
-                                + FormatBarcode(element.primary_volume_tag));
+          SendListLine(dir, "S:" + std::to_string(slot)
+                                + (element.full ? ":F:" : ":E")
+                                + element.primary_volume_tag);
           break;
         }
         case kElementTypeImportExport: {
           auto slot = ElementAddressToSlot(*assignment, element.element_address,
                                            element.element_type_code);
-          SendListLine(dir, "I:" + std::to_string(slot) + ":"
-                                + FormatBarcode(element.primary_volume_tag));
+          SendListLine(dir, "I:" + std::to_string(slot)
+                                + (element.full ? ":F:" : ":E")
+                                + element.primary_volume_tag);
           break;
         }
         default:

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -768,10 +768,12 @@ bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
                        std::to_string(slot) + ":" + element.primary_volume_tag);
         }
       } else if (element.element_type_code == kElementTypeDrive) {
-        if (element.primary_volume_tag.empty()) { continue; }
         auto drive = element.element_address - assignment->dte_addr;
+        auto volume_name = element.primary_volume_tag.empty()
+                               ? std::string{"unknown-media"}
+                               : element.primary_volume_tag;
         SendListLine(dir, "D" + std::to_string(drive) + ":"
-                              + element.primary_volume_tag);
+                              + volume_name);
       }
     }
     return true;

--- a/core/src/stored/scsi_changer.cc
+++ b/core/src/stored/scsi_changer.cc
@@ -316,7 +316,13 @@ std::optional<std::vector<ScsiChangerElementStatus>> ReadStatuses(
     return std::nullopt;
   }
 
-  if (elements.size() < number_of_elements) { return std::nullopt; }
+  if (elements.size() < number_of_elements) {
+    Dmsg3(100,
+          "Native SCSI changer: requested %u element statuses for type 0x%x, "
+          "got %zu\n",
+          static_cast<unsigned>(number_of_elements),
+          static_cast<unsigned>(element_type), elements.size());
+  }
 
   return elements;
 }

--- a/core/src/stored/scsi_changer.h
+++ b/core/src/stored/scsi_changer.h
@@ -76,6 +76,9 @@ enum class NativeScsiLoadResult
   kError
 };
 
+inline constexpr slot_number_t kLoadedSlotUnknown
+    = static_cast<slot_number_t>(kInvalidSlotNumber - 1);
+
 bool IsNativeScsiChangerCommand(const char* changer_command);
 bool ParseScsiChangerElementAddressAssignment(
     const uint8_t* data,

--- a/core/src/stored/scsi_changer.h
+++ b/core/src/stored/scsi_changer.h
@@ -1,0 +1,109 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+ */
+
+#ifndef BAREOS_STORED_SCSI_CHANGER_H_
+#define BAREOS_STORED_SCSI_CHANGER_H_
+
+#include "include/bareos.h"
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+class BareosSocket;
+
+namespace storagedaemon {
+
+class Device;
+class DeviceControlRecord;
+
+struct ScsiChangerElementAddressAssignment {
+  uint16_t mte_addr{};
+  uint16_t mte_count{};
+  uint16_t se_addr{};
+  uint16_t se_count{};
+  uint16_t iee_addr{};
+  uint16_t iee_count{};
+  uint16_t dte_addr{};
+  uint16_t dte_count{};
+};
+
+struct ScsiChangerElementStatus {
+  uint8_t element_type_code{};
+  uint16_t element_address{};
+  bool full{};
+  bool import_export{};
+  bool except{};
+  bool access{};
+  bool export_enabled{};
+  bool import_enabled{};
+  bool lun_valid{};
+  bool id_valid{};
+  bool not_bus{};
+  bool invert{};
+  bool source_valid{};
+  uint8_t asc{};
+  uint8_t ascq{};
+  uint8_t scsi_id{};
+  uint8_t scsi_lun{};
+  uint16_t src_se_addr{};
+  std::string primary_volume_tag{};
+};
+
+bool IsNativeScsiChangerCommand(const char* changer_command);
+bool ParseScsiChangerElementAddressAssignment(
+    const uint8_t* data,
+    std::size_t size,
+    ScsiChangerElementAddressAssignment& assignment);
+bool ParseScsiChangerElementStatusData(
+    const uint8_t* data,
+    std::size_t size,
+    std::vector<ScsiChangerElementStatus>& elements);
+bool ParseScsiLogSenseSupportedPages(const uint8_t* data,
+                                     std::size_t size,
+                                     std::vector<uint8_t>& pages);
+std::vector<uint16_t> GetScsiChangerTransportElementAddresses(
+    const ScsiChangerElementAddressAssignment& assignment);
+std::vector<std::string> GetDriveDiagnosticDeviceCandidates(
+    const char* diag_device_name,
+    const char* archive_device_name);
+std::string FormatNativeScsiDiagnosticStatus(const char* changer_command,
+                                             const char* changer_name,
+                                             const char* diag_device_name,
+                                             const char* archive_device_name,
+                                             bool drive_tapealert_enabled);
+
+slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr);
+bool NativeScsiLoadSlot(DeviceControlRecord* dcr, slot_number_t slot);
+bool NativeScsiUnloadSlot(DeviceControlRecord* dcr, slot_number_t slot);
+bool NativeScsiUnloadDrive(DeviceControlRecord* dcr, Device* dev);
+bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,
+                              BareosSocket* dir,
+                              const char* cmd);
+bool NativeScsiAutochangerTransferCmd(DeviceControlRecord* dcr,
+                                      BareosSocket* dir,
+                                      slot_number_t src_slot,
+                                      slot_number_t dst_slot);
+void ReportNativeScsiChangerDiagnostics(DeviceControlRecord* dcr);
+
+} /* namespace storagedaemon */
+
+#endif  // BAREOS_STORED_SCSI_CHANGER_H_

--- a/core/src/stored/scsi_changer.h
+++ b/core/src/stored/scsi_changer.h
@@ -68,6 +68,13 @@ struct ScsiChangerElementStatus {
   std::string primary_volume_tag{};
 };
 
+enum class NativeScsiLoadResult
+{
+  kSuccess,
+  kSlotEmpty,
+  kError
+};
+
 bool IsNativeScsiChangerCommand(const char* changer_command);
 bool ParseScsiChangerElementAddressAssignment(
     const uint8_t* data,
@@ -92,7 +99,8 @@ std::string FormatNativeScsiDiagnosticStatus(const char* changer_command,
                                              bool drive_tapealert_enabled);
 
 slot_number_t NativeScsiGetLoadedSlot(DeviceControlRecord* dcr);
-bool NativeScsiLoadSlot(DeviceControlRecord* dcr, slot_number_t slot);
+NativeScsiLoadResult NativeScsiLoadSlot(DeviceControlRecord* dcr,
+                                        slot_number_t slot);
 bool NativeScsiUnloadSlot(DeviceControlRecord* dcr, slot_number_t slot);
 bool NativeScsiUnloadDrive(DeviceControlRecord* dcr, Device* dev);
 bool NativeScsiAutochangerCmd(DeviceControlRecord* dcr,

--- a/core/src/stored/scsi_changer.h
+++ b/core/src/stored/scsi_changer.h
@@ -71,6 +71,7 @@ struct ScsiChangerElementStatus {
 enum class NativeScsiLoadResult
 {
   kSuccess,
+  kLoadedNotReady,
   kSlotEmpty,
   kError
 };

--- a/core/src/stored/sd_plugins.cc
+++ b/core/src/stored/sd_plugins.cc
@@ -30,6 +30,7 @@
 #include "stored/stored.h"
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
+#include "stored/drive_tapealert_monitor.h"
 #include "stored/stored_jcr_impl.h"
 #include "sd_plugins.h"
 #include "lib/crypto_cache.h"
@@ -307,6 +308,8 @@ bRC GeneratePluginEvent(JobControlRecord* jcr,
   bSdEvent event;
   alist<PluginContext*>* plugin_ctx_list;
   bRC rc = bRC_OK;
+
+  HandleDriveTapealertEvent(jcr, eventType, value);
 
   if (!sd_plugin_list) {
     Dmsg0(debuglevel, "No bplugin_list: GeneratePluginEvent ignored.\n");

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -82,7 +82,7 @@ static void OutputStatus(JobControlRecord* jcr,
   ListTerminatedJobs(sp);
   ListDevices(jcr, sp, devicenames);
 
-  if (!sp->api) {
+  if (!sp->api && init_done.load(std::memory_order_acquire)) {
     len = Mmsg(msg, T_("Used Volume status:\n"));
     sp->send(msg, len);
   }
@@ -219,10 +219,13 @@ static void ListDevices(JobControlRecord* jcr,
   }
 
   if (!init_done.load(std::memory_order_acquire)) {
-    len = Mmsg(msg,
-               T_("Storage daemon device initialization is still running; "
-                  "tape open/rewind may still be in progress.\n"));
+    len = Mmsg(msg, T_("Storage daemon device initialization is still running; "
+                       "tape open/rewind may still be in progress.\n"));
     sp->send(msg, len);
+    if (!sp->api) {
+      len = PmStrcpy(msg, "====\n\n");
+      sp->send(msg, len);
+    }
     return;
   }
 

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -33,6 +33,7 @@
 #include "stored/device_control_record.h"
 #include "stored/stored_jcr_impl.h"
 #include "stored/spool.h"
+#include "stored/scsi_changer.h"
 #include "stored/status.h"
 #include "lib/status_packet.h"
 #include "lib/edit.h"
@@ -187,6 +188,16 @@ static void get_device_specific_status(DeviceResource* device_resource,
   if (device_resource && device_resource->dev
       && device_resource->dev->DeviceStatus(&dst)) {
     if (dst.status_length > 0) { sp->send(dst.status, dst.status_length); }
+  }
+
+  auto native_scsi_status = FormatNativeScsiDiagnosticStatus(
+      device_resource ? device_resource->changer_command : nullptr,
+      device_resource ? device_resource->changer_name : nullptr,
+      device_resource ? device_resource->diag_device_name : nullptr,
+      device_resource ? device_resource->archive_device_string : nullptr,
+      device_resource ? device_resource->drive_tapealert_enabled : false);
+  if (!native_scsi_status.empty()) {
+    sp->send(native_scsi_status.c_str(), native_scsi_status.size());
   }
   FreePoolMemory(dst.status);
 }

--- a/core/src/stored/status.cc
+++ b/core/src/stored/status.cc
@@ -207,6 +207,14 @@ static void ListDevices(JobControlRecord* jcr,
     sp->send(msg, len);
   }
 
+  if (!init_done.load(std::memory_order_acquire)) {
+    len = Mmsg(msg,
+               T_("Storage daemon device initialization is still running; "
+                  "tape open/rewind may still be in progress.\n"));
+    sp->send(msg, len);
+    return;
+  }
+
   foreach_res (changer, R_AUTOCHANGER) {
     // See if we need to list this autochanger.
     if (devicenames
@@ -351,6 +359,14 @@ static void ListVolumes(StatusPacket* sp, const char* devicenames)
 {
   int len;
   PoolMem msg(PM_MESSAGE);
+
+  if (!init_done.load(std::memory_order_acquire)) {
+    len = Mmsg(msg,
+               T_("Volume status is unavailable while device initialization "
+                  "is still running.\n"));
+    sp->send(msg, len);
+    return;
+  }
 
   foreach_vol ([&](auto* vol) {
     Device* dev = vol->dev;

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -549,7 +549,7 @@ extern "C" void* device_initialization(void*)
     jcr->sd_impl->dcr = nullptr;
   }
   FreeJcr(jcr);
-  init_done.store(true, std::memory_order_release);
+  SignalDeviceInitializationComplete();
   return nullptr;
 }
 

--- a/core/src/stored/stored.cc
+++ b/core/src/stored/stored.cc
@@ -549,7 +549,7 @@ extern "C" void* device_initialization(void*)
     jcr->sd_impl->dcr = nullptr;
   }
   FreeJcr(jcr);
-  init_done = true;
+  init_done.store(true, std::memory_order_release);
   return nullptr;
 }
 

--- a/core/src/stored/stored_conf.cc
+++ b/core/src/stored/stored_conf.cc
@@ -200,6 +200,7 @@ static const ResourceItem dev_items[] = {
   { "UnmountCommand", CFG_TYPE_STRNAME, ITEM(res_dev, unmount_command), {}},
   { "LabelType", CFG_TYPE_LABEL, ITEM(res_dev, label_type), {config::DeprecatedSince{23, 0, 0}}},
   { "NoRewindOnClose", CFG_TYPE_BOOL, ITEM(res_dev, norewindonclose), {config::DefaultValue{"true"}}},
+  { "MaximumFileSizeImmediateFilemark", CFG_TYPE_BOOL, ITEM(res_dev, max_file_size_immediate_filemark), {config::DefaultValue{"true"}, config::Description{"If enabled, filemarks written when MaximumFileSize is reached use the tape driver's immediate/non-blocking mode when supported. Set to no to keep the previous blocking behavior."}}},
   { "DriveTapeAlertEnabled", CFG_TYPE_BOOL, ITEM(res_dev, drive_tapealert_enabled), {}},
   { "DriveCryptoEnabled", CFG_TYPE_BOOL, ITEM(res_dev, drive_crypto_enabled), {}},
   { "QueryCryptoStatus", CFG_TYPE_BOOL, ITEM(res_dev, query_crypto_status), {}},

--- a/core/src/stored/stored_globals.cc
+++ b/core/src/stored/stored_globals.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2019 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -30,10 +30,12 @@ ConfigurationParser* my_config = nullptr;
 StorageResource* me;
 char* configfile;
 
-std::atomic<bool> init_done = false;
+std::atomic<bool> init_done{false};
 uint32_t vol_session_time;
 
 static std::mutex mutex_;
+static std::mutex device_init_mutex_;
+static std::condition_variable device_init_cv_;
 static uint32_t vol_session_id_ = 0;
 
 uint32_t NewVolSessionId()
@@ -45,6 +47,24 @@ uint32_t NewVolSessionId()
   id = vol_session_id_;
   mutex_.unlock();
   return id;
+}
+
+void SignalDeviceInitializationComplete()
+{
+  {
+    std::lock_guard lock(device_init_mutex_);
+    init_done.store(true, std::memory_order_release);
+  }
+  device_init_cv_.notify_all();
+}
+
+void WaitForDeviceInitialization()
+{
+  if (init_done.load(std::memory_order_acquire)) { return; }
+
+  std::unique_lock lock(device_init_mutex_);
+  device_init_cv_.wait(
+      lock, []() { return init_done.load(std::memory_order_acquire); });
 }
 
 } /* namespace storagedaemon */

--- a/core/src/stored/stored_globals.cc
+++ b/core/src/stored/stored_globals.cc
@@ -30,7 +30,7 @@ ConfigurationParser* my_config = nullptr;
 StorageResource* me;
 char* configfile;
 
-bool init_done = false;
+std::atomic<bool> init_done = false;
 uint32_t vol_session_time;
 
 static std::mutex mutex_;

--- a/core/src/stored/stored_globals.h
+++ b/core/src/stored/stored_globals.h
@@ -46,8 +46,6 @@ BAREOS_IMPORT uint32_t vol_session_time;
 BAREOS_IMPORT uint32_t NewVolSessionId();
 BAREOS_IMPORT void SignalDeviceInitializationComplete();
 BAREOS_IMPORT void WaitForDeviceInitialization();
-BAREOS_IMPORT void SignalDeviceInitializationComplete();
-BAREOS_IMPORT void WaitForDeviceInitialization();
 
 } /* namespace storagedaemon */
 

--- a/core/src/stored/stored_globals.h
+++ b/core/src/stored/stored_globals.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,8 @@
 #define BAREOS_STORED_STORED_GLOBALS_H_
 
 #include <atomic>
+#include <condition_variable>
+#include <mutex>
 
 #include "include/bareos.h"
 
@@ -42,6 +44,10 @@ BAREOS_IMPORT char* configfile;
 BAREOS_IMPORT std::atomic<bool> init_done;
 BAREOS_IMPORT uint32_t vol_session_time;
 BAREOS_IMPORT uint32_t NewVolSessionId();
+BAREOS_IMPORT void SignalDeviceInitializationComplete();
+BAREOS_IMPORT void WaitForDeviceInitialization();
+BAREOS_IMPORT void SignalDeviceInitializationComplete();
+BAREOS_IMPORT void WaitForDeviceInitialization();
 
 } /* namespace storagedaemon */
 

--- a/core/src/stored/stored_globals.h
+++ b/core/src/stored/stored_globals.h
@@ -24,6 +24,8 @@
 #ifndef BAREOS_STORED_STORED_GLOBALS_H_
 #define BAREOS_STORED_STORED_GLOBALS_H_
 
+#include <atomic>
+
 #include "include/bareos.h"
 
 class ConfigurationParser;
@@ -37,7 +39,7 @@ BAREOS_IMPORT StorageResource* me;
 
 BAREOS_IMPORT char* configfile;
 
-BAREOS_IMPORT bool init_done;
+BAREOS_IMPORT std::atomic<bool> init_done;
 BAREOS_IMPORT uint32_t vol_session_time;
 BAREOS_IMPORT uint32_t NewVolSessionId();
 

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -280,6 +280,11 @@ if(NOT client-only)
     ADDITIONAL_SOURCES ../dird/ndmp_slot2elemaddr.cc
     LINK_LIBRARIES ${LINK_LIBRARIES}
   )
+  bareos_add_test(
+    native_scsi_autochanger_config_test
+    LINK_LIBRARIES testing_common Bareos::SD Bareos::LibSD Bareos::Lib
+                   GTest::gtest_main
+  )
 
   bareos_add_test(pruning LINK_LIBRARIES testing_common GTest::gtest_main)
   bareos_add_test(
@@ -305,6 +310,10 @@ if(NOT client-only)
     scheduler_job_item_queue
     LINK_LIBRARIES Bareos::Dir Bareos::Lib Bareos::Findlib Bareos::SQL
                    GTest::gtest_main
+  )
+  bareos_add_test(
+    scsi_changer_test
+    LINK_LIBRARIES Bareos::Lib Bareos::LibSD GTest::gtest_main
   )
   bareos_add_test(sd_backend LINK_LIBRARIES ${LINK_LIBRARIES})
   if(${CMAKE_SYSTEM_NAME} MATCHES "SunOS") # disable on solaris

--- a/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/autochanger/native.conf
+++ b/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/autochanger/native.conf
@@ -1,0 +1,14 @@
+Autochanger {
+  Name = NativeScsiAutochanger
+  Changer Device = /dev/null
+  Device = NativeScsiDrive0
+  Device = NativeScsiDrive1
+  Changer Command = "builtin:scsi"
+}
+
+Autochanger {
+  Name = ScriptAutochanger
+  Changer Device = /dev/null
+  Device = ScriptChangerDrive0
+  Changer Command = "/usr/lib/bareos/scripts/mtx-changer %c %o %S %a %d"
+}

--- a/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/device/drives.conf
+++ b/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/device/drives.conf
@@ -1,0 +1,39 @@
+Device {
+  Name = NativeScsiDrive0
+  Media Type = File
+  Archive Device = /dev/null
+  Device Type = File
+  LabelMedia = yes
+  Random Access = yes
+  AutomaticMount = yes
+  RemovableMedia = no
+  AlwaysOpen = no
+  Drive Index = 0
+  DriveTapeAlertEnabled = yes
+}
+
+Device {
+  Name = NativeScsiDrive1
+  Media Type = File
+  Archive Device = /dev/null
+  Device Type = File
+  LabelMedia = yes
+  Random Access = yes
+  AutomaticMount = yes
+  RemovableMedia = no
+  AlwaysOpen = no
+  Drive Index = 1
+}
+
+Device {
+  Name = ScriptChangerDrive0
+  Media Type = File
+  Archive Device = /dev/null
+  Device Type = File
+  LabelMedia = yes
+  Random Access = yes
+  AutomaticMount = yes
+  RemovableMedia = no
+  AlwaysOpen = no
+  Drive Index = 0
+}

--- a/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/storage/myself.conf.in
+++ b/core/src/tests/configs/native_scsi_autochanger/bareos-sd.d/storage/myself.conf.in
@@ -1,0 +1,5 @@
+Storage {
+  Name = test-sd
+  @UNCOMMENT_SD_BACKEND_DIRECTORY@Backend Directory = @BACKEND_OUTPUT_DIRECTORY@
+  Working Directory = @PROJECT_BINARY_DIR@/
+}

--- a/core/src/tests/configs/stored_multiplied_device/bareos-sd.d/device/FileStorage.conf
+++ b/core/src/tests/configs/stored_multiplied_device/bareos-sd.d/device/FileStorage.conf
@@ -8,6 +8,7 @@ Device {
   AutomaticMount = yes;               # when device opened, read it
   RemovableMedia = no;
   AlwaysOpen = no;
+  MaximumFileSizeImmediateFilemark = no
   Description = "Multi device"
   Count = 3
 }

--- a/core/src/tests/multiplied_device_test.cc
+++ b/core/src/tests/multiplied_device_test.cc
@@ -29,6 +29,7 @@
 
 #include "lib/alist.h"
 #include "lib/parse_conf.h"
+#include "stored/backends/generic_tape_device.h"
 #include "stored/stored_conf.h"
 #include "stored/stored_globals.h"
 #include <iostream>
@@ -75,6 +76,17 @@ TEST(sd, MultipliedDeviceTest_ConfigParameter)
   ASSERT_TRUE(d);
 
   EXPECT_EQ(d->count, 3);
+  EXPECT_FALSE(d->max_file_size_immediate_filemark);
+}
+
+TEST(sd, MaxFileSizeImmediateFilemarkOperation)
+{
+  EXPECT_FALSE(UseImmediateWriteFilemarkOperation(false));
+#if defined(MTWEOFI)
+  EXPECT_TRUE(UseImmediateWriteFilemarkOperation(true));
+#else
+  EXPECT_FALSE(UseImmediateWriteFilemarkOperation(true));
+#endif
 }
 
 static uint32_t CountAllDeviceResources(ConfigurationParser& config)

--- a/core/src/tests/native_scsi_autochanger_config_test.cc
+++ b/core/src/tests/native_scsi_autochanger_config_test.cc
@@ -1,0 +1,91 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+ */
+
+#include "gtest/gtest.h"
+
+#include "include/bareos.h"
+#include "stored/autochanger.h"
+#include "stored/autochanger_resource.h"
+#include "stored/device_resource.h"
+#include "stored/scsi_changer.h"
+#include "testing_sd_common.h"
+
+using namespace storagedaemon;
+
+TEST(sd, NativeScsiAutochangerInitCopiesCommandAndDriveNumbers)
+{
+  InitSdGlobals();
+
+  auto storage_config = StoragePrepareResources("configs/native_scsi_autochanger/");
+  ASSERT_TRUE(storage_config);
+
+  auto* changer = dynamic_cast<AutochangerResource*>(
+      storage_config->GetResWithName(R_AUTOCHANGER, "NativeScsiAutochanger", false));
+  ASSERT_TRUE(changer);
+
+  auto* drive0 = dynamic_cast<DeviceResource*>(
+      storage_config->GetResWithName(R_DEVICE, "NativeScsiDrive0", false));
+  auto* drive1 = dynamic_cast<DeviceResource*>(
+      storage_config->GetResWithName(R_DEVICE, "NativeScsiDrive1", false));
+  ASSERT_TRUE(drive0);
+  ASSERT_TRUE(drive1);
+
+  ASSERT_TRUE(InitAutochangers());
+
+  EXPECT_EQ(drive0->changer_res, changer);
+  EXPECT_EQ(drive1->changer_res, changer);
+  ASSERT_NE(drive0->changer_command, nullptr);
+  ASSERT_NE(drive1->changer_command, nullptr);
+  EXPECT_TRUE(IsNativeScsiChangerCommand(drive0->changer_command));
+  EXPECT_TRUE(IsNativeScsiChangerCommand(drive1->changer_command));
+  EXPECT_STREQ(drive0->changer_name, "/dev/null");
+  EXPECT_STREQ(drive1->changer_name, "/dev/null");
+  EXPECT_TRUE(drive0->drive_tapealert_enabled);
+  EXPECT_FALSE(drive1->drive_tapealert_enabled);
+  EXPECT_EQ(drive0->drive, 0);
+  EXPECT_EQ(drive1->drive, 1);
+}
+
+TEST(sd, ScriptAutochangerInitKeepsFallbackCommand)
+{
+  InitSdGlobals();
+
+  auto storage_config = StoragePrepareResources("configs/native_scsi_autochanger/");
+  ASSERT_TRUE(storage_config);
+
+  auto* changer = dynamic_cast<AutochangerResource*>(
+      storage_config->GetResWithName(R_AUTOCHANGER, "ScriptAutochanger", false));
+  ASSERT_TRUE(changer);
+
+  auto* drive = dynamic_cast<DeviceResource*>(
+      storage_config->GetResWithName(R_DEVICE, "ScriptChangerDrive0", false));
+  ASSERT_TRUE(drive);
+
+  ASSERT_TRUE(InitAutochangers());
+
+  EXPECT_EQ(drive->changer_res, changer);
+  ASSERT_NE(drive->changer_command, nullptr);
+  EXPECT_FALSE(IsNativeScsiChangerCommand(drive->changer_command));
+  EXPECT_STREQ(drive->changer_command,
+               "/usr/lib/bareos/scripts/mtx-changer %c %o %S %a %d");
+  EXPECT_STREQ(drive->changer_name, "/dev/null");
+  EXPECT_EQ(drive->drive, 0);
+}

--- a/core/src/tests/scsi_changer_test.cc
+++ b/core/src/tests/scsi_changer_test.cc
@@ -1,0 +1,239 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+ */
+
+#include "stored/scsi_changer.h"
+#include "stored/drive_tapealert_monitor.h"
+
+#include <gtest/gtest.h>
+
+#include <array>
+
+using namespace storagedaemon;
+
+TEST(sd, NativeScsiChangerCommandSelector)
+{
+  EXPECT_TRUE(IsNativeScsiChangerCommand("builtin:scsi"));
+  EXPECT_FALSE(IsNativeScsiChangerCommand(""));
+  EXPECT_FALSE(IsNativeScsiChangerCommand("/usr/lib/bareos/scripts/mtx-changer"));
+}
+
+TEST(sd, DriveDiagnosticDeviceCandidates)
+{
+  EXPECT_EQ(GetDriveDiagnosticDeviceCandidates(nullptr, nullptr).size(), 0U);
+
+  auto archive_only
+      = GetDriveDiagnosticDeviceCandidates(nullptr, "/dev/nst0");
+  ASSERT_EQ(archive_only.size(), 1U);
+  EXPECT_EQ(archive_only[0], "/dev/nst0");
+
+  auto diag_and_archive
+      = GetDriveDiagnosticDeviceCandidates("/dev/sg1", "/dev/nst0");
+  ASSERT_EQ(diag_and_archive.size(), 2U);
+  EXPECT_EQ(diag_and_archive[0], "/dev/sg1");
+  EXPECT_EQ(diag_and_archive[1], "/dev/nst0");
+
+  auto deduplicated
+      = GetDriveDiagnosticDeviceCandidates("/dev/sg1", "/dev/sg1");
+  ASSERT_EQ(deduplicated.size(), 1U);
+  EXPECT_EQ(deduplicated[0], "/dev/sg1");
+}
+
+TEST(sd, ScsiChangerTransportElementAddresses)
+{
+  ScsiChangerElementAddressAssignment assignment{};
+  assignment.mte_addr = 0x0010;
+  assignment.mte_count = 3;
+
+  auto transports = GetScsiChangerTransportElementAddresses(assignment);
+  ASSERT_EQ(transports.size(), 3U);
+  EXPECT_EQ(transports[0], 0x0010);
+  EXPECT_EQ(transports[1], 0x0011);
+  EXPECT_EQ(transports[2], 0x0012);
+
+  assignment.mte_count = 0;
+  EXPECT_TRUE(GetScsiChangerTransportElementAddresses(assignment).empty());
+}
+
+TEST(sd, FormatNativeScsiDiagnosticStatus)
+{
+  auto native = FormatNativeScsiDiagnosticStatus("builtin:scsi", "/dev/sg0",
+                                                 "/dev/sg1", "/dev/nst0", true);
+  EXPECT_NE(native.find("Changer backend: native SCSI"), std::string::npos);
+  EXPECT_NE(native.find("Changer device: /dev/sg0"), std::string::npos);
+  EXPECT_NE(native.find("Drive diagnostics via: /dev/sg1, /dev/nst0"),
+            std::string::npos);
+  EXPECT_NE(native.find("Drive TapeAlert monitoring: enabled"),
+            std::string::npos);
+
+  auto tapealert_only = FormatNativeScsiDiagnosticStatus(
+      nullptr, nullptr, nullptr, "/dev/nst0", true);
+  EXPECT_EQ(tapealert_only,
+            "    Drive diagnostics via: /dev/nst0\n"
+            "    Drive TapeAlert monitoring: enabled\n");
+
+  auto empty = FormatNativeScsiDiagnosticStatus(nullptr, nullptr, nullptr,
+                                                nullptr, false);
+  EXPECT_TRUE(empty.empty());
+}
+
+TEST(sd, DriveTapealertPollingEvents)
+{
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventDeviceInit));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventVolumeLoad));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventLabelVerified));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventLabelWrite));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventReadError));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventWriteError));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventVolumeUnload));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventDeviceRelease));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventDeviceOpen));
+  EXPECT_TRUE(IsDriveTapealertPollingEvent(bSdEventDeviceClose));
+  EXPECT_FALSE(IsDriveTapealertPollingEvent(bSdEventJobEnd));
+  EXPECT_FALSE(IsDriveTapealertPollingEvent(bSdEventChangerLock));
+}
+
+TEST(sd, ParseScsiChangerElementAddressAssignment)
+{
+  std::array<uint8_t, 24> page{};
+  page[0] = 0x12;
+  page[6] = 0x00;
+  page[7] = 0x10;
+  page[8] = 0x00;
+  page[9] = 0x01;
+  page[10] = 0x00;
+  page[11] = 0x20;
+  page[12] = 0x00;
+  page[13] = 0x18;
+  page[14] = 0x00;
+  page[15] = 0x40;
+  page[16] = 0x00;
+  page[17] = 0x04;
+  page[18] = 0x00;
+  page[19] = 0x50;
+  page[20] = 0x00;
+  page[21] = 0x02;
+
+  ScsiChangerElementAddressAssignment assignment;
+  ASSERT_TRUE(
+      ParseScsiChangerElementAddressAssignment(page.data(), page.size(), assignment));
+  EXPECT_EQ(assignment.mte_addr, 0x0010);
+  EXPECT_EQ(assignment.mte_count, 1);
+  EXPECT_EQ(assignment.se_addr, 0x0020);
+  EXPECT_EQ(assignment.se_count, 0x18);
+  EXPECT_EQ(assignment.iee_addr, 0x0040);
+  EXPECT_EQ(assignment.iee_count, 4);
+  EXPECT_EQ(assignment.dte_addr, 0x0050);
+  EXPECT_EQ(assignment.dte_count, 2);
+}
+
+TEST(sd, ParseScsiChangerElementStatus)
+{
+  std::array<uint8_t, 28> data{};
+  data[2] = 0x00;
+  data[3] = 0x01;
+  data[6] = 0x00;
+  data[7] = 0x14;
+
+  data[8] = 0x04;
+  data[10] = 0x00;
+  data[11] = 0x0c;
+  data[13] = 0x00;
+  data[14] = 0x00;
+  data[15] = 0x0c;
+
+  data[16] = 0x00;
+  data[17] = 0x50;
+  data[18] = 0x01;
+  data[20] = 0x11;
+  data[21] = 0x22;
+  data[25] = 0x80;
+  data[26] = 0x00;
+  data[27] = 0x23;
+
+  std::vector<ScsiChangerElementStatus> elements;
+  ASSERT_TRUE(ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
+  ASSERT_EQ(elements.size(), 1U);
+  EXPECT_EQ(elements[0].element_type_code, 0x04);
+  EXPECT_EQ(elements[0].element_address, 0x0050);
+  EXPECT_TRUE(elements[0].full);
+  EXPECT_TRUE(elements[0].source_valid);
+  EXPECT_EQ(elements[0].asc, 0x11);
+  EXPECT_EQ(elements[0].ascq, 0x22);
+  EXPECT_EQ(elements[0].src_se_addr, 0x0023);
+}
+
+TEST(sd, ParseScsiLogSenseSupportedPages)
+{
+  std::array<uint8_t, 8> data{};
+  data[0] = 0x00;
+  data[2] = 0x00;
+  data[3] = 0x04;
+  data[4] = 0x00;
+  data[5] = 0x02;
+  data[6] = 0x2e;
+  data[7] = 0x3f;
+
+  std::vector<uint8_t> pages;
+  ASSERT_TRUE(ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
+  ASSERT_EQ(pages.size(), 4U);
+  EXPECT_EQ(pages[0], 0x00);
+  EXPECT_EQ(pages[1], 0x02);
+  EXPECT_EQ(pages[2], 0x2e);
+  EXPECT_EQ(pages[3], 0x3f);
+}
+
+TEST(sd, RejectTruncatedScsiLogSenseSupportedPages)
+{
+  std::array<uint8_t, 7> data{};
+  data[0] = 0x00;
+  data[2] = 0x00;
+  data[3] = 0x04;
+  data[4] = 0x00;
+  data[5] = 0x02;
+  data[6] = 0x2e;
+
+  std::vector<uint8_t> pages;
+  EXPECT_FALSE(ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
+}
+
+TEST(sd, RejectWrongScsiLogSensePage)
+{
+  std::array<uint8_t, 8> data{};
+  data[0] = 0x2e;
+  data[2] = 0x00;
+  data[3] = 0x04;
+  data[4] = 0x00;
+  data[5] = 0x02;
+  data[6] = 0x2e;
+  data[7] = 0x3f;
+
+  std::vector<uint8_t> pages;
+  EXPECT_FALSE(ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
+}
+
+TEST(sd, ParseEmptyScsiChangerElementStatus)
+{
+  std::array<uint8_t, 8> data{};
+  std::vector<ScsiChangerElementStatus> elements;
+
+  ASSERT_TRUE(ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
+  EXPECT_TRUE(elements.empty());
+}

--- a/core/src/tests/scsi_changer_test.cc
+++ b/core/src/tests/scsi_changer_test.cc
@@ -32,15 +32,15 @@ TEST(sd, NativeScsiChangerCommandSelector)
 {
   EXPECT_TRUE(IsNativeScsiChangerCommand("builtin:scsi"));
   EXPECT_FALSE(IsNativeScsiChangerCommand(""));
-  EXPECT_FALSE(IsNativeScsiChangerCommand("/usr/lib/bareos/scripts/mtx-changer"));
+  EXPECT_FALSE(
+      IsNativeScsiChangerCommand("/usr/lib/bareos/scripts/mtx-changer"));
 }
 
 TEST(sd, DriveDiagnosticDeviceCandidates)
 {
   EXPECT_EQ(GetDriveDiagnosticDeviceCandidates(nullptr, nullptr).size(), 0U);
 
-  auto archive_only
-      = GetDriveDiagnosticDeviceCandidates(nullptr, "/dev/nst0");
+  auto archive_only = GetDriveDiagnosticDeviceCandidates(nullptr, "/dev/nst0");
   ASSERT_EQ(archive_only.size(), 1U);
   EXPECT_EQ(archive_only[0], "/dev/nst0");
 
@@ -113,7 +113,7 @@ TEST(sd, DriveTapealertPollingEvents)
 TEST(sd, ParseScsiChangerElementAddressAssignment)
 {
   std::array<uint8_t, 24> page{};
-  page[0] = 0x12;
+  page[0] = 0x17;
   page[6] = 0x00;
   page[7] = 0x10;
   page[8] = 0x00;
@@ -132,8 +132,8 @@ TEST(sd, ParseScsiChangerElementAddressAssignment)
   page[21] = 0x02;
 
   ScsiChangerElementAddressAssignment assignment;
-  ASSERT_TRUE(
-      ParseScsiChangerElementAddressAssignment(page.data(), page.size(), assignment));
+  ASSERT_TRUE(ParseScsiChangerElementAddressAssignment(page.data(), page.size(),
+                                                       assignment));
   EXPECT_EQ(assignment.mte_addr, 0x0010);
   EXPECT_EQ(assignment.mte_count, 1);
   EXPECT_EQ(assignment.se_addr, 0x0020);
@@ -142,6 +142,16 @@ TEST(sd, ParseScsiChangerElementAddressAssignment)
   EXPECT_EQ(assignment.iee_count, 4);
   EXPECT_EQ(assignment.dte_addr, 0x0050);
   EXPECT_EQ(assignment.dte_count, 2);
+}
+
+TEST(sd, RejectShortScsiChangerElementAddressAssignment)
+{
+  std::array<uint8_t, 24> page{};
+  page[0] = 0x16;
+
+  ScsiChangerElementAddressAssignment assignment;
+  EXPECT_FALSE(ParseScsiChangerElementAddressAssignment(
+      page.data(), page.size(), assignment));
 }
 
 TEST(sd, ParseScsiChangerElementStatus)
@@ -169,7 +179,8 @@ TEST(sd, ParseScsiChangerElementStatus)
   data[27] = 0x23;
 
   std::vector<ScsiChangerElementStatus> elements;
-  ASSERT_TRUE(ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
+  ASSERT_TRUE(
+      ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
   ASSERT_EQ(elements.size(), 1U);
   EXPECT_EQ(elements[0].element_type_code, 0x04);
   EXPECT_EQ(elements[0].element_address, 0x0050);
@@ -211,7 +222,8 @@ TEST(sd, RejectTruncatedScsiLogSenseSupportedPages)
   data[6] = 0x2e;
 
   std::vector<uint8_t> pages;
-  EXPECT_FALSE(ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
+  EXPECT_FALSE(
+      ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
 }
 
 TEST(sd, RejectWrongScsiLogSensePage)
@@ -226,7 +238,8 @@ TEST(sd, RejectWrongScsiLogSensePage)
   data[7] = 0x3f;
 
   std::vector<uint8_t> pages;
-  EXPECT_FALSE(ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
+  EXPECT_FALSE(
+      ParseScsiLogSenseSupportedPages(data.data(), data.size(), pages));
 }
 
 TEST(sd, ParseEmptyScsiChangerElementStatus)
@@ -234,6 +247,7 @@ TEST(sd, ParseEmptyScsiChangerElementStatus)
   std::array<uint8_t, 8> data{};
   std::vector<ScsiChangerElementStatus> elements;
 
-  ASSERT_TRUE(ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
+  ASSERT_TRUE(
+      ParseScsiChangerElementStatusData(data.data(), data.size(), elements));
   EXPECT_TRUE(elements.empty());
 }

--- a/core/src/win32/compat/include/sys/mtio.h
+++ b/core/src/win32/compat/include/sys/mtio.h
@@ -79,6 +79,7 @@ struct mtop {
 #define MTCOMPRESSION 32 /* Control compression with SCSI mode page 15.  */
 #define MTSETPART 33     /* Change the active tape partition.  */
 #define MTMKPART 34      /* Format the tape with one or two partitions.  */
+#define MTWEOFI 35 /* Write an end-of-file record without waiting.  */
 
 /* structure for MTIOCGET - mag tape get status command */
 

--- a/docs/manuals/source/Appendix/Troubleshooting.rst
+++ b/docs/manuals/source/Appendix/Troubleshooting.rst
@@ -385,8 +385,9 @@ Please consider the following information when testing tape speed:
    committed to tape. If you need the previous blocking behavior, set
    :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no`\ .
    After upgrading older Bareos installations, set this option to ``no`` if
-   your tape backend or operating procedures depend on waiting for each
-   rollover file-mark to be fully committed before the write path continues.
+   your tape backend overrides ``weof_immediate()`` or your operating
+   procedures depend on waiting for each rollover file-mark to be fully
+   committed before the write path continues.
    Modern tape drives have internal buffers of 1 GiB and more and a write speed of 400MB/s.
    With :config:option:`sd/device/MaximumFileSize = 200G`, such a tape drive will write a file mark
    every 512 seconds or roughly 9 minutes.

--- a/docs/manuals/source/Appendix/Troubleshooting.rst
+++ b/docs/manuals/source/Appendix/Troubleshooting.rst
@@ -379,10 +379,11 @@ Please consider the following information when testing tape speed:
 #. Please set the tape drive device :config:option:`sd/device/MaximumFileSize` to a reasonable value.
    For LTO-7 a value of 200 GiB should work pretty good.
    When Bareos writes to tape, it adds a **file-mark** after :config:option:`sd/device/MaximumFileSize`
-   Bytes to the tape to improve search times on restore. By default these file-marks are written in
-   immediate mode (i.e. the syscall will only return after the file mark was physically written to
-   the tape). Thus every file-mark implies a buffer-flush of the drive which significantly reduces
-   the total write speed.
+   Bytes to the tape to improve search times on restore. By default these
+   rollover file-marks use the tape driver's immediate/non-blocking mode when
+   supported, which avoids stalling the write path until the file-mark is fully
+   committed to tape. If you need the previous blocking behavior, set
+   :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no`\ .
    Modern tape drives have internal buffers of 1 GiB and more and a write speed of 400MB/s.
    With :config:option:`sd/device/MaximumFileSize = 200G`, such a tape drive will write a file mark
    every 512 seconds or roughly 9 minutes.

--- a/docs/manuals/source/Appendix/Troubleshooting.rst
+++ b/docs/manuals/source/Appendix/Troubleshooting.rst
@@ -384,6 +384,9 @@ Please consider the following information when testing tape speed:
    supported, which avoids stalling the write path until the file-mark is fully
    committed to tape. If you need the previous blocking behavior, set
    :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no`\ .
+   After upgrading older Bareos installations, set this option to ``no`` if
+   your tape backend or operating procedures depend on waiting for each
+   rollover file-mark to be fully committed before the write path continues.
    Modern tape drives have internal buffers of 1 GiB and more and a write speed of 400MB/s.
    With :config:option:`sd/device/MaximumFileSize = 200G`, such a tape drive will write a file mark
    every 512 seconds or roughly 9 minutes.

--- a/docs/manuals/source/Configuration/StorageDaemon.rst
+++ b/docs/manuals/source/Configuration/StorageDaemon.rst
@@ -260,13 +260,67 @@ The following is an example of a valid Autochanger resource definition:
      Drive Index = 1
      Autochanger = yes
      ...
-   Device {
-     Name = "LTO8-3"
-     Drive Index = 2
-     Autochanger = yes
-     Autoselect = no
-     ...
+    Device {
+      Name = "LTO8-3"
+      Drive Index = 2
+      Autochanger = yes
+      Autoselect = no
+      ...
+    }
+
+For supported local SCSI changers, the Storage Daemon can also use an in-process
+native changer backend instead of an external changer script:
+
+.. code-block:: bareosconfig
+   :caption: Native SCSI Autochanger Configuration Example
+
+   Autochanger {
+     Name = "LTO8-native"
+     Device = LTO8-1, LTO8-2
+     Changer Device = /dev/sg0
+     Changer Command = "builtin:scsi"
    }
+   Device {
+      Name = "LTO8-1"
+      Archive Device = /dev/nst0
+      DiagnosticDevice = /dev/sg1
+      Drive Index = 0
+      Autochanger = yes
+      DriveTapeAlertEnabled = yes
+      ...
+   }
+   Device {
+      Name = "LTO8-2"
+      Archive Device = /dev/nst1
+      DiagnosticDevice = /dev/sg2
+      Drive Index = 1
+      Autochanger = yes
+      DriveTapeAlertEnabled = yes
+      ...
+   }
+
+With :strong:`Changer Command = "builtin:scsi"`, Bareos talks directly to the
+configured :config:option:`sd/autochanger/ChangerDevice` for changer operations
+and diagnostics. The existing script-based path remains available for unsupported
+hardware or custom changer workflows.
+
+The first native SCSI implementation is intentionally conservative:
+
+- it targets supported local SCSI changers and tape drives,
+- it preserves the usual changer commands (`load`, `unload`, `loaded`, `slots`,
+  `list`, `listall`, `transfer`),
+- it can use :config:option:`sd/device/DiagnosticDevice` for direct drive
+  readiness checks and drive diagnostics,
+- it reuses :config:option:`sd/device/DriveTapeAlertEnabled` for direct drive
+  TapeAlert reads in the native path.
+
+Current limitations of the native path are:
+
+- changers with multiple robot arms are handled conservatively by retrying
+  `MOVE MEDIUM` across all reported transport elements, but Bareos does not yet
+  make topology-aware arm selections,
+- the NDMP changer codepath remains separate; the local native SCSI backend does
+  not depend on the NDMP SMC implementation.
 
 Please note that it is important to include the :config:option:`sd/device/Autochanger = yes`\  directive
 in each device definition that belongs to an Autochanger. A device definition should not belong to more

--- a/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
@@ -30,7 +30,8 @@ Especially when updating the |dir| (together with the corresponding |sd|) it is 
 - If you use tape storage with :config:option:`sd/device/MaximumFileSize`, review
   the :config:option:`sd/device/MaximumFileSizeImmediateFilemark` setting before
   restarting the upgraded storage daemon. Bareos now uses non-blocking rollover
-  filemarks by default; set
+  filemarks by default. This especially affects tape backends that override
+  ``weof_immediate()``; set
   :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no` to keep the
   previous blocking behavior after upgrade.
 - Update your operating system to the latest security and patch level of the publisher.

--- a/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
@@ -30,8 +30,8 @@ Especially when updating the |dir| (together with the corresponding |sd|) it is 
 - If you use tape storage with :config:option:`sd/device/MaximumFileSize`, review
   the :config:option:`sd/device/MaximumFileSizeImmediateFilemark` setting before
   restarting the upgraded storage daemon. Bareos now uses non-blocking rollover
-  filemarks by default. This especially affects tape backends that override
-  ``weof_immediate()``; set
+  filemarks by default. This changes tape backends that override
+  ``weof_immediate()`` from ``weof(1)`` to ``weof_immediate(1)`` on upgrade; set
   :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no` to keep the
   previous blocking behavior after upgrade.
 - Update your operating system to the latest security and patch level of the publisher.

--- a/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/UpdatingBareos.rst
@@ -27,6 +27,12 @@ We consider both operations usually safe and they can be applied without restric
 Especially when updating the |dir| (together with the corresponding |sd|) it is recommended to do a number of security steps before going ahead:
 
 - Read the :ref:`Bareos current release notes <bareos-current-releasenotes>` and watch out for changes that might impact your installation. Take special care for the :strong:`Breaking Changes` paragraph, as it contains the information about changes that require your special attention when upgrading your installation as they might require adaptions of the configuration.
+- If you use tape storage with :config:option:`sd/device/MaximumFileSize`, review
+  the :config:option:`sd/device/MaximumFileSizeImmediateFilemark` setting before
+  restarting the upgraded storage daemon. Bareos now uses non-blocking rollover
+  filemarks by default; set
+  :config:option:`sd/device/MaximumFileSizeImmediateFilemark = no` to keep the
+  previous blocking behavior after upgrade.
 - Update your operating system to the latest security and patch level of the publisher.
 - Empty the running jobs queue.
 - Run :strong:`BackupCatalog` or equivalent as last job (keep the most up to date database dump & configuration state).

--- a/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
+++ b/docs/manuals/source/TasksAndConcepts/AutochangerSupport.rst
@@ -10,7 +10,7 @@ Bareos provides autochanger support for reading and writing tapes. In order to w
 
 -  The package **bareos-storage-tape** must be installed.
 
--  A script that actually controls the autochanger according to commands sent by Bareos. Bareos contains the script :command:`mtx-changer`, that utilize the command :command:`mtx`. It’s config file is normally located at :file:`/etc/bareos/mtx-changer.conf`
+-  Either a script that controls the autochanger according to commands sent by Bareos, or the native local SCSI backend described below. Bareos contains the script :command:`mtx-changer`, that utilize the command :command:`mtx`. It’s config file is normally located at :file:`/etc/bareos/mtx-changer.conf`
 
 -  That each Volume (tape) to be used must be defined in the Catalog and have a Slot number assigned to it so that Bareos knows where the Volume is in the autochanger. This is generally done with the :bcommand:`label` command, but can also done after the tape is labeled using the :bcommand:`update slots` command. See below for more details. You must pre-label the tapes manually before using them.
 
@@ -20,7 +20,7 @@ Bareos provides autochanger support for reading and writing tapes. In order to w
 
 -  Set :config:option:`dir/storage/AutoChanger = yes`\ .
 
-Bareos uses its own :command:`mtx-changer` script to interface with a program that actually does the tape changing. Thus in principle, :command:`mtx-changer` can be adapted to function with any autochanger program, or you can call any other script or program. The current version of :command:`mtx-changer` works with the :command:`mtx` program. FreeBSD users might need to adapt this script to use :command:`chio`. For more details, refer
+Bareos uses its own :command:`mtx-changer` script to interface with a program that actually does the tape changing. Thus in principle, :command:`mtx-changer` can be adapted to function with any autochanger program, or you can call any other script or program. The current version of :command:`mtx-changer` works with the :command:`mtx` program. FreeBSD users might need to adapt this script to use :command:`chio`. For supported local hardware, Bareos can also use :strong:`Changer Command = "builtin:scsi"` to talk directly to the changer device instead of shelling out to a changer script. For more details, refer
 to the :ref:`Testing Autochanger <AutochangerTesting>` chapter.
 
 Bareos also supports autochangers with barcode readers. This support includes two Console commands: :bcommand:`label barcodes` and :bcommand:`update slots`. For more details on these commands, see the chapter about :ref:`Barcodes`.
@@ -175,6 +175,22 @@ Following records control how Bareos uses the autochanger:
    Individual driver number, starting at 0.
 
 :config:option:`sd/device/MaximumChangerWait`\
+
+When :config:option:`sd/autochanger/ChangerCommand`\  is set to
+:strong:`"builtin:scsi"`, the Storage Daemon uses its native local SCSI changer
+backend. In that mode, :config:option:`sd/autochanger/ChangerDevice`\  should
+point to the changer control device (for example a Linux :file:`/dev/sgN`
+device), and each drive can optionally set
+:config:option:`sd/device/DiagnosticDevice`\  to a direct-SCSI drive device used
+for readiness checks and diagnostics. If :config:option:`sd/device/DriveTapeAlertEnabled`\
+is enabled, the native path also reads direct drive TapeAlert data.
+
+The native SCSI backend keeps the usual Bareos autochanger behavior and leaves
+the script-based path available as a fallback. For changers that report more
+than one medium transport element, Bareos now retries MOVE MEDIUM operations
+across all reported transport elements. The native path still does not have
+topology-aware arm selection, and the local native changer implementation
+remains separate from the NDMP changer codepath.
 
 
 Specifying Slots When Labeling
@@ -479,7 +495,7 @@ Bareos Autochanger Interface
 
 
 
-Bareos calls the autochanger script that you specify on the Changer Command statement. Normally this script will be the mtx-changer script that we provide, but it can in fact be any program. The only requirement for the script is that it must understand the commands that Bareos uses, which are loaded, load, unload, list, and slots. In addition, each of those commands must return the information in the precise format as specified below:
+Bareos normally calls the autochanger script that you specify on the Changer Command statement. Normally this script will be the mtx-changer script that we provide, but it can in fact be any program. The only requirement for the script is that it must understand the commands that Bareos uses, which are loaded, load, unload, list, and slots. In addition, each of those commands must return the information in the precise format as specified below:
 
 
 
@@ -504,6 +520,12 @@ Bareos calls the autochanger script that you specify on the Changer Command stat
 
 
 Bareos checks the exit status of the program called, and if it is zero, the data is accepted. If the exit status is non-zero, Bareos will print an error message and request the tape be manually mounted on the drive.
+
+When :config:option:`sd/autochanger/ChangerCommand`\  is set to
+:strong:`"builtin:scsi"`, Bareos performs these operations in-process via direct
+SCSI commands instead of calling an external changer script. The user-visible
+operations remain the same, but troubleshooting shifts from shell-script testing
+to verifying direct access to the configured changer and diagnostic devices.
 
 
 .. _Tapespeed and blocksizes:
@@ -801,5 +823,5 @@ TapeAlert Flags
 ---------------
 
 All modern tape drives support extended problem reporting using TapeAlert flags.
-The |sd| can retrieve and report these flags using the :ref:`scsitapealert-sd`
-plugin.
+The |sd| can retrieve and report these flags directly in core when
+:config:option:`sd/device/DriveTapeAlertEnabled`\  is enabled.

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -237,14 +237,14 @@
         "WorkingDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,
-          "default_value": "/usr/local/var/lib/bareos",
+          "default_value": "/var/lib/bareos",
           "platform_specific": true,
           "equals": true
         },
         "BackendDirectory": {
           "datatype": "DIRECTORY_LIST",
           "code": 0,
-          "default_value": "/usr/local/lib64/bareos/backends",
+          "default_value": "/usr/lib64/bareos/backends",
           "platform_specific": true,
           "equals": true,
           "description": "This is the directory where the storage daemon will look for dynamic backends (file, tape, etc.) when it needs to load them."
@@ -270,7 +270,7 @@
         "ScriptsDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,
-          "default_value": "/usr/local/lib/bareos/scripts",
+          "default_value": "/usr/lib/bareos/scripts",
           "platform_specific": true,
           "equals": true,
           "description": "Path to directory containing script files"

--- a/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-sd-config-schema.json
@@ -237,14 +237,14 @@
         "WorkingDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,
-          "default_value": "/var/lib/bareos",
+          "default_value": "/usr/local/var/lib/bareos",
           "platform_specific": true,
           "equals": true
         },
         "BackendDirectory": {
           "datatype": "DIRECTORY_LIST",
           "code": 0,
-          "default_value": "/usr/lib64/bareos/backends",
+          "default_value": "/usr/local/lib64/bareos/backends",
           "platform_specific": true,
           "equals": true,
           "description": "This is the directory where the storage daemon will look for dynamic backends (file, tape, etc.) when it needs to load them."
@@ -270,7 +270,7 @@
         "ScriptsDirectory": {
           "datatype": "DIRECTORY",
           "code": 0,
-          "default_value": "/usr/lib/bareos/scripts",
+          "default_value": "/usr/local/lib/bareos/scripts",
           "platform_specific": true,
           "equals": true,
           "description": "Path to directory containing script files"
@@ -864,6 +864,13 @@
           "code": 0,
           "default_value": "true",
           "equals": true
+        },
+        "MaximumFileSizeImmediateFilemark": {
+          "datatype": "BOOLEAN",
+          "code": 0,
+          "default_value": "true",
+          "equals": true,
+          "description": "If enabled, filemarks written when MaximumFileSize is reached use the tape driver's immediate/non-blocking mode when supported. Set to no to keep the previous blocking behavior."
         },
         "DriveTapeAlertEnabled": {
           "datatype": "BOOLEAN",

--- a/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Standard.conf.in
+++ b/systemtests/tests/heartbeat-interval/etc/bareos/bareos-dir.d/messages/Standard.conf.in
@@ -3,5 +3,4 @@ Messages {
   Description = "Reasonable message delivery -- send most everything to email address and to the console."
   console = all, !skipped, !saved, !audit
   append = "@logdir@/bareos.log" = all, !skipped, !saved, !audit
-  catalog = all, !skipped, !saved, !audit
 }

--- a/systemtests/tests/py3plug-sd/lsan-suppressions.txt
+++ b/systemtests/tests/py3plug-sd/lsan-suppressions.txt
@@ -1,0 +1,1 @@
+leak:libpython*


### PR DESCRIPTION
Only block Director commands that require device initialization.

Allow status-style commands to answer while startup device initialization continues in the background, and report that initialization is still in progress in storage status output.

Make init_done atomic for thread-safe coordination between the startup thread and connection handlers.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- [ ] Correct milestone is set

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
