### PR TITLE
VMware Plugin: Fix local vmdk restore > 2TB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: clarify mssql plugin options [PR #2653]
 - dedupable: remove error on flush [PR #2649]
 - filed: log that WIN32 streams are not supported on non-Windows OS [PR #2657]
+- VMware Plugin: Fix local vmdk restore > 2TB [PR #2687]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2309,4 +2310,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2671]: https://github.com/bareos/bareos/pull/2671
 [PR #2681]: https://github.com/bareos/bareos/pull/2681
 [PR #2684]: https://github.com/bareos/bareos/pull/2684
+[PR #2687]: https://github.com/bareos/bareos/pull/2687
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
+++ b/core/src/vmware/vadp_dumper/bareos_vadp_dumper.cc
@@ -736,6 +736,10 @@ static inline void do_vixdisklib_create(const char* key,
   createParams.capacity = (absolute_disk_length / VIXDISKLIB_SECTOR_SIZE);
   if (disktype) {
     createParams.diskType = lookup_disktype();
+  } else if (absolute_disk_length
+             > (uint64_t)2 * 1024 * 1024 * 1024 * 1024ULL) {
+    // >2TiB requires split sparse to avoid 2TB monolithic VMDK limits
+    createParams.diskType = VIXDISKLIB_DISK_SPLIT_SPARSE;
   } else {
     createParams.diskType = VIXDISKLIB_DISK_MONOLITHIC_SPARSE;
   }

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/VMwarePlugin.rst.inc
@@ -23,6 +23,11 @@ Status
 
 The Plugin can do full, differential and incremental backup and restore of VM disks.
 
+Since :sinceVersion:`25.0.4: VMware Plugin` When using the plugin option
+:strong:`localvmdk=yes`, virtual disks larger than 2TB can now be restored
+to local VMDK files, in which case they will be split into 2GB extents. Restoring
+such virtual disks to existing or recreated VM was always possible.
+
 Since :sinceVersion:`24.0.5: VMware Plugin` The Plugin can now save and recreate
 VMs with VirtualSerialPort devices.
 


### PR DESCRIPTION
Fix bareos_vadp_dumper to restore local VMDK disk that are greater than 2 TB when using the plugin option localvmdk=yes.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

