### PR TITLE
fix reverse-history-search crash on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- fix reverse-history-search crash on windows [PR #2640]
+
 ## [24.0.10] - 2026-04-01
 
 ### Changed
@@ -2026,4 +2029,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2575]: https://github.com/bareos/bareos/pull/2575
 [PR #2583]: https://github.com/bareos/bareos/pull/2583
 [PR #2592]: https://github.com/bareos/bareos/pull/2592
+[PR #2640]: https://github.com/bareos/bareos/pull/2640
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,6 @@ find_package(Git)
 include(BareosVersionFromGit)
 include(BareosExtractVersionInfo)
 include(BareosGetDistInfo)
-include(RemoveNDebugFlag)
 include(ForceOption)
 
 set(BUILDNAME
@@ -196,6 +195,7 @@ endif()
 
 if(BUILD_BAREOS_BINARIES)
   project(bareos C CXX)
+  include(RemoveNDebugFlag)
   if(NOT CMAKE_BUILD_TYPE
      AND NOT CMAKE_C_FLAGS
      AND NOT CMAKE_CXX_FLAGS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -894,6 +894,8 @@ CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ;
 # use our own cmake call instead of cmake macro as it is different on different platforms/versions
 cmake  .. \
   -DCMAKE_VERBOSE_MAKEFILE=ON \
+  -DCMAKE_C_FLAGS_RELEASE:STRING="" \
+  -DCMAKE_CXX_FLAGS_RELEASE:STRING="" \
   -DCMAKE_INSTALL_PREFIX:PATH=/usr \
   -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib \
   -DINCLUDE_INSTALL_DIR:PATH=/usr/include \

--- a/core/src/filed/dir_cmd.cc
+++ b/core/src/filed/dir_cmd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -279,74 +279,6 @@ static bool ValidateCommand(JobControlRecord* jcr,
   }
 
   return allowed;
-}
-
-void CleanupFileset(JobControlRecord* jcr)
-{
-  findFILESET* fileset;
-  findIncludeExcludeItem* incexe;
-  findFOPTS* fo;
-
-  fileset = jcr->fd_impl->ff->fileset;
-  if (fileset) {
-    // Delete FileSet Include lists
-    for (int i = 0; i < fileset->include_list.size(); i++) {
-      incexe = (findIncludeExcludeItem*)fileset->include_list.get(i);
-      for (int j = 0; j < incexe->opts_list.size(); j++) {
-        fo = (findFOPTS*)incexe->opts_list.get(j);
-        if (fo->plugin) { free(fo->plugin); }
-        for (int k = 0; k < fo->regex.size(); k++) {
-          regfree((regex_t*)fo->regex.get(k));
-        }
-        for (int k = 0; k < fo->regexdir.size(); k++) {
-          regfree((regex_t*)fo->regexdir.get(k));
-        }
-        for (int k = 0; k < fo->regexfile.size(); k++) {
-          regfree((regex_t*)fo->regexfile.get(k));
-        }
-        if (fo->size_match) { free(fo->size_match); }
-        fo->regex.destroy();
-        fo->regexdir.destroy();
-        fo->regexfile.destroy();
-        fo->wild.destroy();
-        fo->wilddir.destroy();
-        fo->wildfile.destroy();
-        fo->wildbase.destroy();
-        fo->fstype.destroy();
-        fo->Drivetype.destroy();
-      }
-      incexe->opts_list.destroy();
-      incexe->name_list.destroy();
-      incexe->plugin_list.destroy();
-      incexe->ignoredir.destroy();
-    }
-    fileset->include_list.destroy();
-
-    // Delete FileSet Exclude lists
-    for (int i = 0; i < fileset->exclude_list.size(); i++) {
-      incexe = (findIncludeExcludeItem*)fileset->exclude_list.get(i);
-      for (int j = 0; j < incexe->opts_list.size(); j++) {
-        fo = (findFOPTS*)incexe->opts_list.get(j);
-        if (fo->size_match) { free(fo->size_match); }
-        fo->regex.destroy();
-        fo->regexdir.destroy();
-        fo->regexfile.destroy();
-        fo->wild.destroy();
-        fo->wilddir.destroy();
-        fo->wildfile.destroy();
-        fo->wildbase.destroy();
-        fo->fstype.destroy();
-        fo->Drivetype.destroy();
-      }
-      incexe->opts_list.destroy();
-      incexe->name_list.destroy();
-      incexe->plugin_list.destroy();
-      incexe->ignoredir.destroy();
-    }
-    fileset->exclude_list.destroy();
-    free(fileset);
-  }
-  jcr->fd_impl->ff->fileset = nullptr;
 }
 
 static inline bool AreMaxConcurrentJobsExceeded()

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -34,6 +34,7 @@
 #include "filed/filed_globals.h"
 #include "filed/filed_jcr_impl.h"
 #include "filed/fileset.h"
+#include <cstdlib>
 #include "findlib/match.h"
 #include "lib/berrno.h"
 #include "lib/edit.h"
@@ -73,18 +74,17 @@ std::optional<std::string> job_code_callback_filed(JobControlRecord* jcr,
 bool InitFileset(JobControlRecord* jcr)
 {
   FindFilesPacket* ff;
-  findFILESET* fileset;
 
   if (!jcr->fd_impl->ff) { return false; }
   ff = jcr->fd_impl->ff;
   if (ff->fileset) { return false; }
-  fileset = (findFILESET*)malloc(sizeof(findFILESET));
-  *fileset = findFILESET{};
+  auto* fileset = new findFILESET{};
 
   ff->fileset = fileset;
   fileset->state = state_none;
   fileset->include_list.init(1, true);
   fileset->exclude_list.init(1, true);
+
   return true;
 }
 
@@ -151,7 +151,8 @@ void CleanupFileset(JobControlRecord* jcr)
       incexe->ignoredir.destroy();
     }
     fileset->exclude_list.destroy();
-    free(fileset);
+
+    delete fileset;
   }
   jcr->fd_impl->ff->fileset = nullptr;
 }

--- a/core/src/filed/fileset.cc
+++ b/core/src/filed/fileset.cc
@@ -88,6 +88,75 @@ bool InitFileset(JobControlRecord* jcr)
   return true;
 }
 
+void CleanupFileset(JobControlRecord* jcr)
+{
+  findFILESET* fileset;
+  findIncludeExcludeItem* incexe;
+  findFOPTS* fo;
+
+  fileset = jcr->fd_impl->ff->fileset;
+  if (fileset) {
+    // Delete FileSet Include lists
+    for (int i = 0; i < fileset->include_list.size(); i++) {
+      incexe = (findIncludeExcludeItem*)fileset->include_list.get(i);
+      for (int j = 0; j < incexe->opts_list.size(); j++) {
+        fo = (findFOPTS*)incexe->opts_list.get(j);
+        if (fo->plugin) { free(fo->plugin); }
+        for (int k = 0; k < fo->regex.size(); k++) {
+          regfree((regex_t*)fo->regex.get(k));
+        }
+        for (int k = 0; k < fo->regexdir.size(); k++) {
+          regfree((regex_t*)fo->regexdir.get(k));
+        }
+        for (int k = 0; k < fo->regexfile.size(); k++) {
+          regfree((regex_t*)fo->regexfile.get(k));
+        }
+        if (fo->size_match) { free(fo->size_match); }
+        fo->regex.destroy();
+        fo->regexdir.destroy();
+        fo->regexfile.destroy();
+        fo->wild.destroy();
+        fo->wilddir.destroy();
+        fo->wildfile.destroy();
+        fo->wildbase.destroy();
+        fo->fstype.destroy();
+        fo->Drivetype.destroy();
+      }
+      incexe->opts_list.destroy();
+      incexe->name_list.destroy();
+      incexe->plugin_list.destroy();
+      incexe->ignoredir.destroy();
+    }
+    fileset->include_list.destroy();
+
+    // Delete FileSet Exclude lists
+    for (int i = 0; i < fileset->exclude_list.size(); i++) {
+      incexe = (findIncludeExcludeItem*)fileset->exclude_list.get(i);
+      for (int j = 0; j < incexe->opts_list.size(); j++) {
+        fo = (findFOPTS*)incexe->opts_list.get(j);
+        if (fo->size_match) { free(fo->size_match); }
+        fo->regex.destroy();
+        fo->regexdir.destroy();
+        fo->regexfile.destroy();
+        fo->wild.destroy();
+        fo->wilddir.destroy();
+        fo->wildfile.destroy();
+        fo->wildbase.destroy();
+        fo->fstype.destroy();
+        fo->Drivetype.destroy();
+      }
+      incexe->opts_list.destroy();
+      incexe->name_list.destroy();
+      incexe->plugin_list.destroy();
+      incexe->ignoredir.destroy();
+    }
+    fileset->exclude_list.destroy();
+    free(fileset);
+  }
+  jcr->fd_impl->ff->fileset = nullptr;
+}
+
+
 static void append_file(JobControlRecord* jcr,
                         findIncludeExcludeItem* incexe,
                         const char* buf,

--- a/core/src/findlib/find.h
+++ b/core/src/findlib/find.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2001-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -160,10 +160,10 @@ struct findIncludeExcludeItem {
 
 // FileSet Resource
 struct findFILESET {
-  int state;
-  findIncludeExcludeItem* incexe; /**< Current item */
-  alist<findIncludeExcludeItem*> include_list;
-  alist<findIncludeExcludeItem*> exclude_list;
+  int state{};
+  findIncludeExcludeItem* incexe{}; /**< Current item */
+  alist<findIncludeExcludeItem*> include_list{};
+  alist<findIncludeExcludeItem*> exclude_list{};
 };
 
 // OSX resource fork.

--- a/core/src/lib/cli.cc
+++ b/core/src/lib/cli.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,8 +26,6 @@
 #include "lib/message.h"
 #include "lib/edit.h"
 #include "include/exit_codes.h"
-
-#include <regex>
 
 class BareosCliFormatter : public CLI::Formatter {
  public:
@@ -81,11 +79,29 @@ class BareosCliFormatter : public CLI::Formatter {
   {
     std::stringstream out;
 
-    std::string name = make_option_name(opt, is_positional);
+    std::string orig_name = make_option_name(opt, is_positional);
     // remove option values from string, eg.
     //    -s{false},--no-signals{false}
     // => -s,--no-signals
-    name = std::regex_replace(name, std::regex("\\{[^}]*\\}"), "");
+
+    std::string name;
+    name.reserve(orig_name.size());
+
+    {
+      std::string_view to_parse = orig_name;
+      while (!to_parse.empty()) {
+        auto start_pos = to_parse.find('{');
+        if (start_pos == to_parse.npos) { break; }
+        auto end_pos = to_parse.find('}', start_pos);
+        if (end_pos == to_parse.npos) { break; }
+
+        name.append(to_parse.substr(0, start_pos));
+        to_parse = to_parse.substr(end_pos + 1);
+      }
+
+      name.append(to_parse);
+    }
+
     out << indent << name;
 
     out << make_option_opts(opt);

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -619,22 +619,33 @@ bool IsNameValid(const char* name)
 }
 
 // Add commas to a string, which is presumably a number.
-char* add_commas(char* val, char* buf)
+char* add_commas(const char* val, char* buf)
 {
-  int len, nc;
-  char *p, *q;
-  int i;
+  auto in_length = strlen(val);
+  // we add a comma every three characters, so we have breakpoints at 4, 7, ...
+  auto num_commas = in_length ? (in_length - 1) / 3 : 0;
 
-  if (val != buf) { strcpy(buf, val); }
-  len = strlen(buf);
-  if (len < 1) { len = 1; }
-  nc = (len - 1) / 3;
-  p = buf + len;
-  q = p + nc;
-  *q-- = *p--;
-  for (; nc; nc--) {
-    for (i = 0; i < 3; i++) { *q-- = *p--; }
-    *q-- = ',';
+  if (num_commas == 0) {
+    memmove(buf, val, in_length + 1);
+    return buf;
+  }
+
+  auto out_length = in_length + num_commas;
+  buf[out_length] = '\0';
+
+  // we need to compute where to insert the first comma
+  auto comma_offset = (3 - (in_length % 3)) % 3;
+
+  // we need to copy in reverse, in case val and buf overlap
+  for (int i = in_length - 1; i >= 0; --i) {
+    // we need to move the output by how many commas exist before that
+    // position!
+    auto prev_commas = (i + comma_offset) / 3;
+    buf[i + prev_commas] = val[i];
+  }
+
+  for (size_t i = 0; i < num_commas; ++i) {
+    buf[i * 4 + 3 - comma_offset] = ',';
   }
 
   return buf;

--- a/core/src/lib/edit.cc
+++ b/core/src/lib/edit.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -49,7 +49,7 @@ char* edit_uint64(uint64_t val, char* buf);
 char* edit_int64(int64_t val, char* buf);
 char* edit_int64_with_commas(int64_t val, char* buf);
 
-char* add_commas(char* val, char* buf);
+char* add_commas(const char* val, char* buf);
 bool DurationToUtime(const char* str, utime_t* value);
 bool size_to_uint64(const char* str, uint64_t* value);
 bool speed_to_uint64(const char* str, uint64_t* value);

--- a/core/src/lib/edit.h
+++ b/core/src/lib/edit.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -724,9 +724,9 @@ void DispatchMessage(JobControlRecord* jcr,
             len = strlen(msg);
             if (len > 0) {
               (void)fwrite(msg, len, 1, con_fd);
-              if (msg[len - 1] != '\n') { (void)fwrite("\n", 2, 1, con_fd); }
+              if (msg[len - 1] != '\n') { (void)fwrite("\n", 1, 1, con_fd); }
             } else {
-              (void)fwrite("\n", 2, 1, con_fd);
+              (void)fwrite("\n", 1, 1, con_fd);
             }
             fflush(con_fd);
             console_msg_pending = true;

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -344,44 +344,42 @@ static inline bool PySavePacketToNative(
       if (pSavePkt->object_len > 0) {
         /* As this has to linger as long as the backup is running we save it
          * in our plugin context. */
-        bool object_name_exists = pSavePkt->object_name;
-        bool object_name_is_unicode = PyUnicode_Check(pSavePkt->object_name);
-        bool object_exists = pSavePkt->object;
-        bool object_is_bytearray = PyByteArray_Check(pSavePkt->object);
-        if (object_name_exists && object_name_is_unicode && object_exists
-            && object_is_bytearray) {
-          char* buf;
 
-          if (plugin_priv_ctx->object_name) {
-            free(plugin_priv_ctx->object_name);
-          }
-          plugin_priv_ctx->object_name
-              = strdup(PyUnicode_AsUTF8(pSavePkt->object_name));
-          sp->object_name = plugin_priv_ctx->object_name;
+        if (!pSavePkt->object_name) {
+          PyErr_SetString(PyExc_RuntimeError, "object name missing");
+          return false;
+        }
+        if (!PyUnicode_Check(pSavePkt->object_name)) {
+          PyErr_SetString(PyExc_RuntimeError,
+                          "object name must be unicode type");
+          return false;
+        }
+        if (!pSavePkt->object) {
+          PyErr_SetString(PyExc_RuntimeError, "object missing");
+          return false;
+        }
+        if (!PyByteArray_Check(pSavePkt->object)) {
+          PyErr_SetString(PyExc_RuntimeError,
+                          "object needs to be of type bytearray");
+          return false;
+        }
 
-          sp->object_len = pSavePkt->object_len;
-          sp->index = pSavePkt->object_index;
+        if (plugin_priv_ctx->object_name) {
+          free(plugin_priv_ctx->object_name);
+        }
+        plugin_priv_ctx->object_name
+            = strdup(PyUnicode_AsUTF8(pSavePkt->object_name));
+        sp->object_name = plugin_priv_ctx->object_name;
 
-          if ((buf = PyByteArray_AsString(pSavePkt->object))) {
-            if (plugin_priv_ctx->object) { free(plugin_priv_ctx->object); }
-            plugin_priv_ctx->object = (char*)malloc(pSavePkt->object_len);
-            memcpy(plugin_priv_ctx->object, buf, pSavePkt->object_len);
-            sp->object = plugin_priv_ctx->object;
-          } else {
-            return false;
-          }
+        sp->object_len = pSavePkt->object_len;
+        sp->index = pSavePkt->object_index;
+
+        if (char* buf = PyByteArray_AsString(pSavePkt->object)) {
+          if (plugin_priv_ctx->object) { free(plugin_priv_ctx->object); }
+          plugin_priv_ctx->object = (char*)malloc(pSavePkt->object_len);
+          memcpy(plugin_priv_ctx->object, buf, pSavePkt->object_len);
+          sp->object = plugin_priv_ctx->object;
         } else {
-          std::string err_string{};
-          if (!object_name_exists) { err_string = "object name missing"; };
-          if (!object_name_is_unicode) {
-            err_string = "object name must be unicode type";
-          };
-          if (!object_exists) { err_string = "object missing"; };
-          if (!object_is_bytearray) {
-            err_string = "object needs to be of type bytearray";
-          };
-
-          PyErr_SetString(PyExc_RuntimeError, err_string.c_str());
           return false;
         }
       } else {

--- a/core/src/plugins/filed/python/module/bareosfd.cc
+++ b/core/src/plugins/filed/python/module/bareosfd.cc
@@ -341,51 +341,66 @@ static inline bool PySavePacketToNative(
     // Special code for handling restore objects.
     if (IS_FT_OBJECT(sp->type)) {
       // See if a proper restore object was created.
-      if (pSavePkt->object_len > 0) {
-        /* As this has to linger as long as the backup is running we save it
-         * in our plugin context. */
-
-        if (!pSavePkt->object_name) {
-          PyErr_SetString(PyExc_RuntimeError, "object name missing");
-          return false;
-        }
-        if (!PyUnicode_Check(pSavePkt->object_name)) {
-          PyErr_SetString(PyExc_RuntimeError,
-                          "object name must be unicode type");
-          return false;
-        }
-        if (!pSavePkt->object) {
-          PyErr_SetString(PyExc_RuntimeError, "object missing");
-          return false;
-        }
-        if (!PyByteArray_Check(pSavePkt->object)) {
-          PyErr_SetString(PyExc_RuntimeError,
-                          "object needs to be of type bytearray");
-          return false;
-        }
-
-        if (plugin_priv_ctx->object_name) {
-          free(plugin_priv_ctx->object_name);
-        }
-        plugin_priv_ctx->object_name
-            = strdup(PyUnicode_AsUTF8(pSavePkt->object_name));
-        sp->object_name = plugin_priv_ctx->object_name;
-
-        sp->object_len = pSavePkt->object_len;
-        sp->index = pSavePkt->object_index;
-
-        if (char* buf = PyByteArray_AsString(pSavePkt->object)) {
-          if (plugin_priv_ctx->object) { free(plugin_priv_ctx->object); }
-          plugin_priv_ctx->object = (char*)malloc(pSavePkt->object_len);
-          memcpy(plugin_priv_ctx->object, buf, pSavePkt->object_len);
-          sp->object = plugin_priv_ctx->object;
-        } else {
-          return false;
-        }
-      } else {
+      if (pSavePkt->object_len <= 0) {
         PyErr_SetString(PyExc_RuntimeError, "pSavePkt->object_len is <=0");
         return false;
       }
+
+      /* As this has to linger as long as the backup is running we save it
+       * in our plugin context. */
+      if (!pSavePkt->object_name) {
+        PyErr_SetString(PyExc_RuntimeError, "object name missing");
+        return false;
+      }
+      if (!PyUnicode_Check(pSavePkt->object_name)) {
+        PyErr_SetString(PyExc_RuntimeError, "object name must be unicode type");
+        return false;
+      }
+      if (!pSavePkt->object) {
+        PyErr_SetString(PyExc_RuntimeError, "object missing");
+        return false;
+      }
+      if (!PyByteArray_Check(pSavePkt->object)) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "object needs to be of type bytearray");
+        return false;
+      }
+
+      char* buf = PyByteArray_AsString(pSavePkt->object);
+
+      if (!buf) {
+        /* if PyByteArray_AsString() fails even though PyByteArray_Check()
+         * succeeds, then python should have already set an exception itself.
+         * As such we do not set our own exception here to not mask that one. */
+        return false;
+      }
+
+      auto array_size = PyByteArray_Size(pSavePkt->object);
+
+      if (array_size < pSavePkt->object_len) {
+        PyErr_SetString(PyExc_RuntimeError, "object_len >= len(object)");
+        return false;
+      }
+
+      auto* object_name = PyUnicode_AsUTF8(pSavePkt->object_name);
+
+      if (!object_name) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "could not convert object name to c-string");
+        return false;
+      }
+
+      if (plugin_priv_ctx->object_name) { free(plugin_priv_ctx->object_name); }
+      plugin_priv_ctx->object_name = strdup(object_name);
+      sp->object_name = plugin_priv_ctx->object_name;
+
+      sp->object_len = pSavePkt->object_len;
+      sp->index = pSavePkt->object_index;
+
+      if (plugin_priv_ctx->object) { free(plugin_priv_ctx->object); }
+      plugin_priv_ctx->object = (char*)malloc(pSavePkt->object_len);
+      memcpy(plugin_priv_ctx->object, buf, pSavePkt->object_len);
+      sp->object = plugin_priv_ctx->object;
     } else {
       sp->no_read = pSavePkt->no_read;
       sp->delta_seq = pSavePkt->delta_seq;
@@ -396,25 +411,23 @@ static inline bool PySavePacketToNative(
     sp->delta_seq = pSavePkt->delta_seq;
     sp->save_time = pSavePkt->save_time;
 
-    if (PyByteArray_Check(pSavePkt->flags)) {
-      char* flags;
-
-      if (PyByteArray_Size(pSavePkt->flags) != sizeof(sp->flags)) {
-        PyErr_SetString(PyExc_RuntimeError, "PyByteArray_Size(flags) failed");
-        return false;
-      }
-
-      if ((flags = PyByteArray_AsString(pSavePkt->flags))) {
-        memcpy(sp->flags, flags, sizeof(sp->flags));
-      } else {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "PyByteArray_AsString(flags) failed");
-        return false;
-      }
-    } else {
+    if (!PyByteArray_Check(pSavePkt->flags)) {
       PyErr_SetString(PyExc_TypeError, "flags need to be of type bytearray");
       return false;
     }
+
+    if (PyByteArray_Size(pSavePkt->flags) != sizeof(sp->flags)) {
+      PyErr_SetString(PyExc_RuntimeError, "PyByteArray_Size(flags) failed");
+      return false;
+    }
+
+    char* flags = PyByteArray_AsString(pSavePkt->flags);
+    if (!flags) {
+      PyErr_SetString(PyExc_RuntimeError, "PyByteArray_AsString(flags) failed");
+      return false;
+    }
+
+    memcpy(sp->flags, flags, sizeof(sp->flags));
   }
   return true;
 }

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2010 Zilvinas Krapavickas <zkrapavickas@gmail.com>
    Copyright (C) 2013-2014 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/win32/plugins/filed/mssqlvdi-fd.cc
+++ b/core/src/win32/plugins/filed/mssqlvdi-fd.cc
@@ -1309,7 +1309,7 @@ static inline bool SetupVdiDevice(PluginContext* ctx, io_pkt* io)
                            ? VDI_DEFAULT_WAIT
                            : p_ctx->get_configuration_timeout * 1000;  // ms
 
-    Jmsg(ctx, M_INFO, "Calling GetConfiguration with a timeout of %d sec\n.",
+    Jmsg(ctx, M_INFO, "Calling GetConfiguration with a timeout of %d sec\n",
          timeout / 1000);
 
     hr = p_ctx->VDIDeviceSet->GetConfiguration(timeout, &p_ctx->VDIConfig);

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -40,5 +40,5 @@
       "version-string": "2.4.2"
     }
   ],
-  "builtin-baseline": "5e605ddb03c9d1d93692a77dfdabceceb8b8113f"
+  "builtin-baseline": "ec20452cd73280bac2952cf749d3caec5a237490"
 }


### PR DESCRIPTION
**Backport of PR #2614 to bareos-24**

Differences:
* does not include the changes to the ResourceItem as they were first introduced in 25,
* backported 74c684d22775aa75e5f363192cb91b0b02aafdef, as now gcc on win-cross complained about the old `add_commas` code

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2614 is merged
- [x] All functional differences to the original PR are documented above
