### PR TITLE
docs: correct TlsRequire default in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Documentation
 - Add documentation for the barri image file format [PR #2608]
 - docs: PAM add remarks about pam_sss [PR #2660]
+- docs: correct TlsRequire default in docs [PR #2673]
 
 ### Changed
 - matrix.yml: add Fedora 44 [PR #2617]
@@ -2286,4 +2287,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2658]: https://github.com/bareos/bareos/pull/2658
 [PR #2659]: https://github.com/bareos/bareos/pull/2659
 [PR #2660]: https://github.com/bareos/bareos/pull/2660
+[PR #2673]: https://github.com/bareos/bareos/pull/2673
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
@@ -27,7 +27,7 @@ Additional configuration directives have been added to all the daemons (Director
    Enable TLS support. This is by default enabled. If no certificates are configured PSK (Pre Shared Keys) ciphers will be used. If the other side does not support TLS, or cleartext is configured the connection will be aborted. However, for downward compatibility with clients before Bareos-18.2 the daemons can omit transport encryption and cleartext will be sent.
 
 :config:option:`dir/director/TlsRequire`\
-   Require TLS connection, for downward compatibility. This is by default disabled. However, if :strong:`TlsRequire`\ =yes, clients with a version before Bareos-18.2 will be denied if configured to use cleartext.
+   Require TLS connection. This is enabled by default. If :strong:`TlsRequire`\ =no, Bareos can fall back to unencrypted cleartext connections for compatibility with clients before Bareos-18.2.
 
 :config:option:`dir/director/TlsCertificate`\
    The full path and filename of a PEM encoded TLS certificate. It can be used as either a client or server certificate. It is used because PEM files are base64 encoded and hence ASCII text based rather than binary. They may also contain encrypted information.


### PR DESCRIPTION
**Backport of PR #2671 to bareos-25**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

#### Backport quality
- [x] Original PR #2671 is merged
- [x] All functional differences to the original PR are documented above
