### PR TITLE
logrotate: add minsize 100k

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: ensure runscripts are only executed once [PR #2661]
 - core: fix sometimes not preserving used resource pointers [PR #2725]
 - Fix proxmox plugin stalling virtual machines [PR #2733]
+- logrotate: add minsize 100k [PR #2731]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2348,6 +2349,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2721]: https://github.com/bareos/bareos/pull/2721
 [PR #2724]: https://github.com/bareos/bareos/pull/2724
 [PR #2725]: https://github.com/bareos/bareos/pull/2725
+[PR #2731]: https://github.com/bareos/bareos/pull/2731
 [PR #2733]: https://github.com/bareos/bareos/pull/2733
 [PR #2736]: https://github.com/bareos/bareos/pull/2736
 [PR #2737]: https://github.com/bareos/bareos/pull/2737

--- a/core/scripts/logrotate.in
+++ b/core/scripts/logrotate.in
@@ -8,6 +8,7 @@
 #
 @logdir@/bareos*.log {
     monthly
+    minsize 100k
     rotate 6
     notifempty
     missingok

--- a/core/src/plugins/filed/python/test/bareosfd_test.py
+++ b/core/src/plugins/filed/python/test/bareosfd_test.py
@@ -117,8 +117,17 @@ class TestBareosFd(unittest.TestCase):
             test_StatPacket.st_mtime,
             test_StatPacket.st_ctime,
         ):
-            self.assertGreaterEqual(ts_value, timestamp_before - 1.0)
-            self.assertLessEqual(ts_value, timestamp_after + 1.0)
+            # ptyhon time.time() uses CLOCK_REALTIME, while our code
+            # uses time(NULL).  These can differ by a few milliseconds,
+            # which can cause large differences between of rounding.
+            # E.g. we can have
+            #   timestamp_before = 1785830999.000088, and
+            #   ts_value = 1785830998
+            # Which are further apart than 1 second, even time(NULL) probably
+            # just lagged by ~90us behind CLOCK_REALTIME.
+
+            self.assertGreaterEqual(ts_value, timestamp_before - 2.0)
+            self.assertLessEqual(ts_value, timestamp_after + 2.0)
 
         # set fixed values for comparison
         test_StatPacket.st_atime = 999


### PR DESCRIPTION
With Bareos 25 rpm installation get separated `bareos-*-install` log
files in /var/log/bareos.

We will now rotate any log file over 100k.

Fix bareos/bareos#2644

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

