### PR TITLE
barri-fd: implement restore on windows clients

### DIFF
--- a/core/src/dird/ua_purge.cc
+++ b/core/src/dird/ua_purge.cc
@@ -542,7 +542,7 @@ bool PurgeJobsFromVolume(UaContext* ua, MediaDbRecord* mr, bool force)
     } else {
       PurgeJobsFromCatalog(ua, jobids.c_str());
       ua->InfoMsg(
-          T_("%" PRIuz " Jobs%s on Volume \"%s\" purged from catalog.\n"),
+          T_("%" PRIuz " Job%s on Volume \"%s\" purged from catalog.\n"),
           lst.size(), lst.size() <= 1 ? "" : "s", mr->VolumeName);
     }
   }

--- a/core/src/filed/restore.cc
+++ b/core/src/filed/restore.cc
@@ -1162,6 +1162,7 @@ bool StoreData(JobControlRecord* jcr,
         BErrNo be;
         Jmsg2(jcr, M_ERROR, 0, T_("Write error on %s: %s\n"),
               jcr->fd_impl->last_fname, be.bstrerror(bfd->BErrNo));
+        return false;
       }
     }
   }

--- a/core/src/findlib/attribs.cc
+++ b/core/src/findlib/attribs.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2002-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -368,32 +368,59 @@ bool SetAttributes(JobControlRecord* jcr,
    * simply fall through and we will do it the universal way. */
 #endif
 
-  old_mask = umask(0);
-  if (IsBopen(ofd)) {
-    boffset_t fsize;
-    char ec1[50], ec2[50];
 
-    fsize = blseek(ofd, 0, SEEK_END);
-    if (attr->type == FT_REG && fsize > 0 && attr->statp.st_size > 0
-        && fsize != (boffset_t)attr->statp.st_size) {
-      Jmsg3(jcr, M_ERROR, 0,
-            T_("File size of restored file %s not correct. Original %s, "
-               "restored %s.\n"),
-            attr->ofname, edit_uint64(attr->statp.st_size, ec1),
-            edit_uint64(fsize, ec2));
+  /* For some reason someone decided to implement windows support by
+   * implementing a posix layer that translates "normal" posix calls
+   * to a windows implementation, so that (in theory) you can just
+   * write this as if it was unix-only, and have it work on windows.
+   *
+   * Sadly this implementation of this layer is not normal, and you
+   * constantly run into situations where the code looks completely correct,
+   * but its actually doing something different than you expect.
+   *
+   * Normally attr->statp.st_size is signed, so to check for "unset" sizes
+   * (which are mostly set to 0 or -1), you can just check st_size > 0.
+   * And this is the way this code checked it for ages, until someone
+   * (which is sadly me) decided to test sparse files + io in core on windows.
+   * Conclusion: The stat field on windows is unsigned, so st_size{-1} > 0
+   * always holds.
+   *
+   * As such we introduced this ugly function to do the check here.
+   * */
+
+  auto has_set_size = [](struct stat& input) -> bool {
+    if constexpr (std::is_unsigned_v<decltype(input.st_size)>) {
+      return (input.st_size != 0)
+             && (input.st_size
+                 != std::numeric_limits<decltype(input.st_size)>::max());
+    } else {
+      return input.st_size > 0;
     }
-  } else {
-    struct stat st;
-    char ec1[50], ec2[50];
+  };
 
-    if (lstat(attr->ofname, &st) == 0) {
-      if (attr->type == FT_REG && st.st_size > 0 && attr->statp.st_size > 0
-          && st.st_size != attr->statp.st_size) {
+  old_mask = umask(0);
+  if (has_set_size(attr->statp) && attr->type == FT_REG) {
+    if (IsBopen(ofd)) {
+      boffset_t fsize;
+      fsize = blseek(ofd, 0, SEEK_END);
+
+      if (fsize > 0 && fsize != (boffset_t)attr->statp.st_size) {
         Jmsg3(jcr, M_ERROR, 0,
-              T_("File size of restored file %s not correct. Original %s, "
-                 "restored %s.\n"),
-              attr->ofname, edit_uint64(attr->statp.st_size, ec1),
-              edit_uint64(st.st_size, ec2));
+              T_("File size of restored file %s not correct. Original %zu, "
+                 "restored %zu.\n"),
+              attr->ofname, static_cast<size_t>(attr->statp.st_size),
+              static_cast<size_t>(fsize));
+      }
+    } else {
+      struct stat st;
+      if (lstat(attr->ofname, &st) == 0) {
+        if (st.st_size > 0 && st.st_size != attr->statp.st_size) {
+          Jmsg3(jcr, M_ERROR, 0,
+                T_("File size of restored file %s not correct. Original %zu, "
+                   "restored %zu.\n"),
+                attr->ofname, static_cast<size_t>(attr->statp.st_size),
+                static_cast<size_t>(st.st_size));
+        }
       }
     }
   }

--- a/core/src/findlib/bfile.cc
+++ b/core/src/findlib/bfile.cc
@@ -901,7 +901,7 @@ boffset_t blseek(BareosFilePacket* bfd, boffset_t offset, int whence)
   LONG offset_high = (LONG)(offset >> 32);
   DWORD dwResult;
 
-  if (bfd->cmd_plugin && plugin_blseek) {
+  if (bfd->cmd_plugin && plugin_blseek && !bfd->do_io_in_core) {
     return plugin_blseek(bfd, offset, whence);
   }
 
@@ -1142,9 +1142,10 @@ ssize_t bread(BareosFilePacket* bfd, void* buf, size_t count)
 
 ssize_t bwrite(BareosFilePacket* bfd, void* buf, size_t count)
 {
-  if (bfd->cmd_plugin && plugin_bwrite)
+  if (bfd->cmd_plugin && plugin_bwrite && !bfd->do_io_in_core) {
     // plugin does read/write
-    if (!bfd->do_io_in_core) { return plugin_bwrite(bfd, buf, count); }
+    return plugin_bwrite(bfd, buf, count);
+  }
 
   const char* ptr = static_cast<const char*>(buf);
 
@@ -1175,7 +1176,7 @@ boffset_t blseek(BareosFilePacket* bfd, boffset_t offset, int whence)
 {
   boffset_t pos;
 
-  if (bfd->cmd_plugin && plugin_bwrite) {
+  if (bfd->cmd_plugin && plugin_blseek && !bfd->do_io_in_core) {
     return plugin_blseek(bfd, offset, whence);
   }
   pos = (boffset_t)lseek(bfd->filedes, offset, whence);

--- a/core/src/lib/util.h
+++ b/core/src/lib/util.h
@@ -275,4 +275,21 @@ template <fixed_string S> struct ci_string {
   }
 };
 
+inline std::vector<std::string_view> split_string_view(std::string_view input,
+                                                       char c)
+{
+  std::vector<std::string_view> result;
+  auto current = input;
+  for (;;) {
+    std::optional split = split_first(current, c);
+    if (!split) {
+      result.push_back(current);
+      break;
+    }
+    result.push_back(split->first);
+    current = split->second;
+  }
+
+  return result;
+}
 #endif  // BAREOS_LIB_UTIL_H_

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -19,7 +19,9 @@
    02110-1301, USA.
 */
 
+#include <variant>
 #include "include/job_types.h"
+#include "lib/util.h"
 #if !defined(PLUGIN_NAME)
 #  error PLUGIN_NAME not set
 #endif
@@ -40,6 +42,8 @@
 
 #include <charconv>
 #include <memory>
+
+#include <tl/expected.hpp>
 
 #if defined(MSVC_JOINED_THE_MODERN_WORLD)
 #  define warn_msg(ctx, fmt, ...) \
@@ -95,8 +99,9 @@ on restore:
 )" PLUGIN_NAME
       R"(:<target>,
   where <target> is one of the following:
-    files=file1,file2,file3 - restore the disks to the chosen files
-    directory=dir           - restore the disks into the directory
+    disks=file1,file2,file3 - restore the disks to the chosen disks
+    vhdx-directory=dir      - restore the disks as vhdx files into the directory
+    raw-directory=dir       - restore the disks as raw files into the directory
     copy=path               - copy the barri image to the following path
 
   The copy option allows you to restore the image via the barri cli tool instead
@@ -162,7 +167,6 @@ std::size_t next_option(std::string_view& to_parse,
   debug_msg(300, " => input = {}", input);
 
   auto key = trim_right(next_part(input, '='));
-
 
   debug_msg(300, " => key = {}, value = {}", key, input);
   *value = trim(input);
@@ -269,6 +273,13 @@ void set_private_context(PluginContext* ctx, plugin_ctx* priv_ctx)
 {
   ctx->plugin_private_context = priv_ctx;
 }
+
+enum class file : std::size_t
+{
+  Dump,
+  Log,
+  Count,
+};
 
 namespace backup {
 struct plugin_arguments {
@@ -496,13 +507,6 @@ struct session_ctx {
   }
 };
 
-enum class file : std::size_t
-{
-  Dump,
-  Log,
-  Count,
-};
-
 struct context : ::context {
   virtual ~context() = default;
 
@@ -691,6 +695,77 @@ bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 };  // namespace backup
 
 namespace restore {
+using copy_location = std::string;
+using drive_list = std::vector<std::string>;
+
+struct plugin_arguments {
+  using Error = tl::unexpected<std::string>;
+
+  static std::optional<plugin_arguments> parse(PluginContext* ctx,
+                                               std::string_view str)
+  {
+    static constexpr std::string_view keywords[]
+        = {"disks", "vhdx-directory", "raw-directory", "copy"};
+
+    auto name = next_part(str, ':');
+
+    debug_msg(ctx, 300, "got name = '{}'", name);
+
+    if (name != PLUGIN_NAME) {
+      err_msg(ctx, "bad plugin options received, expected '{}', got '{}'",
+              PLUGIN_NAME, name);
+      return {};
+    }
+
+    plugin_arguments args{};
+    for (;;) {
+      str = trim_left(str);
+
+      if (str.size() == 0) { break; }
+
+      // we always choose the last option set, i.e. if
+      //  drives=a,b,c dump=k drives=l,m,n
+      // is given, we treat it the same as drives=l,m,n
+      // This allows the user to overwrite the options via FdPluginOptions
+
+      std::string_view value = {};
+      switch (next_option(str, keywords, &value)) {
+        case index_of(keywords, "disks"): {
+          debug_msg(ctx, 300, "parsing drives value '{}'", value);
+
+          auto paths = split_string_view(value, ',');
+
+          // checking of whether the paths are valid are done later
+          auto& list = args.target.emplace<drive_list>();
+          list.insert(list.end(), paths.begin(), paths.end());
+        } break;
+
+        case index_of(keywords, "copy"): {
+          debug_msg(ctx, 300, "parsing dump value '{}'", value);
+
+          args.target.emplace<copy_location>(value);
+        } break;
+
+        case index_of(keywords, "vhdx-directory"): {
+        } break;
+
+        case index_of(keywords, "raw-directory"): {
+        } break;
+
+        default: {
+          fatal_msg(ctx, "could not parse plugin options string '{}'", str);
+
+          return std::nullopt;
+        } break;
+      }
+    }
+
+    return args;
+  }
+
+  std::variant<std::monostate, copy_location, drive_list> target;
+};
+
 struct context : ::context {
   virtual ~context() = default;
 
@@ -700,23 +775,131 @@ struct context : ::context {
     return nullptr;
   }
 
-
   bool parse(PluginContext* ctx, const char* text) override
   {
-    (void)ctx;
-    (void)text;
-    return false;
+    std::optional opt = plugin_arguments::parse(ctx, text);
+    if (!opt) { return false; }
+    args = std::move(*opt);
+    return true;
   }
 
-  bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) override;
-};
+  bRC start_file(PluginContext* ctx, const char* name)
+  {
+    (void)ctx;
+    (void)name;
+    return bRC_OK;
+  }
 
-bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
-{
-  (void)ctx;
-  (void)pkt;
-  return bRC_Error;
-}
+  bRC end_current_file(PluginContext* ctx)
+  {
+    (void)ctx;
+    current_file_type.reset();
+    return bRC_OK;
+  }
+
+  bRC pluginIO_Session(drive_list& list,
+                       PluginContext* ctx,
+                       filedaemon::io_pkt* pkt)
+  {
+    (void)list;
+    (void)ctx;
+    (void)pkt;
+    return bRC_Error;
+  }
+
+  bRC pluginIO_Dump(copy_location& loc,
+                    PluginContext* ctx,
+                    filedaemon::io_pkt* pkt)
+  {
+    switch (pkt->func) {
+      case filedaemon::IO_OPEN: {
+        if (current_file_type.has_value()) {
+          fatal_msg(ctx, "Internal error occured: cannot open second file");
+          return bRC_Error;
+        }
+
+        std::string_view path{pkt->fname};
+        if (path.ends_with(log_ending)) {
+          current_file_type = file::Log;
+
+          auto log_path = loc;
+          log_path += log_ending;
+
+          // std::wstring utf16 = make_win32_path_UTF8_2_wchar(log_path);
+
+          auto hndl = CreateFileA(log_path.c_str(), GENERIC_WRITE, 0, NULL,
+                                  CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+          if (hndl == INVALID_HANDLE_VALUE) {
+            warn_msg(ctx, "Could create log file {} for writing", log_path);
+            return bRC_Error;
+          } else {
+            pkt->hndl = hndl;
+            pkt->status = IoStatus::do_io_in_core;
+
+            return bRC_OK;
+          }
+        } else if (path.ends_with(dump_ending)) {
+          current_file_type = file::Dump;
+          auto hndl = CreateFileA(loc.c_str(), GENERIC_WRITE, 0, NULL,
+                                  CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
+          if (hndl == INVALID_HANDLE_VALUE) {
+            warn_msg(ctx, "Could create dump file {} for writing", loc);
+            return bRC_Error;
+          } else {
+            pkt->hndl = hndl;
+            pkt->status = IoStatus::do_io_in_core;
+
+            return bRC_OK;
+          }
+
+          return bRC_Error;
+        } else {
+          fatal_msg(ctx, "cannot restore '{}': unknown file ending", path);
+          return bRC_Error;
+        }
+
+
+      } break;
+      case filedaemon::IO_CLOSE: {
+        if (!current_file_type.has_value()) {
+          fatal_msg(
+              ctx,
+              "Internal error occured: cannot close file if none are open");
+          return bRC_Error;
+        }
+
+        current_file_type.reset();
+
+        CloseHandle(pkt->hndl);
+
+        return bRC_Error;
+      } break;
+      default: {
+        fatal_msg(ctx,
+                  "Internal error occured: received unexpected instruction: {}",
+                  pkt->func);
+        return bRC_Error;
+      } break;
+    }
+  }
+
+  bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) override
+  {
+    if (auto* list = std::get_if<drive_list>(&args.target)) {
+      return pluginIO_Session(*list, ctx, pkt);
+    }
+
+    if (auto* loc = std::get_if<copy_location>(&args.target)) {
+      return pluginIO_Dump(*loc, ctx, pkt);
+    }
+
+    fatal_msg(ctx, "Cannot do IO as it was not set up yet!");
+    return bRC_Error;
+  }
+
+  std::optional<file> current_file_type{};
+  plugin_arguments args;
+};
 };  // namespace restore
 
 backup::context* get_backup_context(PluginContext* ctx)
@@ -881,7 +1064,7 @@ bRC startBackupFile(PluginContext* ctx, filedaemon::save_pkt* sp)
     }
   }
 
-  if (bctx->current_file == backup::file::Dump) {
+  if (bctx->current_file == file::Dump) {
     // setting this does not do anything yet.  Maybe it will in the future
     sp->portable = true;  // we do not create windows backup data streams
 
@@ -894,7 +1077,7 @@ bRC startBackupFile(PluginContext* ctx, filedaemon::save_pkt* sp)
     sp->statp.st_size = -1;
     sp->statp.st_blksize = 4096;
     sp->statp.st_blocks = 1;
-  } else if (bctx->current_file == backup::file::Log) {
+  } else if (bctx->current_file == file::Log) {
     if (!bctx->current_session) {
       fatal_msg(ctx, "cannot backup log of a session that does not exist");
       return bRC_Error;
@@ -928,9 +1111,9 @@ bRC endBackupFile(PluginContext* ctx)
     return bRC_Error;
   }
 
-  bctx->current_file = static_cast<backup::file>(
-      static_cast<std::size_t>(bctx->current_file) + 1);
-  if (bctx->current_file != backup::file::Count) { return bRC_More; }
+  bctx->current_file
+      = static_cast<file>(static_cast<std::size_t>(bctx->current_file) + 1);
+  if (bctx->current_file != file::Count) { return bRC_More; }
   return bRC_OK;
 }
 
@@ -946,7 +1129,7 @@ bRC startRestoreFile(PluginContext* ctx, const char* file_name)
     return bRC_Error;
   }
 
-  return bRC_OK;
+  return rctx->start_file(ctx, file_name);
 }
 
 bRC endRestoreFile(PluginContext* ctx)
@@ -960,7 +1143,8 @@ bRC endRestoreFile(PluginContext* ctx)
   }
 
   DebugLog(ctx, 500, "finished restoring file");
-  return bRC_OK;
+
+  return rctx->end_current_file(ctx);
 }
 
 bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -679,15 +679,14 @@ bRC endBackupFile(PluginContext* ctx)
 
 bRC startRestoreFile(PluginContext* ctx, const char* file_name)
 {
-  (void)ctx;
-  (void)file_name;
-  return bRC_Error;
+  DebugLog(ctx, 500, "starting to restore '{}'", file_name);
+  return bRC_OK;
 }
 
 bRC endRestoreFile(PluginContext* ctx)
 {
-  (void)ctx;
-  return bRC_Error;
+  DebugLog(ctx, 500, "finished restoring file");
+  return bRC_OK;
 }
 
 bRC pluginIO_Dump(PluginContext* ctx, filedaemon::io_pkt* pkt)

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -19,6 +19,7 @@
    02110-1301, USA.
 */
 
+#include "include/job_types.h"
 #if !defined(PLUGIN_NAME)
 #  error PLUGIN_NAME not set
 #endif
@@ -244,6 +245,32 @@ constexpr std::size_t index_of(std::span<const std::string_view> keywords,
   throw std::logic_error{"no such keyword"};
 }
 
+struct context {
+  virtual bool parse(PluginContext* ctx, const char* text) = 0;
+  virtual bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) = 0;
+  virtual ~context() = default;
+};
+
+struct plugin_ctx {
+  struct CoUninitializer {
+    ~CoUninitializer() { CoUninitialize(); }
+  };
+
+  CoUninitializer unititializer{};
+  std::unique_ptr<context> context;
+};
+
+plugin_ctx* get_private_context(PluginContext* ctx)
+{
+  return reinterpret_cast<plugin_ctx*>(ctx->plugin_private_context);
+}
+
+void set_private_context(PluginContext* ctx, plugin_ctx* priv_ctx)
+{
+  ctx->plugin_private_context = priv_ctx;
+}
+
+namespace backup {
 struct plugin_arguments {
   static std::optional<plugin_arguments> parse(PluginContext* ctx,
                                                std::string_view str)
@@ -469,8 +496,53 @@ struct session_ctx {
   }
 };
 
-struct plugin_ctx {
-  void set_plugin_args(plugin_arguments args_) { args = args_; }
+enum class file : std::size_t
+{
+  Dump,
+  Log,
+  Count,
+};
+
+struct context : ::context {
+  virtual ~context() = default;
+
+  file current_file = file::Dump;
+
+  static std::unique_ptr<context> make(PluginContext* ctx)
+  {
+    std::optional client_name = bVar::Get<bVar::Client>(ctx);
+    if (!client_name) {
+      fatal_msg(ctx, "could not retrieve client name from the bareos api!");
+      return nullptr;
+    }
+
+    auto now = time(NULL);
+
+    auto bctx = std::make_unique<context>();
+
+    std::string_view hostname{client_name.value()};
+    bctx->dump_file_name
+        = libbareos::format("@BARRI/{}{}", hostname, dump_ending);
+    bctx->log_file_name
+        = libbareos::format("@BARRI/{}{}", hostname, log_ending);
+
+    bctx->timestamp = now;
+
+    return bctx;
+  }
+
+
+  bool parse(PluginContext* ctx, const char* text) override
+  {
+    std::optional parsed = plugin_arguments::parse(ctx, text);
+    if (!parsed) { return false; }
+
+    args = std::move(*parsed);
+    return true;
+  }
+
+  std::optional<session_ctx> current_session;
+  plugin_arguments args;
 
   void begin_session(PluginContext* ctx) { current_session.emplace(ctx, args); }
 
@@ -482,38 +554,186 @@ struct plugin_ctx {
 
   bool has_session() const { return current_session.has_value(); }
 
-  std::optional<session_ctx> current_session;
-
-  struct CoUninitializer {
-    ~CoUninitializer() { CoUninitialize(); }
-  };
-
-  CoUninitializer unititializer{};
-  plugin_arguments args{};
-
-  enum class file : std::size_t
-  {
-    Dump,
-    Log,
-    Count,
-  };
-  file current_file = file::Dump;
-
   std::string dump_file_name;
   std::string log_file_name;
   time_t timestamp;
   std::size_t log_bytes_sent = 0;
+
+  bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) override;
 };
 
-plugin_ctx* get_private_context(PluginContext* ctx)
+bRC pluginIO_Dump(context* bctx, PluginContext* ctx, filedaemon::io_pkt* pkt)
 {
-  return reinterpret_cast<plugin_ctx*>(ctx->plugin_private_context);
+  switch (pkt->func) {
+    case filedaemon::IO_OPEN: {
+      if (bctx->has_session()) {
+        err_msg(ctx, "context can only be created once");
+        pkt->status = -1;
+        return bRC_Error;
+      }
+      try {
+        bctx->begin_session(ctx);
+        pkt->status = 0;
+        return bRC_OK;
+      } catch (const std::exception& ex) {
+        err_msg(ctx, "could not start: {}", ex.what());
+        pkt->status = -1;
+        return bRC_Error;
+      } catch (...) {
+        err_msg(ctx, "could not start: unknown error occurred");
+        pkt->status = -1;
+        return bRC_Error;
+      }
+    } break;
+    case filedaemon::IO_READ: {
+      if (pkt->count < 0) {
+        err_msg(ctx, "its impossible to read {} bytes...", pkt->count);
+        pkt->status = -1;
+        return bRC_Error;
+      }
+      pkt->status = bctx->session_read(
+          std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
+      return bRC_OK;
+    } break;
+    case filedaemon::IO_CLOSE: {
+      if (!bctx->has_session()) {
+        err_msg(ctx, "context can only be closed, if its open");
+        pkt->status = -1;
+        return bRC_Error;
+      }
+      pkt->status = 0;
+      return bRC_OK;
+    } break;
+  }
+
+  fatal_msg(ctx, "unhandled code path: {}", pkt->func);
+  return bRC_Error;
 }
 
-void set_private_context(PluginContext* ctx, plugin_ctx* priv_ctx)
+bRC pluginIO_Log(context* bctx, PluginContext* ctx, filedaemon::io_pkt* pkt)
 {
-  ctx->plugin_private_context = priv_ctx;
+  switch (pkt->func) {
+    case filedaemon::IO_OPEN: {
+      if (!bctx->has_session()) {
+        err_msg(ctx, "cannot open log: no session open");
+        pkt->status = -1;
+        return bRC_Error;
+      }
+      return bRC_OK;
+    } break;
+    case filedaemon::IO_READ: {
+      if (pkt->count < 0) {
+        err_msg(ctx, "it is impossible to read {} bytes...", pkt->count);
+        pkt->status = -1;
+        return bRC_Error;
+      }
+
+      auto log = bctx->current_session->logger.log();
+
+      std::size_t& log_bytes_sent = bctx->log_bytes_sent;
+      auto bytes_to_read = std::min(log.size() - log_bytes_sent,
+                                    static_cast<std::size_t>(pkt->count));
+
+      memcpy(pkt->buf, log.data() + log_bytes_sent, bytes_to_read);
+      pkt->status = bytes_to_read;
+      log_bytes_sent += bytes_to_read;
+      return bRC_OK;
+    } break;
+    case filedaemon::IO_CLOSE: {
+      pkt->status = 0;
+      return bRC_OK;
+    } break;
+  }
+  fatal_msg(ctx, "unhandled code path: {}", pkt->func);
+  return bRC_Error;
 }
+
+bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
+{
+  auto handler = [&] {
+    switch (current_file) {
+      case file::Dump: {
+        return &pluginIO_Dump;
+      } break;
+      case file::Log: {
+        return &pluginIO_Log;
+      } break;
+      default: {
+        return static_cast<decltype(&pluginIO_Dump)>(nullptr);
+      } break;
+    }
+  }();
+
+  if (!handler) {
+    fatal_msg(ctx, "could not find handler for file {}",
+              static_cast<std::size_t>(current_file));
+    return bRC_Error;
+  }
+
+
+  switch (pkt->func) {
+    case filedaemon::IO_OPEN:
+      [[fallthrough]];
+    case filedaemon::IO_READ:
+      [[fallthrough]];
+    case filedaemon::IO_CLOSE: {
+      return handler(this, ctx, pkt);
+    } break;
+
+    case filedaemon::IO_WRITE: {
+      err_msg(ctx, "restores are not supported during a backup");
+      pkt->status = -1;
+      return bRC_Error;
+    } break;
+  }
+  return bRC_Error;
+}
+};  // namespace backup
+
+namespace restore {
+struct context : ::context {
+  virtual ~context() = default;
+
+  static std::unique_ptr<context> make(PluginContext*)
+  {
+    (void)ctx;
+    return nullptr;
+  }
+
+
+  bool parse(PluginContext* ctx, const char* text) override
+  {
+    (void)ctx;
+    (void)text;
+    return false;
+  }
+
+  bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) override;
+};
+
+bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
+{
+  (void)ctx;
+  (void)pkt;
+  return bRC_Error;
+}
+};  // namespace restore
+
+backup::context* get_backup_context(PluginContext* ctx)
+{
+  auto* pctx = get_private_context(ctx);
+
+  return dynamic_cast<backup::context*>(pctx->context.get());
+}
+
+restore::context* get_restore_context(PluginContext* ctx)
+{
+  auto* pctx = get_private_context(ctx);
+  (void)pctx;
+
+  return dynamic_cast<restore::context*>(pctx->context.get());
+}
+
 
 bRC newPlugin(PluginContext* ctx)
 {
@@ -533,23 +753,6 @@ bRC newPlugin(PluginContext* ctx)
   RegisterBareosEvent(ctx, filedaemon::bEventEstimateCommand);
   RegisterBareosEvent(ctx, filedaemon::bEventBackupCommand);
   RegisterBareosEvent(ctx, filedaemon::bEventRestoreObject);
-
-  std::optional client_name = bVar::Get<bVar::Client>(ctx);
-  if (!client_name) {
-    fatal_msg(ctx, "could not retrieve client name from the bareos api!");
-    return bRC_Error;
-  }
-
-  auto now = time(NULL);
-
-  auto pctx = get_private_context(ctx);
-
-  std::string_view hostname{client_name.value()};
-  pctx->dump_file_name
-      = libbareos::format("@BARRI/{}{}", hostname, dump_ending);
-  pctx->log_file_name = libbareos::format("@BARRI/{}{}", hostname, log_ending);
-
-  pctx->timestamp = now;
 
   return bRC_OK;
 }
@@ -576,44 +779,80 @@ bRC setPluginValue(PluginContext*, filedaemon::pVariable, void*)
 bRC handlePluginEvent(PluginContext* ctx, filedaemon::bEvent* event, void* data)
 {
   auto* pctx = get_private_context(ctx);
-  switch (event->eventType) {
-    case filedaemon::bEventPluginCommand: {
-      std::optional arguments
-          = plugin_arguments::parse(ctx, static_cast<const char*>(data));
+  if (!pctx->context) {
+    std::optional job_type = bVar::Get<bVar::Type>(ctx);
 
-      if (!arguments) {
-        DebugLog(ctx, 300, "plugin option string could not be parsed");
-        return bRC_Error;
-      }
-      pctx->set_plugin_args(std::move(arguments.value()));
-      return bRC_OK;
-    } break;
+    if (!job_type) {
+      DebugLog(ctx, 300, "could not query job type!");
+      return bRC_Error;
+    }
 
-    case filedaemon::bEventNewPluginOptions:
-      [[fallthrough]];
-    case filedaemon::bEventBackupCommand:
-      [[fallthrough]];
-    case filedaemon::bEventEstimateCommand:
-      [[fallthrough]];
-    case filedaemon::bEventRestoreCommand: {
-      std::optional arguments
-          = plugin_arguments::parse(ctx, static_cast<const char*>(data));
+    if (*job_type == JT_RESTORE) {
+      // if its set to restore, then we are definitely a restore job
 
-      if (!arguments) {
-        DebugLog(ctx, 300, "plugin option string could not be parsed");
+      auto rctx = restore::context::make(ctx);
+      if (!rctx) {
+        fatal_msg(ctx, "Could not start a restore job");
         return bRC_Error;
       }
 
-      pctx->set_plugin_args(std::move(arguments.value()));
-      return bRC_OK;
-    } break;
+      pctx->context = std::move(rctx);
+    } else {
+      // we take a guess and say this is a backup job (as we only support
+      // these two options!)
+
+      auto bctx = backup::context::make(ctx);
+      if (!bctx) {
+        fatal_msg(ctx, "Could not start a backup job");
+        return bRC_Error;
+      }
+
+      pctx->context = std::move(bctx);
+    }
   }
-  return bRC_Error;
+
+
+  if (auto* bctx = get_backup_context(ctx)) {
+    switch (event->eventType) {
+      case filedaemon::bEventNewPluginOptions:
+        [[fallthrough]];
+      case filedaemon::bEventPluginCommand: {
+        if (!bctx->parse(ctx, static_cast<const char*>(data))) {
+          DebugLog(ctx, 300, "plugin option string could not be parsed");
+          return bRC_Error;
+        }
+        return bRC_OK;
+      } break;
+    }
+  } else if (auto* rctx = get_restore_context(ctx)) {
+    switch (event->eventType) {
+      case filedaemon::bEventNewPluginOptions:
+        [[fallthrough]];
+      case filedaemon::bEventRestoreCommand: {
+        if (!rctx->parse(ctx, static_cast<const char*>(data))) {
+          DebugLog(ctx, 300, "plugin option string could not be parsed");
+          return bRC_Error;
+        }
+        return bRC_OK;
+      } break;
+    }
+  } else {
+    fatal_msg(ctx, "Context was not setup properly");
+    return bRC_Error;
+  }
+
+  warn_msg(ctx, "Unknown event {} passed", (int)event->eventType);
+  return bRC_OK;
 }
 
 bRC startBackupFile(PluginContext* ctx, filedaemon::save_pkt* sp)
 {
-  auto* pctx = get_private_context(ctx);
+  auto* bctx = get_backup_context(ctx);
+
+  if (!bctx) {
+    fatal_msg(ctx, "Backup Context was not set before {}", __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
 
   // first we check if this is a full backup.  If not, we reject the backup
   {
@@ -642,34 +881,34 @@ bRC startBackupFile(PluginContext* ctx, filedaemon::save_pkt* sp)
     }
   }
 
-  if (pctx->current_file == plugin_ctx::file::Dump) {
+  if (bctx->current_file == backup::file::Dump) {
     // setting this does not do anything yet.  Maybe it will in the future
     sp->portable = true;  // we do not create windows backup data streams
 
-    sp->fname = const_cast<char*>(pctx->dump_file_name.c_str());
+    sp->fname = const_cast<char*>(bctx->dump_file_name.c_str());
     sp->type = FT_REG;
     sp->statp.st_mode = 0700 | S_IFREG;
-    sp->statp.st_ctime = pctx->timestamp;
-    sp->statp.st_mtime = pctx->timestamp;
-    sp->statp.st_atime = pctx->timestamp;
+    sp->statp.st_ctime = bctx->timestamp;
+    sp->statp.st_mtime = bctx->timestamp;
+    sp->statp.st_atime = bctx->timestamp;
     sp->statp.st_size = -1;
     sp->statp.st_blksize = 4096;
     sp->statp.st_blocks = 1;
-  } else if (pctx->current_file == plugin_ctx::file::Log) {
-    if (!pctx->current_session) {
+  } else if (bctx->current_file == backup::file::Log) {
+    if (!bctx->current_session) {
       fatal_msg(ctx, "cannot backup log of a session that does not exist");
       return bRC_Error;
     }
 
     sp->portable = true;  // we do not create windows backup data streams
 
-    sp->fname = const_cast<char*>(pctx->log_file_name.c_str());
+    sp->fname = const_cast<char*>(bctx->log_file_name.c_str());
     sp->type = FT_REG;
     sp->statp.st_mode = 0700 | S_IFREG;
-    sp->statp.st_ctime = pctx->timestamp;
-    sp->statp.st_mtime = pctx->timestamp;
-    sp->statp.st_atime = pctx->timestamp;
-    sp->statp.st_size = pctx->current_session->logger.log().size();
+    sp->statp.st_ctime = bctx->timestamp;
+    sp->statp.st_mtime = bctx->timestamp;
+    sp->statp.st_atime = bctx->timestamp;
+    sp->statp.st_size = bctx->current_session->logger.log().size();
     sp->statp.st_blksize = 4096;
     sp->statp.st_blocks = (sp->statp.st_size + 4095) / 4096;
   } else {
@@ -682,152 +921,59 @@ bRC startBackupFile(PluginContext* ctx, filedaemon::save_pkt* sp)
 
 bRC endBackupFile(PluginContext* ctx)
 {
-  auto* pctx = get_private_context(ctx);
-  pctx->current_file = static_cast<plugin_ctx::file>(
-      static_cast<std::size_t>(pctx->current_file) + 1);
-  if (pctx->current_file != plugin_ctx::file::Count) { return bRC_More; }
+  auto* bctx = get_backup_context(ctx);
+
+  if (!bctx) {
+    fatal_msg(ctx, "Backup Context was not set before {}", __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
+
+  bctx->current_file = static_cast<backup::file>(
+      static_cast<std::size_t>(bctx->current_file) + 1);
+  if (bctx->current_file != backup::file::Count) { return bRC_More; }
   return bRC_OK;
 }
 
 bRC startRestoreFile(PluginContext* ctx, const char* file_name)
 {
   DebugLog(ctx, 500, "starting to restore '{}'", file_name);
+
+  auto* rctx = get_restore_context(ctx);
+
+  if (!rctx) {
+    fatal_msg(ctx, "Restore Context was not set before {}",
+              __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
+
   return bRC_OK;
 }
 
 bRC endRestoreFile(PluginContext* ctx)
 {
+  auto* rctx = get_restore_context(ctx);
+
+  if (!rctx) {
+    fatal_msg(ctx, "Restore Context was not set before {}",
+              __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
+
   DebugLog(ctx, 500, "finished restoring file");
   return bRC_OK;
 }
 
-bRC pluginIO_Dump(PluginContext* ctx, filedaemon::io_pkt* pkt)
-{
-  auto* pctx = get_private_context(ctx);
-  switch (pkt->func) {
-    case filedaemon::IO_OPEN: {
-      if (pctx->has_session()) {
-        err_msg(ctx, "context can only be created once");
-        pkt->status = -1;
-        return bRC_Error;
-      }
-      try {
-        pctx->begin_session(ctx);
-        pkt->status = 0;
-        return bRC_OK;
-      } catch (const std::exception& ex) {
-        err_msg(ctx, "could not start: {}", ex.what());
-        pkt->status = -1;
-        return bRC_Error;
-      } catch (...) {
-        err_msg(ctx, "could not start: unknown error occurred");
-        pkt->status = -1;
-        return bRC_Error;
-      }
-    } break;
-    case filedaemon::IO_READ: {
-      if (pkt->count < 0) {
-        err_msg(ctx, "its impossible to read {} bytes...", pkt->count);
-        pkt->status = -1;
-        return bRC_Error;
-      }
-      pkt->status = pctx->session_read(
-          std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
-      return bRC_OK;
-    } break;
-    case filedaemon::IO_CLOSE: {
-      if (!pctx->has_session()) {
-        err_msg(ctx, "context can only be closed, if its open");
-        pkt->status = -1;
-        return bRC_Error;
-      }
-      pkt->status = 0;
-      return bRC_OK;
-    } break;
-  }
-
-  fatal_msg(ctx, "unhandled code path: {}", pkt->func);
-  return bRC_Error;
-}
-
-bRC pluginIO_Log(PluginContext* ctx, filedaemon::io_pkt* pkt)
-{
-  auto* pctx = get_private_context(ctx);
-  switch (pkt->func) {
-    case filedaemon::IO_OPEN: {
-      if (!pctx->has_session()) {
-        err_msg(ctx, "cannot open log: no session open");
-        pkt->status = -1;
-        return bRC_Error;
-      }
-      return bRC_OK;
-    } break;
-    case filedaemon::IO_READ: {
-      if (pkt->count < 0) {
-        err_msg(ctx, "it is impossible to read {} bytes...", pkt->count);
-        pkt->status = -1;
-        return bRC_Error;
-      }
-
-      auto log = pctx->current_session->logger.log();
-
-      std::size_t& log_bytes_sent = pctx->log_bytes_sent;
-      auto bytes_to_read = std::min(log.size() - log_bytes_sent,
-                                    static_cast<std::size_t>(pkt->count));
-
-      memcpy(pkt->buf, log.data() + log_bytes_sent, bytes_to_read);
-      pkt->status = bytes_to_read;
-      log_bytes_sent += bytes_to_read;
-      return bRC_OK;
-    } break;
-    case filedaemon::IO_CLOSE: {
-      pkt->status = 0;
-      return bRC_OK;
-    } break;
-  }
-  fatal_msg(ctx, "unhandled code path: {}", pkt->func);
-  return bRC_Error;
-}
-
 bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 {
-  auto* pctx = get_private_context(ctx);
-
-  auto handler = [&] {
-    switch (pctx->current_file) {
-      case plugin_ctx::file::Dump: {
-        return &pluginIO_Dump;
-      } break;
-      case plugin_ctx::file::Log: {
-        return &pluginIO_Log;
-      } break;
-    }
-    return static_cast<decltype(&pluginIO_Dump)>(nullptr);
-  }();
-
-  if (!handler) {
-    fatal_msg(ctx, "could not find handler for file {}",
-              static_cast<std::size_t>(pctx->current_file));
+  if (auto* bctx = get_backup_context(ctx)) {
+    return bctx->pluginIO(ctx, pkt);
+  } else if (auto* rctx = get_restore_context(ctx)) {
+    return rctx->pluginIO(ctx, pkt);
+  } else {
+    fatal_msg(ctx, "context is not setup properly, but {} is called",
+              __PRETTY_FUNCTION__);
     return bRC_Error;
   }
-
-
-  switch (pkt->func) {
-    case filedaemon::IO_OPEN:
-      [[fallthrough]];
-    case filedaemon::IO_READ:
-      [[fallthrough]];
-    case filedaemon::IO_CLOSE: {
-      return handler(ctx, pkt);
-    } break;
-
-    case filedaemon::IO_WRITE: {
-      err_msg(ctx, "restores are not supported on the windows plugin");
-      pkt->status = -1;
-      return bRC_Error;
-    } break;
-  }
-  return bRC_Error;
 }
 
 bRC createFile(PluginContext* ctx, filedaemon::restore_pkt* pkt)

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -1013,6 +1013,7 @@ struct context : ::context {
 
         if (hndl == INVALID_HANDLE_VALUE) {
           warn_msg(ctx, "Could not open file {} for writing", pkt->fname);
+          pkt->status = -1;
           return bRC_Error;
         } else {
           pkt->hndl = hndl;

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -34,6 +34,7 @@
 #include "parser.h"
 #include "dump.h"
 #include "plugin.h"
+#include "restore.h"
 #include "lib/bool_string.h"
 #include <comdef.h>
 #include <time.h>
@@ -455,8 +456,6 @@ struct plugin_arguments {
   bool save_unknown_extents{false};
 };
 
-
-namespace backup {
 struct plugin_logger : public GenericLogger {
   using Clock = std::chrono::steady_clock;
 
@@ -544,6 +543,7 @@ struct plugin_logger : public GenericLogger {
   std::vector<char> messages;
 };
 
+namespace backup {
 struct session_ctx {
   plugin_logger logger;
   std::unique_ptr<dump_context,
@@ -757,6 +757,33 @@ bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 };  // namespace backup
 
 namespace restore {
+struct session {
+  plugin_logger logger;
+
+  restartable_parser* parser{};
+  std::unique_ptr<GenericHandler> handler{};
+
+  session(PluginContext* ctx) : logger{ctx} {}
+
+  template <typename T>
+    requires std::same_as<T, vhdx_directory> || std::same_as<T, raw_directory>
+             || std::same_as<T, disk_ids>
+  bool begin(T dir)
+  {
+    handler = GetHandler(&logger, std::move(dir));
+    if (!handler) { return false; }
+    parser = parse_begin(handler.get(), &logger);
+    if (!parser) { return false; }
+    return true;
+  }
+
+  size_t write() {}
+
+  bool end() {}
+
+  ~session() {}
+};
+
 struct context : ::context {
   virtual ~context() = default;
 
@@ -801,9 +828,56 @@ struct context : ::context {
                        PluginContext* ctx,
                        filedaemon::io_pkt* pkt)
   {
-    (void)list;
-    (void)ctx;
-    (void)pkt;
+    switch (pkt->func) {
+      case filedaemon::IO_OPEN: {
+        if (current_session) {
+          err_msg(ctx, "context can only be created once");
+          pkt->status = -1;
+          return bRC_Error;
+        }
+        try {
+          current_session = parse_begin(handler.get(), &logger);
+          pkt->status = 0;
+          return bRC_OK;
+        } catch (const std::exception& ex) {
+          err_msg(ctx, "could not start: {}", ex.what());
+          pkt->status = -1;
+          return bRC_Error;
+        } catch (...) {
+          err_msg(ctx, "could not start: unknown error occurred");
+          pkt->status = -1;
+          return bRC_Error;
+        }
+      } break;
+      case filedaemon::IO_WRITE: {
+        if (pkt->count < 0) {
+          err_msg(ctx, "its impossible to write {} bytes...", pkt->count);
+          pkt->status = -1;
+          return bRC_Error;
+        }
+        if (!current_session) {
+          err_msg(ctx, "its impossible to write with no session", pkt->count);
+          pkt->status = -1;
+          return bRC_Error;
+        }
+        parse_data(current_session,
+                   std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
+        pkt->status = pkt->count;
+        return bRC_OK;
+      } break;
+      case filedaemon::IO_CLOSE: {
+        if (!current_session) {
+          err_msg(ctx, "context can only be closed, if its open");
+          pkt->status = -1;
+          return bRC_Error;
+        }
+        parse_end(current_session);
+        pkt->status = 0;
+        return bRC_OK;
+      } break;
+    }
+
+    fatal_msg(ctx, "unhandled code path: {}", pkt->func);
     return bRC_Error;
   }
 

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -106,7 +106,7 @@ on restore:
     disks=file1,file2,file3 - restore the disks to the chosen disks
     vhdx-directory=dir      - restore the disks as vhdx files into the directory
     raw-directory=dir       - restore the disks as raw files into the directory
-    copy=path               - copy the barri image to the following path
+    copy=<yes|no>           - if yes, then the data gets restored as simple files
 
   The copy option allows you to restore the image via the barri cli tool instead
   of this filedaemon plugin.
@@ -297,6 +297,9 @@ enum class file : std::size_t
 using copy_location = std::string;
 using drive_list = std::vector<std::string>;
 
+using barri::restore::raw_directory;
+using barri::restore::vhdx_directory;
+
 struct plugin_arguments {
   using Error = tl::unexpected<std::string>;
 
@@ -343,7 +346,7 @@ struct plugin_arguments {
       std::string_view key = {};
       switch (next_option(str, keywords, &key, &value)) {
         case index_of(keywords, "disks"): {
-          debug_msg(ctx, 300, "parsing drives value '{}'", value);
+          debug_msg(ctx, 300, "parsing disks value '{}'", value);
 
           auto paths = split_string_view(value, ',');
 
@@ -353,15 +356,29 @@ struct plugin_arguments {
         } break;
 
         case index_of(keywords, "copy"): {
-          debug_msg(ctx, 300, "parsing dump value '{}'", value);
-
-          args.target.emplace<copy_location>(value);
+          debug_msg(ctx, 300, "parsing copy value '{}'", value);
+          switch (parse_user_bool(value)) {
+            case parse_bool_result::True: {
+              args.dump_to_disk = true;
+            } break;
+            case parse_bool_result::False: {
+              args.dump_to_disk = false;
+            } break;
+            case parse_bool_result::Error: {
+              fatal_msg(ctx, "unexpected value {} for {}", value, key);
+              return std::nullopt;
+            } break;
+          }
         } break;
 
         case index_of(keywords, "vhdx-directory"): {
+          // checking of whether the path is valid is done later
+          args.target.emplace<vhdx_directory>(FromUtf8(value));
         } break;
 
         case index_of(keywords, "raw-directory"): {
+          // checking of whether the path is valid is done later
+          args.target.emplace<raw_directory>(FromUtf8(value));
         } break;
 
         case index_of(keywords, "unknown disks"):
@@ -447,7 +464,9 @@ struct plugin_arguments {
   }
 
   // restore options
-  std::variant<std::monostate, copy_location, drive_list> target;
+  bool dump_to_disk{true};
+  std::variant<std::monostate, drive_list, raw_directory, vhdx_directory>
+      target;
 
   // backup options
   std::vector<size_t> ignored_disks;
@@ -502,6 +521,8 @@ struct plugin_logger : public GenericLogger {
   plugin_logger(PluginContext* ctx_) : GenericLogger{true}, ctx{ctx_} {}
 
   std::span<const char> log() const { return messages; }
+
+  PluginContext* context() { return ctx; }
 
  private:
   void print_progress(Clock::time_point current_ts, std::size_t current_offset)
@@ -770,18 +791,35 @@ struct session {
              || std::same_as<T, disk_ids>
   bool begin(T dir)
   {
-    handler = GetHandler(&logger, std::move(dir));
-    if (!handler) { return false; }
-    parser = parse_begin(handler.get(), &logger);
-    if (!parser) { return false; }
+    try {
+      handler = GetHandler(&logger, std::move(dir));
+      if (!handler) { return false; }
+      parser = parse_begin(handler.get(), &logger);
+      if (!parser) { return false; }
+    } catch (const std::exception& ex) {
+      err_msg(logger.context(), "Exception occured during creation: {}",
+              ex.what());
+      return false;
+    }
     return true;
   }
 
-  size_t write() {}
+  ssize_t write(std::span<const char> data)
+  {
+    try {
+      parse_data(parser, data);
+      return data.size();
+    } catch (const std::exception& ex) {
+      err_msg(logger.context(), "Exception occured during write: {}",
+              ex.what());
+      return -1;
+    }
+  }
 
-  bool end() {}
-
-  ~session() {}
+  ~session()
+  {
+    if (parser) { parse_end(parser); }
+  }
 };
 
 struct context : ::context {
@@ -835,8 +873,9 @@ struct context : ::context {
           pkt->status = -1;
           return bRC_Error;
         }
+
         try {
-          current_session = parse_begin(handler.get(), &logger);
+          current_session.emplace(ctx);
           pkt->status = 0;
           return bRC_OK;
         } catch (const std::exception& ex) {
@@ -860,9 +899,9 @@ struct context : ::context {
           pkt->status = -1;
           return bRC_Error;
         }
-        parse_data(current_session,
-                   std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
-        pkt->status = pkt->count;
+
+        pkt->status = current_session->write(
+            std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
         return bRC_OK;
       } break;
       case filedaemon::IO_CLOSE: {
@@ -871,7 +910,7 @@ struct context : ::context {
           pkt->status = -1;
           return bRC_Error;
         }
-        parse_end(current_session);
+        current_session.reset();
         pkt->status = 0;
         return bRC_OK;
       } break;
@@ -881,9 +920,9 @@ struct context : ::context {
     return bRC_Error;
   }
 
-  bRC pluginIO_Dump(copy_location& loc,
-                    PluginContext* ctx,
-                    filedaemon::io_pkt* pkt)
+  std::optional<session> current_session;
+
+  bRC pluginIO_Dump(PluginContext* ctx, filedaemon::io_pkt* pkt)
   {
     switch (pkt->func) {
       case filedaemon::IO_OPEN: {
@@ -915,12 +954,11 @@ struct context : ::context {
 
   bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) override
   {
+    if (args.dump_to_disk) { return pluginIO_Dump(ctx, pkt); }
+
+
     if (auto* list = std::get_if<drive_list>(&args.target)) {
       return pluginIO_Session(*list, ctx, pkt);
-    }
-
-    if (auto* loc = std::get_if<copy_location>(&args.target)) {
-      return pluginIO_Dump(*loc, ctx, pkt);
     }
 
     fatal_msg(ctx, "Cannot do IO as it was not set up yet!");
@@ -929,6 +967,15 @@ struct context : ::context {
 
   bRC create_file(PluginContext* ctx, filedaemon::restore_pkt* pkt)
   {
+    if (args.dump_to_disk) {
+      // TODO: we should delete @BARRI/ from the pkt->ofname
+      // and restore to there
+
+      pkt->create_status = CF_CORE;
+      return bRC_OK;
+    }
+
+
     if (auto* list = std::get_if<drive_list>(&args.target)) {
       auto fname = std::string_view{pkt->original_file_name};
       if (fname.ends_with(log_ending)) {
@@ -941,14 +988,6 @@ struct context : ::context {
 
       fatal_msg(ctx, "Cannot restore {} of unknown type!", fname);
       return bRC_Error;
-    }
-
-    if (auto* loc = std::get_if<copy_location>(&args.target)) {
-      // TODO: we should delete @BARRI/ from the pkt->ofname
-      // and restore to there
-
-      pkt->create_status = CF_CORE;
-      return bRC_OK;
     }
 
     fatal_msg(ctx, "Cannot create {} as it was not set up yet!",

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -110,6 +110,10 @@ on restore:
 
   The copy option allows you to restore the image via the barri cli tool instead
   of this filedaemon plugin.
+
+  Keep in mind, that you specify full paths with a drive letter, say X:,
+  by using /X/ at the start of the path.  I.e. C:\my\path, becomes
+  /C/my/path.
 )"};
 
 std::string_view trim_left(std::string_view input)
@@ -295,10 +299,12 @@ enum class file : std::size_t
 };
 
 using copy_location = std::string;
-using drive_list = std::vector<std::string>;
 
+using barri::restore::disk_ids;
 using barri::restore::raw_directory;
 using barri::restore::vhdx_directory;
+
+using restore_target = std::variant<disk_ids, raw_directory, vhdx_directory>;
 
 struct plugin_arguments {
   using Error = tl::unexpected<std::string>;
@@ -348,12 +354,85 @@ struct plugin_arguments {
         case index_of(keywords, "disks"): {
           debug_msg(ctx, 300, "parsing disks value '{}'", value);
 
-          auto paths = split_string_view(value, ',');
+          auto ids = split_string_view(value, ',');
 
           // checking of whether the paths are valid are done later
-          auto& list = args.target.emplace<drive_list>();
-          list.insert(list.end(), paths.begin(), paths.end());
+          disk_ids list;
+          list.reserve(ids.size());
+
+          for (auto& id_str : ids) {
+            std::size_t id{};
+            auto result = std::from_chars(id_str.data(),
+                                          id_str.data() + id_str.size(), id);
+
+            if (result.ec != std::errc{}) {
+              err_msg(ctx, "bad disk id '{}': {}", id_str,
+                      std::make_error_code(result.ec).message());
+              return {};
+            }
+
+            if (result.ptr != id_str.data() + id_str.size()) {
+              err_msg(ctx, "bad disk id '{}': junk at end", id_str);
+              return {};
+            }
+
+            list.push_back(id);
+          }
+
+          args.dump_to_disk = false;
+          args.target = std::move(list);
         } break;
+
+        case index_of(keywords, "vhdx-directory"): {
+          // checking of whether the path is valid is done later
+          if (value.empty()) {
+            err_msg(ctx, "vhdx-directory cannot be empty");
+            return std::nullopt;
+          }
+
+          if (value.size() >= 3 && IsPathSeparator(value[0])
+              && IsPathSeparator(value[2])) {
+            auto drive_letter = value[1];
+            std::string path;
+            path += drive_letter;
+            path += ":\\";
+            path += value.substr(3);
+
+            debug_msg(ctx, 300, "Using vhdx dir {}", path);
+            args.target = std::move(vhdx_directory{FromUtf8(path)});
+          } else {
+            debug_msg(ctx, 300, "Using vhdx dir {}", value);
+            args.target = std::move(vhdx_directory{FromUtf8(value)});
+          }
+
+          args.dump_to_disk = false;
+        } break;
+
+        case index_of(keywords, "raw-directory"): {
+          // checking of whether the path is valid is done later
+          if (value.empty()) {
+            err_msg(ctx, "raw-directory cannot be empty");
+            return std::nullopt;
+          }
+
+          if (value.size() >= 3 && IsPathSeparator(value[0])
+              && IsPathSeparator(value[2])) {
+            auto drive_letter = value[1];
+            std::string path;
+            path += drive_letter;
+            path += ":\\";
+            path += value.substr(3);
+
+            debug_msg(ctx, 300, "Using raw dir {}", path);
+            args.target = std::move(raw_directory{FromUtf8(path)});
+          } else {
+            debug_msg(ctx, 300, "Using raw dir {}", value);
+            args.target = std::move(raw_directory{FromUtf8(value)});
+          }
+
+          args.dump_to_disk = false;
+        } break;
+
 
         case index_of(keywords, "copy"): {
           debug_msg(ctx, 300, "parsing copy value '{}'", value);
@@ -369,16 +448,6 @@ struct plugin_arguments {
               return std::nullopt;
             } break;
           }
-        } break;
-
-        case index_of(keywords, "vhdx-directory"): {
-          // checking of whether the path is valid is done later
-          args.target.emplace<vhdx_directory>(FromUtf8(value));
-        } break;
-
-        case index_of(keywords, "raw-directory"): {
-          // checking of whether the path is valid is done later
-          args.target.emplace<raw_directory>(FromUtf8(value));
         } break;
 
         case index_of(keywords, "unknown disks"):
@@ -465,8 +534,7 @@ struct plugin_arguments {
 
   // restore options
   bool dump_to_disk{true};
-  std::variant<std::monostate, drive_list, raw_directory, vhdx_directory>
-      target;
+  std::optional<restore_target> target;
 
   // backup options
   std::vector<size_t> ignored_disks;
@@ -789,10 +857,10 @@ struct session {
   template <typename T>
     requires std::same_as<T, vhdx_directory> || std::same_as<T, raw_directory>
              || std::same_as<T, disk_ids>
-  bool begin(T dir)
+  bool begin(T arg)
   {
     try {
-      handler = GetHandler(&logger, std::move(dir));
+      handler = barri::restore::GetHandler(&logger, std::move(arg));
       if (!handler) { return false; }
       parser = parse_begin(handler.get(), &logger);
       if (!parser) { return false; }
@@ -862,10 +930,13 @@ struct context : ::context {
     return bRC_OK;
   }
 
-  bRC pluginIO_Session(drive_list& list,
-                       PluginContext* ctx,
+  bRC pluginIO_Session(PluginContext* ctx,
+                       restore_target& target,
                        filedaemon::io_pkt* pkt)
   {
+    // this function should only b
+    if (!args.target.has_value()) { return bRC_Error; }
+
     switch (pkt->func) {
       case filedaemon::IO_OPEN: {
         if (current_session) {
@@ -876,6 +947,16 @@ struct context : ::context {
 
         try {
           current_session.emplace(ctx);
+
+          auto start_ok = std::visit(
+              [&](auto& val) { return current_session->begin(val); }, target);
+
+          if (!start_ok) {
+            err_msg(ctx, "could not begin session");
+            pkt->status = -1;
+            return bRC_Error;
+          }
+
           pkt->status = 0;
           return bRC_OK;
         } catch (const std::exception& ex) {
@@ -902,6 +983,7 @@ struct context : ::context {
 
         pkt->status = current_session->write(
             std::span{pkt->buf, static_cast<std::size_t>(pkt->count)});
+        if (pkt->status < 0) { return bRC_Error; }
         return bRC_OK;
       } break;
       case filedaemon::IO_CLOSE: {
@@ -956,13 +1038,12 @@ struct context : ::context {
   {
     if (args.dump_to_disk) { return pluginIO_Dump(ctx, pkt); }
 
-
-    if (auto* list = std::get_if<drive_list>(&args.target)) {
-      return pluginIO_Session(*list, ctx, pkt);
+    if (!args.target.has_value()) {
+      fatal_msg(ctx, "Cannot do IO as it was not set up yet!");
+      return bRC_Error;
     }
 
-    fatal_msg(ctx, "Cannot do IO as it was not set up yet!");
-    return bRC_Error;
+    return pluginIO_Session(ctx, *args.target, pkt);
   }
 
   bRC create_file(PluginContext* ctx, filedaemon::restore_pkt* pkt)
@@ -971,27 +1052,34 @@ struct context : ::context {
       // TODO: we should delete @BARRI/ from the pkt->ofname
       // and restore to there
 
+      debug_msg(ctx, 300, "duming {} to disk at {}", pkt->original_file_name,
+                pkt->ofname);
+
       pkt->create_status = CF_CORE;
       return bRC_OK;
     }
 
-
-    if (auto* list = std::get_if<drive_list>(&args.target)) {
-      auto fname = std::string_view{pkt->original_file_name};
-      if (fname.ends_with(log_ending)) {
-        pkt->create_status = CF_SKIP;
-        return bRC_Skip;
-      } else if (fname.ends_with(dump_ending)) {
-        // we do not actually create files here, so we just ignore this
-        return bRC_OK;
-      }
-
-      fatal_msg(ctx, "Cannot restore {} of unknown type!", fname);
+    if (!args.target.has_value()) {
+      fatal_msg(ctx, "Cannot create {} as context was not set up yet!",
+                pkt->original_file_name);
       return bRC_Error;
     }
 
-    fatal_msg(ctx, "Cannot create {} as it was not set up yet!",
-              pkt->original_file_name);
+    auto fname = std::string_view{pkt->original_file_name};
+    if (fname.ends_with(log_ending)) {
+      debug_msg(ctx, 300, "skipping {}", pkt->original_file_name, pkt->ofname);
+      pkt->create_status = CF_SKIP;
+      return bRC_OK;
+    } else if (fname.ends_with(dump_ending)) {
+      // we do not actually create files here, so we just ignore this
+
+      debug_msg(ctx, 300, "extracting {}", pkt->original_file_name,
+                pkt->ofname);
+      pkt->create_status = CF_EXTRACT;
+      return bRC_OK;
+    }
+
+    fatal_msg(ctx, "Cannot restore {} of unknown type!", fname);
     return bRC_Error;
   }
 
@@ -1060,6 +1148,9 @@ bRC handlePluginEvent(PluginContext* ctx, filedaemon::bEvent* event, void* data)
 {
   auto* pctx = get_private_context(ctx);
   switch (event->eventType) {
+    case filedaemon::bEventJobStart: {
+      return bRC_OK;
+    }
     case filedaemon::bEventNewPluginOptions: {
       std::string_view s{static_cast<const char*>(data)};
 
@@ -1074,7 +1165,15 @@ bRC handlePluginEvent(PluginContext* ctx, filedaemon::bEvent* event, void* data)
 
       if (pctx->option_overrides.empty()) {
         pctx->option_overrides = std::string{s};
+        debug_msg(ctx, 300, "Setting option_overrides to {}",
+                  pctx->option_overrides);
+      } else {
+        debug_msg(ctx, 300,
+                  "Keeping option_overrides at {}, not changing to {}",
+                  pctx->option_overrides, s);
       }
+
+      return bRC_OK;
     } break;
     case filedaemon::bEventPluginCommand: {
       if (!pctx->context) {
@@ -1250,7 +1349,7 @@ bRC endRestoreFile(PluginContext* ctx)
     return bRC_Error;
   }
 
-  DebugLog(ctx, 500, "finished restoring file");
+  debug_msg(ctx, 500, "finished restoring file");
 
   return rctx->end_current_file(ctx);
 }
@@ -1278,10 +1377,11 @@ bRC createFile(PluginContext* ctx, filedaemon::restore_pkt* pkt)
   }
 }
 
-bRC setFileAttributes(PluginContext* ctx, filedaemon::restore_pkt* pkt)
+bRC setFileAttributes(PluginContext* ctx, filedaemon::restore_pkt*)
 {
   if (auto* rctx = get_restore_context(ctx)) {
-    return rctx->create_file(ctx, pkt);
+    debug_msg(ctx, 300, "ignoring set_file_attributes");
+    return bRC_OK;
   } else {
     fatal_msg(ctx, "{} can only be called during restore", __PRETTY_FUNCTION__);
     return bRC_Error;

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -79,15 +79,27 @@ const PluginInformation my_info = {
     .plugin_version = "25.0.3",
     .plugin_description
     = "This plugin allows you to backup your windows system for disaster "
-      "recovery.",
-    .plugin_usage = PLUGIN_NAME
-    R"(:save-unreferenced-disks:save-unreferenced-partitions:save-unreferenced-extents:ignore-disks=<disks to ignore>
+      "recovery & restore it later.",
+    .plugin_usage
+    = "\non backup:\n---\n" PLUGIN_NAME
+      R"(:save-unreferenced-disks:save-unreferenced-partitions:save-unreferenced-extents:ignore-disks=<disks to ignore>
 
   save-unreferenced-disks: try to save disks that contain no snapshotted data
   save-unreferenced-partitions: try to save partitions that contain no snapshotted data
   save-unreferenced-extents: try to save even unsnapshotted parts of partitions
-  disks to ignore: a comma-separated list of disk ids (i.e. '1,2,5') of disks
-                   to not backup
+  disks to ignore: a comma-separated list of disk ids (i.e. '1,2,5') of disks to not backup
+
+on restore:
+---
+)" PLUGIN_NAME
+      R"(:<target>,
+  where <target> is one of the following:
+    files=file1,file2,file3 - restore the disks to the chosen files
+    directory=dir           - restore the disks into the directory
+    copy=path               - copy the barri image to the following path
+
+  The copy option allows you to restore the image via the barri cli tool instead
+  of this filedaemon plugin.
 )"};
 
 std::string_view trim_left(std::string_view input)

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -1052,8 +1052,7 @@ struct context : ::context {
       // TODO: we should delete @BARRI/ from the pkt->ofname
       // and restore to there
 
-      debug_msg(ctx, 300, "duming {} to disk at {}", pkt->original_file_name,
-                pkt->ofname);
+      debug_msg(ctx, 300, "duming {} to disk", pkt->ofname);
 
       pkt->create_status = CF_CORE;
       return bRC_OK;
@@ -1061,20 +1060,19 @@ struct context : ::context {
 
     if (!args.target.has_value()) {
       fatal_msg(ctx, "Cannot create {} as context was not set up yet!",
-                pkt->original_file_name);
+                pkt->ofname);
       return bRC_Error;
     }
 
-    auto fname = std::string_view{pkt->original_file_name};
+    auto fname = std::string_view{pkt->ofname};
     if (fname.ends_with(log_ending)) {
-      debug_msg(ctx, 300, "skipping {}", pkt->original_file_name, pkt->ofname);
+      debug_msg(ctx, 300, "skipping {}", pkt->ofname);
       pkt->create_status = CF_SKIP;
       return bRC_OK;
     } else if (fname.ends_with(dump_ending)) {
       // we do not actually create files here, so we just ignore this
 
-      debug_msg(ctx, 300, "extracting {}", pkt->original_file_name,
-                pkt->ofname);
+      debug_msg(ctx, 300, "extracting {}", pkt->ofname);
       pkt->create_status = CF_EXTRACT;
       return bRC_OK;
     }

--- a/core/src/plugins/filed/windows_dr/plugin.cc
+++ b/core/src/plugins/filed/windows_dr/plugin.cc
@@ -94,6 +94,9 @@ const PluginInformation my_info = {
   save-unreferenced-extents: try to save even unsnapshotted parts of partitions
   disks to ignore: a comma-separated list of disk ids (i.e. '1,2,5') of disks to not backup
 
+  The flags can either be set to yes/no explicitly, otherwise they will default
+  to false if they are not set, and true if they are.
+
 on restore:
 ---
 )" PLUGIN_NAME
@@ -155,6 +158,7 @@ std::string_view next_part(std::string_view& input, char sep)
 
 std::size_t next_option(std::string_view& to_parse,
                         std::span<const std::string_view> keywords,
+                        std::string_view* keyword,
                         std::string_view* value)
 {
   // we dont want to change to_parse, if we cannot find a keyword
@@ -173,6 +177,7 @@ std::size_t next_option(std::string_view& to_parse,
 
   for (size_t i = 0; i < keywords.size(); ++i) {
     if (key == keywords[i]) {
+      *keyword = key;
       debug_msg(300, " => keyword #{}", i);
       // if we found a keyword, then we update to_parse
       to_parse = working_copy;
@@ -206,6 +211,8 @@ std::optional<std::string> insert_numbers(std::vector<std::size_t>& nums,
 
     if (conversion_result.ec != std::errc{}) {
       switch (conversion_result.ec) {
+        default:
+          [[fallthrough]];
         case std::errc::invalid_argument: {
           return libbareos::format("could not parse {} as a number", found);
         } break;
@@ -250,7 +257,10 @@ constexpr std::size_t index_of(std::span<const std::string_view> keywords,
 }
 
 struct context {
-  virtual bool parse(PluginContext* ctx, const char* text) = 0;
+  virtual bool parse(PluginContext* ctx,
+                     const char* text,
+                     std::string_view overrides)
+      = 0;
   virtual bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt) = 0;
   virtual ~context() = default;
 };
@@ -262,6 +272,8 @@ struct plugin_ctx {
 
   CoUninitializer unititializer{};
   std::unique_ptr<context> context;
+
+  std::string option_overrides;
 };
 
 plugin_ctx* get_private_context(PluginContext* ctx)
@@ -281,40 +293,33 @@ enum class file : std::size_t
   Count,
 };
 
-namespace backup {
+using copy_location = std::string;
+using drive_list = std::vector<std::string>;
+
 struct plugin_arguments {
+  using Error = tl::unexpected<std::string>;
+
   static std::optional<plugin_arguments> parse(PluginContext* ctx,
                                                std::string_view str)
   {
-    static constexpr std::string_view save_unreferenced_disks
-        = "save-unreferenced-disks";
-    static constexpr std::string_view save_unreferenced_partitions
-        = "save-unreferenced-partitions";
-    static constexpr std::string_view save_unreferenced_extents
-        = "save-unreferenced-extents";
-    static constexpr std::string_view ignore_disks = "ignore-disks";
-
-    // deprecated but still allowed with the same meaning as above
-    static constexpr std::string_view unknowndisks = "unknown disks";
-    static constexpr std::string_view unknownpartitions = "unknown partitions";
-    static constexpr std::string_view unknownextents = "unknown extents";
-    static constexpr std::string_view ignoredisks = "ignore disks";
-
     static constexpr std::string_view keywords[] = {
-        save_unreferenced_disks,
-        save_unreferenced_partitions,
-        save_unreferenced_extents,
-        ignore_disks,
-
-        unknowndisks,
-        unknownpartitions,
-        unknownextents,
-        ignoredisks,
+        "disks",
+        "vhdx-directory",
+        "raw-directory",
+        "copy",
+        "save-unreferenced-disks",
+        "save-unreferenced-partitions",
+        "save-unreferenced-extents",
+        "ignore-disks",
+        "unknown disks",
+        "unknown partitions",
+        "unknown extents",
+        "ignore disks",
     };
 
     auto name = next_part(str, ':');
 
-    debug_msg(300, "got name = '{}'", name);
+    debug_msg(ctx, 300, "got name = '{}'", name);
 
     if (name != PLUGIN_NAME) {
       err_msg(ctx, "bad plugin options received, expected '{}', got '{}'",
@@ -328,51 +333,95 @@ struct plugin_arguments {
 
       if (str.size() == 0) { break; }
 
+      // we always choose the last option set, i.e. if
+      //  drives=a,b,c dump=k drives=l,m,n
+      // is given, we treat it the same as drives=l,m,n
+      // This allows the user to overwrite the options via FdPluginOptions
+
       std::string_view value = {};
-      switch (next_option(str, keywords, &value)) {
-        case index_of(keywords, save_unreferenced_disks):
-        case index_of(keywords, unknowndisks): {
-          if (!value.empty()) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_disks);
-            return std::nullopt;
-          }
-          args.save_unknown_disks = true;
+      std::string_view key = {};
+      switch (next_option(str, keywords, &key, &value)) {
+        case index_of(keywords, "disks"): {
+          debug_msg(ctx, 300, "parsing drives value '{}'", value);
+
+          auto paths = split_string_view(value, ',');
+
+          // checking of whether the paths are valid are done later
+          auto& list = args.target.emplace<drive_list>();
+          list.insert(list.end(), paths.begin(), paths.end());
         } break;
 
-        case index_of(keywords, save_unreferenced_partitions):
-        case index_of(keywords, unknownpartitions): {
-          if (!value.empty()) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_partitions);
-            return std::nullopt;
-          }
-          args.save_unknown_partitions = true;
+        case index_of(keywords, "copy"): {
+          debug_msg(ctx, 300, "parsing dump value '{}'", value);
+
+          args.target.emplace<copy_location>(value);
         } break;
 
-        case index_of(keywords, save_unreferenced_extents):
-        case index_of(keywords, unknownextents): {
-          if (!value.empty()) {
-            fatal_msg(ctx, "unexpected value {} for {} flag", value,
-                      save_unreferenced_extents);
-            return std::nullopt;
-          }
-          args.save_unknown_extents = true;
+        case index_of(keywords, "vhdx-directory"): {
         } break;
 
-        case index_of(keywords, ignore_disks):
-        case index_of(keywords, ignoredisks): {
+        case index_of(keywords, "raw-directory"): {
+        } break;
+
+        case index_of(keywords, "unknown disks"):
+          [[fallthrough]];
+        case index_of(keywords, "save-unreferenced-disks"): {
           if (value.empty()) {
-            fatal_msg(ctx, "unexpected empty value for {} option",
-                      ignore_disks);
+            args.save_unknown_disks = true;
+          } else if (value == "yes") {
+            args.save_unknown_disks = true;
+          } else if (value == "no") {
+            args.save_unknown_disks = false;
+          } else {
+            fatal_msg(ctx, "unexpected value {} for {}", value, key);
+            return std::nullopt;
+          }
+        } break;
+
+        case index_of(keywords, "unknown partitions"):
+          [[fallthrough]];
+        case index_of(keywords, "save-unreferenced-partitions"): {
+          if (value.empty()) {
+            args.save_unknown_partitions = true;
+          } else if (value == "yes") {
+            args.save_unknown_partitions = true;
+          } else if (value == "no") {
+            args.save_unknown_partitions = false;
+          } else {
+            fatal_msg(ctx, "unexpected value {} for {}", value, key);
+            return std::nullopt;
+          }
+        } break;
+
+        case index_of(keywords, "unknown extents"):
+          [[fallthrough]];
+        case index_of(keywords, "save-unreferenced-extents"): {
+          if (value.empty()) {
+            args.save_unknown_extents = true;
+          } else if (value == "yes") {
+            args.save_unknown_extents = true;
+          } else if (value == "no") {
+            args.save_unknown_extents = false;
+          } else {
+            fatal_msg(ctx, "unexpected value {} for {}", value, key);
+            return std::nullopt;
+          }
+        } break;
+
+        case index_of(keywords, "ignore disks"):
+          [[fallthrough]];
+        case index_of(keywords, "ignore-disks"): {
+          if (value.empty()) {
+            fatal_msg(ctx, "unexpected empty value for {}", key);
             return std::nullopt;
           }
           if (auto error = insert_numbers(args.ignored_disks, value)) {
             fatal_msg(ctx, "could not parse {} as a list of ints ({}): {}",
-                      value, ignore_disks, error.value());
+                      value, key, error.value());
             return std::nullopt;
           }
         } break;
+
         default: {
           fatal_msg(ctx, "could not parse plugin options string '{}'", str,
                     str.size());
@@ -396,13 +445,18 @@ struct plugin_arguments {
     }
   }
 
- private:
+  // restore options
+  std::variant<std::monostate, copy_location, drive_list> target;
+
+  // backup options
   std::vector<size_t> ignored_disks;
   bool save_unknown_disks{false};
   bool save_unknown_partitions{false};
   bool save_unknown_extents{false};
 };
 
+
+namespace backup {
 struct plugin_logger : public GenericLogger {
   using Clock = std::chrono::steady_clock;
 
@@ -536,9 +590,17 @@ struct context : ::context {
   }
 
 
-  bool parse(PluginContext* ctx, const char* text) override
+  bool parse(PluginContext* ctx,
+             const char* text,
+             std::string_view overrides) override
   {
-    std::optional parsed = plugin_arguments::parse(ctx, text);
+    std::string computed_value{text};
+    if (!overrides.empty()) {
+      computed_value += ":";
+      computed_value += overrides;
+    }
+
+    std::optional parsed = plugin_arguments::parse(ctx, computed_value);
     if (!parsed) { return false; }
 
     args = std::move(*parsed);
@@ -695,89 +757,27 @@ bRC context::pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 };  // namespace backup
 
 namespace restore {
-using copy_location = std::string;
-using drive_list = std::vector<std::string>;
-
-struct plugin_arguments {
-  using Error = tl::unexpected<std::string>;
-
-  static std::optional<plugin_arguments> parse(PluginContext* ctx,
-                                               std::string_view str)
-  {
-    static constexpr std::string_view keywords[]
-        = {"disks", "vhdx-directory", "raw-directory", "copy"};
-
-    auto name = next_part(str, ':');
-
-    debug_msg(ctx, 300, "got name = '{}'", name);
-
-    if (name != PLUGIN_NAME) {
-      err_msg(ctx, "bad plugin options received, expected '{}', got '{}'",
-              PLUGIN_NAME, name);
-      return {};
-    }
-
-    plugin_arguments args{};
-    for (;;) {
-      str = trim_left(str);
-
-      if (str.size() == 0) { break; }
-
-      // we always choose the last option set, i.e. if
-      //  drives=a,b,c dump=k drives=l,m,n
-      // is given, we treat it the same as drives=l,m,n
-      // This allows the user to overwrite the options via FdPluginOptions
-
-      std::string_view value = {};
-      switch (next_option(str, keywords, &value)) {
-        case index_of(keywords, "disks"): {
-          debug_msg(ctx, 300, "parsing drives value '{}'", value);
-
-          auto paths = split_string_view(value, ',');
-
-          // checking of whether the paths are valid are done later
-          auto& list = args.target.emplace<drive_list>();
-          list.insert(list.end(), paths.begin(), paths.end());
-        } break;
-
-        case index_of(keywords, "copy"): {
-          debug_msg(ctx, 300, "parsing dump value '{}'", value);
-
-          args.target.emplace<copy_location>(value);
-        } break;
-
-        case index_of(keywords, "vhdx-directory"): {
-        } break;
-
-        case index_of(keywords, "raw-directory"): {
-        } break;
-
-        default: {
-          fatal_msg(ctx, "could not parse plugin options string '{}'", str);
-
-          return std::nullopt;
-        } break;
-      }
-    }
-
-    return args;
-  }
-
-  std::variant<std::monostate, copy_location, drive_list> target;
-};
-
 struct context : ::context {
   virtual ~context() = default;
 
   static std::unique_ptr<context> make(PluginContext*)
   {
-    (void)ctx;
-    return nullptr;
+    auto rctx = std::make_unique<context>();
+
+    return rctx;
   }
 
-  bool parse(PluginContext* ctx, const char* text) override
+  bool parse(PluginContext* ctx,
+             const char* text,
+             std::string_view overrides) override
   {
-    std::optional opt = plugin_arguments::parse(ctx, text);
+    std::string computed_value{text};
+    if (!overrides.empty()) {
+      computed_value += ":";
+      computed_value += overrides;
+    }
+
+    std::optional opt = plugin_arguments::parse(ctx, computed_value);
     if (!opt) { return false; }
     args = std::move(*opt);
     return true;
@@ -813,66 +813,22 @@ struct context : ::context {
   {
     switch (pkt->func) {
       case filedaemon::IO_OPEN: {
-        if (current_file_type.has_value()) {
-          fatal_msg(ctx, "Internal error occured: cannot open second file");
-          return bRC_Error;
-        }
+        auto hndl = CreateFileA(pkt->fname, GENERIC_WRITE, 0, NULL,
+                                CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
 
-        std::string_view path{pkt->fname};
-        if (path.ends_with(log_ending)) {
-          current_file_type = file::Log;
-
-          auto log_path = loc;
-          log_path += log_ending;
-
-          // std::wstring utf16 = make_win32_path_UTF8_2_wchar(log_path);
-
-          auto hndl = CreateFileA(log_path.c_str(), GENERIC_WRITE, 0, NULL,
-                                  CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
-          if (hndl == INVALID_HANDLE_VALUE) {
-            warn_msg(ctx, "Could create log file {} for writing", log_path);
-            return bRC_Error;
-          } else {
-            pkt->hndl = hndl;
-            pkt->status = IoStatus::do_io_in_core;
-
-            return bRC_OK;
-          }
-        } else if (path.ends_with(dump_ending)) {
-          current_file_type = file::Dump;
-          auto hndl = CreateFileA(loc.c_str(), GENERIC_WRITE, 0, NULL,
-                                  CREATE_NEW, FILE_ATTRIBUTE_NORMAL, NULL);
-          if (hndl == INVALID_HANDLE_VALUE) {
-            warn_msg(ctx, "Could create dump file {} for writing", loc);
-            return bRC_Error;
-          } else {
-            pkt->hndl = hndl;
-            pkt->status = IoStatus::do_io_in_core;
-
-            return bRC_OK;
-          }
-
+        if (hndl == INVALID_HANDLE_VALUE) {
+          warn_msg(ctx, "Could not open file {} for writing", pkt->fname);
           return bRC_Error;
         } else {
-          fatal_msg(ctx, "cannot restore '{}': unknown file ending", path);
-          return bRC_Error;
+          pkt->hndl = hndl;
+          pkt->status = IoStatus::do_io_in_core;
+
+          return bRC_OK;
         }
-
-
       } break;
       case filedaemon::IO_CLOSE: {
-        if (!current_file_type.has_value()) {
-          fatal_msg(
-              ctx,
-              "Internal error occured: cannot close file if none are open");
-          return bRC_Error;
-        }
-
-        current_file_type.reset();
-
-        CloseHandle(pkt->hndl);
-
-        return bRC_Error;
+        if (CloseHandle(pkt->hndl) == 0) { return bRC_Error; }
+        return bRC_OK;
       } break;
       default: {
         fatal_msg(ctx,
@@ -894,6 +850,35 @@ struct context : ::context {
     }
 
     fatal_msg(ctx, "Cannot do IO as it was not set up yet!");
+    return bRC_Error;
+  }
+
+  bRC create_file(PluginContext* ctx, filedaemon::restore_pkt* pkt)
+  {
+    if (auto* list = std::get_if<drive_list>(&args.target)) {
+      auto fname = std::string_view{pkt->original_file_name};
+      if (fname.ends_with(log_ending)) {
+        pkt->create_status = CF_SKIP;
+        return bRC_Skip;
+      } else if (fname.ends_with(dump_ending)) {
+        // we do not actually create files here, so we just ignore this
+        return bRC_OK;
+      }
+
+      fatal_msg(ctx, "Cannot restore {} of unknown type!", fname);
+      return bRC_Error;
+    }
+
+    if (auto* loc = std::get_if<copy_location>(&args.target)) {
+      // TODO: we should delete @BARRI/ from the pkt->ofname
+      // and restore to there
+
+      pkt->create_status = CF_CORE;
+      return bRC_OK;
+    }
+
+    fatal_msg(ctx, "Cannot create {} as it was not set up yet!",
+              pkt->original_file_name);
     return bRC_Error;
   }
 
@@ -928,7 +913,6 @@ bRC newPlugin(PluginContext* ctx)
   }
 
   set_private_context(ctx, new plugin_ctx);
-  RegisterBareosEvent(ctx, filedaemon::bEventPluginCommand);
   RegisterBareosEvent(ctx, filedaemon::bEventNewPluginOptions);
   RegisterBareosEvent(ctx, filedaemon::bEventPluginCommand);
   RegisterBareosEvent(ctx, filedaemon::bEventJobStart);
@@ -962,66 +946,77 @@ bRC setPluginValue(PluginContext*, filedaemon::pVariable, void*)
 bRC handlePluginEvent(PluginContext* ctx, filedaemon::bEvent* event, void* data)
 {
   auto* pctx = get_private_context(ctx);
-  if (!pctx->context) {
-    std::optional job_type = bVar::Get<bVar::Type>(ctx);
+  switch (event->eventType) {
+    case filedaemon::bEventNewPluginOptions: {
+      std::string_view s{static_cast<const char*>(data)};
 
-    if (!job_type) {
-      DebugLog(ctx, 300, "could not query job type!");
-      return bRC_Error;
-    }
-
-    if (*job_type == JT_RESTORE) {
-      // if its set to restore, then we are definitely a restore job
-
-      auto rctx = restore::context::make(ctx);
-      if (!rctx) {
-        fatal_msg(ctx, "Could not start a restore job");
+      if (!s.starts_with("barri:")) {
+        err_msg(
+            ctx,
+            "Could not parse plugin options: they do not start with barri:!");
         return bRC_Error;
       }
 
-      pctx->context = std::move(rctx);
-    } else {
-      // we take a guess and say this is a backup job (as we only support
-      // these two options!)
+      s.remove_prefix(sizeof("barri:") - 1);
 
-      auto bctx = backup::context::make(ctx);
+      if (pctx->option_overrides.empty()) {
+        pctx->option_overrides = std::string{s};
+      }
+    } break;
+    case filedaemon::bEventPluginCommand: {
+      if (!pctx->context) {
+        debug_msg(ctx, 300, "setting up a backup context");
+        auto bctx = backup::context::make(ctx);
+        if (!bctx) {
+          fatal_msg(ctx, "Could not setup the backup context");
+          return bRC_Error;
+        }
+
+        pctx->context = std::move(bctx);
+      }
+
+      auto* bctx = get_backup_context(ctx);
+
       if (!bctx) {
-        fatal_msg(ctx, "Could not start a backup job");
+        // this can happen if we somehow setup a restore context before
+        fatal_msg(ctx, "instructed to execute a backup command during restore");
         return bRC_Error;
       }
 
-      pctx->context = std::move(bctx);
-    }
-  }
-
-
-  if (auto* bctx = get_backup_context(ctx)) {
-    switch (event->eventType) {
-      case filedaemon::bEventNewPluginOptions:
-        [[fallthrough]];
-      case filedaemon::bEventPluginCommand: {
-        if (!bctx->parse(ctx, static_cast<const char*>(data))) {
-          DebugLog(ctx, 300, "plugin option string could not be parsed");
+      if (!bctx->parse(ctx, static_cast<const char*>(data),
+                       pctx->option_overrides)) {
+        debug_msg(ctx, 300, "plugin option string could not be parsed");
+        return bRC_Error;
+      }
+      return bRC_OK;
+    } break;
+    case filedaemon::bEventRestoreCommand: {
+      if (!pctx->context) {
+        debug_msg(ctx, 300, "setting up a restore context");
+        auto rctx = restore::context::make(ctx);
+        if (!rctx) {
+          fatal_msg(ctx, "could not setup the restore context");
           return bRC_Error;
         }
-        return bRC_OK;
-      } break;
-    }
-  } else if (auto* rctx = get_restore_context(ctx)) {
-    switch (event->eventType) {
-      case filedaemon::bEventNewPluginOptions:
-        [[fallthrough]];
-      case filedaemon::bEventRestoreCommand: {
-        if (!rctx->parse(ctx, static_cast<const char*>(data))) {
-          DebugLog(ctx, 300, "plugin option string could not be parsed");
-          return bRC_Error;
-        }
-        return bRC_OK;
-      } break;
-    }
-  } else {
-    fatal_msg(ctx, "Context was not setup properly");
-    return bRC_Error;
+
+        pctx->context = std::move(rctx);
+      }
+
+      auto* rctx = get_restore_context(ctx);
+
+      if (!rctx) {
+        // this can happen if we somehow setup a backup context before
+        fatal_msg(ctx, "instructed to execute a restore command during backup");
+        return bRC_Error;
+      }
+
+      if (!rctx->parse(ctx, static_cast<const char*>(data),
+                       pctx->option_overrides)) {
+        debug_msg(ctx, 300, "plugin option string could not be parsed");
+        return bRC_Error;
+      }
+      return bRC_OK;
+    } break;
   }
 
   warn_msg(ctx, "Unknown event {} passed", (int)event->eventType);
@@ -1162,16 +1157,22 @@ bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 
 bRC createFile(PluginContext* ctx, filedaemon::restore_pkt* pkt)
 {
-  (void)ctx;
-  (void)pkt;
-  return bRC_Error;
+  if (auto* rctx = get_restore_context(ctx)) {
+    return rctx->create_file(ctx, pkt);
+  } else {
+    fatal_msg(ctx, "{} can only be called during restore", __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
 }
 
 bRC setFileAttributes(PluginContext* ctx, filedaemon::restore_pkt* pkt)
 {
-  (void)ctx;
-  (void)pkt;
-  return bRC_Error;
+  if (auto* rctx = get_restore_context(ctx)) {
+    return rctx->create_file(ctx, pkt);
+  } else {
+    fatal_msg(ctx, "{} can only be called during restore", __PRETTY_FUNCTION__);
+    return bRC_Error;
+  }
 }
 
 bRC checkFile(PluginContext* ctx, char* file_name)

--- a/core/src/plugins/filed/windows_dr/plugin_linux.cc
+++ b/core/src/plugins/filed/windows_dr/plugin_linux.cc
@@ -65,8 +65,8 @@ const PluginInformation my_info = {
     .plugin_date = "July 2025",
     .plugin_version = "1.0.0",
     .plugin_description
-    = "This plugin allows you to backup your windows system for disaster "
-      "recovery.",
+    = "This plugin allows you to restore your windows disaster "
+      "recovery image.",
     .plugin_usage = R"(barri-fd:<target>,
   where <target> is one of the following:
     files=file1,file2,file3 - restore the disks to the chosen files

--- a/core/src/plugins/filed/windows_dr/plugin_linux.cc
+++ b/core/src/plugins/filed/windows_dr/plugin_linux.cc
@@ -654,6 +654,7 @@ bRC pluginIO(PluginContext* ctx, filedaemon::io_pkt* pkt)
 
     if (ending_start == path.npos) {
       fatal_msg(ctx, "cannot restore '{}': unknown file ending", path);
+      return bRC_Error;
     }
 
     auto ending = path.substr(ending_start);


### PR DESCRIPTION
**Backport of PR #2729 to bareos-25**

Some parts of the pr were not applicable anymore, and some things needed to be added.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

#### Backport quality
- [ ] Original PR #2729 is merged
- [ ] All functional differences to the original PR are documented above
