### PR TITLE
spec: use gcc-15 for rhel builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dedupable: remove error on flush [PR #2658]
 - docs: clarify mssql plugin options [PR #2659]
 - VMware Plugin: Fix local vmdk restore > 2TB [PR #2691]
+- spec: use gcc-15 for rhel builds [PR #2707]
 
 ## [25.0.3] - 2026-04-01
 
@@ -2298,4 +2299,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2692]: https://github.com/bareos/bareos/pull/2692
 [PR #2693]: https://github.com/bareos/bareos/pull/2693
 [PR #2697]: https://github.com/bareos/bareos/pull/2697
+[PR #2707]: https://github.com/bareos/bareos/pull/2707
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/packaging/bareos-universal-client.spec
+++ b/core/platforms/packaging/bareos-universal-client.spec
@@ -44,13 +44,12 @@ Vendor:     The Bareos Team
 %define CMAKE_BUILDDIR       cmake-build
 
 
-# use modernized GCC 14 toolchain for C++20 support
-%if 0%{?rhel} && 0%{?rhel} <= 9
-BuildRequires: gcc-toolset-14-gcc
-BuildRequires: gcc-toolset-14-annobin-plugin-gcc
-BuildRequires: gcc-toolset-14-gcc-c++
+# use modernized GCC 15 toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} <= 10
+BuildRequires: gcc-toolset-15-gcc
+BuildRequires: gcc-toolset-15-gcc-plugin-annobin
+BuildRequires: gcc-toolset-15-gcc-c++
 %define glusterfs 1
-%define enable_grpc 0
 %endif
 
 
@@ -214,9 +213,13 @@ export MTX=/usr/sbin/mtx
 mkdir %{CMAKE_BUILDDIR}
 pushd %{CMAKE_BUILDDIR}
 
-# use modernized GCC 14 toolchain for C++20 support
-%if 0%{?rhel} && 0%{?rhel} <= 9
-source /opt/rh/gcc-toolset-14/enable
+# use modernized GCC toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} < 10
+source /opt/rh/gcc-toolset-15/enable
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} >= 10
+source /usr/lib/gcc-toolset/15-env.source
 %endif
 
 # use modern compiler on suse 15

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -57,11 +57,11 @@ Vendor:     The Bareos Team
 %define glusterfs 1
 %endif
 
-# use modernized GCC 14 toolchain for C++20 support
-%if 0%{?rhel} && 0%{?rhel} <= 9
-BuildRequires: gcc-toolset-14-gcc
-BuildRequires: gcc-toolset-14-annobin-plugin-gcc
-BuildRequires: gcc-toolset-14-gcc-c++
+# use modernized GCC 15 toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} <= 10
+BuildRequires: gcc-toolset-15-gcc
+BuildRequires: gcc-toolset-15-gcc-plugin-annobin
+BuildRequires: gcc-toolset-15-gcc-c++
 %define glusterfs 1
 # rhel <=8 does not have grpc
 %if 0%{?rhel} && 0%{?rhel} <= 8
@@ -839,9 +839,13 @@ export MTX=/usr/sbin/mtx
 mkdir %{CMAKE_BUILDDIR}
 pushd %{CMAKE_BUILDDIR}
 
-# use modernized GCC 14 toolchain for C++20 support
-%if 0%{?rhel} && 0%{?rhel} <= 9
-source /opt/rh/gcc-toolset-14/enable
+# use modernized GCC toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} < 10
+source /opt/rh/gcc-toolset-15/enable
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} >= 10
+source /usr/lib/gcc-toolset/15-env.source
 %endif
 
 # use modern compiler on suse 15

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -57,12 +57,15 @@ Vendor:     The Bareos Team
 %define glusterfs 1
 %endif
 
+%if 0%{?rhel} && 0%{?rhel} <= 9
+
+%define glusterfs 1
+%endif
 # use modernized GCC 15 toolchain for C++20 support
 %if 0%{?rhel} && 0%{?rhel} <= 10
 BuildRequires: gcc-toolset-15-gcc
 BuildRequires: gcc-toolset-15-gcc-plugin-annobin
 BuildRequires: gcc-toolset-15-gcc-c++
-%define glusterfs 1
 # rhel <=8 does not have grpc
 %if 0%{?rhel} && 0%{?rhel} <= 8
 %define enable_grpc 0

--- a/core/src/plugins/filed/grpc/CMakeLists.txt
+++ b/core/src/plugins/filed/grpc/CMakeLists.txt
@@ -27,6 +27,8 @@ if(ENABLE_GRPC)
     )
   endif()
 
+  set(_grpc_gcc_no_error_cpp "$<$<CXX_COMPILER_ID:GNU>:-Wno-error=cpp>")
+
   set(PROTO_OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}/proto")
   make_directory(${PROTO_OUTPUT_DIR})
   # Proto file
@@ -82,6 +84,10 @@ if(ENABLE_GRPC)
   target_add_proto_sources(
     grpc-proto "proto/plugin.proto" "proto/events.proto" "proto/bareos.proto"
     "proto/common.proto"
+  )
+  target_compile_options(
+    grpc-proto PUBLIC
+      ${_grpc_gcc_no_error_cpp}
   )
   target_link_libraries(
     grpc-proto PUBLIC gRPC::grpc++_reflection gRPC::grpc++

--- a/core/src/plugins/filed/grpc/CMakeLists.txt
+++ b/core/src/plugins/filed/grpc/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2024-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2024-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -85,10 +85,7 @@ if(ENABLE_GRPC)
     grpc-proto "proto/plugin.proto" "proto/events.proto" "proto/bareos.proto"
     "proto/common.proto"
   )
-  target_compile_options(
-    grpc-proto PUBLIC
-      ${_grpc_gcc_no_error_cpp}
-  )
+  target_compile_options(grpc-proto PUBLIC ${_grpc_gcc_no_error_cpp})
   target_link_libraries(
     grpc-proto PUBLIC gRPC::grpc++_reflection gRPC::grpc++
                       protobuf::libprotobuf


### PR DESCRIPTION
**Backport of PR #2705 to bareos-25**

Disabled glusterfs on rhel10.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2705 is merged
- [x] All functional differences to the original PR are documented above
