### PR TITLE
Disable EL 10 ARM64 and ULC OpenSSL 1.1 builds

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -85,7 +85,6 @@ OS:
       CUSTOM_TEST_IMAGES: [ RHEL ]
       ARCH:
         - x86_64
-        - aarch64
     "9":
       TYPE: rpm
       IMAGE: rhel9

--- a/.matrix.yml
+++ b/.matrix.yml
@@ -8,15 +8,6 @@ OS:
       ARCH:
         - x86_64
   ULC_rpm:
-    "OpenSSL_1.1":
-      TYPE: scripted
-      IMAGE: "rhel8"
-      BUILD_SCRIPT: CD/rpm/build-ulc.sh
-      FINISH_SCRIPT: CD/rpm/finish-ulc.sh
-      CUSTOM_TEST_IMAGES: [ Rocky-9, SLE-15_sp6 ]
-      ARCH:
-        - x86_64
-        - aarch64
     "OpenSSL_3.0":
       TYPE: scripted
       IMAGE: "rhel9"
@@ -27,15 +18,6 @@ OS:
         - x86_64
         - aarch64
   ULC_deb:
-    "OpenSSL_1.1":
-      TYPE: scripted
-      IMAGE: "ubuntu20.04"
-      BUILD_SCRIPT: CD/deb/build-ulc.sh
-      FINISH_SCRIPT: CD/deb/finish-ulc.sh
-      CUSTOM_TEST_IMAGES: [ "Debian-11" ]
-      ARCH:
-        - x86_64
-        - aarch64
     "OpenSSL_3.0":
       TYPE: scripted
       IMAGE: "ubuntu22.04"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
+- Disable EL 10 ARM64 and ULC OpenSSL 1.1 builds [PR #2665]
 
 ### Fixed
 - VMware Plugin: Fix NVRAM backup when datacenter is not in root folder [PR #2461]
@@ -2297,4 +2298,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2649]: https://github.com/bareos/bareos/pull/2649
 [PR #2653]: https://github.com/bareos/bareos/pull/2653
 [PR #2663]: https://github.com/bareos/bareos/pull/2663
+[PR #2665]: https://github.com/bareos/bareos/pull/2665
 [unreleased]: https://github.com/bareos/bareos/tree/master


### PR DESCRIPTION
Due to limited resources we need to cut back on ARM packages.
This PR removes the EL 10 packages for ARM as well as the ULC packages for OpenSSL 1.1 (which is EOL since September 2023).

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- If a release should wait for this PR to be finished, set that release's milestone.
