### PR TITLE
docs: correct TlsRequire default in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 
 ## [Unreleased]
 
+### Documentation
+- docs: correct TlsRequire default in docs [PR #2675]
+
 ## [23.1.7] - 2026-04-01
 
 ### Changed
@@ -1772,4 +1775,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2515]: https://github.com/bareos/bareos/pull/2515
 [PR #2518]: https://github.com/bareos/bareos/pull/2518
 [PR #2551]: https://github.com/bareos/bareos/pull/2551
+[PR #2675]: https://github.com/bareos/bareos/pull/2675
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/TransportEncryption.rst
@@ -27,7 +27,7 @@ Additional configuration directives have been added to all the daemons (Director
    Enable TLS support. This is by default enabled. If no certificates are configured PSK (Pre Shared Keys) ciphers will be used. If the other side does not support TLS, or cleartext is configured the connection will be aborted. However, for downward compatibility with clients before Bareos-18.2 the daemons can omit transport encryption and cleartext will be sent.
 
 :config:option:`dir/director/TlsRequire`\
-   Require TLS connection, for downward compatibility. This is by default disabled. However, if :strong:`TlsRequire`\ =yes, clients with a version before Bareos-18.2 will be denied if configured to use cleartext.
+   Require TLS connection. This is enabled by default. If :strong:`TlsRequire`\ =no, Bareos can fall back to unencrypted cleartext connections for compatibility with clients before Bareos-18.2.
 
 :config:option:`dir/director/TlsCertificate`\
    The full path and filename of a PEM encoded TLS certificate. It can be used as either a client or server certificate. It is used because PEM files are base64 encoded and hence ASCII text based rather than binary. They may also contain encrypted information.


### PR DESCRIPTION
**Backport of PR #2671 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

#### Backport quality
- [x] Original PR #2671 is merged
- [x] All functional differences to the original PR are documented above
