### PR TITLE
console: add `update volume encrypt` command

### DIFF
--- a/core/src/cats/cats.h
+++ b/core/src/cats/cats.h
@@ -937,6 +937,7 @@ class BareosDb : public BareosDbQueryEnum {
   bool UpdatePoolRecord(JobControlRecord* jcr, PoolDbRecord* pr);
   bool UpdateStorageRecord(JobControlRecord* jcr, StorageDbRecord* sr);
   bool UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr);
+  bool UpdateMediaEncryptionKey(JobControlRecord* jcr, MediaDbRecord* mr);
   bool UpdateMediaDefaults(JobControlRecord* jcr, MediaDbRecord* mr);
   bool UpdateCounterRecord(JobControlRecord* jcr, CounterDbRecord* cr);
   bool UpdateQuotaGracetime(JobControlRecord* jcr, JobDbRecord* jr);

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -368,6 +368,34 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
 }
 
 /**
+ * Update only the EncryptionKey field for a Media record.
+ *
+ * Used by "update volume encrypt" to set a new hardware encryption key
+ * on a previously unencrypted volume without relabeling it.
+ * The generic UpdateMediaRecord() intentionally does not touch EncryptionKey
+ * to avoid accidental clobbering from stale MediaDbRecord instances.
+ *
+ * Returns: false on failure
+ *          true on success
+ */
+bool BareosDb::UpdateMediaEncryptionKey(JobControlRecord* jcr,
+                                        MediaDbRecord* mr)
+{
+  char ed1[50];
+  char esc_key[MAX_ESCAPE_NAME_LENGTH];
+
+  DbLocker _{this};
+  EscapeString(jcr, esc_key, mr->EncrKey, strlen(mr->EncrKey));
+  Mmsg(cmd,
+       "UPDATE Media SET EncryptionKey='%s' WHERE MediaId=%s",
+       esc_key, edit_int64(mr->MediaId, ed1));
+
+  Dmsg1(400, "%s\n", cmd);
+
+  return UpdateDb(jcr, cmd) > 0;
+}
+
+/**
  * Update the Media Record Default values from Pool
  *
  * Returns: false on failure

--- a/core/src/dird/ua_label.cc
+++ b/core/src/dird/ua_label.cc
@@ -485,6 +485,19 @@ static int do_label(UaContext* ua, const char*, bool relabel)
     label_encrypt = true;
   }
 
+  // Look for the force keyword (must be zapped before get_storage_resource)
+  bool label_force = false;
+  if ((i = FindArg(ua, NT_("force"))) > 0) {
+    *ua->argk[i] = 0; /* zap force keyword */
+    label_force = true;
+  }
+
+  if (label_encrypt && !me->keyencrkey.value && !label_force) {
+    ua->ErrorMsg(T_("Cannot encrypt volume: no Key Encryption Key (KEK) "
+                    "configured in the Director.\n"));
+    return 1;
+  }
+
   store.store = get_storage_resource(ua, true, label_barcodes);
   if (!store.store) { return 1; }
 

--- a/core/src/dird/ua_label.cc
+++ b/core/src/dird/ua_label.cc
@@ -201,7 +201,7 @@ static inline bool native_send_label_request(UaContext* ua,
  * the old key somewhere save so you can use bscrypto to
  * convert them for the new wrap key.
  */
-static bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr)
+bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr)
 {
   int length;
   char* passphrase;

--- a/core/src/dird/ua_label.h
+++ b/core/src/dird/ua_label.h
@@ -25,6 +25,7 @@
 namespace directordaemon {
 
 bool IsVolumeNameLegal(UaContext* ua, const char* name);
+bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr);
 bool SendLabelRequest(UaContext* ua,
                       StorageResource* store,
                       MediaDbRecord* mr,

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -32,6 +32,7 @@
 #include "cats/cats.h"
 #include "include/bareos.h"
 #include "dird.h"
+#include "dird/dird_globals.h"
 #include "dird/director_jcr_impl.h"
 #include "dird/next_vol.h"
 #include "dird/sd_cmds.h"
@@ -526,6 +527,12 @@ static void UpdateVolEncrypt(UaContext* ua, MediaDbRecord* mr)
            "Re-keying an encrypted volume is not supported as it would\n"
            "make existing encrypted data unreadable.\n"),
         mr->VolumeName);
+    return;
+  }
+
+  if (!me->keyencrkey.value && FindArg(ua, NT_("force")) <= 0) {
+    ua->ErrorMsg(T_("Cannot encrypt volume: no Key Encryption Key (KEK) "
+                    "configured in the Director.\n"));
     return;
   }
 

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -38,6 +38,7 @@
 #include "dird/storage.h"
 #include "dird/ua_db.h"
 #include "dird/ua_input.h"
+#include "dird/ua_label.h"
 #include "dird/ua_select.h"
 #include "lib/bool_string.h"
 #include "lib/edit.h"
@@ -506,6 +507,44 @@ static void UpdateVolenabled(UaContext* ua, char* val, MediaDbRecord* mr)
   }
 }
 
+/**
+ * Add a hardware encryption key to a previously unencrypted volume.
+ *
+ * A new random key is generated (and optionally wrapped with the director's
+ * KeyEncryptionKey) and stored in the catalog. The key takes effect the next
+ * time the volume is mounted in a drive that has DriveCryptoEnabled = yes and
+ * the scsicrypto storage plugin loaded.
+ *
+ * Re-keying an already-encrypted volume is rejected to prevent making existing
+ * encrypted data unreadable.
+ */
+static void UpdateVolEncrypt(UaContext* ua, MediaDbRecord* mr)
+{
+  if (mr->EncrKey[0] != '\0') {
+    ua->ErrorMsg(
+        T_("Volume \"%s\" already has an encryption key set.\n"
+           "Re-keying an encrypted volume is not supported as it would\n"
+           "make existing encrypted data unreadable.\n"),
+        mr->VolumeName);
+    return;
+  }
+
+  if (!GenerateNewEncryptionKey(ua, mr)) { return; }
+
+  if (DbLocker _{ua->db}; !ua->db->UpdateMediaEncryptionKey(ua->jcr, mr)) {
+    ua->ErrorMsg(T_("Error setting encryption key on Volume \"%s\": ERR=%s\n"),
+                 mr->VolumeName, ua->db->strerror());
+    return;
+  }
+
+  ua->InfoMsg(
+      T_("Encryption key set for Volume \"%s\".\n"
+         "The key takes effect the next time the volume is mounted.\n"
+         "Ensure DriveCryptoEnabled = yes on the storage device and\n"
+         "that the scsicrypto storage plugin is loaded.\n"),
+      mr->VolumeName);
+}
+
 static void UpdateVolActiononpurge(UaContext* ua, char* val, MediaDbRecord* mr)
 {
   PoolMem ret;
@@ -559,6 +598,16 @@ static bool UpdateVolume(UaContext* ua)
                       NULL};
 
 #define AllFromPool 11 /* keep this updated with above */
+
+  /* Handle bare-flag keywords that take no value */
+  {
+    MediaDbRecord mr;
+    if (FindArg(ua, NT_("encrypt")) > 0) {
+      if (!SelectMediaDbr(ua, &mr)) { return false; }
+      UpdateVolEncrypt(ua, &mr);
+      done = true;
+    }
+  }
 
   for (i = 0; kw[i]; i++) {
     int j;
@@ -657,12 +706,13 @@ static bool UpdateVolume(UaContext* ua)
     AddPrompt(ua, T_("RecyclePool"));                /* 15 */
     AddPrompt(ua, T_("Action On Purge"));            /* 16 */
     AddPrompt(ua, T_("Storage"));                    /* 17 */
-    AddPrompt(ua, T_("Done"));                       /* 18 */
+    AddPrompt(ua, T_("Encrypt Volume"));             /* 18 */
+    AddPrompt(ua, T_("Done"));                       /* 19 */
     i = DoPrompt(ua, "", T_("Select parameter to modify"), NULL, 0);
 
     /* For All Volumes, All Volumes from Pool, and Done, we don't need
      * a Volume record */
-    if (i != 12 && i != 13 && i != 18) {
+    if (i != 12 && i != 13 && i != 19) {
       if (!SelectMediaDbr(ua, &mr)) { /* Get Volume record */
         return false;
       }
@@ -851,6 +901,10 @@ static bool UpdateVolume(UaContext* ua)
         UpdateVolStorage(ua, sr.Name, &mr);
         ua->InfoMsg(T_("New Storage is: %s\n"), sr.Name);
         return true;
+
+      case 18: /* Encrypt Volume */
+        UpdateVolEncrypt(ua, &mr);
+        break;
 
       default: /* Done or error */
         ua->InfoMsg(T_("Selection terminated.\n"));


### PR DESCRIPTION
As a user of Bareos with LTO and encryption, I want to be able to make non-encrypted volumes encrypted without relabeling them. 
For this I need a command to add an encryption key to a currently unencrypted volume.



### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
