### PR TITLE
core: fixup fadvise usage

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -46,6 +46,7 @@ Carlos A. Molina G
 Carlos Rodrigues
 Carsten Paeth
 Chris Lee
+Chris Lockfort
 Chris Matthews
 Christer Fletcher
 Christian Eichelmann

--- a/core/src/dird/catreq.cc
+++ b/core/src/dird/catreq.cc
@@ -735,8 +735,8 @@ bool DespoolAttributesFromFile(JobControlRecord* jcr, const char* file)
     goto bail_out;
   }
 
-#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_WILLNEED)
-  posix_fadvise(spool_fd, 0, 0, POSIX_FADV_WILLNEED);
+#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_NOREUSE)
+  posix_fadvise(spool_fd, 0, 0, POSIX_FADV_NOREUSE);
 #endif
 
   while ((nbytes = read(spool_fd, (char*)&pktsiz, sizeof(int32_t)))

--- a/core/src/findlib/bfile.cc
+++ b/core/src/findlib/bfile.cc
@@ -1048,11 +1048,11 @@ int bopen(BareosFilePacket* bfd,
   bfd->win32Decomplugin_private_context.bIsInData = false;
   bfd->win32Decomplugin_private_context.liNextHeader = 0;
 
-#  if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_WILLNEED)
+#  if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_NOREUSE)
   /* If not RDWR or WRONLY must be Read Only */
   if (bfd->filedes != -1 && !(flags & (O_RDWR | O_WRONLY))) {
-    int status = posix_fadvise(bfd->filedes, 0, 0, POSIX_FADV_WILLNEED);
-    Dmsg3(400, "Did posix_fadvise WILLNEED on %s filedes=%d status=%d\n", fname,
+    int status = posix_fadvise(bfd->filedes, 0, 0, POSIX_FADV_NOREUSE);
+    Dmsg3(400, "Did posix_fadvise NOREUSE on %s filedes=%d status=%d\n", fname,
           bfd->filedes, status);
   }
 #  endif

--- a/core/src/lib/bsock.cc
+++ b/core/src/lib/bsock.cc
@@ -222,8 +222,8 @@ bool BareosSocket::despool(void UpdateAttrSpoolSize(ssize_t size),
     return false;
   }
 
-#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_WILLNEED)
-  posix_fadvise(spool_fd_, 0, 0, POSIX_FADV_WILLNEED);
+#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_NOREUSE)
+  posix_fadvise(spool_fd_, 0, 0, POSIX_FADV_NOREUSE);
 #endif
 
   while ((nbytes = read(spool_fd_, (char*)&pktsiz, sizeof(int32_t)))

--- a/core/src/stored/spool.cc
+++ b/core/src/stored/spool.cc
@@ -302,8 +302,14 @@ static bool DespoolData(DeviceControlRecord* dcr, bool commit)
   Dmsg1(800, "read/write block size = %d\n", block->buf_len);
   lseek(rdcr->spool_fd, 0, SEEK_SET); /* rewind */
 
-#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_WILLNEED)
-  posix_fadvise(rdcr->spool_fd, 0, 0, POSIX_FADV_WILLNEED);
+#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_NOREUSE)
+  /* Avoid excessive thrashing of the host's page cache */
+  posix_fadvise(rdcr->spool_fd, 0, 0, POSIX_FADV_NOREUSE);
+#endif
+
+#if defined(HAVE_POSIX_FADVISE) && defined(POSIX_FADV_SEQUENTIAL)
+  /* Increases the readahead on some filesystems */
+  posix_fadvise(rdcr->spool_fd, 0, 0, POSIX_FADV_SEQUENTIAL);
 #endif
 
   /* Add run time, to get current wait time */


### PR DESCRIPTION
- Reduce page cache thrashing
- Possibly improve despool perf/reduce shoe-shining via larger readahead

My environment's spool/despool server has a lot of memory pressure, and pushing 12TiB of data through the page cache twice to do LTO-8 tape spool/despools does not help the problem. We tested this change by ld_preload shimming bareos' fadvise calls ( https://gist.github.com/clockfort/120a5ea7f92915a2547f86227b8f2a40 ) and it greatly improved memory pressure / overall perf.

There's probably also some other places that could use FADV_SEQUENTIAL, if I poked my head around more, or other low hanging fruit to avoid thrashing the page caches unnecessarily of the servers being backed up as well, which could make backups less disruptive to whatever main application is actively running on those servers.

As a flag, on old 2006 linux (<2.6.18) WILLNEED and NOREUSE were treated the same; only in linux 6.3+ (2023) does it have the good page marking behavior. ([manpage](https://man7.org/linux/man-pages/man2/posix_fadvise.2.html#:~:text=POSIX_FADV_NOREUSE%0A%20%20%20%20%20%20%20%20%20%20%20%20%20%20The%20specified,streaming%20large%20files.))
Old FreeBSD before like ?freebsd10? (2014) this change would be detrimental, as FreeBSD previously very questionably implemented NOREUSE by just making things O_DIRECT with no caching at all, which is undesirable for this application.

If we think it's necessary, I could add some detection for linux <6.3 to have the old behavior, though I kind of hate it because it's just extra code kludge that will stick around forever.



### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
