### PR TITLE
deprecate: FD alias, Counter res,  var substitutions in label format  and fix when= handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - filed: log that WIN32 streams are not supported on non-Windows OS [PR #2657]
 - VMware Plugin: Fix local vmdk restore > 2TB [PR #2687]
 - bpipe plugin: add unique suffix to file name [PR #2613]
+- deprecate: FD alias, Counter res,  var substitutions in label format  and fix when= handling [PR #2695]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2315,4 +2316,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2684]: https://github.com/bareos/bareos/pull/2684
 [PR #2687]: https://github.com/bareos/bareos/pull/2687
 [PR #2689]: https://github.com/bareos/bareos/pull/2689
+[PR #2695]: https://github.com/bareos/bareos/pull/2695
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -466,14 +466,15 @@ static ResourceTable dird_resource_tables[] = {
   { "Messages", "Messages", msgs_items, R_MSGS, sizeof(MessagesResource),
       [] (){ res_msgs = new MessagesResource(); }, reinterpret_cast<BareosResource**>(&res_msgs) },
   { "Counter", "Counters", counter_items, R_COUNTER, sizeof(CounterResource),
-      [] (){ res_counter = new CounterResource(); }, reinterpret_cast<BareosResource**>(&res_counter) },
+    [] (){ res_counter = new CounterResource(); }, reinterpret_cast<BareosResource**>(&res_counter),
+    {}, true },
   { "Profile", "Profiles", profile_items, R_PROFILE, sizeof(ProfileResource),
       [] (){ res_profile = new ProfileResource(); }, reinterpret_cast<BareosResource**>(&res_profile) },
   { "Console", "Consoles", con_items, R_CONSOLE, sizeof(ConsoleResource),
       [] (){ res_con = new ConsoleResource(); }, reinterpret_cast<BareosResource**>(&res_con) },
   { "User", "Users", user_items, R_USER, sizeof(UserResource),
       [] (){ res_user = new UserResource(); }, reinterpret_cast<BareosResource**>(&res_user) },
-  { nullptr, nullptr, nullptr, 0, 0, nullptr, nullptr }
+  { }
 };
 
 /**

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -391,7 +391,7 @@ static const ResourceItem pool_items[] = {
   { "Name", CFG_TYPE_NAME, ITEM(res_pool, resource_name_), {config::Required{}, config::Description{"The name of the resource."}}},
   { "Description", CFG_TYPE_STR, ITEM(res_pool, description_), {}},
   { "PoolType", CFG_TYPE_POOLTYPE, ITEM(res_pool, pool_type), {config::DefaultValue{"Backup"}}},
-  { "LabelFormat", CFG_TYPE_STRNAME, ITEM(res_pool, label_format), {}},
+  { "LabelFormat", CFG_TYPE_STRNAME, ITEM(res_pool, label_format), {config::Code{CFG_STR_TYPE_LABEL_FORMAT}}},
   { "LabelType", CFG_TYPE_LABEL, ITEM(res_pool, LabelType), {config::DeprecatedSince{23, 0, 0}}},
   { "CleaningPrefix", CFG_TYPE_STRNAME, ITEM(res_pool, cleaning_prefix), {config::DefaultValue{"CLN"}}},
   { "UseCatalog", CFG_TYPE_BOOL, ITEM(res_pool, use_catalog), {config::DefaultValue{"true"}}},

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -637,15 +637,20 @@ int ModifyJobParameters(UaContext* ua, JobControlRecord* jcr, RunContext& rc)
         break;
       case 6:
         /* When */
-        if (GetCmd(ua, T_("Please enter desired start time as YYYY-MM-DD "
-                          "HH:MM:SS (return for now): "))) {
+        for (;;) {
+          if (!GetCmd(ua, T_("Please enter desired start time as YYYY-MM-DD "
+                             "HH:MM:SS (return for now): "))) {
+            break;
+          }
           if (ua->cmd[0] == 0) {
             jcr->sched_time = time(NULL);
           } else {
-            jcr->sched_time = StrToUtime(ua->cmd);
-            if (jcr->sched_time == 0) {
-              ua->SendMsg(T_("Invalid time, using current time.\n"));
-              jcr->sched_time = time(NULL);
+            auto parsed = StrToUtime(ua->cmd);
+            if (parsed == 0) {
+              ua->SendMsg(T_("Invalid time specification.\n"));
+              continue;
+            } else {
+              jcr->sched_time = parsed;
             }
           }
           goto try_again;

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -863,8 +863,10 @@ static bool ResetRestoreContext(UaContext* ua,
   if (rc.when) {
     jcr->sched_time = StrToUtime(rc.when);
     if (jcr->sched_time == 0) {
-      ua->SendMsg(T_("Invalid time, using current time.\n"));
-      jcr->sched_time = time(NULL);
+      ua->SendMsg(
+          T_("Invalid time specification in when; expected: \"YYYY-MM-DD "
+             "HH:MM:SS\"\n"));
+      return false;
     }
     rc.when = NULL;
   }

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -312,7 +312,17 @@ int ConfigurationParser::GetResourceTableIndex(const char* resource_type_name)
       return i;
     }
     for (const auto& alias : resource_definitions_[i].aliases) {
-      if (Bstrcasecmp(alias.name.c_str(), resource_type_name)) { return i; }
+      if (Bstrcasecmp(alias.name.c_str(), resource_type_name)) {
+        std::string warning
+            = "Found resource alias usage \"" + alias.name
+              + "\" in configuration which is discouraged, consider using \""
+              + resource_definitions_[i].name + "\" instead.";
+        if (std::find(warnings_.begin(), warnings_.end(), warning)
+            == warnings_.end()) {
+          AddWarning(warning);
+        }
+        return i;
+      }
     }
   }
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -78,6 +78,8 @@ struct ResourceTable {
     std::string name, group_name;
   };
   std::vector<Alias> aliases = {}; /* Resource name and group name aliases */
+
+  bool deprecated = false;
 };
 
 // Common Resource definitions

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -172,6 +172,12 @@ enum
   CFG_TYPE_CIPHER = 301 /* Encryption Cipher */
 };
 
+enum string_type : int
+{
+  CFG_STR_TYPE_DEFAULT,
+  CFG_STR_TYPE_LABEL_FORMAT,
+};
+
 struct DatatypeName {
   const int number;
   const char* name;

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -232,6 +232,13 @@ ConfigParserStateMachine::ParserInitResource(int token)
     return ParseInternalReturnCode::kError;
   }
 
+  if (resource_table->deprecated && parser_pass_number_ == 1) {
+    my_config_.AddWarning(std::string("using deprecated resource type \"")
+                          + resource_table->name + "\" on line "
+                          + std::to_string(lexical_parser_->line_no)
+                          + " of file " + lexical_parser_->fname);
+  }
+
   bool init_done = false;
 
   if (resource_table && resource_table->items) {

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -443,6 +443,21 @@ void ConfigurationParser::StoreStrname(lexer* lc,
 {
   LexGetToken(lc, BCT_NAME);
   if (pass == 1) {
+    if (item->code == CFG_STR_TYPE_LABEL_FORMAT) {
+      // it would be better to do this by adding a new config type
+      // but as this is only very temporary, and adding a type correctly
+      // is very hard, this way was chosen instead
+
+      // as only the director knows about label formats, we have to do it this
+      // way
+      if (strchr(lc->str, '$') != nullptr || strchr(lc->str, '[') != nullptr) {
+        AddWarning(std::string("use of variable substitutions in ") + item->name
+                   + " on line " + std::to_string(lc->line_no) + " of file "
+                   + lc->fname + " is deprecated");
+      }
+    }
+
+
     char** p = GetItemVariablePointer<char**>(*item);
     if (*p) { free(*p); }
     *p = strdup(lc->str);

--- a/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
+++ b/docs/manuals/source/Configuration/CustomizingTheConfiguration.rst
@@ -1082,6 +1082,8 @@ Depending on the directive, Bareos will expand to the following variables:
 Variable Expansion on Volume Labels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+.. deprecated:: 26.0.0
+
 When labeling a new volume (see :config:option:`dir/pool/LabelFormat`\ ), following Bareos internal variables can be used:
 
 ===================== ========================================

--- a/docs/manuals/source/Configuration/FileDaemon.rst
+++ b/docs/manuals/source/Configuration/FileDaemon.rst
@@ -30,7 +30,7 @@ Client Resource
    single: Resource; Client
    single: Client Resource
 
-The Client (or File Daemon) resource defines the name of the Client (as used by the Director) as
+The Client resource defines the name of the Client (as used by the Director) as
 well as the port on which the Client listens for Director connections.
 
 Start of the Client records. There must be one and only one Client resource in the configuration

--- a/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
+++ b/docs/manuals/source/include/autogenerated/bareos-dir-config-schema.json
@@ -2096,7 +2096,7 @@
         },
         "LabelFormat": {
           "datatype": "STRNAME",
-          "code": 0,
+          "code": 1,
           "equals": true
         },
         "LabelType": {

--- a/docs/manuals/source/manually_added_config_directive_descriptions/dir-pool-LabelFormat.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/dir-pool-LabelFormat.rst.inc
@@ -9,3 +9,6 @@ If no variable expansion characters are found in the string, the Volume name wil
 **File-0002**, ...
 
 In almost all cases, you should enclose the format specification (part after the equal sign) in double quotes (:file:`"`).
+
+.. warning::
+   Variable expansion is deprecated since :sinceVersion:`26.0.0: deprecate variable expansion in label format`.

--- a/systemtests/tests/python-bareos/CMakeLists.txt
+++ b/systemtests/tests/python-bareos/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2021 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -20,7 +20,7 @@
 get_filename_component(BASENAME ${CMAKE_CURRENT_BINARY_DIR} NAME)
 # python-bareos does not work on installed files
 if(PYTHON_EXECUTABLE AND NOT RUN_SYSTEMTESTS_ON_INSTALLED_FILES)
-  create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
+  create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME} IGNORE_CONFIG_WARNINGS)
 else()
   create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME} DISABLED)
 endif()


### PR DESCRIPTION
Now `when=` on the command line does not default to the current time, but errors out instead, if a bad specification is given.

When modifying the value, it also does not default to the current time on error anymore, but instead asks again.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
