### PR TITLE
spec: use gcc-15 for rhel builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Documentation
 - docs: correct TlsRequire default in docs [PR #2675]
 
+### Changed
+- spec: use gcc-15 for rhel builds [PR #2709]
+
 ## [23.1.7] - 2026-04-01
 
 ### Changed
@@ -1776,4 +1779,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2518]: https://github.com/bareos/bareos/pull/2518
 [PR #2551]: https://github.com/bareos/bareos/pull/2551
 [PR #2675]: https://github.com/bareos/bareos/pull/2675
+[PR #2709]: https://github.com/bareos/bareos/pull/2709
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/platforms/packaging/bareos.spec
+++ b/core/platforms/packaging/bareos.spec
@@ -110,6 +110,14 @@ BuildRequires: devtoolset-8-gcc
 BuildRequires: devtoolset-8-gcc-c++
 %endif
 
+# use modernized GCC 15 toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} > 7 && 0%{?rhel} <= 10
+BuildRequires: gcc-toolset-15-gcc
+BuildRequires: gcc-toolset-15-gcc-plugin-annobin
+BuildRequires: gcc-toolset-15-gcc-c++
+%endif
+
+
 %if 0%{?suse_version} < 1500 && 0%{?suse_version} >= 1210
 BuildRequires: gcc9
 BuildRequires: gcc9-c++
@@ -846,6 +854,15 @@ pushd %{CMAKE_BUILDDIR}
 # use Developer Toolset 8 compiler as standard is too old
 %if 0%{?rhel} == 7
 source /opt/rh/devtoolset-8/enable
+%endif
+
+# use modernized GCC toolchain for C++20 support
+%if 0%{?rhel} && 0%{?rhel} > 7 && 0%{?rhel} < 10
+source /opt/rh/gcc-toolset-15/enable
+%endif
+
+%if 0%{?rhel} && 0%{?rhel} >= 10
+source /usr/lib/gcc-toolset/15-env.source
 %endif
 
 # use modern compiler on suse

--- a/core/src/ndmp/CMakeLists.txt
+++ b/core/src/ndmp/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -196,6 +196,7 @@ bareos_disable_warnings(
   -Wcast-function-type
   -Wincompatible-pointer-types
   -Wenum-compare
+  -Wold-style-definition
   C_ONLY
 )
 

--- a/core/src/ndmp/ndml_nmb.c
+++ b/core/src/ndmp/ndml_nmb.c
@@ -34,6 +34,12 @@
  *
  */
 
+// C23 changed the semantics of a function declaration without parameters
+#if __STDC_VERSION__ >= 202311L
+#define VARARG_PARAMETER_LIST ...
+#else
+#define VARARG_PARAMETER_LIST
+#endif
 
 #include "ndmlib.h"
 
@@ -74,7 +80,7 @@ void ndmnmb_snoop(struct ndmlog* log,
 {
   int rc, nl, i;
   char buf[2048];
-  int (*ndmpp)();
+  int (*ndmpp)(VARARG_PARAMETER_LIST);
   int level5 = 5;
   int level6 = 6;
 

--- a/core/src/ndmp/ndmp9.x
+++ b/core/src/ndmp/ndmp9.x
@@ -223,7 +223,7 @@ enum ndmp9_message {
 /*
  * Common message bodies
  */
-%extern bool_t xdr_ndmp9_no_arguments();
+%extern bool_t xdr_ndmp9_no_arguments(register XDR *xdrs, uint64_t *objp);
 %#define ndmp9_no_arguments int
 
 struct ndmp9_just_error_reply {

--- a/core/src/ndmp/ndmp_translate.h
+++ b/core/src/ndmp/ndmp_translate.h
@@ -34,6 +34,13 @@
  *
  */
 
+// C23 changed the semantics of a function declaration without parameters
+#if __STDC_VERSION__ >= 202311L
+#define VARARG_PARAMETER_LIST ...
+#else
+#define VARARG_PARAMETER_LIST
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -153,15 +160,15 @@ struct reqrep_xlate {
   int vx_message;
   ndmp9_message v9_message;
 
-  int (*request_xto9)(/* void *vxbody, void *v9body */);
-  int (*request_9tox)(/* void *v9body, void *vxbody */);
-  int (*reply_xto9)(/* void *vxbody, void *v9body */);
-  int (*reply_9tox)(/* void *v9body, void *vxbody */);
+  int (*request_xto9)(VARARG_PARAMETER_LIST/* void *vxbody, void *v9body */);
+  int (*request_9tox)(VARARG_PARAMETER_LIST/* void *v9body, void *vxbody */);
+  int (*reply_xto9)(VARARG_PARAMETER_LIST/* void *vxbody, void *v9body */);
+  int (*reply_9tox)(VARARG_PARAMETER_LIST/* void *v9body, void *vxbody */);
 
-  int (*free_request_xto9)(/* void *v9body */);
-  int (*free_request_9tox)(/* void *vxbody */);
-  int (*free_reply_xto9)(/* void *v9body */);
-  int (*free_reply_9tox)(/* void *vxbody */);
+  int (*free_request_xto9)(VARARG_PARAMETER_LIST/* void *v9body */);
+  int (*free_request_9tox)(VARARG_PARAMETER_LIST/* void *vxbody */);
+  int (*free_reply_xto9)(VARARG_PARAMETER_LIST/* void *v9body */);
+  int (*free_reply_9tox)(VARARG_PARAMETER_LIST/* void *vxbody */);
 };
 
 struct reqrep_xlate_version_table {


### PR DESCRIPTION
**Backport of PR #2705 to bareos-23**

Added a small fix to keep ndmp compiling on newer gcc versions.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2705 is merged
- [x] All functional differences to the original PR are documented above
