### PR TITLE
dedupable: remove error on flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python-dir: fix not registering python thread state correctly#2493 [PR #2605]
 - bvfs: fix cache race [PR #2650]
 - mssqlvdi: set default for serveraddress+instance on restore [PR #2652]
+- dedupable: remove error on flush [PR #2658]
 
 ## [25.0.3] - 2026-04-01
 
@@ -2281,5 +2282,6 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2639]: https://github.com/bareos/bareos/pull/2639
 [PR #2650]: https://github.com/bareos/bareos/pull/2650
 [PR #2652]: https://github.com/bareos/bareos/pull/2652
+[PR #2658]: https://github.com/bareos/bareos/pull/2658
 [PR #2660]: https://github.com/bareos/bareos/pull/2660
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/dedupable_device.cc
+++ b/core/src/stored/backends/dedupable_device.cc
@@ -456,8 +456,11 @@ bool dedup_device::eod(DeviceControlRecord* dcr)
 bool dedup_device::d_flush(DeviceControlRecord*)
 {
   if (!openvol) {
-    Emsg0(M_ERROR, 0, T_("Trying to flush dedup volume when none are open.\n"));
-    return false;
+    // this can happen if a device gets released before any volumes were
+    // loaded, or after the volume was already released.
+
+    Dmsg0(100, T_("Trying to flush dedup volume when none are open.\n"));
+    return true;
   }
 
   try {


### PR DESCRIPTION
**Backport of PR #2649 to bareos-25**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2649 is merged
- [x] All functional differences to the original PR are documented above
