### PR TITLE
core: fix sometimes not preserving used resource pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - contrib: media_vault use scriptdir [PR #2689]
 - Improve database encoding error handling [PR #2696]
 - core: ensure runscripts are only executed once [PR #2661]
+- core: fix sometimes not preserving used resource pointers [PR #2725]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2341,4 +2342,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2720]: https://github.com/bareos/bareos/pull/2720
 [PR #2721]: https://github.com/bareos/bareos/pull/2721
 [PR #2724]: https://github.com/bareos/bareos/pull/2724
+[PR #2725]: https://github.com/bareos/bareos/pull/2725
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3990,13 +3990,15 @@ static bool SaveResource(int type, const ResourceItem* items, int pass)
   return true;
 }
 
-std::vector<JobResource*> GetAllJobResourcesByClientName(std::string name)
+std::vector<JobResource*> GetAllJobResourcesByClientName(
+    ConfigResourcesContainer* container,
+    std::string_view name)
 {
   std::vector<JobResource*> all_matching_jobs;
   JobResource* job{nullptr};
 
   do {
-    job = static_cast<JobResource*>(my_config->GetNextRes(R_JOB, job));
+    job = static_cast<JobResource*>(container->GetNextRes(R_JOB, job));
     if (job && job->client) {
       if (job->client->resource_name_ == name) {
         all_matching_jobs.push_back(job);

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3991,7 +3991,7 @@ static bool SaveResource(int type, const ResourceItem* items, int pass)
 }
 
 std::vector<JobResource*> GetAllJobResourcesByClientName(
-    ConfigResourcesContainer* container,
+    LoadedConfiguration* container,
     std::string_view name)
 {
   std::vector<JobResource*> all_matching_jobs;

--- a/core/src/dird/dird_conf.cc
+++ b/core/src/dird/dird_conf.cc
@@ -3994,12 +3994,14 @@ std::vector<JobResource*> GetAllJobResourcesByClientName(
     LoadedConfiguration* container,
     std::string_view name)
 {
+  if (!container) { return {}; }
+
   std::vector<JobResource*> all_matching_jobs;
   JobResource* job{nullptr};
 
   do {
     job = static_cast<JobResource*>(container->GetNextRes(R_JOB, job));
-    if (job && job->client) {
+    if (job && job->client && job->client->resource_name_) {
       if (job->client->resource_name_ == name) {
         all_matching_jobs.push_back(job);
       }

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -648,7 +648,7 @@ const char* GetUsageStringForConsoleConfigureCommand();
 void DestroyConfigureUsageString();
 bool PopulateDefs();
 std::vector<JobResource*> GetAllJobResourcesByClientName(
-    ConfigResourcesContainer* container,
+    LoadedConfiguration* container,
     std::string_view name);
 
 } /* namespace directordaemon */

--- a/core/src/dird/dird_conf.h
+++ b/core/src/dird/dird_conf.h
@@ -36,6 +36,7 @@
 #include "dird/date_time_mask.h"
 #include "lib/alist.h"
 #include "lib/messages_resource.h"
+#include "lib/parse_conf.h"
 #include "lib/resource_item.h"
 #include "lib/tls_conf.h"
 
@@ -646,7 +647,9 @@ std::optional<std::string> job_code_callback_director(JobControlRecord* jcr,
 const char* GetUsageStringForConsoleConfigureCommand();
 void DestroyConfigureUsageString();
 bool PopulateDefs();
-std::vector<JobResource*> GetAllJobResourcesByClientName(std::string name);
+std::vector<JobResource*> GetAllJobResourcesByClientName(
+    ConfigResourcesContainer* container,
+    std::string_view name);
 
 } /* namespace directordaemon */
 #endif  // BAREOS_DIRD_DIRD_CONF_H_

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -35,7 +35,7 @@
 
 typedef struct s_tree_root TREE_ROOT;
 
-class ConfigResourcesContainer;
+class LoadedConfiguration;
 
 namespace directordaemon {
 class JobResource;
@@ -104,10 +104,10 @@ struct Resources {
 };
 
 struct DirectorJcrImpl {
-  DirectorJcrImpl( std::shared_ptr<ConfigResourcesContainer> configuration_resources_container) : job_config_resources_container_(configuration_resources_container) {
+  DirectorJcrImpl( std::shared_ptr<LoadedConfiguration> config) : used_config_for_job(config) {
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
-  std::shared_ptr<ConfigResourcesContainer> job_config_resources_container_;
+  std::shared_ptr<LoadedConfiguration> used_config_for_job;
   pthread_t SD_msg_chan{};        /**< Message channel thread id */
   bool SD_msg_chan_started{};     /**< Message channel thread started */
   std::condition_variable term_wait{}; /**< Wait for job termination */

--- a/core/src/dird/director_jcr_impl.h
+++ b/core/src/dird/director_jcr_impl.h
@@ -104,7 +104,7 @@ struct Resources {
 };
 
 struct DirectorJcrImpl {
-  DirectorJcrImpl( std::shared_ptr<LoadedConfiguration> config) : used_config_for_job(config) {
+  DirectorJcrImpl(std::shared_ptr<LoadedConfiguration> config) : used_config_for_job(std::move(config)) {
     RestoreJobId = 0; MigrateJobId = 0; VerifyJobId = 0;
   }
   std::shared_ptr<LoadedConfiguration> used_config_for_job;

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -27,14 +27,18 @@
 
 namespace directordaemon {
 
-JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr)
+JobControlRecord* NewDirectorJcr(
+    JCR_free_HANDLER* DirdFreeJcr,
+    std::shared_ptr<ConfigResourcesContainer> config)
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
-  jcr->dir_impl = new DirectorJcrImpl(my_config->config_resources_container_);
+  if (config) {
+    Dmsg1(10, "NewDirectorJcr: configuration_resources_ is at %p %s\n",
+          config->configuration_resources_.data(),
+          config->TimeStampAsString().c_str());
+  }
+  jcr->dir_impl = new DirectorJcrImpl(std::move(config));
   register_jcr(jcr);
-  Dmsg1(10, "NewDirectorJcr: configuration_resources_ is at %p %s\n",
-        my_config->config_resources_container_->configuration_resources_.data(),
-        my_config->config_resources_container_->TimeStampAsString().c_str());
   return jcr;
 }
 

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -24,8 +24,7 @@
 
 namespace directordaemon {
 
-JobControlRecord* NewDirectorJcr(
-    std::shared_ptr<ConfigResourcesContainer> config)
+JobControlRecord* NewDirectorJcr(std::shared_ptr<LoadedConfiguration> config)
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);
   if (config) {

--- a/core/src/dird/jcr_util.cc
+++ b/core/src/dird/jcr_util.cc
@@ -19,16 +19,12 @@
    02110-1301, USA.
 */
 
-#include "dird/dird_globals.h"
-#include "dird/director_jcr_impl.h"
-#include "lib/parse_bsr.h"
-#include "lib/parse_conf.h"
-
+#include "dird/jcr_util.h"
+#include "dird/job.h"
 
 namespace directordaemon {
 
 JobControlRecord* NewDirectorJcr(
-    JCR_free_HANDLER* DirdFreeJcr,
     std::shared_ptr<ConfigResourcesContainer> config)
 {
   JobControlRecord* jcr = new_jcr(DirdFreeJcr);

--- a/core/src/dird/jcr_util.h
+++ b/core/src/dird/jcr_util.h
@@ -30,9 +30,8 @@
 
 namespace directordaemon {
 
-JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr,
-                                 std::shared_ptr<ConfigResourcesContainer>
-                                 = my_config->GetResourcesContainer());
+JobControlRecord* NewDirectorJcr(
+    std::shared_ptr<ConfigResourcesContainer> conf);
 
 } /* namespace directordaemon */
 #endif  // BAREOS_DIRD_JCR_UTIL_H_

--- a/core/src/dird/jcr_util.h
+++ b/core/src/dird/jcr_util.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -22,11 +22,17 @@
 #ifndef BAREOS_DIRD_JCR_UTIL_H_
 #define BAREOS_DIRD_JCR_UTIL_H_
 
+#include "dird/dird_globals.h"
 #include "dird/director_jcr_impl.h"
+#include "lib/parse_conf.h"
+
+#include <memory>
 
 namespace directordaemon {
 
-JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr);
+JobControlRecord* NewDirectorJcr(JCR_free_HANDLER* DirdFreeJcr,
+                                 std::shared_ptr<ConfigResourcesContainer>
+                                 = my_config->GetResourcesContainer());
 
 } /* namespace directordaemon */
 #endif  // BAREOS_DIRD_JCR_UTIL_H_

--- a/core/src/dird/jcr_util.h
+++ b/core/src/dird/jcr_util.h
@@ -30,8 +30,7 @@
 
 namespace directordaemon {
 
-JobControlRecord* NewDirectorJcr(
-    std::shared_ptr<ConfigResourcesContainer> conf);
+JobControlRecord* NewDirectorJcr(std::shared_ptr<LoadedConfiguration> conf);
 
 } /* namespace directordaemon */
 #endif  // BAREOS_DIRD_JCR_UTIL_H_

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -640,7 +640,10 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
        * conflicts.  We now create a new job, copying the
        * appropriate fields. */
       jcr->setJobStatusWithPriorityCheck(JS_WaitStartTime);
-      njcr = NewDirectorJcr(DirdFreeJcr);
+
+      // we reuse the pointers of jcr, so we need to save its config
+      njcr = NewDirectorJcr(DirdFreeJcr,
+                            jcr->dir_impl->job_config_resources_container_);
       SetJcrDefaults(njcr, jcr->dir_impl->res.job);
       njcr->dir_impl->reschedule_count = jcr->dir_impl->reschedule_count;
       njcr->sched_time = jcr->sched_time;

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -642,7 +642,7 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
       jcr->setJobStatusWithPriorityCheck(JS_WaitStartTime);
 
       // we reuse the pointers of jcr, so we need to save its config
-      njcr = NewDirectorJcr(jcr->dir_impl->job_config_resources_container_);
+      njcr = NewDirectorJcr(jcr->dir_impl->used_config_for_job);
       SetJcrDefaults(njcr, jcr->dir_impl->res.job);
       njcr->dir_impl->reschedule_count = jcr->dir_impl->reschedule_count;
       njcr->sched_time = jcr->sched_time;

--- a/core/src/dird/jobq.cc
+++ b/core/src/dird/jobq.cc
@@ -642,8 +642,7 @@ static bool RescheduleJob(JobControlRecord* jcr, jobq_t* jq, jobq_item_t* je)
       jcr->setJobStatusWithPriorityCheck(JS_WaitStartTime);
 
       // we reuse the pointers of jcr, so we need to save its config
-      njcr = NewDirectorJcr(DirdFreeJcr,
-                            jcr->dir_impl->job_config_resources_container_);
+      njcr = NewDirectorJcr(jcr->dir_impl->job_config_resources_container_);
       SetJcrDefaults(njcr, jcr->dir_impl->res.job);
       njcr->dir_impl->reschedule_count = jcr->dir_impl->reschedule_count;
       njcr->sched_time = jcr->sched_time;

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1000,7 +1000,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
   JobControlRecord* mig_jcr = NULL; /* newly migrated job */
 
   ApplyPoolOverrides(jcr);
-  auto used_config = my_config->config_resources_container_;
+  auto used_config = my_config->loaded_configuration;
 
   if (!AllowDuplicateJob(jcr)) { return false; }
 

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1000,6 +1000,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
   JobControlRecord* mig_jcr = NULL; /* newly migrated job */
 
   ApplyPoolOverrides(jcr);
+  auto used_config = my_config->config_resources_container_;
 
   if (!AllowDuplicateJob(jcr)) { return false; }
 
@@ -1119,7 +1120,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
     }
 
     // Create a migration jcr
-    mig_jcr = NewDirectorJcr(DirdFreeJcr);
+    mig_jcr = NewDirectorJcr(DirdFreeJcr, used_config);
     jcr->dir_impl->mig_jcr = mig_jcr;
     mig_jcr->dir_impl->previous_jr = prev_jr;
 

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1000,7 +1000,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
   JobControlRecord* mig_jcr = NULL; /* newly migrated job */
 
   ApplyPoolOverrides(jcr);
-  auto used_config = my_config->loaded_configuration;
+  auto used_config = my_config->GetCurrentConfiguration();
 
   if (!AllowDuplicateJob(jcr)) { return false; }
 

--- a/core/src/dird/migrate.cc
+++ b/core/src/dird/migrate.cc
@@ -1120,7 +1120,7 @@ bool DoMigrationInit(JobControlRecord* jcr)
     }
 
     // Create a migration jcr
-    mig_jcr = NewDirectorJcr(DirdFreeJcr, used_config);
+    mig_jcr = NewDirectorJcr(used_config);
     jcr->dir_impl->mig_jcr = mig_jcr;
     mig_jcr->dir_impl->previous_jr = prev_jr;
 

--- a/core/src/dird/reload.cc
+++ b/core/src/dird/reload.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -200,7 +200,7 @@ bool DoReloadConfig()
 
   DbSqlPoolFlush();
 
-  auto backup_container = my_config->BackupResourcesContainer();
+  auto backup_container = my_config->BackupCurrentConfiguration();
   Dmsg0(100, "Reloading config file\n");
 
 
@@ -216,14 +216,14 @@ bool DoReloadConfig()
 
     // make sure that jobs that keep the last configuration alive
     // also keep alive this config in case they (accidentally) access it.
-    backup_container->SetNext(my_config->GetResourcesContainer());
+    backup_container->SetNext(my_config->GetCurrentConfiguration());
 
     Dmsg0(10, "Director's configuration file reread successfully.\n");
   } else {  // parse config failed
     Jmsg(nullptr, M_ERROR, 0, T_("Please correct the configuration in %s\n"),
          my_config->get_base_config_path().c_str());
     Jmsg(nullptr, M_ERROR, 0, T_("Resetting to previous configuration.\n"));
-    my_config->RestoreResourcesContainer(std::move(backup_container));
+    my_config->RestoreConfiguration(std::move(backup_container));
     // me is changed above by CheckResources()
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
     assert(me);

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -41,7 +41,7 @@ RunOnIncomingConnectInterval::RunOnIncomingConnectInterval(
     std::string client_name)
     : client_name_(std::move(client_name))
     , scheduler_(Scheduler::GetMainScheduler())
-    , used_config_{my_config->GetResourcesContainer()}
+    , used_config_{my_config->GetCurrentConfiguration()}
 {
   // initialize database by job settings
 }

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -21,6 +21,7 @@
    02110-1301, USA.
 */
 
+#include "dird/dird_globals.h"
 #include "include/bareos.h"
 #include "cats/cats.h"
 #include "dird/dird_conf.h"
@@ -40,6 +41,7 @@ RunOnIncomingConnectInterval::RunOnIncomingConnectInterval(
     std::string client_name)
     : client_name_(std::move(client_name))
     , scheduler_(Scheduler::GetMainScheduler())
+    , used_config_{my_config->GetResourcesContainer()}
 {
   // initialize database by job settings
 }
@@ -48,14 +50,17 @@ RunOnIncomingConnectInterval::RunOnIncomingConnectInterval(
     std::string client_name,
     Scheduler& scheduler,
     BareosDb* db)
-    : client_name_(std::move(client_name)), scheduler_(scheduler), db_(db)
+    : client_name_(std::move(client_name))
+    , scheduler_(scheduler)
+    , db_(db)
+    , used_config_{my_config->GetCurrentConfiguration()}
 {
   // constructor used for tests to inject mocked scheduler and database
 }
 
 time_t RunOnIncomingConnectInterval::FindLastJobStart(JobResource* job)
 {
-  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr);
+  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr, used_config_);
   SetJcrDefaults(jcr, job);
   auto db = db_ != nullptr ? db_ : GetDatabaseConnection(jcr);
   if (db == nullptr) {
@@ -125,7 +130,7 @@ void RunOnIncomingConnectInterval::RunJobIfIntervalExceeded(
 void RunOnIncomingConnectInterval::Run()
 {
   std::vector<JobResource*> job_resources
-      = GetAllJobResourcesByClientName(client_name_);
+      = GetAllJobResourcesByClientName(used_config_.get(), client_name_);
 
   if (job_resources.empty()) { return; }
 

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -60,7 +60,7 @@ RunOnIncomingConnectInterval::RunOnIncomingConnectInterval(
 
 time_t RunOnIncomingConnectInterval::FindLastJobStart(JobResource* job)
 {
-  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr, used_config_);
+  JobControlRecord* jcr = NewDirectorJcr(used_config_);
   SetJcrDefaults(jcr, job);
   auto db = db_ != nullptr ? db_ : GetDatabaseConnection(jcr);
   if (db == nullptr) {

--- a/core/src/dird/run_on_incoming_connect_interval.cc
+++ b/core/src/dird/run_on_incoming_connect_interval.cc
@@ -123,7 +123,8 @@ void RunOnIncomingConnectInterval::RunJobIfIntervalExceeded(
 
   if (!job_ran_before || interval_time_exceeded) {
     Dmsg1(800, "Add job %s to scheduler queue.\n", job->resource_name_);
-    scheduler_.AddJobWithNoRunResourceToQueue(job, JobTrigger::kClient);
+    scheduler_.AddJobWithNoRunResourceToQueue(used_config_, job,
+                                              JobTrigger::kClient);
   }
 }
 

--- a/core/src/dird/run_on_incoming_connect_interval.h
+++ b/core/src/dird/run_on_incoming_connect_interval.h
@@ -60,7 +60,7 @@ class RunOnIncomingConnectInterval {
   std::string client_name_;
   Scheduler& scheduler_;
   BareosDb* db_{nullptr};
-  std::shared_ptr<ConfigResourcesContainer> used_config_;
+  std::shared_ptr<LoadedConfiguration> used_config_;
 };
 
 }  // namespace directordaemon

--- a/core/src/dird/run_on_incoming_connect_interval.h
+++ b/core/src/dird/run_on_incoming_connect_interval.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2019-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,7 @@
 #define BAREOS_DIRD_RUN_ON_INCOMING_CONNECT_INTERVAL_H_
 
 #include <string>
+#include "lib/parse_conf.h"
 
 class BareosDb;
 
@@ -59,6 +60,7 @@ class RunOnIncomingConnectInterval {
   std::string client_name_;
   Scheduler& scheduler_;
   BareosDb* db_{nullptr};
+  std::shared_ptr<ConfigResourcesContainer> used_config_;
 };
 
 }  // namespace directordaemon

--- a/core/src/dird/scheduler.cc
+++ b/core/src/dird/scheduler.cc
@@ -56,8 +56,7 @@ Scheduler& Scheduler::GetMainScheduler() noexcept
   return scheduler;
 }
 
-Scheduler::Scheduler() noexcept
-    : impl_(std::make_unique<SchedulerPrivate>()) {};
+Scheduler::Scheduler() noexcept : impl_(std::make_unique<SchedulerPrivate>()) {}
 
 Scheduler::Scheduler(std::unique_ptr<SchedulerTimeAdapter> time_adapter,
                      std::function<void(JobControlRecord*)> ExecuteJob) noexcept

--- a/core/src/dird/scheduler.cc
+++ b/core/src/dird/scheduler.cc
@@ -70,7 +70,7 @@ Scheduler::Scheduler(std::unique_ptr<SchedulerTimeAdapter> time_adapter,
 Scheduler::~Scheduler() = default;
 
 void Scheduler::AddJobWithNoRunResourceToQueue(
-    std::shared_ptr<ConfigResourcesContainer> config,
+    std::shared_ptr<LoadedConfiguration> config,
     JobResource* job,
     JobTrigger job_trigger)
 {

--- a/core/src/dird/scheduler.cc
+++ b/core/src/dird/scheduler.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -56,7 +56,8 @@ Scheduler& Scheduler::GetMainScheduler() noexcept
   return scheduler;
 }
 
-Scheduler::Scheduler() noexcept : impl_(std::make_unique<SchedulerPrivate>()){};
+Scheduler::Scheduler() noexcept
+    : impl_(std::make_unique<SchedulerPrivate>()) {};
 
 Scheduler::Scheduler(std::unique_ptr<SchedulerTimeAdapter> time_adapter,
                      std::function<void(JobControlRecord*)> ExecuteJob) noexcept
@@ -68,10 +69,12 @@ Scheduler::Scheduler(std::unique_ptr<SchedulerTimeAdapter> time_adapter,
 
 Scheduler::~Scheduler() = default;
 
-void Scheduler::AddJobWithNoRunResourceToQueue(JobResource* job,
-                                               JobTrigger job_trigger)
+void Scheduler::AddJobWithNoRunResourceToQueue(
+    std::shared_ptr<ConfigResourcesContainer> config,
+    JobResource* job,
+    JobTrigger job_trigger)
 {
-  impl_->AddJobWithNoRunResourceToQueue(job, job_trigger);
+  impl_->AddJobWithNoRunResourceToQueue(std::move(config), job, job_trigger);
 }
 
 void Scheduler::Run()

--- a/core/src/dird/scheduler.h
+++ b/core/src/dird/scheduler.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,7 @@
 #define BAREOS_DIRD_SCHEDULER_H_
 
 #include "dird/job_trigger.h"
+#include "lib/parse_conf.h"
 
 #include <memory>
 #include <functional>
@@ -47,7 +48,10 @@ class Scheduler {
   void Run();
   void Terminate();
   void ClearQueue();
-  void AddJobWithNoRunResourceToQueue(JobResource* job, JobTrigger job_trigger);
+  void AddJobWithNoRunResourceToQueue(
+      std::shared_ptr<ConfigResourcesContainer> config,
+      JobResource* job,
+      JobTrigger job_trigger);
   static Scheduler& GetMainScheduler() noexcept;
 
  private:

--- a/core/src/dird/scheduler.h
+++ b/core/src/dird/scheduler.h
@@ -49,7 +49,7 @@ class Scheduler {
   void Terminate();
   void ClearQueue();
   void AddJobWithNoRunResourceToQueue(
-      std::shared_ptr<ConfigResourcesContainer> config,
+      std::shared_ptr<LoadedConfiguration> config,
       JobResource* job,
       JobTrigger job_trigger);
   static Scheduler& GetMainScheduler() noexcept;

--- a/core/src/dird/scheduler_job_item_queue.cc
+++ b/core/src/dird/scheduler_job_item_queue.cc
@@ -83,7 +83,7 @@ SchedulerJobItem SchedulerJobItemQueue::TopItem() const
 }
 
 void SchedulerJobItemQueue::EmplaceItem(
-    std::shared_ptr<ConfigResourcesContainer> conf,
+    std::shared_ptr<LoadedConfiguration> conf,
     JobResource* job,
     RunResource* run,
     time_t runtime,

--- a/core/src/dird/scheduler_job_item_queue.cc
+++ b/core/src/dird/scheduler_job_item_queue.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2022 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -21,6 +21,7 @@
 
 #include "include/bareos.h"
 #include "dird/dird_conf.h"
+#include "lib/parse_conf.h"
 #include "scheduler_job_item_queue.h"
 
 #include <iostream>
@@ -81,11 +82,14 @@ SchedulerJobItem SchedulerJobItemQueue::TopItem() const
   return job_item_with_highest_priority;
 }
 
-void SchedulerJobItemQueue::EmplaceItem(JobResource* job,
-                                        RunResource* run,
-                                        time_t runtime,
-                                        JobTrigger job_trigger)
+void SchedulerJobItemQueue::EmplaceItem(
+    std::shared_ptr<ConfigResourcesContainer> conf,
+    JobResource* job,
+    RunResource* run,
+    time_t runtime,
+    JobTrigger job_trigger)
 {
+  if (!conf) { throw std::invalid_argument("Invalid Argument: conf is NULL"); }
   if (job == nullptr) {
     throw std::invalid_argument("Invalid Argument: JobResource is undefined");
   }
@@ -97,7 +101,8 @@ void SchedulerJobItemQueue::EmplaceItem(JobResource* job,
                      : default_priority;
 
   std::lock_guard<std::mutex> lg(impl_->mutex);
-  impl_->priority_queue.emplace(job, run, runtime, priority, job_trigger);
+  impl_->priority_queue.emplace(std::move(conf), job, run, runtime, priority,
+                                job_trigger);
 }
 
 bool SchedulerJobItemQueue::Empty() const

--- a/core/src/dird/scheduler_job_item_queue.h
+++ b/core/src/dird/scheduler_job_item_queue.h
@@ -52,7 +52,7 @@ struct SchedulerJobItem {
       , job_trigger(job_kickoff_in)
   {
     is_valid = job && runtime;
-  };
+  }
 
   bool operator==(const SchedulerJobItem& rhs) const
   {

--- a/core/src/dird/scheduler_job_item_queue.h
+++ b/core/src/dird/scheduler_job_item_queue.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -24,6 +24,7 @@
 
 #include "include/bareos.h"
 #include "dird/job_trigger.h"
+#include "lib/parse_conf.h"
 
 #include <memory>
 #include <queue>
@@ -36,20 +37,15 @@ class JobResource;
 struct SchedulerJobItemQueuePrivate;
 
 struct SchedulerJobItem {
-  ~SchedulerJobItem() = default;
-
   SchedulerJobItem() = default;
-  SchedulerJobItem(const SchedulerJobItem& other) = default;
-  SchedulerJobItem(SchedulerJobItem&& other) = default;
-  SchedulerJobItem& operator=(const SchedulerJobItem& other) = default;
-  SchedulerJobItem& operator=(SchedulerJobItem&& other) = default;
-
-  SchedulerJobItem(JobResource* job_in,
+  SchedulerJobItem(std::shared_ptr<ConfigResourcesContainer> config,
+                   JobResource* job_in,
                    RunResource* run_in,
                    time_t runtime_in,
                    int priority_in,
                    JobTrigger job_kickoff_in) noexcept
-      : job(job_in)
+      : container{std::move(config)}
+      , job(job_in)
       , run(run_in)
       , runtime(runtime_in)
       , priority(priority_in)
@@ -64,8 +60,7 @@ struct SchedulerJobItem {
            && run == rhs.run;
   }
 
-  bool operator!=(const SchedulerJobItem& rhs) const { return !(*this == rhs); }
-
+  std::shared_ptr<ConfigResourcesContainer> container{};
   JobResource* job{nullptr};
   RunResource* run{nullptr};
   time_t runtime{0};
@@ -81,7 +76,8 @@ class SchedulerJobItemQueue {
 
   SchedulerJobItem TopItem() const;
   SchedulerJobItem TakeOutTopItem();
-  void EmplaceItem(JobResource* job,
+  void EmplaceItem(std::shared_ptr<ConfigResourcesContainer> conf,
+                   JobResource* job,
                    RunResource* run,
                    time_t runtime,
                    JobTrigger job_trigger);

--- a/core/src/dird/scheduler_job_item_queue.h
+++ b/core/src/dird/scheduler_job_item_queue.h
@@ -38,13 +38,13 @@ struct SchedulerJobItemQueuePrivate;
 
 struct SchedulerJobItem {
   SchedulerJobItem() = default;
-  SchedulerJobItem(std::shared_ptr<ConfigResourcesContainer> config,
+  SchedulerJobItem(std::shared_ptr<LoadedConfiguration> config_to_use,
                    JobResource* job_in,
                    RunResource* run_in,
                    time_t runtime_in,
                    int priority_in,
                    JobTrigger job_kickoff_in) noexcept
-      : container{std::move(config)}
+      : config{std::move(config_to_use)}
       , job(job_in)
       , run(run_in)
       , runtime(runtime_in)
@@ -60,7 +60,7 @@ struct SchedulerJobItem {
            && run == rhs.run;
   }
 
-  std::shared_ptr<ConfigResourcesContainer> container{};
+  std::shared_ptr<LoadedConfiguration> config{};
   JobResource* job{nullptr};
   RunResource* run{nullptr};
   time_t runtime{0};
@@ -76,7 +76,7 @@ class SchedulerJobItemQueue {
 
   SchedulerJobItem TopItem() const;
   SchedulerJobItem TakeOutTopItem();
-  void EmplaceItem(std::shared_ptr<ConfigResourcesContainer> conf,
+  void EmplaceItem(std::shared_ptr<LoadedConfiguration> conf,
                    JobResource* job,
                    RunResource* run,
                    time_t runtime,

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -127,7 +127,7 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
 JobControlRecord* SchedulerPrivate::TryCreateJobControlRecord(
     const SchedulerJobItem& next_job)
 {
-  JobControlRecord* jcr = NewDirectorJcr(next_job.container);
+  JobControlRecord* jcr = NewDirectorJcr(next_job.config);
   SetJcrDefaults(jcr, next_job.job);
   if (next_job.run != nullptr) {
     next_job.run->scheduled_last = time_adapter->time_source_->SystemTime();
@@ -201,7 +201,7 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
   date_time_next_hour.PrintDebugMessage(local_debuglevel);
 
   JobResource* job = nullptr;
-  auto used_conf = my_config->config_resources_container_;
+  auto used_conf = my_config->loaded_configuration;
 
   foreach_res (job, R_JOB) {
     if (!IsAutomaticSchedulerJob(job)) { continue; }
@@ -236,7 +236,7 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
 }
 
 void SchedulerPrivate::AddJobToQueue(
-    std::shared_ptr<ConfigResourcesContainer> config,
+    std::shared_ptr<LoadedConfiguration> config,
     JobResource* job,
     RunResource* run,
     time_t now,
@@ -265,7 +265,7 @@ void SchedulerPrivate::AddJobToQueue(
 }
 
 void SchedulerPrivate::AddJobWithNoRunResourceToQueue(
-    std::shared_ptr<ConfigResourcesContainer> config,
+    std::shared_ptr<LoadedConfiguration> config,
     JobResource* job,
     JobTrigger job_trigger)
 {

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -127,7 +127,7 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
 JobControlRecord* SchedulerPrivate::TryCreateJobControlRecord(
     const SchedulerJobItem& next_job)
 {
-  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr, next_job.container);
+  JobControlRecord* jcr = NewDirectorJcr(next_job.container);
   SetJcrDefaults(jcr, next_job.job);
   if (next_job.run != nullptr) {
     next_job.run->scheduled_last = time_adapter->time_source_->SystemTime();

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -127,7 +127,7 @@ static void SetJcrFromRunResource(JobControlRecord* jcr, RunResource* run)
 JobControlRecord* SchedulerPrivate::TryCreateJobControlRecord(
     const SchedulerJobItem& next_job)
 {
-  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr);
+  JobControlRecord* jcr = NewDirectorJcr(DirdFreeJcr, next_job.container);
   SetJcrDefaults(jcr, next_job.job);
   if (next_job.run != nullptr) {
     next_job.run->scheduled_last = time_adapter->time_source_->SystemTime();
@@ -201,6 +201,7 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
   date_time_next_hour.PrintDebugMessage(local_debuglevel);
 
   JobResource* job = nullptr;
+  auto used_conf = my_config->config_resources_container_;
 
   foreach_res (job, R_JOB) {
     if (!IsAutomaticSchedulerJob(job)) { continue; }
@@ -220,11 +221,11 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
       if (run_this_hour || run_next_hour) {
         time_t runtime = CalculateRuntime(date_time_now.time, run->minute);
         if (run_this_hour) {
-          AddJobToQueue(job, run, date_time_now.time, runtime,
+          AddJobToQueue(used_conf, job, run, date_time_now.time, runtime,
                         JobTrigger::kScheduler);
         }
         if (run_next_hour) {
-          AddJobToQueue(job, run, date_time_now.time,
+          AddJobToQueue(used_conf, job, run, date_time_now.time,
                         runtime + seconds_per_hour.count(),
                         JobTrigger::kScheduler);
         }
@@ -234,11 +235,13 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
   Dmsg0(local_debuglevel, "Finished AddJobsForThisAndNextHourToQueue\n");
 }
 
-void SchedulerPrivate::AddJobToQueue(JobResource* job,
-                                     RunResource* run,
-                                     time_t now,
-                                     time_t runtime,
-                                     JobTrigger job_trigger)
+void SchedulerPrivate::AddJobToQueue(
+    std::shared_ptr<ConfigResourcesContainer> config,
+    JobResource* job,
+    RunResource* run,
+    time_t now,
+    time_t runtime,
+    JobTrigger job_trigger)
 {
   Dmsg1(local_debuglevel + 100, "Scheduler: Try AddJobToQueue %s.\n",
         job->resource_name_);
@@ -253,18 +256,21 @@ void SchedulerPrivate::AddJobToQueue(JobResource* job,
     Dmsg1(local_debuglevel + 100, "Scheduler: Put job %s into queue.\n",
           job->resource_name_);
 
-    prioritised_job_item_queue.EmplaceItem(job, run, runtime, job_trigger);
+    prioritised_job_item_queue.EmplaceItem(std::move(config), job, run, runtime,
+                                           job_trigger);
 
   } catch (const std::invalid_argument& e) {
     Dmsg1(local_debuglevel + 100, "Could not emplace job: %s\n", e.what());
   }
 }
 
-void SchedulerPrivate::AddJobWithNoRunResourceToQueue(JobResource* job,
-                                                      JobTrigger job_trigger)
+void SchedulerPrivate::AddJobWithNoRunResourceToQueue(
+    std::shared_ptr<ConfigResourcesContainer> config,
+    JobResource* job,
+    JobTrigger job_trigger)
 {
   time_t now = time_adapter->time_source_->SystemTime();
-  AddJobToQueue(job, nullptr, now, now, job_trigger);
+  AddJobToQueue(std::move(config), job, nullptr, now, now, job_trigger);
 }
 
 class DefaultSchedulerTimeAdapter : public SchedulerTimeAdapter {

--- a/core/src/dird/scheduler_private.cc
+++ b/core/src/dird/scheduler_private.cc
@@ -201,7 +201,7 @@ void SchedulerPrivate::AddJobsForThisAndNextHourToQueue()
   date_time_next_hour.PrintDebugMessage(local_debuglevel);
 
   JobResource* job = nullptr;
-  auto used_conf = my_config->loaded_configuration;
+  auto used_conf = my_config->GetCurrentConfiguration();
 
   foreach_res (job, R_JOB) {
     if (!IsAutomaticSchedulerJob(job)) { continue; }

--- a/core/src/dird/scheduler_private.h
+++ b/core/src/dird/scheduler_private.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2021 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -25,6 +25,7 @@
 #define BAREOS_DIRD_SCHEDULER_PRIVATE_H_
 
 #include "dird/scheduler_job_item_queue.h"
+#include "lib/parse_conf.h"
 
 #include <atomic>
 #include <functional>
@@ -46,7 +47,10 @@ class SchedulerPrivate {
 
   void WaitForJobsToRun();
   void FillSchedulerJobQueueOrSleep();
-  void AddJobWithNoRunResourceToQueue(JobResource* job, JobTrigger job_trigger);
+  void AddJobWithNoRunResourceToQueue(
+      std::shared_ptr<ConfigResourcesContainer> config,
+      JobResource* job,
+      JobTrigger job_trigger);
 
   std::unique_ptr<SchedulerTimeAdapter> time_adapter;
   SchedulerJobItemQueue prioritised_job_item_queue;
@@ -60,7 +64,8 @@ class SchedulerPrivate {
   std::function<void(JobControlRecord*)> ExecuteJobCallback_;
   JobControlRecord* TryCreateJobControlRecord(const SchedulerJobItem& next_job);
   void AddJobsForThisAndNextHourToQueue();
-  void AddJobToQueue(JobResource* job,
+  void AddJobToQueue(std::shared_ptr<ConfigResourcesContainer> config,
+                     JobResource* job,
                      RunResource* run,
                      time_t now,
                      time_t runtime,

--- a/core/src/dird/scheduler_private.h
+++ b/core/src/dird/scheduler_private.h
@@ -48,7 +48,7 @@ class SchedulerPrivate {
   void WaitForJobsToRun();
   void FillSchedulerJobQueueOrSleep();
   void AddJobWithNoRunResourceToQueue(
-      std::shared_ptr<ConfigResourcesContainer> config,
+      std::shared_ptr<LoadedConfiguration> config,
       JobResource* job,
       JobTrigger job_trigger);
 
@@ -64,7 +64,7 @@ class SchedulerPrivate {
   std::function<void(JobControlRecord*)> ExecuteJobCallback_;
   JobControlRecord* TryCreateJobControlRecord(const SchedulerJobItem& next_job);
   void AddJobsForThisAndNextHourToQueue();
-  void AddJobToQueue(std::shared_ptr<ConfigResourcesContainer> config,
+  void AddJobToQueue(std::shared_ptr<LoadedConfiguration> config,
                      JobResource* job,
                      RunResource* run,
                      time_t now,

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -1524,7 +1524,7 @@ static bool ListNextvol(UaContext* ua, int ndays)
     if ((job = select_job_resource(ua)) == NULL) { return false; }
   }
 
-  jcr = NewDirectorJcr(DirdFreeJcr, used_config);
+  jcr = NewDirectorJcr(used_config);
   time_t now = time(NULL);
   bool found = false;
   if (job->schedule) {

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -395,10 +395,9 @@ static void ShowDisabledSchedules(UaContext* ua)
 static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
 {
   for (int j = 0; j <= my_config->r_num_ - 1; j++) {
-    if (my_config->config_resources_container_->configuration_resources_[j]) {
+    if (my_config->loaded_configuration->configuration_resources_[j]) {
       my_config->DumpResourceCb_(
-          j,
-          my_config->config_resources_container_->configuration_resources_[j],
+          j, my_config->loaded_configuration->configuration_resources_[j],
           bsendmsg, ua, hide_sensitive_data, verbose);
     }
   }
@@ -478,8 +477,7 @@ bool show_cmd(UaContext* ua, const char*)
       for (const auto& command : show_cmd_available_resources) {
         if (bstrncasecmp(res_name, command.first, len)) {
           type = command.second;
-          res = my_config->config_resources_container_
-                    ->configuration_resources_[type];
+          res = my_config->loaded_configuration->configuration_resources_[type];
           break;
         }
       }
@@ -1513,7 +1511,7 @@ static bool ListNextvol(UaContext* ua, int ndays)
   JobResource* job{nullptr};
   JobControlRecord* jcr;
   UnifiedStorageResource store;
-  auto used_config = my_config->GetResourcesContainer();
+  auto used_config = my_config->GetCurrentConfiguration();
   if (const char* job_name = GetArgValue(ua, "job")) {
     job = ua->GetJobResWithName(job_name);
     if (!job) {

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -1513,6 +1513,7 @@ static bool ListNextvol(UaContext* ua, int ndays)
   JobResource* job{nullptr};
   JobControlRecord* jcr;
   UnifiedStorageResource store;
+  auto used_config = my_config->GetResourcesContainer();
   if (const char* job_name = GetArgValue(ua, "job")) {
     job = ua->GetJobResWithName(job_name);
     if (!job) {
@@ -1523,7 +1524,7 @@ static bool ListNextvol(UaContext* ua, int ndays)
     if ((job = select_job_resource(ua)) == NULL) { return false; }
   }
 
-  jcr = NewDirectorJcr(DirdFreeJcr);
+  jcr = NewDirectorJcr(DirdFreeJcr, used_config);
   time_t now = time(NULL);
   bool found = false;
   if (job->schedule) {

--- a/core/src/dird/ua_output.cc
+++ b/core/src/dird/ua_output.cc
@@ -394,11 +394,11 @@ static void ShowDisabledSchedules(UaContext* ua)
 // Enter with Resources locked
 static void ShowAll(UaContext* ua, bool hide_sensitive_data, bool verbose)
 {
+  auto conf = my_config->GetCurrentConfiguration();
   for (int j = 0; j <= my_config->r_num_ - 1; j++) {
-    if (my_config->loaded_configuration->configuration_resources_[j]) {
-      my_config->DumpResourceCb_(
-          j, my_config->loaded_configuration->configuration_resources_[j],
-          bsendmsg, ua, hide_sensitive_data, verbose);
+    if (conf->configuration_resources_[j]) {
+      my_config->DumpResourceCb_(j, conf->configuration_resources_[j], bsendmsg,
+                                 ua, hide_sensitive_data, verbose);
     }
   }
 }
@@ -474,10 +474,11 @@ bool show_cmd(UaContext* ua, const char*)
     if (!ua->argv[i]) { /* was a name given? */
       // No name, dump all resources of specified type
       recurse = 1;
+      auto conf = my_config->GetCurrentConfiguration();
       for (const auto& command : show_cmd_available_resources) {
         if (bstrncasecmp(res_name, command.first, len)) {
           type = command.second;
-          res = my_config->loaded_configuration->configuration_resources_[type];
+          res = conf->configuration_resources_[type];
           break;
         }
       }

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -384,7 +384,7 @@ int DoRunCmd(UaContext* ua, const char*)
 
   /* Create JobControlRecord to run job.  NOTE!!! after this point, FreeJcr()
    * before returning. */
-  auto* jcr = NewDirectorJcr(DirdFreeJcr, used_config);
+  auto* jcr = NewDirectorJcr(used_config);
   SetJcrDefaults(jcr, rc.job);
   jcr->dir_impl->unlink_bsr
       = ua->jcr->dir_impl->unlink_bsr; /* copy unlink flag from caller */

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -24,6 +24,7 @@
  * @file
  * BAREOS Director -- Run Command
  */
+#include "dird/dird_globals.h"
 #include "include/bareos.h"
 #include "dird.h"
 #include "dird/director_jcr_impl.h"
@@ -370,11 +371,12 @@ bool reRunCmd(UaContext* ua, const char*)
  */
 int DoRunCmd(UaContext* ua, const char*)
 {
-  JobControlRecord* jcr = NULL;
   RunContext rc;
   int status, length;
   bool valid_response;
   bool do_pool_overrides = true;
+
+  auto used_config = my_config->config_resources_container_;
 
   if (!OpenClientDb(ua)) { return 0; }
 
@@ -382,13 +384,11 @@ int DoRunCmd(UaContext* ua, const char*)
 
   /* Create JobControlRecord to run job.  NOTE!!! after this point, FreeJcr()
    * before returning. */
-  if (!jcr) {
-    jcr = NewDirectorJcr(DirdFreeJcr);
-    SetJcrDefaults(jcr, rc.job);
-    jcr->dir_impl->unlink_bsr
-        = ua->jcr->dir_impl->unlink_bsr; /* copy unlink flag from caller */
-    ua->jcr->dir_impl->unlink_bsr = false;
-  }
+  auto* jcr = NewDirectorJcr(DirdFreeJcr, used_config);
+  SetJcrDefaults(jcr, rc.job);
+  jcr->dir_impl->unlink_bsr
+      = ua->jcr->dir_impl->unlink_bsr; /* copy unlink flag from caller */
+  ua->jcr->dir_impl->unlink_bsr = false;
 
   // Transfer JobIds to new restore Job
   if (ua->jcr->JobIds) {

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -376,7 +376,7 @@ int DoRunCmd(UaContext* ua, const char*)
   bool valid_response;
   bool do_pool_overrides = true;
 
-  auto used_config = my_config->config_resources_container_;
+  auto used_config = my_config->loaded_configuration;
 
   if (!OpenClientDb(ua)) { return 0; }
 

--- a/core/src/dird/ua_run.cc
+++ b/core/src/dird/ua_run.cc
@@ -376,7 +376,7 @@ int DoRunCmd(UaContext* ua, const char*)
   bool valid_response;
   bool do_pool_overrides = true;
 
-  auto used_config = my_config->loaded_configuration;
+  auto used_config = my_config->GetCurrentConfiguration();
 
   if (!OpenClientDb(ua)) { return 0; }
 

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -59,7 +59,7 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
   if (job_type == JT_SYSTEM) {
     jcr = NewDirectorJcr({});
   } else {
-    auto conf = my_config->loaded_configuration;
+    auto conf = my_config->GetCurrentConfiguration();
     jcr = NewDirectorJcr(conf);
 
     /* The job and defaults are not really used, but we set them up to ensure

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -57,10 +57,10 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 
   // exclude JT_SYSTEM job from shared config counting
   if (job_type == JT_SYSTEM) {
-    jcr = NewDirectorJcr(DirdFreeJcr, {});
+    jcr = NewDirectorJcr({});
   } else {
     auto conf = my_config->config_resources_container_;
-    jcr = NewDirectorJcr(DirdFreeJcr, conf);
+    jcr = NewDirectorJcr(conf);
 
     /* The job and defaults are not really used, but we set them up to ensure
      * that everything is correctly initialized. */

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -59,7 +59,7 @@ JobControlRecord* new_control_jcr(const char* base_name, int job_type)
   if (job_type == JT_SYSTEM) {
     jcr = NewDirectorJcr({});
   } else {
-    auto conf = my_config->config_resources_container_;
+    auto conf = my_config->loaded_configuration;
     jcr = NewDirectorJcr(conf);
 
     /* The job and defaults are not really used, but we set them up to ensure

--- a/core/src/dird/ua_server.cc
+++ b/core/src/dird/ua_server.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2007 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2023 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -54,18 +54,19 @@ namespace directordaemon {
 JobControlRecord* new_control_jcr(const char* base_name, int job_type)
 {
   JobControlRecord* jcr;
-  jcr = NewDirectorJcr(DirdFreeJcr);
 
   // exclude JT_SYSTEM job from shared config counting
   if (job_type == JT_SYSTEM) {
-    jcr->dir_impl->job_config_resources_container_ = nullptr;
-  }
+    jcr = NewDirectorJcr(DirdFreeJcr, {});
+  } else {
+    auto conf = my_config->config_resources_container_;
+    jcr = NewDirectorJcr(DirdFreeJcr, conf);
 
-  /* The job and defaults are not really used, but we set them up to ensure that
-   * everything is correctly initialized. */
-  {
-    ResLocker _{my_config};
-    jcr->dir_impl->res.job = (JobResource*)my_config->GetNextRes(R_JOB, NULL);
+    /* The job and defaults are not really used, but we set them up to ensure
+     * that everything is correctly initialized. */
+    jcr->dir_impl->res.job
+        = dynamic_cast<JobResource*>(conf->GetNextRes(R_JOB, NULL));
+    ASSERT(jcr->dir_impl->res.job);
     SetJcrDefaults(jcr, jcr->dir_impl->res.job);
   }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -530,7 +530,12 @@ ConfigurationParser::BackupCurrentConfiguration()
 std::shared_ptr<LoadedConfiguration>
 ConfigurationParser::GetCurrentConfiguration()
 {
-  return loaded_configuration;
+  std::shared_ptr<LoadedConfiguration> ptr;
+  {
+    ResLocker _{this};
+    ptr = loaded_configuration;
+  }
+  return ptr;
 }
 
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -122,7 +122,7 @@ ConfigurationParser::ConfigurationParser(
   // config resources container needs to access our members, so this
   // needs to always happen after we initialised everything else
   config_resources_container_
-      = std::make_shared<ConfigResourcesContainer>(this);
+      = std::make_shared<ConfigResourcesContainer>(FreeResourceCb_, r_num_);
 }
 
 std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
@@ -524,7 +524,7 @@ ConfigurationParser::BackupResourcesContainer()
 {
   auto backup_table = config_resources_container_;
   config_resources_container_
-      = std::make_shared<ConfigResourcesContainer>(this);
+      = std::make_shared<ConfigResourcesContainer>(FreeResourceCb_, r_num_);
   return backup_table;
 }
 

--- a/core/src/lib/parse_conf.cc
+++ b/core/src/lib/parse_conf.cc
@@ -119,10 +119,10 @@ ConfigurationParser::ConfigurationParser(
   DumpResourceCb_ = DumpResourceCb;
   FreeResourceCb_ = FreeResourceCb;
 
-  // config resources container needs to access our members, so this
+  // LoadedConfiguration needs to access our members, so this
   // needs to always happen after we initialised everything else
-  config_resources_container_
-      = std::make_shared<ConfigResourcesContainer>(FreeResourceCb_, r_num_);
+  loaded_configuration
+      = std::make_shared<LoadedConfiguration>(FreeResourceCb_, r_num_);
 }
 
 std::string ConfigurationParser::CreateOwnQualifiedNameForNetworkDump() const
@@ -189,7 +189,7 @@ bool ConfigurationParser::ParseConfig()
                                  &ConfigurationParser_PrintWarning);
   if (success && ParseConfigReadyCb_) { ParseConfigReadyCb_(*this); }
 
-  config_resources_container_->SetTimestampToNow();
+  loaded_configuration->SetTimestampToNow();
 
   return success;
 }
@@ -265,15 +265,14 @@ bool ConfigurationParser::AppendToResourcesChain(BareosResource* new_resource,
     return false;
   }
 
-  if (!config_resources_container_->configuration_resources_[rindex]) {
-    config_resources_container_->configuration_resources_[rindex]
-        = new_resource;
+  if (!loaded_configuration->configuration_resources_[rindex]) {
+    loaded_configuration->configuration_resources_[rindex] = new_resource;
     Dmsg3(900, "Inserting first %s res: %s index=%d\n", ResToStr(rcode),
           new_resource->resource_name_, rindex);
   } else {  // append
     BareosResource* last = nullptr;
     BareosResource* current
-        = config_resources_container_->configuration_resources_[rindex];
+        = loaded_configuration->configuration_resources_[rindex];
     do {
       if (bstrcmp(current->resource_name_, new_resource->resource_name_)) {
         Emsg2(M_ERROR, 0,
@@ -512,26 +511,26 @@ bool ConfigurationParser::FindConfigPath(PoolMem& full_path)
   return found;
 }
 
-void ConfigurationParser::RestoreResourcesContainer(
-    std::shared_ptr<ConfigResourcesContainer>&& backup_table)
+void ConfigurationParser::RestoreConfiguration(
+    std::shared_ptr<LoadedConfiguration>&& backup_table)
 {
-  std::swap(config_resources_container_, backup_table);
+  std::swap(loaded_configuration, backup_table);
   backup_table.reset();
 }
 
-std::shared_ptr<ConfigResourcesContainer>
-ConfigurationParser::BackupResourcesContainer()
+std::shared_ptr<LoadedConfiguration>
+ConfigurationParser::BackupCurrentConfiguration()
 {
-  auto backup_table = config_resources_container_;
-  config_resources_container_
-      = std::make_shared<ConfigResourcesContainer>(FreeResourceCb_, r_num_);
+  auto backup_table = loaded_configuration;
+  loaded_configuration
+      = std::make_shared<LoadedConfiguration>(FreeResourceCb_, r_num_);
   return backup_table;
 }
 
-std::shared_ptr<ConfigResourcesContainer>
-ConfigurationParser::GetResourcesContainer()
+std::shared_ptr<LoadedConfiguration>
+ConfigurationParser::GetCurrentConfiguration()
 {
-  return config_resources_container_;
+  return loaded_configuration;
 }
 
 
@@ -549,15 +548,14 @@ bool ConfigurationParser::RemoveResource(int rcode, const char* name)
    */
   last = nullptr;
   for (BareosResource* res
-       = config_resources_container_->configuration_resources_[rindex];
+       = loaded_configuration->configuration_resources_[rindex];
        res; res = res->next_) {
     if (bstrcmp(res->resource_name_, name)) {
       if (!last) {
         Dmsg2(900,
               T_("removing resource %s, name=%s (first resource in list)\n"),
               ResToStr(rcode), name);
-        config_resources_container_->configuration_resources_[rindex]
-            = res->next_;
+        loaded_configuration->configuration_resources_[rindex] = res->next_;
       } else {
         Dmsg2(900, T_("removing resource %s, name=%s\n"), ResToStr(rcode),
               name);
@@ -610,9 +608,8 @@ void ConfigurationParser::DumpResources(sender* sendit,
                                         bool hide_sensitive_data)
 {
   for (int i = 0; i <= r_num_ - 1; i++) {
-    if (config_resources_container_->configuration_resources_[i]) {
-      DumpResourceCb_(i,
-                      config_resources_container_->configuration_resources_[i],
+    if (loaded_configuration->configuration_resources_[i]) {
+      DumpResourceCb_(i, loaded_configuration->configuration_resources_[i],
                       sendit, sock, hide_sensitive_data, false);
     }
   }

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -47,7 +47,7 @@
 struct ResourceItem;
 class ConfigParserStateMachine;
 class ConfigurationParser;
-class ConfigResourcesContainer;
+class LoadedConfiguration;
 /* For storing name_addr items in res_items table */
 
 /* using offsetof on non-standard-layout types is conditionally supported. As
@@ -225,7 +225,7 @@ class ConfigurationParser {
   BareosResource* own_resource_{nullptr}; /* Pointer to own resource */
   const ResourceTable* resource_definitions_{
       0}; /* Pointer to table of permitted resources */
-  std::shared_ptr<ConfigResourcesContainer> config_resources_container_;
+  std::shared_ptr<LoadedConfiguration> loaded_configuration;
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_{nullptr};
@@ -259,9 +259,9 @@ class ConfigurationParser {
   const std::string& get_base_config_path() const { return used_config_path_; }
   void FreeResources();
 
-  std::shared_ptr<ConfigResourcesContainer> GetResourcesContainer();
-  std::shared_ptr<ConfigResourcesContainer> BackupResourcesContainer();
-  void RestoreResourcesContainer(std::shared_ptr<ConfigResourcesContainer>&&);
+  std::shared_ptr<LoadedConfiguration> GetCurrentConfiguration();
+  std::shared_ptr<LoadedConfiguration> BackupCurrentConfiguration();
+  void RestoreConfiguration(std::shared_ptr<LoadedConfiguration>&&);
 
   void InitResource(int rcode,
                     const ResourceItem items[],
@@ -441,8 +441,7 @@ class ConfigurationParser {
   void SetResourceDefaultsParserPass2(const ResourceItem* item);
 };
 
-
-class ConfigResourcesContainer {
+class LoadedConfiguration {
  private:
   std::chrono::time_point<std::chrono::system_clock> timestamp_{};
   /* `next_` points to the immediate successor of this configuration.  This
@@ -451,24 +450,24 @@ class ConfigResourcesContainer {
    * saving it as well), then the daemon will not crash because of use
    * after free, as the newer configurations are now also kept alive
    * implicitly as well. */
-  std::shared_ptr<ConfigResourcesContainer> next_ = nullptr;
+  std::shared_ptr<LoadedConfiguration> next_ = nullptr;
   FreeResourceCb_t free_res = nullptr;
 
  public:
   std::vector<BareosResource*> configuration_resources_ = {};
 
-  ConfigResourcesContainer() = default;
-  ConfigResourcesContainer(FreeResourceCb_t resource_freer,
-                           std::size_t resource_type_count)
+  LoadedConfiguration() = default;
+  LoadedConfiguration(FreeResourceCb_t resource_freer,
+                      std::size_t resource_type_count)
       : free_res{resource_freer}, configuration_resources_(resource_type_count)
   {
-    Dmsg1(10, "ConfigResourcesContainer: new configuration_resources_ %p\n",
+    Dmsg1(10, "LoadedConfiguration: new configuration_resources_ %p\n",
           configuration_resources_.data());
   }
 
-  ~ConfigResourcesContainer()
+  ~LoadedConfiguration()
   {
-    Dmsg1(10, "ConfigResourcesContainer freeing %p %s\n",
+    Dmsg1(10, "LoadedConfiguration: freeing %p %s\n",
           configuration_resources_.data(), TPAsString(timestamp_).c_str());
 
     for (size_t i = 0; i < configuration_resources_.size(); ++i) {
@@ -479,7 +478,7 @@ class ConfigResourcesContainer {
   void SetTimestampToNow() { timestamp_ = std::chrono::system_clock::now(); }
   std::string TimeStampAsString() { return TPAsString(timestamp_); }
 
-  void SetNext(std::shared_ptr<ConfigResourcesContainer> next)
+  void SetNext(std::shared_ptr<LoadedConfiguration> next)
   {
     next_ = std::move(next);
   }
@@ -487,7 +486,6 @@ class ConfigResourcesContainer {
   BareosResource* GetNextRes(int rcode, BareosResource* res) const;
   BareosResource* GetResWithName(int rcode, std::string_view name) const;
 };
-
 
 bool PrintMessage(void* sock, const char* fmt, ...) PRINTF_LIKE(2, 3);
 bool IsTlsConfigured(TlsResource* tls_resource);
@@ -504,12 +502,12 @@ const char* DatatypeToDescription(int type);
  * the pointer passed into and also get a reference to the configuration that
  * we then keep for the lifetime of the loop.
  */
-inline std::shared_ptr<ConfigResourcesContainer> _init_foreach_res_(
+inline std::shared_ptr<LoadedConfiguration> _init_foreach_res_(
     ConfigurationParser* config,
     void* var)
 {
   memset(var, 0, sizeof(void*));
-  return config->GetResourcesContainer();
+  return config->GetCurrentConfiguration();
 }
 
 // Loop through each resource of type, returning in var

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -456,6 +456,8 @@ class ConfigResourcesContainer {
 
  public:
   std::vector<BareosResource*> configuration_resources_ = {};
+
+  ConfigResourcesContainer() = default;
   ConfigResourcesContainer(ConfigurationParser* config)
       : free_res{config->FreeResourceCb_}
       , configuration_resources_(config->r_num_)

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -458,9 +458,9 @@ class ConfigResourcesContainer {
   std::vector<BareosResource*> configuration_resources_ = {};
 
   ConfigResourcesContainer() = default;
-  ConfigResourcesContainer(ConfigurationParser* config)
-      : free_res{config->FreeResourceCb_}
-      , configuration_resources_(config->r_num_)
+  ConfigResourcesContainer(FreeResourceCb_t resource_freer,
+                           std::size_t resource_type_count)
+      : free_res{resource_freer}, configuration_resources_(resource_type_count)
   {
     Dmsg1(10, "ConfigResourcesContainer: new configuration_resources_ %p\n",
           configuration_resources_.data());

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -481,6 +481,9 @@ class ConfigResourcesContainer {
   {
     next_ = std::move(next);
   }
+
+  BareosResource* GetNextRes(int rcode, BareosResource* res) const;
+  BareosResource* GetResWithName(int rcode, std::string_view name) const;
 };
 
 

--- a/core/src/lib/parse_conf.h
+++ b/core/src/lib/parse_conf.h
@@ -224,8 +224,7 @@ class ConfigurationParser {
   int32_t r_own_{0};                      /* own resource type */
   BareosResource* own_resource_{nullptr}; /* Pointer to own resource */
   const ResourceTable* resource_definitions_{
-      0}; /* Pointer to table of permitted resources */
-  std::shared_ptr<LoadedConfiguration> loaded_configuration;
+      0};                      /* Pointer to table of permitted resources */
   mutable brwlock_t res_lock_; /* Resource lock */
 
   SaveResourceCb_t SaveResourceCb_{nullptr};
@@ -339,6 +338,8 @@ class ConfigurationParser {
     STORE_SIZE,
     STORE_SPEED
   };
+
+  std::shared_ptr<LoadedConfiguration> loaded_configuration;
 
   std::string config_default_filename_; /* default config filename, that is
                                            used, if no filename is given */

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -151,7 +151,7 @@ ConfigParserStateMachine::ScanResource(int token)
           if (my_config_.store_res_) {
             my_config_.store_res_(lexical_parser_, item, resource_item_index,
                                   parser_pass_number_,
-                                  my_config_.loaded_configuration
+                                  my_config_.GetCurrentConfiguration()
                                       ->configuration_resources_.data());
           }
         }
@@ -298,10 +298,10 @@ bool ConfigParserStateMachine::InitParserPass()
 void ConfigParserStateMachine::DumpResourcesAfterSecondPass()
 {
   if (debug_level >= 900 && parser_pass_number_ == 2) {
+    auto conf = my_config_.GetCurrentConfiguration();
     for (int i = 0; i <= my_config_.r_num_ - 1; i++) {
-      my_config_.DumpResourceCb_(
-          i, my_config_.loaded_configuration->configuration_resources_[i],
-          PrintMessage, nullptr, false, false);
+      my_config_.DumpResourceCb_(i, conf->configuration_resources_[i],
+                                 PrintMessage, nullptr, false, false);
     }
   }
 }

--- a/core/src/lib/parse_conf_state_machine.cc
+++ b/core/src/lib/parse_conf_state_machine.cc
@@ -151,7 +151,7 @@ ConfigParserStateMachine::ScanResource(int token)
           if (my_config_.store_res_) {
             my_config_.store_res_(lexical_parser_, item, resource_item_index,
                                   parser_pass_number_,
-                                  my_config_.config_resources_container_
+                                  my_config_.loaded_configuration
                                       ->configuration_resources_.data());
           }
         }
@@ -300,8 +300,7 @@ void ConfigParserStateMachine::DumpResourcesAfterSecondPass()
   if (debug_level >= 900 && parser_pass_number_ == 2) {
     for (int i = 0; i <= my_config_.r_num_ - 1; i++) {
       my_config_.DumpResourceCb_(
-          i,
-          my_config_.config_resources_container_->configuration_resources_[i],
+          i, my_config_.loaded_configuration->configuration_resources_[i],
           PrintMessage, nullptr, false, false);
     }
   }

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -99,9 +99,9 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
 {
   if (lock) {
     ResLocker _{this};
-    return config_resources_container_->GetResWithName(rcode, name);
+    return loaded_configuration->GetResWithName(rcode, name);
   } else {
-    return config_resources_container_->GetResWithName(rcode, name);
+    return loaded_configuration->GetResWithName(rcode, name);
   }
 }
 
@@ -122,7 +122,7 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
 BareosResource* ConfigurationParser::GetNextRes(int rcode,
                                                 BareosResource* res) const
 {
-  return config_resources_container_->GetNextRes(rcode, res);
+  return loaded_configuration->GetNextRes(rcode, res);
 }
 
 const char* ConfigurationParser::ResToStr(int rcode) const
@@ -2305,8 +2305,8 @@ const char* DatatypeToDescription(int type)
 
 
 // Return resource of type rcode that matches name
-BareosResource* ConfigResourcesContainer::GetResWithName(int rcode,
-                                                         std::string_view name) const
+BareosResource* LoadedConfiguration::GetResWithName(int rcode,
+                                                    std::string_view name) const
 {
   int rindex = rcode;
 
@@ -2330,8 +2330,8 @@ BareosResource* ConfigResourcesContainer::GetResWithName(int rcode,
  * call second arg (res) is NULL, on subsequent
  * calls, it is called with previous value.
  */
-BareosResource* ConfigResourcesContainer::GetNextRes(int rcode,
-                                                     BareosResource* res) const
+BareosResource* LoadedConfiguration::GetNextRes(int rcode,
+                                                BareosResource* res) const
 {
   BareosResource* nres;
   int rindex = rcode;

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -97,29 +97,11 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
                                                     std::string_view name,
                                                     bool lock) const
 {
-  int rindex = rcode;
-
-  auto find_res = [&]() -> BareosResource* {
-    auto& containers = config_resources_container_->configuration_resources_;
-    if (rindex < 0 || static_cast<std::size_t>(rindex) >= containers.size()) {
-      return nullptr;
-    }
-
-    auto* res = containers[rindex];
-
-    while (res) {
-      if (name == res->resource_name_) { break; }
-      res = res->next_;
-    }
-
-    return res;
-  };
-
   if (lock) {
     ResLocker _{this};
-    return find_res();
+    return config_resources_container_->GetResWithName(rcode, name);
   } else {
-    return find_res();
+    return config_resources_container_->GetResWithName(rcode, name);
   }
 }
 
@@ -140,16 +122,7 @@ BareosResource* ConfigurationParser::GetResWithName(int rcode,
 BareosResource* ConfigurationParser::GetNextRes(int rcode,
                                                 BareosResource* res) const
 {
-  BareosResource* nres;
-  int rindex = rcode;
-
-  if (res == NULL) {
-    nres = config_resources_container_->configuration_resources_[rindex];
-  } else {
-    nres = res->next_;
-  }
-
-  return nres;
+  return config_resources_container_->GetNextRes(rcode, res);
 }
 
 const char* ConfigurationParser::ResToStr(int rcode) const
@@ -2328,4 +2301,46 @@ const char* DatatypeToDescription(int type)
   }
 
   return NULL;
+}
+
+
+// Return resource of type rcode that matches name
+BareosResource* ConfigResourcesContainer::GetResWithName(int rcode,
+                                                         std::string_view name) const
+{
+  int rindex = rcode;
+
+  auto& containers = configuration_resources_;
+  if (rindex < 0 || static_cast<std::size_t>(rindex) >= containers.size()) {
+    return nullptr;
+  }
+
+  auto* res = containers[rindex];
+
+  while (res) {
+    if (res->resource_name_ == name) { break; }
+    res = res->next_;
+  }
+
+  return res;
+}
+
+/*
+ * Return next resource of type rcode. On first
+ * call second arg (res) is NULL, on subsequent
+ * calls, it is called with previous value.
+ */
+BareosResource* ConfigResourcesContainer::GetNextRes(int rcode,
+                                                     BareosResource* res) const
+{
+  BareosResource* nres;
+  int rindex = rcode;
+
+  if (res == NULL) {
+    nres = configuration_resources_[rindex];
+  } else {
+    nres = res->next_;
+  }
+
+  return nres;
 }

--- a/core/src/lib/res.cc
+++ b/core/src/lib/res.cc
@@ -2308,14 +2308,12 @@ const char* DatatypeToDescription(int type)
 BareosResource* LoadedConfiguration::GetResWithName(int rcode,
                                                     std::string_view name) const
 {
-  int rindex = rcode;
-
   auto& containers = configuration_resources_;
-  if (rindex < 0 || static_cast<std::size_t>(rindex) >= containers.size()) {
+  if (rcode < 0 || static_cast<std::size_t>(rcode) >= containers.size()) {
     return nullptr;
   }
 
-  auto* res = containers[rindex];
+  auto* res = containers[rcode];
 
   while (res) {
     if (res->resource_name_ == name) { break; }
@@ -2333,14 +2331,12 @@ BareosResource* LoadedConfiguration::GetResWithName(int rcode,
 BareosResource* LoadedConfiguration::GetNextRes(int rcode,
                                                 BareosResource* res) const
 {
-  BareosResource* nres;
-  int rindex = rcode;
+  if (res) { return res->next_; }
 
-  if (res == NULL) {
-    nres = configuration_resources_[rindex];
-  } else {
-    nres = res->next_;
+  auto& containers = configuration_resources_;
+  if (rcode < 0 || static_cast<std::size_t>(rcode) >= containers.size()) {
+    return nullptr;
   }
 
-  return nres;
+  return containers[rcode];
 }

--- a/core/src/lib/try_tls_handshake_as_a_server.h
+++ b/core/src/lib/try_tls_handshake_as_a_server.h
@@ -35,7 +35,7 @@ struct UsePasswordsFromConfig : TlsSecretProvider {
   {
     // keep a shared_ptr to the current config, so a reload won't
     // free the memory we're going to use in the private context
-    config_table_ = parser->GetResourcesContainer();
+    config = parser->GetCurrentConfiguration();
   }
 
 
@@ -116,7 +116,7 @@ struct UsePasswordsFromConfig : TlsSecretProvider {
  protected:
   ConfigurationParser* parser;
   BareosResource* chosen_resource{nullptr};
-  std::shared_ptr<ConfigResourcesContainer> config_table_;
+  std::shared_ptr<LoadedConfiguration> config;
 };
 
 // look not only in the config for passwords, but also

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -83,7 +83,8 @@ void CatalogTest::SetUp()
 
   // connect to database
   {
-    jcr = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+    jcr = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr,
+                                         my_config->GetResourcesContainer());
     jcr->dir_impl->res.catalog
         = (directordaemon::CatalogResource*)my_config->GetResWithName(
             directordaemon::R_CATALOG, catalog_backend_name.c_str());

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -83,7 +83,7 @@ void CatalogTest::SetUp()
 
   // connect to database
   {
-    jcr = directordaemon::NewDirectorJcr(my_config->GetResourcesContainer());
+    jcr = directordaemon::NewDirectorJcr(my_config->GetCurrentConfiguration());
     jcr->dir_impl->res.catalog
         = (directordaemon::CatalogResource*)my_config->GetResWithName(
             directordaemon::R_CATALOG, catalog_backend_name.c_str());

--- a/core/src/tests/catalog.cc
+++ b/core/src/tests/catalog.cc
@@ -83,8 +83,7 @@ void CatalogTest::SetUp()
 
   // connect to database
   {
-    jcr = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr,
-                                         my_config->GetResourcesContainer());
+    jcr = directordaemon::NewDirectorJcr(my_config->GetResourcesContainer());
     jcr->dir_impl->res.catalog
         = (directordaemon::CatalogResource*)my_config->GetResWithName(
             directordaemon::R_CATALOG, catalog_backend_name.c_str());

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -36,7 +36,7 @@ TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
 
 
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -55,7 +55,7 @@ TEST(DirectorToClientConnection, DoesNotDowngradeToClearTextWhenTlsRequired)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -78,7 +78,7 @@ TEST(DirectorToClientConnection, DowngradesToClearTextWhenTlsNotRequired)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2022-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2022-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -35,8 +35,8 @@ TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
 
 
-  JobControlRecord* jcr
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -54,8 +54,8 @@ TEST(DirectorToClientConnection, DoesNotDowngradeToClearTextWhenTlsRequired)
 
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
-  JobControlRecord* jcr
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -77,8 +77,8 @@ TEST(DirectorToClientConnection, DowngradesToClearTextWhenTlsNotRequired)
 
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
-  JobControlRecord* jcr
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,

--- a/core/src/tests/dir_fd_connection.cc
+++ b/core/src/tests/dir_fd_connection.cc
@@ -36,7 +36,7 @@ TEST(DirectorToClientConnection, DoesNotConnectWhenDisabled)
 
 
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -55,7 +55,7 @@ TEST(DirectorToClientConnection, DoesNotDowngradeToClearTextWhenTlsRequired)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,
@@ -78,7 +78,7 @@ TEST(DirectorToClientConnection, DowngradesToClearTextWhenTlsNotRequired)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   InitMsg(nullptr, nullptr);
   JobControlRecord* jcr = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
 
   jcr->dir_impl->res.client = static_cast<directordaemon::ClientResource*>(
       directordaemon::my_config->GetResWithName(directordaemon::R_CLIENT,

--- a/core/src/tests/pruning.cc
+++ b/core/src/tests/pruning.cc
@@ -37,13 +37,13 @@ TEST(Pruning, ExcludeRunningJobsFromList)
   if (!director_config) { return; }
 
   JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
   jcr1->JobId = 1;
   JobControlRecord* jcr2 = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
   jcr2->JobId = 2;
   JobControlRecord* jcr3 = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
   jcr3->JobId = 3;
 
   std::vector<JobId_t> pruninglist{0, 0, 1, 2, 3, 4, 5};
@@ -63,7 +63,7 @@ TEST(Pruning, TransformJobidsTobedeleted)
   if (!director_config) { return; }
 
   JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
-      director_config->GetResourcesContainer());
+      director_config->GetCurrentConfiguration());
   jcr1->JobId = 1;
 
   directordaemon::UaContext* ua = directordaemon::new_ua_context(jcr1);

--- a/core/src/tests/pruning.cc
+++ b/core/src/tests/pruning.cc
@@ -37,13 +37,13 @@ TEST(Pruning, ExcludeRunningJobsFromList)
   if (!director_config) { return; }
 
   JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
   jcr1->JobId = 1;
   JobControlRecord* jcr2 = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
   jcr2->JobId = 2;
   JobControlRecord* jcr3 = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
   jcr3->JobId = 3;
 
   std::vector<JobId_t> pruninglist{0, 0, 1, 2, 3, 4, 5};
@@ -63,7 +63,7 @@ TEST(Pruning, TransformJobidsTobedeleted)
   if (!director_config) { return; }
 
   JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
-      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
+      director_config->GetResourcesContainer());
   jcr1->JobId = 1;
 
   directordaemon::UaContext* ua = directordaemon::new_ua_context(jcr1);

--- a/core/src/tests/pruning.cc
+++ b/core/src/tests/pruning.cc
@@ -36,14 +36,14 @@ TEST(Pruning, ExcludeRunningJobsFromList)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   if (!director_config) { return; }
 
-  JobControlRecord* jcr1
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
   jcr1->JobId = 1;
-  JobControlRecord* jcr2
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr2 = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
   jcr2->JobId = 2;
-  JobControlRecord* jcr3
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr3 = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
   jcr3->JobId = 3;
 
   std::vector<JobId_t> pruninglist{0, 0, 1, 2, 3, 4, 5};
@@ -62,8 +62,8 @@ TEST(Pruning, TransformJobidsTobedeleted)
   PConfigParser director_config(DirectorPrepareResources(path_to_config));
   if (!director_config) { return; }
 
-  JobControlRecord* jcr1
-      = directordaemon::NewDirectorJcr(directordaemon::DirdFreeJcr);
+  JobControlRecord* jcr1 = directordaemon::NewDirectorJcr(
+      directordaemon::DirdFreeJcr, director_config->GetResourcesContainer());
   jcr1->JobId = 1;
 
   directordaemon::UaContext* ua = directordaemon::new_ua_context(jcr1);

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -90,7 +90,7 @@ static bool find(std::vector<JobResource*> jobs, std::string jobname)
 TEST_F(RunOnIncomingConnectIntervalTest, find_all_jobs_for_client)
 {
   std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
-      my_config->loaded_configuration.get(), "bareos-fd")};
+      my_config->GetCurrentConfiguration().get(), "bareos-fd")};
 
   EXPECT_EQ(jobs.size(), 4);
 
@@ -104,7 +104,7 @@ TEST_F(RunOnIncomingConnectIntervalTest,
        find_all_connect_interval_jobs_for_client)
 {
   std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
-      my_config->loaded_configuration.get(), "bareos-fd")};
+      my_config->GetCurrentConfiguration().get(), "bareos-fd")};
 
   auto end = std::remove_if(jobs.begin(), jobs.end(), [](JobResource* job) {
     return job->RunOnIncomingConnectInterval == 0;

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -90,7 +90,7 @@ static bool find(std::vector<JobResource*> jobs, std::string jobname)
 TEST_F(RunOnIncomingConnectIntervalTest, find_all_jobs_for_client)
 {
   std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
-      my_config->config_resources_container_.get(), "bareos-fd")};
+      my_config->loaded_configuration.get(), "bareos-fd")};
 
   EXPECT_EQ(jobs.size(), 4);
 
@@ -104,7 +104,7 @@ TEST_F(RunOnIncomingConnectIntervalTest,
        find_all_connect_interval_jobs_for_client)
 {
   std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
-      my_config->config_resources_container_.get(), "bareos-fd")};
+      my_config->loaded_configuration.get(), "bareos-fd")};
 
   auto end = std::remove_if(jobs.begin(), jobs.end(), [](JobResource* job) {
     return job->RunOnIncomingConnectInterval == 0;

--- a/core/src/tests/run_on_incoming_connect_interval.cc
+++ b/core/src/tests/run_on_incoming_connect_interval.cc
@@ -89,7 +89,8 @@ static bool find(std::vector<JobResource*> jobs, std::string jobname)
 
 TEST_F(RunOnIncomingConnectIntervalTest, find_all_jobs_for_client)
 {
-  std::vector<JobResource*> jobs{GetAllJobResourcesByClientName("bareos-fd")};
+  std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
+      my_config->config_resources_container_.get(), "bareos-fd")};
 
   EXPECT_EQ(jobs.size(), 4);
 
@@ -102,7 +103,8 @@ TEST_F(RunOnIncomingConnectIntervalTest, find_all_jobs_for_client)
 TEST_F(RunOnIncomingConnectIntervalTest,
        find_all_connect_interval_jobs_for_client)
 {
-  std::vector<JobResource*> jobs{GetAllJobResourcesByClientName("bareos-fd")};
+  std::vector<JobResource*> jobs{GetAllJobResourcesByClientName(
+      my_config->config_resources_container_.get(), "bareos-fd")};
 
   auto end = std::remove_if(jobs.begin(), jobs.end(), [](JobResource* job) {
     return job->RunOnIncomingConnectInterval == 0;

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -1,7 +1,7 @@
 /*
   BAREOS® - Backup Archiving REcovery Open Sourced
 
-  Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+  Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
   This program is Free Software; you can redistribute it and/or
   modify it under the terms of version three of the GNU Affero General Public
@@ -326,7 +326,8 @@ TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
       my_config->GetResWithName(R_JOB, "backup-bareos-fd"))};
   ASSERT_TRUE(job) << "Job Resource \"backup-bareos-fd\" not found";
 
-  scheduler->AddJobWithNoRunResourceToQueue(job, JobTrigger::kUndefined);
+  scheduler->AddJobWithNoRunResourceToQueue(my_config->GetResourcesContainer(),
+                                            job, JobTrigger::kUndefined);
 
   scheduler_thread.join();
   ASSERT_EQ(counter_of_number_of_jobs_run, 1);

--- a/core/src/tests/scheduler.cc
+++ b/core/src/tests/scheduler.cc
@@ -326,8 +326,8 @@ TEST_F(SchedulerTest, add_job_with_no_run_resource_to_queue)
       my_config->GetResWithName(R_JOB, "backup-bareos-fd"))};
   ASSERT_TRUE(job) << "Job Resource \"backup-bareos-fd\" not found";
 
-  scheduler->AddJobWithNoRunResourceToQueue(my_config->GetResourcesContainer(),
-                                            job, JobTrigger::kUndefined);
+  scheduler->AddJobWithNoRunResourceToQueue(
+      my_config->GetCurrentConfiguration(), job, JobTrigger::kUndefined);
 
   scheduler_thread.join();
   ASSERT_EQ(counter_of_number_of_jobs_run, 1);

--- a/core/src/tests/scheduler_job_item_queue.cc
+++ b/core/src/tests/scheduler_job_item_queue.cc
@@ -44,7 +44,7 @@ TEST(scheduler_job_item_queue, job_item)
   SchedulerJobItem item;
   EXPECT_FALSE(item.is_valid);
 
-  auto conf = std::make_shared<ConfigResourcesContainer>();
+  auto conf = std::make_shared<LoadedConfiguration>();
   JobResource job;
   RunResource run;
 
@@ -55,7 +55,7 @@ TEST(scheduler_job_item_queue, job_item)
 
 TEST(scheduler_job_item_queue, compare_job_items)
 {
-  auto conf = std::make_shared<ConfigResourcesContainer>();
+  auto conf = std::make_shared<LoadedConfiguration>();
   JobResource job[2];
   RunResource run[2];
 
@@ -73,7 +73,7 @@ TEST(scheduler_job_item_queue, priority_and_time)
 {
   time_t now = time(nullptr);
 
-  auto unused = std::make_shared<ConfigResourcesContainer>();
+  auto unused = std::make_shared<LoadedConfiguration>();
   std::vector<JobResource> job_resources(4);
   std::vector<RunResource> run_resources(job_resources.size());
 
@@ -119,7 +119,7 @@ TEST(scheduler_job_item_queue, priority_and_time)
 
 TEST(scheduler_job_item_queue, job_resource_undefined)
 {
-  auto unused = std::make_shared<ConfigResourcesContainer>();
+  auto unused = std::make_shared<LoadedConfiguration>();
   bool failed{false};
   RunResource run;
   try {
@@ -134,7 +134,7 @@ TEST(scheduler_job_item_queue, job_resource_undefined)
 
 TEST(scheduler_job_item_queue, runtime_undefined)
 {
-  auto unused = std::make_shared<ConfigResourcesContainer>();
+  auto unused = std::make_shared<LoadedConfiguration>();
   bool failed{false};
   JobResource job;
   RunResource run;

--- a/core/src/tests/scheduler_job_item_queue.cc
+++ b/core/src/tests/scheduler_job_item_queue.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -19,6 +19,7 @@
    02110-1301, USA.
 */
 
+#include "lib/parse_conf.h"
 #if defined(HAVE_MINGW)
 #  include "include/bareos.h"
 #  include "gtest/gtest.h"
@@ -43,23 +44,25 @@ TEST(scheduler_job_item_queue, job_item)
   SchedulerJobItem item;
   EXPECT_FALSE(item.is_valid);
 
+  auto conf = std::make_shared<ConfigResourcesContainer>();
   JobResource job;
   RunResource run;
 
-  SchedulerJobItem item_unitialised(&job, &run, time(nullptr), 0,
+  SchedulerJobItem item_unitialised(conf, &job, &run, time(nullptr), 0,
                                     JobTrigger::kUndefined);
   EXPECT_TRUE(item_unitialised.is_valid);
 }
 
 TEST(scheduler_job_item_queue, compare_job_items)
 {
+  auto conf = std::make_shared<ConfigResourcesContainer>();
   JobResource job[2];
   RunResource run[2];
 
-  SchedulerJobItem item1(&job[0], &run[0], time(nullptr), 10,
+  SchedulerJobItem item1(conf, &job[0], &run[0], time(nullptr), 10,
                          JobTrigger::kUndefined);
   SchedulerJobItem item2 = item1;
-  SchedulerJobItem item3(&job[1], &run[1], time(nullptr) + 3600, 11,
+  SchedulerJobItem item3(conf, &job[1], &run[1], time(nullptr) + 3600, 11,
                          JobTrigger::kUndefined);
 
   EXPECT_EQ(item1, item2);
@@ -70,6 +73,7 @@ TEST(scheduler_job_item_queue, priority_and_time)
 {
   time_t now = time(nullptr);
 
+  auto unused = std::make_shared<ConfigResourcesContainer>();
   std::vector<JobResource> job_resources(4);
   std::vector<RunResource> run_resources(job_resources.size());
 
@@ -79,23 +83,27 @@ TEST(scheduler_job_item_queue, priority_and_time)
   time_t runtime = now;
   run_resources[0].Priority = 10;
   job_resources[0].selection_type = 1;  // runs first (see above)
-  scheduler_job_item_queue.EmplaceItem(&job_resources[0], &run_resources[0],
-                                       runtime, JobTrigger::kUndefined);
+  scheduler_job_item_queue.EmplaceItem(unused, &job_resources[0],
+                                       &run_resources[0], runtime,
+                                       JobTrigger::kUndefined);
   runtime = now + 1;
   run_resources[1].Priority = 10;
   job_resources[1].selection_type = 3;
-  scheduler_job_item_queue.EmplaceItem(&job_resources[1], &run_resources[1],
-                                       runtime, JobTrigger::kUndefined);
+  scheduler_job_item_queue.EmplaceItem(unused, &job_resources[1],
+                                       &run_resources[1], runtime,
+                                       JobTrigger::kUndefined);
   runtime = now + 1;
   run_resources[2].Priority = 11;
   job_resources[2].selection_type = 4;  // runs last
-  scheduler_job_item_queue.EmplaceItem(&job_resources[2], &run_resources[2],
-                                       runtime, JobTrigger::kUndefined);
+  scheduler_job_item_queue.EmplaceItem(unused, &job_resources[2],
+                                       &run_resources[2], runtime,
+                                       JobTrigger::kUndefined);
   runtime = now + 1;
   run_resources[3].Priority = 9;
   job_resources[3].selection_type = 2;
-  scheduler_job_item_queue.EmplaceItem(&job_resources[3], &run_resources[3],
-                                       runtime, JobTrigger::kUndefined);
+  scheduler_job_item_queue.EmplaceItem(unused, &job_resources[3],
+                                       &run_resources[3], runtime,
+                                       JobTrigger::kUndefined);
 
   int item_position = 1;
   while (!scheduler_job_item_queue.Empty()) {
@@ -111,10 +119,11 @@ TEST(scheduler_job_item_queue, priority_and_time)
 
 TEST(scheduler_job_item_queue, job_resource_undefined)
 {
+  auto unused = std::make_shared<ConfigResourcesContainer>();
   bool failed{false};
   RunResource run;
   try {
-    scheduler_job_item_queue.EmplaceItem(nullptr, &run, 123,
+    scheduler_job_item_queue.EmplaceItem(unused, nullptr, &run, 123,
                                          JobTrigger::kUndefined);
   } catch (const std::invalid_argument& e) {
     EXPECT_STREQ(e.what(), "Invalid Argument: JobResource is undefined");
@@ -125,11 +134,13 @@ TEST(scheduler_job_item_queue, job_resource_undefined)
 
 TEST(scheduler_job_item_queue, runtime_undefined)
 {
+  auto unused = std::make_shared<ConfigResourcesContainer>();
   bool failed{false};
   JobResource job;
   RunResource run;
   try {
-    scheduler_job_item_queue.EmplaceItem(&job, &run, 0, JobTrigger::kUndefined);
+    scheduler_job_item_queue.EmplaceItem(unused, &job, &run, 0,
+                                         JobTrigger::kUndefined);
   } catch (const std::invalid_argument& e) {
     EXPECT_STREQ(e.what(), "Invalid Argument: runtime is invalid");
     failed = true;

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -68,7 +68,7 @@ TEST(setdevice, scan_command_line)
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
 
   std::unique_ptr<JobControlRecord, decltype(&Test_FreeJcr)> jcr(
-      NewDirectorJcr(my_config->GetResourcesContainer()), &Test_FreeJcr);
+      NewDirectorJcr(my_config->GetCurrentConfiguration()), &Test_FreeJcr);
 
   std::unique_ptr<UaContext, decltype(&FreeUaContext)> ua(
       new_ua_context(jcr.get()), &FreeUaContext);

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -68,7 +68,7 @@ TEST(setdevice, scan_command_line)
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
 
   std::unique_ptr<JobControlRecord, decltype(&Test_FreeJcr)> jcr(
-                                                                 NewDirectorJcr(directordaemon::DirdFreeJcr, my_config->GetResourcesContainer()), &Test_FreeJcr);
+      NewDirectorJcr(my_config->GetResourcesContainer()), &Test_FreeJcr);
 
   std::unique_ptr<UaContext, decltype(&FreeUaContext)> ua(
       new_ua_context(jcr.get()), &FreeUaContext);

--- a/core/src/tests/setdevice.cc
+++ b/core/src/tests/setdevice.cc
@@ -68,7 +68,7 @@ TEST(setdevice, scan_command_line)
   my_config = InitDirConfig(path_to_config_file.c_str(), M_ERROR_TERM);
 
   std::unique_ptr<JobControlRecord, decltype(&Test_FreeJcr)> jcr(
-      NewDirectorJcr(directordaemon::DirdFreeJcr), &Test_FreeJcr);
+                                                                 NewDirectorJcr(directordaemon::DirdFreeJcr, my_config->GetResourcesContainer()), &Test_FreeJcr);
 
   std::unique_ptr<UaContext, decltype(&FreeUaContext)> ua(
       new_ua_context(jcr.get()), &FreeUaContext);

--- a/core/src/tests/test_config_parser_dir.cc
+++ b/core/src/tests/test_config_parser_dir.cc
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2019-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2019-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -118,20 +118,20 @@ TEST_F(ConfigParser_Dir, bareos_configparser_tests)
   my_config->DumpResources(PrintMessage, NULL);
 
   {
-    auto backup = my_config->BackupResourcesContainer();
+    auto backup = my_config->BackupCurrentConfiguration();
     my_config->ParseConfig();
 
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
     my_config->own_resource_ = me;
     ASSERT_NE(nullptr, me);
-    my_config->RestoreResourcesContainer(std::move(backup));
+    my_config->RestoreConfiguration(std::move(backup));
     ASSERT_NE(nullptr, me);
   }
-  // If a config already exists, BackupResourcesContainer() needs to be called
+  // If a config already exists, BackupCurrentConfiguration() needs to be called
   // before ParseConfig(), otherwise memory of the existing config is not freed
   // completely
   {
-    auto backup = my_config->BackupResourcesContainer();
+    auto backup = my_config->BackupCurrentConfiguration();
     my_config->ParseConfig();
 
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
@@ -154,14 +154,14 @@ TEST_F(ConfigParser_Dir, foreach_res_and_reload)
   my_config->ParseConfig();
 
   [[maybe_unused]] auto do_reload = [](bool keep_config) {
-    auto backup = my_config->BackupResourcesContainer();
+    auto backup = my_config->BackupCurrentConfiguration();
     my_config->ParseConfig();
 
     me = (DirectorResource*)my_config->GetNextRes(R_DIRECTOR, nullptr);
     my_config->own_resource_ = me;
     ASSERT_NE(nullptr, me);
     if (!keep_config) {
-      my_config->RestoreResourcesContainer(std::move(backup));
+      my_config->RestoreConfiguration(std::move(backup));
       ASSERT_NE(nullptr, me);
     }
   };
@@ -174,7 +174,6 @@ TEST_F(ConfigParser_Dir, foreach_res_and_reload)
     std::unique_lock lk(cv_m);
     BareosResource* client;
     client = (BareosResource*)0xfefe;
-    // auto handle = my_config->GetResourcesContainer();
     foreach_res (client, R_CLIENT) {
       cv.wait(lk);
       printf("%p %s\n", client->resource_name_, client->resource_name_);

--- a/systemtests/tests/py3plug-fd-incus/CMakeLists.txt
+++ b/systemtests/tests/py3plug-fd-incus/CMakeLists.txt
@@ -62,7 +62,16 @@ if(INCUS)
       CACHE STRING "base container image for the incus test"
   )
 
-  # incus only allows alphanumeric characters + hyphens in names
+  # incus only allows alphanumeric characters + hyphens in names but only a max
+  # of 63 characters; we leave 13 chars to the tests so we can only create a
+  # name of length 50
+
+  # Quote: Incus instance names must be 1 to 63 characters long and contain only
+  # ASCII letters, numbers, and dashes. They must not start with a digit or a
+  # dash, and they cannot end with a dash
+
+  set(MAX_LENGTH 50)
+
   if(DEFINED CIUID)
     string(REGEX REPLACE "[^A-Za-z0-9]" "-" INCUS_VM_NAME
                          "${INCUS_VM_BASE_NAME}-${CIUID}"
@@ -70,6 +79,30 @@ if(INCUS)
     string(REGEX REPLACE "[^A-Za-z0-9]" "-" INCUS_CT_NAME
                          "${INCUS_CT_BASE_NAME}-${CIUID}"
     )
+
+    string(LENGTH "${INCUS_VM_NAME}" VM_LENGTH)
+    string(LENGTH "${INCUS_CT_NAME}" CT_LENGTH)
+
+    if(VM_LENGTH GREATER MAX_LENGTH)
+      message(
+        "incus: Generated vm name ${INCUS_VM_NAME} is too long.  Generating fallback name"
+      )
+
+      math(EXPR MAX_SUB_LEN "${MAX_LENGTH} - 3") # VM-
+      string(SUBSTRING "${CIUID}" 0 ${MAX_SUB_LEN} USED_CIUID)
+      string(REGEX REPLACE "[^A-Za-z0-9]" "-" INCUS_VM_NAME "VM-${USED_CIUID}")
+    endif()
+
+    if(CT_LENGTH GREATER MAX_LENGTH)
+      message(
+        "incus: Generated ct name ${INCUS_CT_NAME} is too long.  Generating fallback name"
+      )
+
+      math(EXPR MAX_SUB_LEN "${MAX_LENGTH} - 3") # CT-
+      string(SUBSTRING "${CIUID}" 0 ${MAX_SUB_LEN} USED_CIUID)
+      string(REGEX REPLACE "[^A-Za-z0-9]" "-" INCUS_CT_NAME "CT-${USED_CIUID}")
+    endif()
+
   else()
     string(REGEX REPLACE "[^A-Za-z0-9]" "-" INCUS_VM_NAME
                          "${INCUS_VM_BASE_NAME}"
@@ -78,6 +111,11 @@ if(INCUS)
                          "${INCUS_CT_BASE_NAME}"
     )
   endif()
+
+  # remove trailing `-` this can happen if e.g. the string is too long and got
+  # cutoff at a bad place
+  string(REGEX REPLACE "-+$" "" INCUS_VM_NAME "${INCUS_VM_NAME}")
+  string(REGEX REPLACE "-+$" "" INCUS_CT_NAME "${INCUS_CT_NAME}")
 
   message("incus: using ${INCUS_VM_NAME} / ${INCUS_CT_NAME}")
   create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME} NO_GRPC)

--- a/webui-vue/package-lock.json
+++ b/webui-vue/package-lock.json
@@ -1512,11 +1512,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "dev": true
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -3910,9 +3909,9 @@
       }
     },
     "immutable": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "dev": true
     },
     "is-extglob": {


### PR DESCRIPTION
Some sections of the code still did not ensure that the resource pointers that they use/get are actually preserved by a configuration.
This PR fixes this by ensuring that every job that gets created saves the resources that it uses.

This PR also fixes an issue with the incus test that only occurs when you have a vm/ct name that is too long.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
