### PR TITLE
tools: bextract and friends should be able to use autochangers

### DIFF
--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -148,7 +148,8 @@ int main(int argc, char* argv[])
                   "Specify the input device name "
                   "(either as name of a Bareos Storage Daemon Device resource "
                   "or identical to the "
-                  "Archive Device in a Bareos Storage Daemon Device resource).")
+                  "Archive Device in a Bareos Storage Daemon Device resource, "
+                  "or a local file volume path).")
       ->type_name(" ");
 
   std::string output_archive;
@@ -157,7 +158,8 @@ int main(int argc, char* argv[])
                   "Specify the output device name "
                   "(either as name of a Bareos Storage Daemon Device resource "
                   "or identical to the "
-                  "Archive Device in a Bareos Storage Daemon Device resource).")
+                  "Archive Device in a Bareos Storage Daemon Device resource, "
+                  "or a local file volume path).")
       ->type_name(" ");
 
   ParseBareosApp(bcopy_app, argc, argv);
@@ -168,9 +170,6 @@ int main(int argc, char* argv[])
 
   working_directory = work_dir.c_str();
 
-  my_config = InitSdConfig(configFile.c_str(), M_CONFIG_ERROR);
-  ParseSdConfig(configFile.c_str(), M_CONFIG_ERROR);
-
   if (input_archive.empty()) {
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
@@ -179,6 +178,20 @@ int main(int argc, char* argv[])
     printf(T_("Missing output device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
+  }
+
+  const bool config_explicit = !configFile.empty();
+  const bool use_sd_config
+      = config_explicit || !IsDirectLocalVolumePath(input_archive.c_str())
+        || !IsDirectLocalVolumePath(output_archive.c_str());
+
+  my_config = nullptr;
+  if (use_sd_config) {
+    my_config = InitSdConfig(configFile.c_str(), M_CONFIG_ERROR);
+    ParseSdConfig(configFile.c_str(), M_CONFIG_ERROR);
+  } else if (!DirectorName.empty()) {
+    Emsg0(M_ERROR_TERM, 0,
+          T_("--director requires a Storage Daemon configuration.\n"));
   }
 
 
@@ -195,10 +208,12 @@ int main(int argc, char* argv[])
     }
   }
 
-  LoadSdPlugins(me->plugin_directory, me->plugin_names);
+  if (my_config) {
+    LoadSdPlugins(me->plugin_directory, me->plugin_names);
 
-  ReadCryptoCache(me->working_directory, "bareos-sd",
-                  GetFirstPortHostOrder(me->SDaddrs));
+    ReadCryptoCache(me->working_directory, "bareos-sd",
+                    GetFirstPortHostOrder(me->SDaddrs));
+  }
 
   // Setup and acquire input device for reading
   Dmsg0(100, "About to setup input jcr\n");

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -170,12 +170,12 @@ int main(int argc, char* argv[])
   working_directory = work_dir.c_str();
 
   if (input_archive.empty()) {
-    LoadSdConfigForDeviceListingIfAvailable(configFile.c_str());
+    LoadSdConfigIfAvailable(configFile.c_str());
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
   } else if (output_archive.empty()) {
-    LoadSdConfigForDeviceListingIfAvailable(configFile.c_str());
+    LoadSdConfigIfAvailable(configFile.c_str());
     printf(T_("Missing output device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -146,20 +146,18 @@ int main(int argc, char* argv[])
   bcopy_app
       .add_option("input-archive", input_archive,
                   "Specify the input device name "
-                  "(either as name of a Bareos Storage Daemon Device resource "
-                  "or identical to the "
-                  "Archive Device in a Bareos Storage Daemon Device resource, "
-                  "or a local file volume path).")
+                  "(either the name of a Bareos Storage Daemon Device "
+                  "resource, the Archive Device in such a resource, or a "
+                  "local file volume path).")
       ->type_name(" ");
 
   std::string output_archive;
   bcopy_app
       .add_option("output-archive", output_archive,
                   "Specify the output device name "
-                  "(either as name of a Bareos Storage Daemon Device resource "
-                  "or identical to the "
-                  "Archive Device in a Bareos Storage Daemon Device resource, "
-                  "or a local file volume path).")
+                  "(either the name of a Bareos Storage Daemon Device "
+                  "resource, the Archive Device in such a resource, or a "
+                  "local file volume path).")
       ->type_name(" ");
 
   ParseBareosApp(bcopy_app, argc, argv);

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -171,10 +171,12 @@ int main(int argc, char* argv[])
   working_directory = work_dir.c_str();
 
   if (input_archive.empty()) {
+    LoadSdConfigForDeviceListingIfAvailable(configFile.c_str());
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
   } else if (output_archive.empty()) {
+    LoadSdConfigForDeviceListingIfAvailable(configFile.c_str());
     printf(T_("Missing output device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -183,8 +183,9 @@ int main(int argc, char* argv[])
 
   const bool config_explicit = !configFile.empty();
   const bool use_sd_config
-      = config_explicit || !IsDirectLocalVolumePath(input_archive.c_str())
-        || !IsDirectLocalVolumePath(output_archive.c_str());
+      = config_explicit
+        || !IsLocalFilesystemVolumePath(input_archive.c_str())
+        || !IsLocalFilesystemVolumePath(output_archive.c_str());
 
   my_config = nullptr;
   if (use_sd_config) {

--- a/core/src/stored/bcopy.cc
+++ b/core/src/stored/bcopy.cc
@@ -97,7 +97,7 @@ int main(int argc, char* argv[])
       ->type_name("<bootstrap>");
 
   std::string configFile;
-  bcopy_app
+  auto config_option = bcopy_app
       .add_option("-c,--config", configFile,
                   "Use <path> as configuration file or directory.")
       ->check(CLI::ExistingPath)
@@ -108,6 +108,7 @@ int main(int argc, char* argv[])
       .add_option("-D,--director", DirectorName,
                   "Specify a director name specified in the storage. "
                   "Configuration file for the Key Encryption Key selection.")
+      ->needs(config_option)
       ->type_name("<director>");
 
   AddDebugOptions(bcopy_app);
@@ -189,9 +190,6 @@ int main(int argc, char* argv[])
   if (use_sd_config) {
     my_config = InitSdConfig(configFile.c_str(), M_CONFIG_ERROR);
     ParseSdConfig(configFile.c_str(), M_CONFIG_ERROR);
-  } else if (!DirectorName.empty()) {
-    Emsg0(M_ERROR_TERM, 0,
-          T_("--director requires a Storage Daemon configuration.\n"));
   }
 
 

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -224,6 +224,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bextract_app, argc, argv);
 
   if (archive_device_name.empty()) {
+    LoadSdConfigForDeviceListingIfAvailable(configfile);
     printf(T_("Missing device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -211,7 +211,8 @@ int main(int argc, char* argv[])
       .add_option("bareos-archive-device-name", archive_device_name,
                   "Specify the input device name (either as name of a Bareos "
                   "Storage Daemon Device resource or identical to the Archive "
-                  "Device in a Bareos Storage Daemon Device resource).")
+                  "Device in a Bareos Storage Daemon Device resource, or a "
+                  "local file volume path).")
       ->type_name(" ");
 
   std::string directory_to_store_files;
@@ -222,13 +223,24 @@ int main(int argc, char* argv[])
 
   ParseBareosApp(bextract_app, argc, argv);
 
-  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
-  ParseSdConfig(configfile, M_CONFIG_ERROR);
-
   if (archive_device_name.empty()) {
     printf(T_("Missing device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
+  }
+
+  const bool config_explicit = configfile != nullptr;
+  const bool use_sd_config
+      = config_explicit
+        || !IsDirectLocalVolumePath(archive_device_name.c_str());
+
+  my_config = nullptr;
+  if (use_sd_config) {
+    my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+    ParseSdConfig(configfile, M_CONFIG_ERROR);
+  } else if (!DirectorName.empty()) {
+    Emsg0(M_ERROR_TERM, 0,
+          T_("--director requires a Storage Daemon configuration.\n"));
   }
 
   static DirectorResource* director = nullptr;
@@ -244,11 +256,12 @@ int main(int argc, char* argv[])
     }
   }
 
-  LoadSdPlugins(me->plugin_directory, me->plugin_names);
+  if (my_config) {
+    LoadSdPlugins(me->plugin_directory, me->plugin_names);
 
-
-  ReadCryptoCache(me->working_directory, "bareos-sd",
-                  GetFirstPortHostOrder(me->SDaddrs));
+    ReadCryptoCache(me->working_directory, "bareos-sd",
+                    GetFirstPortHostOrder(me->SDaddrs));
+  }
 
   if (!got_inc) {                      /* If no include file, */
     AddFnameToIncludeList(ff, 0, "/"); /*   include everything */

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -224,7 +224,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bextract_app, argc, argv);
 
   if (archive_device_name.empty()) {
-    LoadSdConfigForDeviceListingIfAvailable(configfile);
+    LoadSdConfigIfAvailable(configfile);
     printf(T_("Missing device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bextract.cc
+++ b/core/src/stored/bextract.cc
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
   const bool config_explicit = configfile != nullptr;
   const bool use_sd_config
       = config_explicit
-        || !IsDirectLocalVolumePath(archive_device_name.c_str());
+        || !IsLocalFilesystemVolumePath(archive_device_name.c_str());
 
   my_config = nullptr;
   if (use_sd_config) {

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -217,7 +217,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bls_app, argc, argv);
 
   if (device_names.size() == 0) {
-    LoadSdConfigForDeviceListingIfAvailable(configfile);
+    LoadSdConfigIfAvailable(configfile);
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -227,7 +227,7 @@ int main(int argc, char* argv[])
   const bool all_direct_local
       = std::all_of(device_names.begin(), device_names.end(),
                     [](const std::string& device_name) {
-                      return IsDirectLocalVolumePath(device_name.c_str());
+                      return IsLocalFilesystemVolumePath(device_name.c_str());
                     });
   const bool use_sd_config = config_explicit || !all_direct_local;
 

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -29,6 +29,7 @@
 #if !defined(HAVE_MSVC)
 #  include <unistd.h>
 #endif
+#include <algorithm>
 #include "include/bareos.h"
 #include "include/exit_codes.h"
 #include "include/streams.h"
@@ -209,18 +210,33 @@ int main(int argc, char* argv[])
                   "Specify the input device name "
                   "(either as name of a Bareos Storage Daemon Device resource "
                   "or identical to the "
-                  "Archive Device in a Bareos Storage Daemon Device resource).")
+                  "Archive Device in a Bareos Storage Daemon Device resource, "
+                  "or a local file volume path).")
       ->type_name(" ");
 
   ParseBareosApp(bls_app, argc, argv);
-
-  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
-  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (device_names.size() == 0) {
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
+  }
+
+  const bool config_explicit = configfile != nullptr;
+  const bool all_direct_local
+      = std::all_of(device_names.begin(), device_names.end(),
+                    [](const std::string& device_name) {
+                      return IsDirectLocalVolumePath(device_name.c_str());
+                    });
+  const bool use_sd_config = config_explicit || !all_direct_local;
+
+  my_config = nullptr;
+  if (use_sd_config) {
+    my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+    ParseSdConfig(configfile, M_CONFIG_ERROR);
+  } else if (!DirectorName.empty()) {
+    Emsg0(M_ERROR_TERM, 0,
+          T_("--director requires a Storage Daemon configuration.\n"));
   }
 
   if (!DirectorName.empty()) {
@@ -235,10 +251,12 @@ int main(int argc, char* argv[])
     }
   }
 
-  LoadSdPlugins(me->plugin_directory, me->plugin_names);
+  if (my_config) {
+    LoadSdPlugins(me->plugin_directory, me->plugin_names);
 
-  ReadCryptoCache(me->working_directory, "bareos-sd",
-                  GetFirstPortHostOrder(me->SDaddrs));
+    ReadCryptoCache(me->working_directory, "bareos-sd",
+                    GetFirstPortHostOrder(me->SDaddrs));
+  }
 
   if (ff->included_files_list == nullptr) { AddFnameToIncludeList(ff, 0, "/"); }
 

--- a/core/src/stored/bls.cc
+++ b/core/src/stored/bls.cc
@@ -217,6 +217,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bls_app, argc, argv);
 
   if (device_names.size() == 0) {
+    LoadSdConfigForDeviceListingIfAvailable(configfile);
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bscan_app, argc, argv);
 
   if (device_name.empty()) {
-    LoadSdConfigForDeviceListingIfAvailable(configfile);
+    LoadSdConfigIfAvailable(configfile);
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -250,7 +250,7 @@ int main(int argc, char* argv[])
 
   const bool config_explicit = configfile != nullptr;
   const bool use_sd_config
-      = config_explicit || !IsDirectLocalVolumePath(device_name.c_str());
+      = config_explicit || !IsLocalFilesystemVolumePath(device_name.c_str());
 
   my_config = nullptr;
   if (use_sd_config) {

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -286,7 +286,19 @@ int main(int argc, char* argv[])
   if (!work_dir.empty()) {
     working_directory = work_dir.c_str();
   } else if (!my_config) {
+#if defined(HAVE_WIN32)
+    static char temp_directory[MAX_PATH];
+    auto temp_directory_length
+        = GetTempPathA(sizeof(temp_directory), temp_directory);
+    if (temp_directory_length > 0
+        && temp_directory_length < sizeof(temp_directory)) {
+      working_directory = temp_directory;
+    } else {
+      working_directory = "C:\\Windows\\Temp";
+    }
+#else
     working_directory = "/tmp";
+#endif
   } else if (!me->working_directory) {
     Emsg1(M_ERROR_TERM, 0,
           T_("No Working Directory defined in %s. Cannot continue.\n"),

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -235,18 +235,29 @@ int main(int argc, char* argv[])
       .add_option("device_name", device_name,
                   "Specify the input device name (either as name of a Bareos "
                   "Storage Daemon Device resource or identical to the Archive "
-                  "Device in a Bareos Storage Daemon Device resource).")
+                  "Device in a Bareos Storage Daemon Device resource, or a "
+                  "local file volume path).")
       ->type_name(" ");
 
   ParseBareosApp(bscan_app, argc, argv);
-
-  my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
-  ParseSdConfig(configfile, M_CONFIG_ERROR);
 
   if (device_name.empty()) {
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;
+  }
+
+  const bool config_explicit = configfile != nullptr;
+  const bool use_sd_config
+      = config_explicit || !IsDirectLocalVolumePath(device_name.c_str());
+
+  my_config = nullptr;
+  if (use_sd_config) {
+    my_config = InitSdConfig(configfile, M_CONFIG_ERROR);
+    ParseSdConfig(configfile, M_CONFIG_ERROR);
+  } else if (!DirectorName.empty()) {
+    Emsg0(M_ERROR_TERM, 0,
+          T_("--director requires a Storage Daemon configuration.\n"));
   }
 
   DirectorResource* director = nullptr;
@@ -262,15 +273,19 @@ int main(int argc, char* argv[])
     }
   }
 
-  LoadSdPlugins(me->plugin_directory, me->plugin_names);
+  if (my_config) {
+    LoadSdPlugins(me->plugin_directory, me->plugin_names);
 
-  ReadCryptoCache(me->working_directory, "bareos-sd",
-                  GetFirstPortHostOrder(me->SDaddrs));
+    ReadCryptoCache(me->working_directory, "bareos-sd",
+                    GetFirstPortHostOrder(me->SDaddrs));
+  }
 
   /* Check if -w option given, otherwise use resource for working directory
    */
   if (!work_dir.empty()) {
     working_directory = work_dir.c_str();
+  } else if (!my_config) {
+    working_directory = "/tmp";
   } else if (!me->working_directory) {
     Emsg1(M_ERROR_TERM, 0,
           T_("No Working Directory defined in %s. Cannot continue.\n"),

--- a/core/src/stored/bscan.cc
+++ b/core/src/stored/bscan.cc
@@ -242,6 +242,7 @@ int main(int argc, char* argv[])
   ParseBareosApp(bscan_app, argc, argv);
 
   if (device_name.empty()) {
+    LoadSdConfigForDeviceListingIfAvailable(configfile);
     printf(T_("Missing input device. %sNothing done.\n"),
            AvailableDevicesListing().c_str());
     return BEXIT_CLI_PARSING_ERROR;

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -89,16 +89,15 @@ static bool DeviceSupportsAccess(const DeviceResource* device_resource,
   }
 }
 
-static std::string StripQuotes(const char* resource_name)
+static std::string StripQuotes(std::string_view resource_name)
 {
-  std::string normalized{resource_name};
-  if (normalized.size() >= 2 && normalized.front() == '"'
-      && normalized.back() == '"') {
-    normalized.erase(0, 1);
-    normalized.pop_back();
+  if (resource_name.size() >= 2 && resource_name.front() == '"'
+      && resource_name.back() == '"') {
+    resource_name.remove_prefix(1);
+    resource_name.remove_suffix(1);
   }
 
-  return normalized;
+  return std::string(resource_name);
 }
 
 static const char* AccessDescription(bool readonly)

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -440,6 +440,7 @@ static std::string ListDevicesInConfig(const ConfigurationParser* config)
   for (BareosResource* resource = nullptr;
        (resource = config->GetNextRes(R_DEVICE, resource));) {
     DeviceResource* device = dynamic_cast<DeviceResource*>(resource);
+    if (device->changer_res) { continue; }
     std::string device_str;
     device_str += " \"";
     device_str += device->resource_name_;

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -113,6 +113,8 @@ static bool TryStatPath(const std::string& path, struct stat& statp)
 
 static std::string DirectoryName(const std::string& path)
 {
+  // Return the parent path component. A trailing separator is ignored, and the
+  // root path stays rooted instead of becoming empty.
   auto separator = path.find_last_of("/\\");
   if (separator == std::string::npos) { return "."; }
   if (separator == 0) { return path.substr(0, 1); }
@@ -121,6 +123,8 @@ static std::string DirectoryName(const std::string& path)
 
 static std::string BaseName(const std::string& path)
 {
+  // Return the final path component. If the input ends in a separator or is
+  // the root path, the basename is empty.
   auto separator = path.find_last_of("/\\");
   if (separator == std::string::npos) { return path; }
   return path.substr(separator + 1);

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -45,8 +45,175 @@
 #include "include/jcr.h"
 
 #include <algorithm>
+#include <cstdio>
+#include <vector>
 
 namespace storagedaemon {
+
+namespace {
+
+struct DeviceResolutionResult {
+  DeviceResource* device_resource{nullptr};
+  std::string detail;
+};
+
+static bool DeviceSupportsAccess(const DeviceResource* device_resource,
+                                 bool readonly)
+{
+  switch (device_resource->access_mode) {
+    case IODirection::READ_WRITE:
+      return true;
+    case IODirection::READ:
+      return readonly;
+    case IODirection::WRITE:
+      return !readonly;
+    case IODirection::NONE:
+    default:
+      return false;
+  }
+}
+
+static std::string StripQuotes(const char* resource_name)
+{
+  std::string normalized{resource_name};
+  if (normalized.size() >= 2 && normalized.front() == '"'
+      && normalized.back() == '"') {
+    normalized.erase(0, 1);
+    normalized.pop_back();
+  }
+
+  return normalized;
+}
+
+static std::string AccessDescription(bool readonly)
+{
+  return readonly ? "reading" : "writing";
+}
+
+static std::string FormatDeviceChoice(const DeviceResource* device_resource)
+{
+  return "\"" + std::string(device_resource->resource_name_) + "\" ("
+         + device_resource->archive_device_string + ")";
+}
+
+static std::string FormatAutochangerSelectionPrompt(
+    const AutochangerResource* autochanger_resource,
+    const std::vector<DeviceResource*>& devices)
+{
+  std::string prompt = T_("Autochanger \"");
+  prompt += autochanger_resource->resource_name_;
+  prompt += T_("\" has multiple suitable devices. Choose one:\n");
+
+  for (std::size_t i = 0; i < devices.size(); ++i) {
+    prompt += "  ";
+    prompt += std::to_string(i + 1);
+    prompt += ") ";
+    prompt += FormatDeviceChoice(devices[i]);
+    if (devices[i]->autoselect) { prompt += " [autoselect]"; }
+    prompt += '\n';
+  }
+
+  prompt += T_("Enter selection number: ");
+  return prompt;
+}
+
+static std::string FormatAutochangerCandidates(
+    const AutochangerResource* autochanger_resource,
+    const std::vector<DeviceResource*>& devices,
+    bool readonly)
+{
+  std::string detail = T_("Autochanger \"");
+  detail += autochanger_resource->resource_name_;
+  detail += T_("\" has multiple devices suitable for ");
+  detail += AccessDescription(readonly);
+  detail += T_(". Please specify one of these Device resources explicitly:\n");
+
+  for (const auto* device_resource : devices) {
+    detail += "  ";
+    detail += FormatDeviceChoice(device_resource);
+    if (device_resource->autoselect) { detail += " [autoselect]"; }
+    detail += '\n';
+  }
+
+  return detail;
+}
+
+static DeviceResource* PromptForAutochangerDevice(
+    const AutochangerResource* autochanger_resource,
+    const std::vector<DeviceResource*>& devices)
+{
+  if (!isatty(fileno(stdin))) { return nullptr; }
+
+  while (true) {
+    auto prompt = FormatAutochangerSelectionPrompt(autochanger_resource, devices);
+    if (fputs(prompt.c_str(), stderr) < 0) { return nullptr; }
+    fflush(stderr);
+
+    char buffer[64];
+    if (!fgets(buffer, sizeof(buffer), stdin)) { return nullptr; }
+
+    char* end = nullptr;
+    errno = 0;
+    auto selection = strtol(buffer, &end, 10);
+    if (errno == 0 && end != buffer && selection >= 1
+        && static_cast<std::size_t>(selection) <= devices.size()) {
+      return devices[selection - 1];
+    }
+
+    if (fputs(T_("Invalid selection.\n"), stderr) < 0) { return nullptr; }
+  }
+}
+
+static DeviceResolutionResult ResolveAutochangerDevice(
+    const AutochangerResource* autochanger_resource,
+    bool readonly)
+{
+  DeviceResolutionResult result;
+  std::vector<DeviceResource*> eligible_devices;
+  std::vector<DeviceResource*> eligible_autoselect_devices;
+
+  DeviceResource* device_resource = nullptr;
+  int i;
+  foreach_alist_index (i, device_resource, autochanger_resource->device_resources)
+  {
+    if (!DeviceSupportsAccess(device_resource, readonly)) { continue; }
+
+    eligible_devices.emplace_back(device_resource);
+    if (device_resource->autoselect) {
+      eligible_autoselect_devices.emplace_back(device_resource);
+    }
+  }
+
+  if (eligible_autoselect_devices.size() == 1) {
+    result.device_resource = eligible_autoselect_devices.front();
+    return result;
+  }
+
+  if (eligible_devices.size() == 1) {
+    result.device_resource = eligible_devices.front();
+    return result;
+  }
+
+  if (eligible_devices.empty()) {
+    result.detail = T_("Autochanger \"");
+    result.detail += autochanger_resource->resource_name_;
+    result.detail += T_("\" has no devices suitable for ");
+    result.detail += AccessDescription(readonly);
+    result.detail += ".\n";
+    return result;
+  }
+
+  result.device_resource
+      = PromptForAutochangerDevice(autochanger_resource, eligible_devices);
+  if (!result.device_resource) {
+    result.detail = FormatAutochangerCandidates(autochanger_resource,
+                                                eligible_devices, readonly);
+  }
+
+  return result;
+}
+
+}  // namespace
 
 /* Forward referenced functions */
 static bool setup_to_access_device(DeviceControlRecord* dcr,
@@ -54,8 +221,8 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
                                    char* dev_name,
                                    const std::string& VolumeName,
                                    bool readonly);
-static DeviceResource* find_device_res(char* archive_device_string,
-                                       bool readonly);
+static DeviceResolutionResult find_device_res(char* archive_device_string,
+                                              bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
 
 
@@ -139,9 +306,46 @@ std::string AvailableDevicesListing()
     device_str += ")\n";
     devices.emplace_back(std::move(device_str));
   }
+
+  std::vector<std::string> autochangers;
+  for (BareosResource* resource = nullptr;
+       (resource = my_config->GetNextRes(R_AUTOCHANGER, resource));) {
+    auto* autochanger = dynamic_cast<AutochangerResource*>(resource);
+    std::string autochanger_str;
+    autochanger_str += " \"";
+    autochanger_str += autochanger->resource_name_;
+    autochanger_str += "\"";
+
+    std::vector<std::string> members;
+    DeviceResource* device = nullptr;
+    int i;
+    foreach_alist_index (i, device, autochanger->device_resources)
+    {
+      members.emplace_back(FormatDeviceChoice(device));
+    }
+    std::sort(members.begin(), members.end());
+
+    if (!members.empty()) {
+      autochanger_str += " ->";
+      for (const auto& member : members) {
+        autochanger_str += "\n    ";
+        autochanger_str += member;
+      }
+    }
+    autochanger_str += '\n';
+    autochangers.emplace_back(std::move(autochanger_str));
+  }
+
   std::sort(devices.begin(), devices.end());
+  std::sort(autochangers.begin(), autochangers.end());
   std::string devices_str = "Available Devices:\n";
   for (const std::string& device : devices) { devices_str += device; }
+  if (!autochangers.empty()) {
+    devices_str += "Available Autochangers:\n";
+    for (const std::string& autochanger : autochangers) {
+      devices_str += autochanger;
+    }
+  }
   return devices_str;
 }
 /**
@@ -190,10 +394,17 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
     }
   }
 
-  if ((device_resource = find_device_res(dev_name, readonly)) == NULL) {
-    Jmsg2(jcr, M_FATAL, 0,
-          T_("Cannot find device \"%s\" in config file %s.\n%s"), dev_name,
-          configfile, AvailableDevicesListing().c_str());
+  auto resolved_device = find_device_res(dev_name, readonly);
+  device_resource = resolved_device.device_resource;
+  if (device_resource == NULL) {
+    if (!resolved_device.detail.empty()) {
+      Jmsg3(jcr, M_FATAL, 0, T_("Cannot use device \"%s\" in config file %s.\n%s"),
+            dev_name, configfile, resolved_device.detail.c_str());
+    } else {
+      Jmsg2(jcr, M_FATAL, 0,
+            T_("Cannot find device \"%s\" in config file %s.\n%s"), dev_name,
+            configfile, AvailableDevicesListing().c_str());
+    }
     return false;
   }
 
@@ -282,11 +493,13 @@ static void MyFreeJcr(JobControlRecord* jcr)
  * Returns: NULL on failure
  *          Device resource pointer on success
  */
-static DeviceResource* find_device_res(char* archive_device_string,
-                                       bool readonly)
+static DeviceResolutionResult find_device_res(char* archive_device_string,
+                                              bool readonly)
 {
+  DeviceResolutionResult result;
   bool found = false;
   DeviceResource* device_resource;
+  auto normalized_resource_name = StripQuotes(archive_device_string);
 
   Dmsg0(900, "Enter find_device_res\n");
   foreach_res (device_resource, R_DEVICE) {
@@ -301,16 +514,11 @@ static DeviceResource* find_device_res(char* archive_device_string,
 
   if (!found) {
     /* Search for name of Device resource rather than archive name */
-    if (archive_device_string[0] == '"') {
-      int len = strlen(archive_device_string);
-      bstrncpy(archive_device_string, archive_device_string + 1, len + 1);
-      len--;
-      if (len > 0) { archive_device_string[len - 1] = 0; /* zap trailing " */ }
-    }
     foreach_res (device_resource, R_DEVICE) {
       Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
-            archive_device_string);
-      if (bstrcmp(device_resource->resource_name_, archive_device_string)) {
+            normalized_resource_name.c_str());
+      if (bstrcmp(device_resource->resource_name_,
+                  normalized_resource_name.c_str())) {
         found = true;
         break;
       }
@@ -318,18 +526,38 @@ static DeviceResource* find_device_res(char* archive_device_string,
   }
 
   if (!found) {
-    Pmsg2(0, T_("Could not find device \"%s\" in config file %s.\n"),
-          archive_device_string, configfile);
-    return NULL;
+    AutochangerResource* autochanger_resource;
+    foreach_res (autochanger_resource, R_AUTOCHANGER) {
+      Dmsg2(900, "Compare %s and %s\n", autochanger_resource->resource_name_,
+            normalized_resource_name.c_str());
+      if (bstrcmp(autochanger_resource->resource_name_,
+                  normalized_resource_name.c_str())) {
+        result = ResolveAutochangerDevice(autochanger_resource, readonly);
+        device_resource = result.device_resource;
+        found = (device_resource != nullptr);
+        break;
+      }
+    }
+  }
+
+  if (!found) {
+    if (result.detail.empty()) {
+      Pmsg2(0, T_("Could not find device \"%s\" in config file %s.\n"),
+            archive_device_string, configfile);
+    }
+    return result;
   }
 
   if (readonly) {
-    Pmsg1(0, T_("Using device: \"%s\" for reading.\n"), archive_device_string);
+    Pmsg1(0, T_("Using device: \"%s\" for reading.\n"),
+          device_resource->resource_name_);
   } else {
-    Pmsg1(0, T_("Using device: \"%s\" for writing.\n"), archive_device_string);
+    Pmsg1(0, T_("Using device: \"%s\" for writing.\n"),
+          device_resource->resource_name_);
   }
 
-  return device_resource;
+  result.device_resource = device_resource;
+  return result;
 }
 
 // Device got an error, attempt to analyse it

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -126,7 +126,7 @@ static std::string DirectoryName(const std::string& path)
   return path.substr(0, separator);
 }
 
-#if defined(HAVE_WIN32) && defined(BUILD_TESTING)
+#if defined(HAVE_WIN32)
 std::string DirectoryNameForTest(const std::string& path)
 {
   return DirectoryName(path);

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -39,6 +39,7 @@
 #include "stored/device.h"
 #include "stored/device_control_record.h"
 #include "stored/bsr.h"
+#include "stored/sd_backends.h"
 #include "stored/stored_jcr_impl.h"
 #include "lib/parse_bsr.h"
 #include "lib/parse_conf.h"
@@ -46,7 +47,18 @@
 
 #include <algorithm>
 #include <cstdio>
+#include <limits.h>
+#include <memory>
+#include <string_view>
+#include <sys/stat.h>
 #include <vector>
+#if defined(HAVE_WIN32)
+#  include <windows.h>
+#else
+#  include <unistd.h>
+#endif
+
+extern char* exepath;
 
 namespace storagedaemon {
 
@@ -55,7 +67,10 @@ namespace {
 struct DeviceResolutionResult {
   DeviceResource* device_resource{nullptr};
   std::string detail;
+  std::string inferred_volume_name;
 };
+
+static std::vector<std::unique_ptr<DeviceResource>> synthetic_device_resources;
 
 static bool DeviceSupportsAccess(const DeviceResource* device_resource,
                                  bool readonly)
@@ -88,6 +103,108 @@ static std::string StripQuotes(const char* resource_name)
 static std::string AccessDescription(bool readonly)
 {
   return readonly ? "reading" : "writing";
+}
+
+static bool TryStatPath(const std::string& path, struct stat& statp)
+{
+  return !path.empty() && stat(path.c_str(), &statp) == 0;
+}
+
+static bool IsDirectLocalVolumeStat(const struct stat& statp)
+{
+  return S_ISREG(statp.st_mode) || S_ISDIR(statp.st_mode);
+}
+
+static std::string DirectoryName(const std::string& path)
+{
+  auto separator = path.find_last_of("/\\");
+  if (separator == std::string::npos) { return "."; }
+  if (separator == 0) { return path.substr(0, 1); }
+  return path.substr(0, separator);
+}
+
+static std::string BaseName(const std::string& path)
+{
+  auto separator = path.find_last_of("/\\");
+  if (separator == std::string::npos) { return path; }
+  return path.substr(separator + 1);
+}
+
+static std::string GetExecutableDirectory()
+{
+#if defined(HAVE_WIN32)
+  char path[MAX_PATH];
+  auto len = GetModuleFileNameA(nullptr, path, sizeof(path));
+  if (len > 0 && len < sizeof(path)) {
+    return DirectoryName(std::string(path, len));
+  }
+#else
+  char path[PATH_MAX];
+  auto len = readlink("/proc/self/exe", path, sizeof(path) - 1);
+  if (len > 0) {
+    path[len] = '\0';
+    return DirectoryName(path);
+  }
+#endif
+
+  if (exepath && exepath[0]) { return exepath; }
+  return {};
+}
+
+static bool EnsureFileBackendLoaded()
+{
+#if defined(HAVE_DYNAMIC_SD_BACKENDS)
+  const std::string device_type{DeviceType::B_FILE_DEV};
+  if (ImplementationFactory<Device>::IsRegistered(device_type)) { return true; }
+
+  std::vector<std::string> backend_directories{PATH_BAREOS_BACKENDDIR};
+  auto executable_directory = GetExecutableDirectory();
+  if (!executable_directory.empty()) {
+    std::string build_tree_backend_dir{std::move(executable_directory)};
+    if (!IsPathSeparator(build_tree_backend_dir.back())) {
+      build_tree_backend_dir += PathSeparator;
+    }
+    build_tree_backend_dir += "backends";
+    backend_directories.emplace_back(std::move(build_tree_backend_dir));
+  }
+
+  return LoadStorageBackend(device_type, backend_directories);
+#else
+  return true;
+#endif
+}
+
+static DeviceResolutionResult ResolveDirectLocalVolumePath(std::string path)
+{
+  DeviceResolutionResult result;
+  struct stat statp;
+  if (!TryStatPath(path, statp) || !IsDirectLocalVolumeStat(statp)) {
+    return result;
+  }
+
+  if (!EnsureFileBackendLoaded()) {
+    result.detail = T_(
+        "Cannot load the file storage backend needed for direct "
+        "local volume access.\n");
+    return result;
+  }
+
+  auto device_resource = std::make_unique<DeviceResource>();
+  auto display_path = path;
+  if (S_ISREG(statp.st_mode)) {
+    result.inferred_volume_name = BaseName(path);
+    path = DirectoryName(path);
+  }
+
+  device_resource->resource_name_ = strdup(display_path.c_str());
+  device_resource->archive_device_string = strdup(path.c_str());
+  device_resource->media_type = strdup("");
+  device_resource->device_type = DeviceType::B_FILE_DEV;
+
+  result.device_resource = device_resource.get();
+  synthetic_device_resources.emplace_back(std::move(device_resource));
+
+  return result;
 }
 
 static std::string FormatDeviceChoice(const DeviceResource* device_resource)
@@ -145,7 +262,8 @@ static DeviceResource* PromptForAutochangerDevice(
   if (!isatty(fileno(stdin))) { return nullptr; }
 
   while (true) {
-    auto prompt = FormatAutochangerSelectionPrompt(autochanger_resource, devices);
+    auto prompt
+        = FormatAutochangerSelectionPrompt(autochanger_resource, devices);
     if (fputs(prompt.c_str(), stderr) < 0) { return nullptr; }
     fflush(stderr);
 
@@ -174,8 +292,8 @@ static DeviceResolutionResult ResolveAutochangerDevice(
 
   DeviceResource* device_resource = nullptr;
   int i;
-  foreach_alist_index (i, device_resource, autochanger_resource->device_resources)
-  {
+  foreach_alist_index (i, device_resource,
+                       autochanger_resource->device_resources) {
     if (!DeviceSupportsAccess(device_resource, readonly)) { continue; }
 
     eligible_devices.emplace_back(device_resource);
@@ -224,6 +342,15 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
 static DeviceResolutionResult find_device_res(char* archive_device_string,
                                               bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
+
+bool IsDirectLocalVolumePath(const char* device_name)
+{
+  if (!device_name) { return false; }
+
+  auto normalized_path = StripQuotes(device_name);
+  struct stat statp;
+  return TryStatPath(normalized_path, statp) && IsDirectLocalVolumeStat(statp);
+}
 
 
 JobControlRecord* SetupDummyJcr(const char* name,
@@ -275,7 +402,7 @@ JobControlRecord* SetupJcr(const char* name,
 {
   JobControlRecord* jcr = SetupDummyJcr(name, bsr, director);
 
-  InitAutochangers();
+  if (my_config) { InitAutochangers(); }
   CreateVolumeLists();
 
   if (!setup_to_access_device(dcr, jcr, dev_name, VolumeName, readonly)) {
@@ -294,6 +421,12 @@ JobControlRecord* SetupJcr(const char* name,
 
 std::string AvailableDevicesListing()
 {
+  if (!my_config) {
+    return T_(
+        "Direct local file volume paths may be used without an SD "
+        "configuration.\n");
+  }
+
   std::vector<std::string> devices;
   for (BareosResource* resource = nullptr;
        (resource = my_config->GetNextRes(R_DEVICE, resource));) {
@@ -319,8 +452,7 @@ std::string AvailableDevicesListing()
     std::vector<std::string> members;
     DeviceResource* device = nullptr;
     int i;
-    foreach_alist_index (i, device, autochanger->device_resources)
-    {
+    foreach_alist_index (i, device, autochanger->device_resources) {
       members.emplace_back(FormatDeviceChoice(device));
     }
     std::sort(members.begin(), members.end());
@@ -360,7 +492,6 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
                                    bool readonly)
 {
   Device* dev;
-  char* p;
   DeviceResource* device_resource;
   char VolName[MAX_NAME_LENGTH];
 
@@ -381,31 +512,40 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
     VolName[0] = 0;
   }
 
-  if (!jcr->sd_impl->read_session.bsr && VolName[0] == 0) {
-    if (!bstrncmp(dev_name, "/dev/", 5)) {
-      /* Try stripping file part */
-      p = dev_name + strlen(dev_name);
-
-      while (p > dev_name && !IsPathSeparator(*p)) p--;
-      if (IsPathSeparator(*p)) {
-        bstrncpy(VolName, p + 1, sizeof(VolName));
-        *p = 0;
-      }
-    }
-  }
-
   auto resolved_device = find_device_res(dev_name, readonly);
   device_resource = resolved_device.device_resource;
   if (device_resource == NULL) {
     if (!resolved_device.detail.empty()) {
-      Jmsg3(jcr, M_FATAL, 0, T_("Cannot use device \"%s\" in config file %s.\n%s"),
-            dev_name, configfile, resolved_device.detail.c_str());
+      if (configfile) {
+        Jmsg3(jcr, M_FATAL, 0,
+              T_("Cannot use device \"%s\" in config file %s.\n%s"), dev_name,
+              configfile, resolved_device.detail.c_str());
+      } else {
+        Jmsg2(jcr, M_FATAL, 0, T_("Cannot use device \"%s\".\n%s"), dev_name,
+              resolved_device.detail.c_str());
+      }
     } else {
-      Jmsg2(jcr, M_FATAL, 0,
-            T_("Cannot find device \"%s\" in config file %s.\n%s"), dev_name,
-            configfile, AvailableDevicesListing().c_str());
+      if (configfile) {
+        Jmsg2(jcr, M_FATAL, 0,
+              T_("Cannot find device \"%s\" in config file %s.\n%s"), dev_name,
+              configfile, AvailableDevicesListing().c_str());
+      } else {
+        Jmsg2(jcr, M_FATAL, 0, T_("Cannot use device \"%s\".\n%s"), dev_name,
+              AvailableDevicesListing().c_str());
+      }
     }
     return false;
+  }
+
+  if (!jcr->sd_impl->read_session.bsr && VolName[0] == 0) {
+    if (!resolved_device.inferred_volume_name.empty()) {
+      bstrncpy(VolName, resolved_device.inferred_volume_name.c_str(),
+               sizeof(VolName));
+    } else if (!bstrncmp(dev_name, "/dev/", 5)) {
+      auto* p = dev_name + strlen(dev_name);
+      while (p > dev_name && !IsPathSeparator(*p)) p--;
+      if (IsPathSeparator(*p)) { bstrncpy(VolName, p + 1, sizeof(VolName)); }
+    }
   }
 
   dev = FactoryCreateDevice(jcr, device_resource);
@@ -502,46 +642,54 @@ static DeviceResolutionResult find_device_res(char* archive_device_string,
   auto normalized_resource_name = StripQuotes(archive_device_string);
 
   Dmsg0(900, "Enter find_device_res\n");
-  foreach_res (device_resource, R_DEVICE) {
-    Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
-          archive_device_string);
-    if (bstrcmp(device_resource->archive_device_string,
-                archive_device_string)) {
-      found = true;
-      break;
-    }
-  }
-
-  if (!found) {
-    /* Search for name of Device resource rather than archive name */
+  if (my_config) {
     foreach_res (device_resource, R_DEVICE) {
-      Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
-            normalized_resource_name.c_str());
-      if (bstrcmp(device_resource->resource_name_,
-                  normalized_resource_name.c_str())) {
+      Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
+            archive_device_string);
+      if (bstrcmp(device_resource->archive_device_string,
+                  archive_device_string)) {
         found = true;
         break;
       }
     }
-  }
 
-  if (!found) {
-    AutochangerResource* autochanger_resource;
-    foreach_res (autochanger_resource, R_AUTOCHANGER) {
-      Dmsg2(900, "Compare %s and %s\n", autochanger_resource->resource_name_,
-            normalized_resource_name.c_str());
-      if (bstrcmp(autochanger_resource->resource_name_,
-                  normalized_resource_name.c_str())) {
-        result = ResolveAutochangerDevice(autochanger_resource, readonly);
-        device_resource = result.device_resource;
-        found = (device_resource != nullptr);
-        break;
+    if (!found) {
+      /* Search for name of Device resource rather than archive name */
+      foreach_res (device_resource, R_DEVICE) {
+        Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
+              normalized_resource_name.c_str());
+        if (bstrcmp(device_resource->resource_name_,
+                    normalized_resource_name.c_str())) {
+          found = true;
+          break;
+        }
+      }
+    }
+
+    if (!found) {
+      AutochangerResource* autochanger_resource;
+      foreach_res (autochanger_resource, R_AUTOCHANGER) {
+        Dmsg2(900, "Compare %s and %s\n", autochanger_resource->resource_name_,
+              normalized_resource_name.c_str());
+        if (bstrcmp(autochanger_resource->resource_name_,
+                    normalized_resource_name.c_str())) {
+          result = ResolveAutochangerDevice(autochanger_resource, readonly);
+          device_resource = result.device_resource;
+          found = (device_resource != nullptr);
+          break;
+        }
       }
     }
   }
 
   if (!found) {
-    if (result.detail.empty()) {
+    result = ResolveDirectLocalVolumePath(normalized_resource_name);
+    device_resource = result.device_resource;
+    found = (device_resource != nullptr);
+  }
+
+  if (!found) {
+    if (result.detail.empty() && configfile) {
       Pmsg2(0, T_("Could not find device \"%s\" in config file %s.\n"),
             archive_device_string, configfile);
     }

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -101,7 +101,7 @@ static std::string StripQuotes(const char* resource_name)
   return normalized;
 }
 
-static std::string AccessDescription(bool readonly)
+static const char* AccessDescription(bool readonly)
 {
   return readonly ? "reading" : "writing";
 }

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -432,17 +432,11 @@ JobControlRecord* SetupJcr(const char* name,
   return jcr;
 }
 
-std::string AvailableDevicesListing()
+static std::string ListDevicesInConfig(const ConfigurationParser* config)
 {
-  if (!my_config) {
-    return T_(
-        "Direct local file volume paths may be used without an SD "
-        "configuration.\n");
-  }
-
   std::vector<std::string> devices;
   for (BareosResource* resource = nullptr;
-       (resource = my_config->GetNextRes(R_DEVICE, resource));) {
+       (resource = config->GetNextRes(R_DEVICE, resource));) {
     DeviceResource* device = dynamic_cast<DeviceResource*>(resource);
     std::string device_str;
     device_str += " \"";
@@ -455,7 +449,7 @@ std::string AvailableDevicesListing()
 
   std::vector<std::string> autochangers;
   for (BareosResource* resource = nullptr;
-       (resource = my_config->GetNextRes(R_AUTOCHANGER, resource));) {
+       (resource = config->GetNextRes(R_AUTOCHANGER, resource));) {
     auto* autochanger = dynamic_cast<AutochangerResource*>(resource);
     std::string autochanger_str;
     autochanger_str += " \"";
@@ -492,6 +486,17 @@ std::string AvailableDevicesListing()
     }
   }
   return devices_str;
+}
+
+std::string AvailableDevicesListing()
+{
+  if (!my_config) {
+    return T_(
+        "Direct local file volume paths may be used without an SD "
+        "configuration.\n");
+  }
+
+  return ListDevicesInConfig(my_config);
 }
 /**
  * Setup device, jcr, and prepare to access device.

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -356,7 +356,7 @@ bool IsLocalFilesystemVolumePath(const char* device_name)
       && (S_ISREG(statp.st_mode) || S_ISDIR(statp.st_mode));
 }
 
-void LoadSdConfigForDeviceListingIfAvailable(const char* config_path)
+void LoadSdConfigIfAvailable(const char* config_path)
 {
   if (my_config || !config_path || config_path[0] == '\0') { return; }
 

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -137,7 +137,7 @@ static std::string GetExecutableDirectory()
   if (len > 0 && len < sizeof(path)) {
     return DirectoryName(std::string(path, len));
   }
-#else
+#elif defined(HAVE_LINUX_OS)
   char path[PATH_MAX];
   auto len = readlink("/proc/self/exe", path, sizeof(path) - 1);
   if (len > 0) {

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -694,7 +694,7 @@ static DeviceResolutionResult find_device_res(char* archive_device_string,
     }
   }
 
-  if (!found) {
+  if (!found && result.detail.empty()) {
     result = ResolveDirectLocalVolumePath(normalized_resource_name);
     device_resource = result.device_resource;
     found = (device_resource != nullptr);

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -457,9 +457,7 @@ static std::string ListDevicesInConfig(const ConfigurationParser* config)
     autochanger_str += "\"";
 
     std::vector<std::string> members;
-    DeviceResource* device = nullptr;
-    int i;
-    foreach_alist_index (i, device, autochanger->device_resources) {
+    for (auto* device : autochanger->device_resources) {
       members.emplace_back(FormatDeviceChoice(device));
     }
     std::sort(members.begin(), members.end());

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -146,6 +146,7 @@ static std::string GetExecutableDirectory()
   }
 #endif
 
+  // Non-Linux platforms use the path captured during startup by MyNameIs().
   if (exepath && exepath[0]) { return exepath; }
   return {};
 }
@@ -343,7 +344,7 @@ static DeviceResolutionResult find_device_res(char* archive_device_string,
                                               bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
 
-bool IsDirectLocalVolumePath(const char* device_name)
+bool IsLocalFilesystemVolumePath(const char* device_name)
 {
   if (!device_name) { return false; }
 

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -346,6 +346,8 @@ static void MyFreeJcr(JobControlRecord* jcr);
 
 bool IsLocalFilesystemVolumePath(const char* device_name)
 {
+  // Direct local paths are regular files or directories that can be used
+  // without an SD device resource.
   if (!device_name) { return false; }
 
   auto normalized_path = StripQuotes(device_name);

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -40,6 +40,7 @@
 #include "stored/device_control_record.h"
 #include "stored/bsr.h"
 #include "stored/sd_backends.h"
+#include "stored/stored_conf.h"
 #include "stored/stored_jcr_impl.h"
 #include "lib/parse_bsr.h"
 #include "lib/parse_conf.h"
@@ -350,6 +351,17 @@ bool IsDirectLocalVolumePath(const char* device_name)
   auto normalized_path = StripQuotes(device_name);
   struct stat statp;
   return TryStatPath(normalized_path, statp) && IsDirectLocalVolumeStat(statp);
+}
+
+void LoadSdConfigForDeviceListingIfAvailable(const char* config_path)
+{
+  if (my_config || !config_path || config_path[0] == '\0') { return; }
+
+  struct stat statp;
+  if (stat(config_path, &statp) != 0) { return; }
+
+  my_config = InitSdConfig(config_path, M_CONFIG_ERROR);
+  ParseSdConfig(config_path, M_CONFIG_ERROR);
 }
 
 

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -117,8 +117,21 @@ static std::string DirectoryName(const std::string& path)
   auto separator = path.find_last_of("/\\");
   if (separator == std::string::npos) { return "."; }
   if (separator == 0) { return path.substr(0, 1); }
+#if defined(HAVE_WIN32)
+  if (separator == 2 && path.size() >= 3 && path[1] == ':'
+      && IsPathSeparator(path[2])) {
+    return path.substr(0, 3);
+  }
+#endif
   return path.substr(0, separator);
 }
+
+#if defined(HAVE_WIN32) && defined(BUILD_TESTING)
+std::string DirectoryNameForTest(const std::string& path)
+{
+  return DirectoryName(path);
+}
+#endif
 
 static std::string BaseName(const std::string& path)
 {

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -111,11 +111,6 @@ static bool TryStatPath(const std::string& path, struct stat& statp)
   return !path.empty() && stat(path.c_str(), &statp) == 0;
 }
 
-static bool IsDirectLocalVolumeStat(const struct stat& statp)
-{
-  return S_ISREG(statp.st_mode) || S_ISDIR(statp.st_mode);
-}
-
 static std::string DirectoryName(const std::string& path)
 {
   auto separator = path.find_last_of("/\\");
@@ -179,7 +174,8 @@ static DeviceResolutionResult ResolveDirectLocalVolumePath(std::string path)
 {
   DeviceResolutionResult result;
   struct stat statp;
-  if (!TryStatPath(path, statp) || !IsDirectLocalVolumeStat(statp)) {
+  if (!TryStatPath(path, statp)
+      || (!S_ISREG(statp.st_mode) && !S_ISDIR(statp.st_mode))) {
     return result;
   }
 
@@ -350,7 +346,8 @@ bool IsDirectLocalVolumePath(const char* device_name)
 
   auto normalized_path = StripQuotes(device_name);
   struct stat statp;
-  return TryStatPath(normalized_path, statp) && IsDirectLocalVolumeStat(statp);
+  return TryStatPath(normalized_path, statp)
+      && (S_ISREG(statp.st_mode) || S_ISDIR(statp.st_mode));
 }
 
 void LoadSdConfigForDeviceListingIfAvailable(const char* config_path)

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -478,7 +478,9 @@ static std::string ListDevicesInConfig(const ConfigurationParser* config)
   std::string devices_str = "Available Devices:\n";
   for (const std::string& device : devices) { devices_str += device; }
   if (!autochangers.empty()) {
-    devices_str += "Available Autochangers:\n";
+    devices_str
+        += "Available Autochangers (select one of the listed Device "
+           "resources):\n";
     for (const std::string& autochanger : autochangers) {
       devices_str += autochanger;
     }

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -43,7 +43,7 @@ JobControlRecord* SetupJcr(const char* name,
                            DeviceControlRecord* dcr,
                            const std::string& VolumeName,
                            bool readonly);
-bool IsDirectLocalVolumePath(const char* device_name);
+bool IsLocalFilesystemVolumePath(const char* device_name);
 void LoadSdConfigForDeviceListingIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -45,7 +45,7 @@ JobControlRecord* SetupJcr(const char* name,
                            bool readonly);
 // Return true for a directly stat-able local file or directory path.
 bool IsLocalFilesystemVolumePath(const char* device_name);
-void LoadSdConfigForDeviceListingIfAvailable(const char* config_path);
+void LoadSdConfigIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();
 

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -2,7 +2,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2018-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -43,6 +43,7 @@ JobControlRecord* SetupJcr(const char* name,
                            DeviceControlRecord* dcr,
                            const std::string& VolumeName,
                            bool readonly);
+bool IsDirectLocalVolumePath(const char* device_name);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();
 

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -44,6 +44,7 @@ JobControlRecord* SetupJcr(const char* name,
                            const std::string& VolumeName,
                            bool readonly);
 bool IsDirectLocalVolumePath(const char* device_name);
+void LoadSdConfigForDeviceListingIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();
 

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -43,6 +43,7 @@ JobControlRecord* SetupJcr(const char* name,
                            DeviceControlRecord* dcr,
                            const std::string& VolumeName,
                            bool readonly);
+// Return true for a directly stat-able local file or directory path.
 bool IsLocalFilesystemVolumePath(const char* device_name);
 void LoadSdConfigForDeviceListingIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -49,6 +49,10 @@ void LoadSdConfigIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();
 
+#if defined(HAVE_WIN32) && defined(BUILD_TESTING)
+std::string DirectoryNameForTest(const std::string& path);
+#endif
+
 } /* namespace storagedaemon */
 
 #endif  // BAREOS_STORED_BUTIL_H_

--- a/core/src/stored/butil.h
+++ b/core/src/stored/butil.h
@@ -49,7 +49,7 @@ void LoadSdConfigIfAvailable(const char* config_path);
 void DisplayTapeErrorStatus(JobControlRecord* jcr, Device* dev);
 std::string AvailableDevicesListing();
 
-#if defined(HAVE_WIN32) && defined(BUILD_TESTING)
+#if defined(HAVE_WIN32)
 std::string DirectoryNameForTest(const std::string& path);
 #endif
 

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -131,11 +131,11 @@ TEST_F(sd, backend_load_unload)
   FreeJcr(jcr);
 }
 
-TEST(SdButil, IsDirectLocalVolumePath)
+TEST(SdButil, IsLocalFilesystemVolumePath)
 {
-  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(nullptr));
-  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(""));
-  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(
+  EXPECT_FALSE(storagedaemon::IsLocalFilesystemVolumePath(nullptr));
+  EXPECT_FALSE(storagedaemon::IsLocalFilesystemVolumePath(""));
+  EXPECT_FALSE(storagedaemon::IsLocalFilesystemVolumePath(
       "/path/that/does/not/exist/anywhere"));
 
   TempDirectory temp_directory;
@@ -154,10 +154,12 @@ TEST(SdButil, IsDirectLocalVolumePath)
         + std::string(1, std::filesystem::path::preferred_separator);
   const auto quoted_file_path = "\"" + file_path.string() + "\"";
 
-  EXPECT_TRUE(storagedaemon::IsDirectLocalVolumePath(directory_path.c_str()));
   EXPECT_TRUE(
-      storagedaemon::IsDirectLocalVolumePath(directory_with_separator.c_str()));
-  EXPECT_TRUE(storagedaemon::IsDirectLocalVolumePath(file_path.c_str()));
+      storagedaemon::IsLocalFilesystemVolumePath(directory_path.c_str()));
   EXPECT_TRUE(
-      storagedaemon::IsDirectLocalVolumePath(quoted_file_path.c_str()));
+      storagedaemon::IsLocalFilesystemVolumePath(
+          directory_with_separator.c_str()));
+  EXPECT_TRUE(storagedaemon::IsLocalFilesystemVolumePath(file_path.c_str()));
+  EXPECT_TRUE(
+      storagedaemon::IsLocalFilesystemVolumePath(quoted_file_path.c_str()));
 }

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -163,3 +163,10 @@ TEST(SdButil, IsLocalFilesystemVolumePath)
   EXPECT_TRUE(
       storagedaemon::IsLocalFilesystemVolumePath(quoted_file_path.c_str()));
 }
+
+#if defined(HAVE_WIN32)
+TEST(SdButil, DirectoryNameKeepsWindowsDriveRoot)
+{
+  EXPECT_EQ(storagedaemon::DirectoryNameForTest("C:\\FileInRoot"), "C:\\");
+}
+#endif

--- a/core/src/tests/sd_backend.cc
+++ b/core/src/tests/sd_backend.cc
@@ -29,7 +29,9 @@
 
 
 #include <chrono>
+#include <filesystem>
 #include <future>
+#include <fstream>
 
 #define STORAGE_DAEMON 1
 #include "include/jcr.h"
@@ -52,6 +54,44 @@
 
 using namespace storagedaemon;
 
+namespace {
+
+std::filesystem::path CreateTempDirectory()
+{
+  const auto base = std::filesystem::temp_directory_path();
+  for (int i = 0; i < 100; ++i) {
+    const auto candidate = base / ("bareos-sd-backend-"
+                                   + std::to_string(
+                                       std::chrono::steady_clock::now()
+                                           .time_since_epoch()
+                                           .count())
+                                   + "-" + std::to_string(i));
+    std::error_code ec;
+    if (std::filesystem::create_directory(candidate, ec)) { return candidate; }
+  }
+
+  return {};
+}
+
+class TempDirectory {
+ public:
+  TempDirectory() : directory_(CreateTempDirectory()) {}
+  ~TempDirectory()
+  {
+    if (!directory_.empty()) {
+      std::error_code ec;
+      std::filesystem::remove_all(directory_, ec);
+    }
+  }
+
+  const std::filesystem::path& path() const { return directory_; }
+  bool valid() const { return !directory_.empty(); }
+
+ private:
+  std::filesystem::path directory_;
+};
+
+}  // namespace
 
 // Test that load and unloads a tape device.
 TEST_F(sd, backend_load_unload)
@@ -89,4 +129,35 @@ TEST_F(sd, backend_load_unload)
 
   Dmsg0(100, "cleanup\n");
   FreeJcr(jcr);
+}
+
+TEST(SdButil, IsDirectLocalVolumePath)
+{
+  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(nullptr));
+  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(""));
+  EXPECT_FALSE(storagedaemon::IsDirectLocalVolumePath(
+      "/path/that/does/not/exist/anywhere"));
+
+  TempDirectory temp_directory;
+  ASSERT_TRUE(temp_directory.valid());
+
+  const auto directory_path = temp_directory.path();
+  const auto file_path = directory_path / "direct-volume";
+  {
+    std::ofstream file(file_path);
+    ASSERT_TRUE(file.is_open());
+    file << "bareos";
+  }
+
+  const auto directory_with_separator
+      = directory_path.string()
+        + std::string(1, std::filesystem::path::preferred_separator);
+  const auto quoted_file_path = "\"" + file_path.string() + "\"";
+
+  EXPECT_TRUE(storagedaemon::IsDirectLocalVolumePath(directory_path.c_str()));
+  EXPECT_TRUE(
+      storagedaemon::IsDirectLocalVolumePath(directory_with_separator.c_str()));
+  EXPECT_TRUE(storagedaemon::IsDirectLocalVolumePath(file_path.c_str()));
+  EXPECT_TRUE(
+      storagedaemon::IsDirectLocalVolumePath(quoted_file_path.c_str()));
 }

--- a/docs/manuals/source/include/autogenerated/usage/bcopy.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bcopy.txt
@@ -28,6 +28,7 @@ Options:
     -D,--director <director>
         Specify a director name specified in the storage. Configuration file 
         for the Key Encryption Key selection. 
+        Needs: -c,--config
 
     -d,--debug-level <level>
         Set debug level to <level>. 

--- a/docs/manuals/source/include/autogenerated/usage/bcopy.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bcopy.txt
@@ -4,12 +4,12 @@ Positionals:
     input-archive  
         Specify the input device name (either as name of a Bareos Storage 
         Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource). 
+        Storage Daemon Device resource, or a local file volume path). 
 
     output-archive  
         Specify the output device name (either as name of a Bareos Storage 
         Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource). 
+        Storage Daemon Device resource, or a local file volume path). 
 
 
 Options:

--- a/docs/manuals/source/include/autogenerated/usage/bcopy.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bcopy.txt
@@ -1,15 +1,15 @@
 Usage: bcopy [OPTIONS] [input-archive] [output-archive]
 
 Positionals:
-    input-archive  
-        Specify the input device name (either as name of a Bareos Storage 
-        Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource, or a local file volume path). 
+    input-archive
+        Specify the input device name (either the name of a Bareos Storage
+        Daemon Device resource, the Archive Device in such a resource, or a
+        local file volume path).
 
-    output-archive  
-        Specify the output device name (either as name of a Bareos Storage 
-        Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource, or a local file volume path). 
+    output-archive
+        Specify the output device name (either the name of a Bareos Storage
+        Daemon Device resource, the Archive Device in such a resource, or a
+        local file volume path).
 
 
 Options:

--- a/docs/manuals/source/include/autogenerated/usage/bextract.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bextract.txt
@@ -4,7 +4,7 @@ Positionals:
     bareos-archive-device-name  
         Specify the input device name (either as name of a Bareos Storage 
         Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource). 
+        Storage Daemon Device resource, or a local file volume path). 
 
     target-directory  
         Specify directory where to store files. 

--- a/docs/manuals/source/include/autogenerated/usage/bls.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bls.txt
@@ -4,7 +4,7 @@ Positionals:
     device-names   ...
         Specify the input device name (either as name of a Bareos Storage 
         Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource). 
+        Storage Daemon Device resource, or a local file volume path). 
 
 
 Options:

--- a/docs/manuals/source/include/autogenerated/usage/bscan.txt
+++ b/docs/manuals/source/include/autogenerated/usage/bscan.txt
@@ -4,7 +4,7 @@ Positionals:
     device_name  
         Specify the input device name (either as name of a Bareos Storage 
         Daemon Device resource or identical to the Archive Device in a Bareos 
-        Storage Daemon Device resource). 
+        Storage Daemon Device resource, or a local file volume path). 
 
 
 Options:


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Currently, an autochanger will not work for bextract/bscan/etc. you have to provide a single device. As this is non-obvious esp. with the automatic file autochangers, providing an autochanger should "just work" or ask which device should be used.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
