### PR TITLE
add `update volume encrypt` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve database encoding error handling [PR #2699]
 - core: ensure runscripts are only executed once [PR #2723]
 
+### Added
+- add `update volume encrypt` command [PR #2727]
+
 ### Changed
 - introduce new webui [PR #2716]
 
@@ -2317,4 +2320,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2713]: https://github.com/bareos/bareos/pull/2713
 [PR #2716]: https://github.com/bareos/bareos/pull/2716
 [PR #2723]: https://github.com/bareos/bareos/pull/2723
+[PR #2727]: https://github.com/bareos/bareos/pull/2727
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/sql_update.cc
+++ b/core/src/cats/sql_update.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -344,6 +344,7 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
        "MaxVolJobs=%d,MaxVolFiles=%d,Enabled=%d,LocationId=%s,"
        "ScratchPoolId=%s,RecyclePoolId=%s,RecycleCount=%d,Recycle=%d,"
        "ActionOnPurge=%d,"
+       "EncryptionKey='%s',"
        "MinBlocksize=%u,MaxBlocksize=%u "
        "WHERE VolumeName='%s'",
        mr->VolJobs, mr->VolFiles, mr->VolBlocks, edit_uint64(mr->VolBytes, ed1),
@@ -356,7 +357,8 @@ bool BareosDb::UpdateMediaRecord(JobControlRecord* jcr, MediaDbRecord* mr)
        mr->Enabled, edit_uint64(mr->LocationId, ed9),
        edit_uint64(mr->ScratchPoolId, ed10),
        edit_uint64(mr->RecyclePoolId, ed11), mr->RecycleCount, mr->Recycle,
-       mr->ActionOnPurge, mr->MinBlocksize, mr->MaxBlocksize, esc_medianame);
+       mr->ActionOnPurge, mr->EncrKey, mr->MinBlocksize, mr->MaxBlocksize,
+       esc_medianame);
 
   Dmsg1(400, "%s\n", cmd);
 

--- a/core/src/dird/CMakeLists.txt
+++ b/core/src/dird/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2017-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2017-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -118,6 +118,7 @@ target_sources(
           ua_update.cc
           vbackup.cc
           verify.cc
+          volume_key.cc
           pthread_detach_if_not_detached.cc
 )
 

--- a/core/src/dird/ua_cmds.cc
+++ b/core/src/dird/ua_cmds.cc
@@ -502,7 +502,7 @@ static struct ua_cmdstruct commands[] = {
      T_("Update volume, pool, slots, job or statistics"),
      NT_("[volume=<volume-name> "
          "[volstatus=<status>] [volretention=<time-def>] "
-         "actiononpurge=<action>] "
+         "[actiononpurge=<action>] [encrypt=<yes/no/rotate>] "
          "[pool=<pool-name>] [recycle=<yes/no>] [slot=<number>] "
          "[inchanger=<yes/no>]] "
          "| [pool=<pool-name> "

--- a/core/src/dird/ua_label.cc
+++ b/core/src/dird/ua_label.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2003-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -45,8 +45,7 @@
 #include "dird/ua_label.h"
 #include "dird/ua_select.h"
 #include "include/auth_protocol_types.h"
-#include "lib/crypto_wrap.h"
-#include "lib/passphrase.h"
+#include "volume_key.h"
 #include "lib/util.h"
 
 namespace directordaemon {
@@ -182,64 +181,6 @@ static inline bool native_send_label_request(UaContext* ua,
   mr->VolBytes = VolBytes;
 
   return retval;
-}
-
-/*
- * Generate a new encryption key for use in volume encryption.
- * We don't ask the user for a encryption key but generate a semi
- * random passphrase of the wanted length which is way stronger.
- * When the config has a wrap key we use that to wrap the newly
- * created passphrase using RFC3394 aes wrap and always convert
- * the passphrase into a base64 encoded string. This key is
- * stored in the database and is passed to the storage daemon
- * when needed. The storage daemon has the same wrap key per
- * director so it can unwrap the passphrase for use.
- *
- * Changing the wrap key will render any previously created
- * crypto keys useless so only change the wrap key after initial
- * setting when you know what you are doing and always store
- * the old key somewhere save so you can use bscrypto to
- * convert them for the new wrap key.
- */
-static bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr)
-{
-  int length;
-  char* passphrase;
-
-  passphrase = generate_crypto_passphrase(DEFAULT_PASSPHRASE_LENGTH);
-  if (!passphrase) {
-    ua->ErrorMsg(
-        T_("Failed to generate new encryption passphrase for Volume %s.\n"),
-        mr->VolumeName);
-    return false;
-  }
-
-  // See if we need to wrap the passphrase.
-  if (me->keyencrkey.value) {
-    char* wrapped_passphrase;
-
-    length = DEFAULT_PASSPHRASE_LENGTH + 8;
-    wrapped_passphrase = (char*)malloc(length);
-    memset(wrapped_passphrase, 0, length);
-    if (auto error = AesWrap(
-            (unsigned char*)me->keyencrkey.value, DEFAULT_PASSPHRASE_LENGTH / 8,
-            (unsigned char*)passphrase, (unsigned char*)wrapped_passphrase)) {
-      ua->ErrorMsg(T_("Failed to wrap passphrase ERR=%s.\n"), error->c_str());
-      free(passphrase);
-      return false;
-    }
-
-    free(passphrase);
-    passphrase = wrapped_passphrase;
-  } else {
-    length = DEFAULT_PASSPHRASE_LENGTH;
-  }
-
-  // The passphrase is always base64 encoded.
-  BinToBase64(mr->EncrKey, sizeof(mr->EncrKey), passphrase, length, true);
-
-  free(passphrase);
-  return true;
 }
 
 bool SendLabelRequest(UaContext* ua,

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -39,9 +39,10 @@
 #include "dird/ua_db.h"
 #include "dird/ua_input.h"
 #include "dird/ua_select.h"
+#include "lib/bool_string.h"
 #include "lib/edit.h"
 #include "lib/util.h"
-#include "lib/bool_string.h"
+#include "volume_key.h"
 
 namespace directordaemon {
 
@@ -314,6 +315,81 @@ static void UpdateVolslot(UaContext* ua, char* val, MediaDbRecord* mr)
   }
 }
 
+static void ReplaceVolEncryptionKey(UaContext* ua, MediaDbRecord* mr)
+{
+  if (!GenerateNewEncryptionKey(ua, mr)) { return; }
+  if (DbLocker _{ua->db}; !ua->db->UpdateMediaRecord(ua->jcr, mr)) {
+    ua->ErrorMsg(T_("Error updating media record: ERR=%s"), ua->db->strerror());
+  } else {
+    ua->InfoMsg("Generated new encryption key for volume '%s' in catalog.\n",
+                mr->VolumeName);
+  }
+}
+
+static void RemoveVolEncryptionKey(UaContext* ua, MediaDbRecord* mr)
+{
+  memset(mr->EncrKey, 0, sizeof(mr->EncrKey));
+  if (DbLocker _{ua->db}; !ua->db->UpdateMediaRecord(ua->jcr, mr)) {
+    ua->ErrorMsg(T_("Error updating media record: ERR=%s"), ua->db->strerror());
+  } else {
+    ua->InfoMsg("Removed encryption key for volume '%s' from catalog.\n",
+                mr->VolumeName);
+  }
+}
+
+static void UpdateVolEncryption(UaContext* ua,
+                                std::string_view val,
+                                MediaDbRecord* mr)
+{
+  const bool key_present = strnlen(mr->EncrKey, 1);
+  const bool vol_is_purged = bstrcmp(mr->VolStatus, NT_("Purged"));
+
+  switch (parse_user_bool(val)) {
+    case parse_bool_result::True:
+      if (key_present) {
+        ua->WarningMsg("Encryption key for volume '%s' already configured.\n",
+                       mr->VolumeName);
+      } else {
+        ReplaceVolEncryptionKey(ua, mr);
+      }
+      break;
+    case parse_bool_result::False:
+      if (!key_present) {
+        ua->WarningMsg("No encryption key for volume '%s' configured.\n",
+                       mr->VolumeName);
+      } else if (!vol_is_purged) {
+        ua->ErrorMsg(
+            "Removing encryption key from volume '%s' requires "
+            "volstatus=Purged\n",
+            mr->VolumeName);
+      } else {
+        ua->WarningMsg(
+            "If the volume is currently mounted, remount before use!\n");
+        RemoveVolEncryptionKey(ua, mr);
+      }
+      break;
+    case parse_bool_result::Error:
+      if (val == ci_string<"rotate">{}) {
+        if (!key_present) {
+          ua->WarningMsg("No encryption key for volume '%s' configured.\n",
+                         mr->VolumeName);
+        } else if (!vol_is_purged) {
+          ua->ErrorMsg(
+              "Rotating encryption key for volume '%s' requires "
+              "volstatus=Purged\n",
+              mr->VolumeName);
+        } else {
+          ua->WarningMsg(
+              "If the volume is currently mounted, remount before use!\n");
+          ReplaceVolEncryptionKey(ua, mr);
+        }
+      } else {
+        ua->ErrorMsg(T_("Valid values for Encrypt are yes/no/rotate\n"));
+      }
+  }
+}
+
+
 // Modify the Pool in which this Volume is located
 void UpdateVolPool(UaContext* ua,
                    char* val,
@@ -538,6 +614,7 @@ static bool UpdateVolume(UaContext* ua)
                       NT_("RecyclePool"),   /* 13 */
                       NT_("ActionOnPurge"), /* 14 */
                       NT_("Storage"),       /* 15 */
+                      NT_("Encrypt"),       /* 16 */
                       NULL};
 
 #define AllFromPool 11 /* keep this updated with above */
@@ -603,6 +680,9 @@ static bool UpdateVolume(UaContext* ua)
           break;
         case 15:
           UpdateVolStorage(ua, ua->argv[j], &mr);
+          break;
+        case 16:
+          UpdateVolEncryption(ua, ua->argv[j], &mr);
           break;
       }
       done = true;

--- a/core/src/dird/ua_update.cc
+++ b/core/src/dird/ua_update.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2016 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -41,6 +41,7 @@
 #include "dird/ua_select.h"
 #include "lib/edit.h"
 #include "lib/util.h"
+#include "lib/bool_string.h"
 
 namespace directordaemon {
 

--- a/core/src/dird/volume_key.cc
+++ b/core/src/dird/volume_key.cc
@@ -1,0 +1,89 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+#include "lib/crypto_wrap.h"
+#include "lib/passphrase.h"
+#include "cats/cats.h"
+#include "dird_conf.h"
+#include "dird_globals.h"
+#include "ua.h"
+
+#include "volume_key.h"
+namespace directordaemon {
+/*
+ * Generate a new encryption key for use in volume encryption.
+ * We don't ask the user for a encryption key but generate a semi
+ * random passphrase of the wanted length which is way stronger.
+ * When the config has a wrap key we use that to wrap the newly
+ * created passphrase using RFC3394 aes wrap and always convert
+ * the passphrase into a base64 encoded string. This key is
+ * stored in the database and is passed to the storage daemon
+ * when needed. The storage daemon has the same wrap key per
+ * director so it can unwrap the passphrase for use.
+ *
+ * Changing the wrap key will render any previously created
+ * crypto keys useless so only change the wrap key after initial
+ * setting when you know what you are doing and always store
+ * the old key somewhere save so you can use bscrypto to
+ * convert them for the new wrap key.
+ */
+
+bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr)
+{
+  int length;
+  char* passphrase;
+
+  passphrase = generate_crypto_passphrase(DEFAULT_PASSPHRASE_LENGTH);
+  if (!passphrase) {
+    ua->ErrorMsg(
+        T_("Failed to generate new encryption passphrase for Volume %s.\n"),
+        mr->VolumeName);
+    return false;
+  }
+
+  // See if we need to wrap the passphrase.
+  if (me->keyencrkey.value) {
+    char* wrapped_passphrase;
+
+    length = DEFAULT_PASSPHRASE_LENGTH + 8;
+    wrapped_passphrase = (char*)malloc(length);
+    memset(wrapped_passphrase, 0, length);
+    if (auto error = AesWrap(
+            (unsigned char*)me->keyencrkey.value, DEFAULT_PASSPHRASE_LENGTH / 8,
+            (unsigned char*)passphrase, (unsigned char*)wrapped_passphrase)) {
+      ua->ErrorMsg(T_("Failed to wrap passphrase ERR=%s.\n"), error->c_str());
+      free(passphrase);
+      free(wrapped_passphrase);
+      return false;
+    }
+
+    free(passphrase);
+    passphrase = wrapped_passphrase;
+  } else {
+    length = DEFAULT_PASSPHRASE_LENGTH;
+  }
+
+  // The passphrase is always base64 encoded.
+  BinToBase64(mr->EncrKey, sizeof(mr->EncrKey), passphrase, length, true);
+
+  free(passphrase);
+  return true;
+}
+}  // namespace directordaemon

--- a/core/src/dird/volume_key.h
+++ b/core/src/dird/volume_key.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2018-2026 Bareos GmbH & Co. KG
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -18,10 +18,15 @@
    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
    02110-1301, USA.
 */
-#ifndef BAREOS_LIB_PASSPHRASE_H_
-#define BAREOS_LIB_PASSPHRASE_H_
 
-#include <cstdint>
-char* generate_crypto_passphrase(uint16_t length);
+#ifndef BAREOS_DIRD_VOLUME_KEY_H_
+#define BAREOS_DIRD_VOLUME_KEY_H_
 
-#endif  // BAREOS_LIB_PASSPHRASE_H_
+struct MediaDbRecord;
+
+namespace directordaemon {
+class UaContext;
+bool GenerateNewEncryptionKey(UaContext* ua, MediaDbRecord* mr);
+}  // namespace directordaemon
+
+#endif  // BAREOS_DIRD_VOLUME_KEY_H_

--- a/core/src/lib/bool_string.h
+++ b/core/src/lib/bool_string.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2020-2020 Bareos GmbH & Co. KG
+   Copyright (C) 2020-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,11 +36,7 @@ class BoolString {
       throw std::out_of_range(err + str_value);
     }
   }
-  template <typename T = std::string>
-  T get() const
-  {
-    return str_value;
-  }
+  template <typename T = std::string> T get() const { return str_value; }
 
  private:
   std::string str_value;
@@ -48,10 +44,92 @@ class BoolString {
   const std::set<std::string> false_values{"false", "no", "0"};
 };
 
-template <>
-inline bool BoolString::get<bool>() const
+template <> inline bool BoolString::get<bool>() const
 {
   return true_values.find(str_value) != true_values.end();
+}
+
+/**
+ * Parses a user provided string for a bool.
+ *
+ * This only works for ascii strings.
+ */
+
+enum class parse_bool_result
+{
+  True,
+  False,
+  Error,
+};
+
+namespace bool_parsing::internal {
+template <size_t N>
+inline bool is_in_vec(const std::string_view (&candidates)[N],
+                      std::string_view value)
+{
+  for (auto candidate : candidates) {
+    if (value.size() == candidate.size()
+        && strncasecmp(value.data(), candidate.data(), value.size()) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline std::pair<parse_bool_result, bool> parse_bool(std::string_view input,
+                                                     bool allow_deprecated
+                                                     = false)
+{
+  static constexpr std::string_view true_accepted[] = {"yes"};
+  static constexpr std::string_view true_deprecated[] = {"true", "1"};
+
+  static constexpr std::string_view false_accepted[] = {"no"};
+  static constexpr std::string_view false_deprecated[] = {"false", "0"};
+
+  bool deprecated = false;
+
+  if (is_in_vec(true_accepted, input)) {
+    return {parse_bool_result::True, deprecated};
+  }
+  if (is_in_vec(false_accepted, input)) {
+    return {parse_bool_result::False, deprecated};
+  }
+
+  deprecated = true;
+  if (is_in_vec(true_deprecated, input)) {
+    if (allow_deprecated) {
+      return {parse_bool_result::True, deprecated};
+    } else {
+      return {parse_bool_result::Error, deprecated};
+    }
+  }
+  if (is_in_vec(false_deprecated, input)) {
+    if (allow_deprecated) {
+      return {parse_bool_result::False, deprecated};
+    } else {
+      return {parse_bool_result::Error, deprecated};
+    }
+  }
+
+  return {parse_bool_result::Error, false};
+}
+}  // namespace bool_parsing::internal
+
+static inline parse_bool_result parse_user_bool(std::string_view input)
+{
+  using namespace bool_parsing::internal;
+
+  auto [result, deprecated] = parse_bool(input);
+
+  if (deprecated) {
+    // we do not accept deprecated options in user contexts
+
+    Dmsg0(100, "User passed deprecated option %.*s\n", (int)input.size(),
+          input.data());
+
+    return parse_bool_result::Error;
+  }
+  return result;
 }
 
 #endif  // BAREOS_LIB_BOOL_STRING_H_

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -234,4 +234,45 @@ static_assert(split_first("abc", ',') == std::nullopt);
 static_assert(split_first("abc", 'b')->first == "a");
 static_assert(split_first("abcbd", 'b')->second == "cbd");
 
+// compile-time strings
+template <std::size_t N> struct fixed_string {
+  char value[N];
+
+  constexpr fixed_string(const char (&str)[N]) { std::copy_n(str, N, value); }
+
+  constexpr std::string_view view() const
+  {
+    return {value, N - 1};  // ohne Nullterminator
+  }
+};
+
+template <std::size_t N> fixed_string(const char (&)[N]) -> fixed_string<N>;
+
+// basic constexpr version of tolower(char c)
+inline constexpr char ascii_tolower(char c)
+{
+  return (c >= 'A' && c <= 'Z') ? static_cast<char>(c - 'A' + 'a') : c;
+}
+
+// compile-time string that compares case-insensitively
+template <fixed_string S> struct ci_string {
+  static constexpr std::string_view value = S.view();
+
+  constexpr bool operator==(std::string_view rhs) const
+  {
+    if (value.size() != rhs.size()) return false;
+
+    for (std::size_t i = 0; i < value.size(); ++i) {
+      if (ascii_tolower(value[i]) != ascii_tolower(rhs[i])) return false;
+    }
+
+    return true;
+  }
+
+  friend constexpr bool operator==(std::string_view lhs, ci_string rhs)
+  {
+    return rhs == lhs;
+  }
+};
+
 #endif  // BAREOS_LIB_UTIL_H_

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1969,7 +1969,12 @@ update
          All Volumes from Pool
          All Volumes from all Pools
 
+   You can add, remove or rotate a volume encryption key using :bcommand:`update
+   volume=<volume-name> encrypt=<yes/no/rotate>` for :ref:`scsicrypto-sd`.
 
+   .. warning::
+      As a new encryption key will only be loaded on volume mount, make sure you
+      re-mount any currently mounted volume when changing the encryption key!
 
    For slots :bcommand:`update slots`, Bareos will obtain a list of slots and their barcodes from
    the Storage daemon, and for each barcode found, it will automatically update the slot in the
@@ -2003,7 +2008,7 @@ update
               [recycle=<yes/no>] [slot=<number>] [inchanger=<yes/no>] |
               pool=<pool-name> [maxvolbytes=<size>] [maxvolfiles=<nb>]
               [maxvoljobs=<nb>][enabled=<yes/no>] [recyclepool=<pool-name>]
-              [actiononpurge=<action>] |
+              [actiononpurge=<action>] [encrypt=<yes/no/rotate>] |
               slots [storage=<storage-name>] [scan] |
               jobid=<jobid> [jobname=<name>] [starttime=<time-def>]
               [client=<client-name>] [filesetid=<fileset-id>]

--- a/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/StorageDaemonPlugins/ScsicryptoSd.rst.inc
@@ -39,6 +39,8 @@ Changes in the director
 '''''''''''''''''''''''
 
 The director has been extended with additional code for handling hardware data encryption. The extra keyword **encrypt** on the label of a volume will force the director to generate a new semi-random passphrase for the volume, which will be stored in the database as part of the media information.
+You can use :bcommand:`update volume=<volume-name> encrypt=<yes/no/rotate>` to
+add, remove or rotate the encryption key for an existing volume.
 
 A passphrase is always stored in the database base64-encoded. When a so called **Key Encryption Key** is set in the config of the director, the passphrase is first wrapped using RFC3394 key wrapping and then base64-encoded. By using key wrapping, the keys in the database are safe against people sniffing the info, as the data is still encrypted using the Key Encryption Key (which in essence is just an extra passphrase of the same length as the volume passphrases used).
 


### PR DESCRIPTION
**Backport of PR #2724 to bareos-25**

Besides the backport of the PR itself, some changes to `core/lib/bool_string.h` had to be brought in from the development version.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2724 is merged
- [x] All functional differences to the original PR are documented above
