### PR TITLE
bvfs: fix cache race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - matrix: add ubuntu 26.04 [PR #2635]
 - core: unify parsing of bools [PR #2578]
 - core: remove one "unused" layer of abstraction from our tls code [PR #2631]
+- bvfs: fix cache race [PR #2642]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2281,4 +2282,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2631]: https://github.com/bareos/bareos/pull/2631
 [PR #2635]: https://github.com/bareos/bareos/pull/2635
 [PR #2638]: https://github.com/bareos/bareos/pull/2638
+[PR #2642]: https://github.com/bareos/bareos/pull/2642
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -134,6 +134,7 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
 {
   Dmsg0(dbglevel, "UpdatePathHierarchyCache()\n");
   bool retval = false;
+  int updated_rows = 0;
   uint32_t num;
   char jobid[50];
   edit_uint64(JobId, jobid);
@@ -141,26 +142,24 @@ bool BareosDb::UpdatePathHierarchyCache(JobControlRecord* jcr,
   DbLocker _{this};
   StartTransaction(jcr);
 
-  Mmsg(cmd, "SELECT 1 FROM Job WHERE JobId = %s AND HasCache=1", jobid);
+  /* Claim the cache build atomically so concurrent .bvfs_update runs cannot
+   * both start populating PathVisibility for the same JobId. */
+  Mmsg(cmd, "UPDATE Job SET HasCache=-1 WHERE JobId=%s AND HasCache=0", jobid);
+  updated_rows = UpdateDb(jcr, cmd);
+  if (updated_rows < 0) { goto bail_out; }
+  if (updated_rows == 0) {
+    Mmsg(cmd, "SELECT 1 FROM Job WHERE JobId = %s AND HasCache=1", jobid);
+    if (!QueryDb(jcr, cmd)) { goto bail_out; }
 
-  if (!QueryDb(jcr, cmd) || SqlNumRows() > 0) {
-    Dmsg1(dbglevel, "Already computed %d\n", (uint32_t)JobId);
-    retval = true;
+    if (SqlNumRows() > 0) {
+      Dmsg1(dbglevel, "Already computed %d\n", (uint32_t)JobId);
+      retval = true;
+    } else {
+      Dmsg1(dbglevel, "already in progress %d\n", (uint32_t)JobId);
+      retval = false;
+    }
     goto bail_out;
   }
-
-  /* prevent from DB lock waits when already in progress */
-  Mmsg(cmd, "SELECT 1 FROM Job WHERE JobId = %s AND HasCache=-1", jobid);
-
-  if (!QueryDb(jcr, cmd) || SqlNumRows() > 0) {
-    Dmsg1(dbglevel, "already in progress %d\n", (uint32_t)JobId);
-    retval = false;
-    goto bail_out;
-  }
-
-  /* set HasCache to -1 in Job (in progress) */
-  Mmsg(cmd, "UPDATE Job SET HasCache=-1 WHERE JobId=%s", jobid);
-  UpdateDb(jcr, cmd);
 
   /* need to COMMIT here to ensure that other concurrent .bvfs_update runs
    * see the current HasCache value. A new transaction must only be started


### PR DESCRIPTION
Atomically claim BVFS cache generation before filling PathVisibility so concurrent .bvfs_update runs cannot start the same job twice.

Add a python-bareos system test that runs concurrent BVFS updates against the same job set to cover the regression.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

