### PR TITLE
libcloud plugin: fix error when backing up an empty bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: fix sometimes not preserving used resource pointers [PR #2725]
 - Fix proxmox plugin stalling virtual machines [PR #2733]
 - logrotate: add minsize 100k [PR #2731]
+- libcloud plugin: fix error when backing up an empty bucket [PR #2717]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2344,6 +2345,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2706]: https://github.com/bareos/bareos/pull/2706
 [PR #2711]: https://github.com/bareos/bareos/pull/2711
 [PR #2712]: https://github.com/bareos/bareos/pull/2712
+[PR #2717]: https://github.com/bareos/bareos/pull/2717
 [PR #2719]: https://github.com/bareos/bareos/pull/2719
 [PR #2720]: https://github.com/bareos/bareos/pull/2720
 [PR #2721]: https://github.com/bareos/bareos/pull/2721

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
@@ -177,6 +177,7 @@ class BucketExplorer(ProcessBase):
         obj_count = 0
         task_count = 0
         start_time = time.time()
+        iteration_start_time = time.time()
         for obj in object_iterator:
             if obj_count == 0:
                 iteration_start_time = time.time()

--- a/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
+++ b/core/src/plugins/filed/python/libcloud/bareos_libcloud_api/bucket_explorer.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020-2025 Bareos GmbH & Co. KG
+# Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 #
 # This program is Free Software; you can redistribute it and/or
 # modify it under the terms of version three of the GNU Affero General Public


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

Using the Bareos Apache Libcloud Plugin to backup an empty bucket, the job failed with this error message:
`Error: python3-fd-mod: BareosFdPluginLibcloud: BUCKET_EXPLORER: Error while iterating buckets (local variable 'iteration_start_time' referenced before assignment)
`
This fixes the uninitialized iteration_start_time exception for empty buckets, so that the jobs terminates without error.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
