### PR TITLE
dird: account for VirtualFull jobs in subscription status output

### DIFF
--- a/core/src/cats/dml/0080_subscription_with_clause_0
+++ b/core/src/cats/dml/0080_subscription_with_clause_0
@@ -58,7 +58,7 @@ client_detail AS (
     FROM job j
     INNER JOIN fileset f
       ON j.filesetid = f.filesetid
-    WHERE level = 'F'
+    WHERE level IN ('F', 'f')
       AND j.jobstatus IN ('T','W')
       AND j.type = 'B'
       AND j.jobbytes > 0

--- a/core/src/cats/postgresql_queries.inc
+++ b/core/src/cats/postgresql_queries.inc
@@ -1066,7 +1066,7 @@ client_detail AS (
     FROM job j
     INNER JOIN fileset f
       ON j.filesetid = f.filesetid
-    WHERE level = 'F'
+    WHERE level IN ('F', 'f')
       AND j.jobstatus IN ('T','W')
       AND j.type = 'B'
       AND j.jobbytes > 0

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1736,7 +1736,8 @@ status subscriptions
 
    This shows a combined list of clients and plugins, together with the
    use-count of the plugins and the aggregated amount of backed up frontend
-   data (in gigabytes).
+   data (in gigabytes), based on the latest successful Full or VirtualFull
+   backup per client/fileset.
    At the end a summary shows the accounting-mode (i.e. count- or volume-based)
    alongside with the used, configured and remaining units.
    The value for the configured units can be set in

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-anon.json
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-anon.json
@@ -143,14 +143,20 @@ status subscriptions anonymize
         "size_gb": "1.00"
       },
       {
+        "client": "Client 10006",
+        "plugin": "none (file data)",
+        "count": "1",
+        "size_gb": "2.00"
+      },
+      {
         "client": "TOTAL",
         "plugin": "",
-        "count": "30",
-        "size_gb": "1235815.89"
+        "count": "31",
+        "size_gb": "1235817.89"
       }
     ],
     "unit-summary": {
-      "accounting_mode": "volume-based (1236 volume-based units >= 30 count-based units)",
+      "accounting_mode": "volume-based (1236 volume-based units >= 31 count-based units)",
       "used": "1236",
       "configured": "1240",
       "remaining": "4"

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-anon.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-anon.txt
@@ -27,12 +27,13 @@ Detailed backup unit report:
 | Client 10005 | my-gprc-plugin      |     1 |          1.00 |
 | Client 10005 | noprefix            |     1 |          1.00 |
 | Client 10005 | other python plugin |     1 |          1.00 |
-| TOTAL        |                     |    30 |    1235815.89 |
+| Client 10006 | none (file data)    |     1 |          2.00 |
+| TOTAL        |                     |    31 |    1235817.89 |
 +--------------+---------------------+-------+---------------+
 
 Backup unit summary:
- accounting_mode: volume-based (1236 volume-based units >= 30 count-based units)
+ accounting_mode: volume-based (1236 volume-based units >= 31 count-based units)
             used: 1,236
       configured: 1,240
        remaining: 4
-
+ 

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-client-anon.json
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-client-anon.json
@@ -35,13 +35,18 @@ status subscriptions clients anonymize
         "size_gb": "5.00"
       },
       {
+        "client": "Client 10006",
+        "count": "1",
+        "size_gb": "2.00"
+      },
+      {
         "client": "TOTAL",
-        "count": "30",
-        "size_gb": "1235815.89"
+        "count": "31",
+        "size_gb": "1235817.89"
       }
     ],
     "unit-summary": {
-      "accounting_mode": "volume-based (1236 volume-based units >= 30 count-based units)",
+      "accounting_mode": "volume-based (1236 volume-based units >= 31 count-based units)",
       "used": "1236",
       "configured": "1240",
       "remaining": "4"

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-client-anon.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-client-anon.txt
@@ -10,13 +10,14 @@ Backup unit report aggregated by client:
 | Client 10003 |    10 |       1234.00 |
 | Client 10004 |     9 |    1234567.89 |
 | Client 10005 |     5 |          5.00 |
-| TOTAL        |    30 |    1235815.89 |
+| Client 10006 |     1 |          2.00 |
+| TOTAL        |    31 |    1235817.89 |
 +--------------+-------+---------------+
 For a detailed per-client report run 'status subscriptions client=<client-name>'
 
 Backup unit summary:
- accounting_mode: volume-based (1236 volume-based units >= 30 count-based units)
+ accounting_mode: volume-based (1236 volume-based units >= 31 count-based units)
             used: 1,236
       configured: 1,240
        remaining: 4
-
+ 

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-client.json
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-client.json
@@ -35,13 +35,18 @@ status subscriptions clients
         "size_gb": "2.00"
       },
       {
+        "client": "vfull-only",
+        "count": "1",
+        "size_gb": "2.00"
+      },
+      {
         "client": "TOTAL",
-        "count": "30",
-        "size_gb": "1235815.89"
+        "count": "31",
+        "size_gb": "1235817.89"
       }
     ],
     "unit-summary": {
-      "accounting_mode": "volume-based (1236 volume-based units >= 30 count-based units)",
+      "accounting_mode": "volume-based (1236 volume-based units >= 31 count-based units)",
       "used": "1236",
       "configured": "1240",
       "remaining": "4"

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-client.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-client.txt
@@ -10,13 +10,14 @@ Backup unit report aggregated by client:
 | python-plugins   |     9 |    1234567.89 |
 | special-syntax   |     5 |          5.00 |
 | two-barri-jobs   |     2 |          2.00 |
-| TOTAL            |    30 |    1235815.89 |
+| vfull-only       |     1 |          2.00 |
+| TOTAL            |    31 |    1235817.89 |
 +------------------+-------+---------------+
 For a detailed per-client report run 'status subscriptions client=<client-name>'
 
 Backup unit summary:
- accounting_mode: volume-based (1236 volume-based units >= 30 count-based units)
+ accounting_mode: volume-based (1236 volume-based units >= 31 count-based units)
             used: 1,236
       configured: 1,240
        remaining: 4
-
+ 

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-countbased.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-countbased.txt
@@ -27,13 +27,14 @@ Detailed backup unit report:
 | special-syntax   | noprefix            |     1 |      1.00 |
 | special-syntax   | other python plugin |     1 |      1.00 |
 | two-barri-jobs   | barri               |     2 |      2.00 |
-| TOTAL            |                     |    30 |   5815.89 |
+| vfull-only       | none (file data)   |     1 |      2.00 |
+| TOTAL            |                     |    31 |   5817.89 |
 +------------------+---------------------+-------+-----------+
 
 Backup unit summary:
- accounting_mode: count-based (6 volume-based < 30 count-based)
-            used: 30
+ accounting_mode: count-based (6 volume-based < 31 count-based)
+            used: 31
       configured: 1,240
-       remaining: 1,210
-
-
+       remaining: 1,209
+ 
+ 

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-default.json
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-default.json
@@ -143,14 +143,20 @@ status subscriptions
         "size_gb": "2.00"
       },
       {
+        "client": "vfull-only",
+        "plugin": "none (file data)",
+        "count": "1",
+        "size_gb": "2.00"
+      },
+      {
         "client": "TOTAL",
         "plugin": "",
-        "count": "30",
-        "size_gb": "1235815.89"
+        "count": "31",
+        "size_gb": "1235817.89"
       }
     ],
     "unit-summary": {
-      "accounting_mode": "volume-based (1236 volume-based units >= 30 count-based units)",
+      "accounting_mode": "volume-based (1236 volume-based units >= 31 count-based units)",
       "used": "1236",
       "configured": "1240",
       "remaining": "4"

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-default.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-default.txt
@@ -27,12 +27,13 @@ Detailed backup unit report:
 | special-syntax   | noprefix            |     1 |          1.00 |
 | special-syntax   | other python plugin |     1 |          1.00 |
 | two-barri-jobs   | barri               |     2 |          2.00 |
-| TOTAL            |                     |    30 |    1235815.89 |
+| vfull-only       | none (file data)   |     1 |          2.00 |
+| TOTAL            |                     |    31 |    1235817.89 |
 +------------------+---------------------+-------+---------------+
 
 Backup unit summary:
- accounting_mode: volume-based (1236 volume-based units >= 30 count-based units)
+ accounting_mode: volume-based (1236 volume-based units >= 31 count-based units)
             used: 1,236
       configured: 1,240
        remaining: 4
-
+ 

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-plugin.json
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-plugin.json
@@ -56,8 +56,8 @@ status subscriptions plugins
       },
       {
         "plugin": "none (file data)",
-        "count": "2",
-        "size_gb": "5.00"
+        "count": "3",
+        "size_gb": "7.00"
       },
       {
         "plugin": "noprefix",
@@ -101,12 +101,12 @@ status subscriptions plugins
       },
       {
         "plugin": "TOTAL",
-        "count": "30",
-        "size_gb": "1235815.89"
+        "count": "31",
+        "size_gb": "1235817.89"
       }
     ],
     "unit-summary": {
-      "accounting_mode": "volume-based (1236 volume-based units >= 30 count-based units)",
+      "accounting_mode": "volume-based (1236 volume-based units >= 31 count-based units)",
       "used": "1236",
       "configured": "1240",
       "remaining": "4"

--- a/systemtests/tests/bareos-basic/expected/status-subscriptions-plugin.txt
+++ b/systemtests/tests/bareos-basic/expected/status-subscriptions-plugin.txt
@@ -14,7 +14,7 @@ Backup unit report aggregated by plugin:
 | mariabackup         |     1 |          7.00 |
 | mssqlvdi            |     4 |       1111.00 |
 | my-gprc-plugin      |     1 |          1.00 |
-| none (file data)    |     2 |          5.00 |
+| none (file data)    |     3 |          7.00 |
 | noprefix            |     1 |          1.00 |
 | other python plugin |     1 |          1.00 |
 | ovirt               |     1 |         60.00 |
@@ -23,12 +23,12 @@ Backup unit report aggregated by plugin:
 | proxmox             |     1 |      30000.00 |
 | qumulo              |     1 |     200000.00 |
 | vmware              |     1 |    1000000.00 |
-| TOTAL               |    30 |    1235815.89 |
+| TOTAL               |    31 |    1235817.89 |
 +---------------------+-------+---------------+
 
 Backup unit summary:
- accounting_mode: volume-based (1236 volume-based units >= 30 count-based units)
+ accounting_mode: volume-based (1236 volume-based units >= 31 count-based units)
             used: 1,236
       configured: 1,240
        remaining: 4
-
+ 

--- a/systemtests/tests/bareos-basic/testrunner-status-subscriptions
+++ b/systemtests/tests/bareos-basic/testrunner-status-subscriptions
@@ -54,7 +54,8 @@ INSERT INTO Client (ClientId, Name, UName) VALUES
 (10002, 'file-and-plugins', 'synthetic test client'),
 (10003, 'native-plugins', 'synthetic test client'),
 (10004, 'python-plugins', 'synthetic test client'),
-(10005, 'special-syntax', 'synthetic test client');
+(10005, 'special-syntax', 'synthetic test client'),
+(10006, 'vfull-only', 'synthetic test client');
 INSERT INTO Fileset (FileSetId, Fileset, FileSetText, Md5, CreateTime) VALUES
 (10000, 'file1', E'{\n{\nFile = "/a"\n}\n}', 'x', now()),
 (10001, 'file2', E'{\n{\nFile = "/b"\n}\n}', 'x', now()),
@@ -82,7 +83,8 @@ INSERT INTO Fileset (FileSetId, Fileset, FileSetText, Md5, CreateTime) VALUES
 (10023, 'custom', E'{\n{\nPlugin = "custom-plugin"\n}\n}', 'x', now()),
 (10024, 'grpc1', E'{\n{\nPlugin = "grpc:bareos-grpc-fd-plugin-bridge:python3:arg1:arg2:module_name=bareos-fd-bridged"\n}\n}', 'x', now()),
 (10025, 'grpc2', E'{\n{\nPlugin = "grpc:my-gprc-plugin:arg1=val1:arg2"\n}\n}', 'x', now()),
-(10026, 'noprefix', E'{\n{\nPlugin = "python:arg:module_name=noprefix"\n}\n}', 'x', now());
+(10026, 'noprefix', E'{\n{\nPlugin = "python:arg:module_name=noprefix"\n}\n}', 'x', now()),
+(10027, 'vfull-file', E'{\n{\nFile = "/vf"\n}\n}', 'x', now());
 INSERT INTO Job (JobId, Job, Name, Type, Level, ClientId, JobStatus, JobBytes, ReadBytes, FilesetId) VALUES
 (10000, 'file1-1',  'file1',    'B', 'F', 10000, 'T', 10^9, 1000, 10000),
 (10001, 'file2-1',  'file2',    'B', 'F', 10000, 'T', 1000, 10^9, 10001),
@@ -119,7 +121,8 @@ INSERT INTO Job (JobId, Job, Name, Type, Level, ClientId, JobStatus, JobBytes, R
 (10032, 'custom',   'custom',   'B', 'F', 10005, 'T', 1000, 10^9, 10023),
 (10033, 'grpc1',    'grpc1',    'B', 'F', 10005, 'T', 1000, 10^9, 10024),
 (10034, 'grpc2',    'grpc2',    'B', 'F', 10005, 'T', 1000, 10^9, 10025),
-(10035, 'noprefix', 'noprefix', 'B', 'F', 10005, 'T', 1000, 10^9, 10026);
+(10035, 'noprefix', 'noprefix', 'B', 'F', 10005, 'T', 1000, 10^9, 10026),
+(10036, 'vfull-file', 'vfull-file', 'B', 'f', 10006, 'T', 1000, 2 * 10^9, 10027);
 CREATE TEMPORARY VIEW Job AS SELECT * FROM Job WHERE JobId >= 10000;
 
 @$out $tmp/status-subscriptions-default.txt


### PR DESCRIPTION
The subscription status volume calculation previously only selected Full backup jobs. As a result, client/fileset combinations whose latest or only relevant backup was VirtualFull were omitted from the reported frontend data size and could be undercounted in the unit summary.

Update the subscription query to treat VirtualFull the same as Full for this report by selecting both job levels. Regenerate the embedded PostgreSQL query include so the director uses the updated SQL.

Extend the bareos-basic status-subscriptions system test with a synthetic VirtualFull-only file-data client (named vfull-only) and update the expected text and JSON fixtures to cover the added row, totals, and table layout. Also clarify the bconsole documentation to state that the reported frontend data is based on the latest successful Full or VirtualFull backup per client/fileset.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
