### PR TITLE
dedupable: remove error on flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bvfs: fix cache race [PR #2642]
 - mssqlvdi: set default for serveraddress+instance on restore [PR #879]
 - docs: clarify mssql plugin options [PR #2653]
+- dedupable: remove error on flush [PR #2649]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2288,5 +2289,6 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2635]: https://github.com/bareos/bareos/pull/2635
 [PR #2638]: https://github.com/bareos/bareos/pull/2638
 [PR #2642]: https://github.com/bareos/bareos/pull/2642
+[PR #2649]: https://github.com/bareos/bareos/pull/2649
 [PR #2653]: https://github.com/bareos/bareos/pull/2653
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/dedupable_device.cc
+++ b/core/src/stored/backends/dedupable_device.cc
@@ -456,8 +456,11 @@ bool dedup_device::eod(DeviceControlRecord* dcr)
 bool dedup_device::d_flush(DeviceControlRecord*)
 {
   if (!openvol) {
-    Emsg0(M_ERROR, 0, T_("Trying to flush dedup volume when none are open.\n"));
-    return false;
+    // this can happen if a device gets released before any volumes were
+    // loaded, or after the volume was already released.
+
+    Dmsg0(100, T_("Trying to flush dedup volume when none are open.\n"));
+    return true;
   }
 
   try {


### PR DESCRIPTION

dedupable: remove error on flush

Sadly bareos sometimes tries to flush a device without a volume
loaded.  This can happen if a job (for whatever reason) acquired a
device which it cannot use for reading/writing.  In those cases it
will close the device again without loading a volume.

CleanDevice() then calls flush on the volumeless device.

Fixes the issue described in #2584. 
Trying to flush a volumeless dedupable device will now only 
output a debug message.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR


