### PR TITLE
Fix proxmox plugin stalling virtual machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve database encoding error handling [PR #2696]
 - core: ensure runscripts are only executed once [PR #2661]
 - core: fix sometimes not preserving used resource pointers [PR #2725]
+- Fix proxmox plugin stalling virtual machines [PR #2733]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2345,4 +2346,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2721]: https://github.com/bareos/bareos/pull/2721
 [PR #2724]: https://github.com/bareos/bareos/pull/2724
 [PR #2725]: https://github.com/bareos/bareos/pull/2725
+[PR #2733]: https://github.com/bareos/bareos/pull/2733
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
+++ b/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
@@ -256,9 +256,7 @@ class BareosFdProxmox(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         write_started = False
 
         try:
-            for line in self.log_pipe.readlines(
-                init_timeout=10000, read_timeout=30000
-            ):
+            for line in self.log_pipe.readlines(init_timeout=10000, read_timeout=30000):
                 bareosfd.JobMessage(bareosfd.M_INFO, line)
                 if line.startswith("INFO: Starting Backup of VM"):
                     # """INFO: Starting Backup of VM 999010 (qemu)"""

--- a/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
+++ b/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
@@ -257,7 +257,7 @@ class BareosFdProxmox(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
 
         try:
             for line in self.log_pipe.readlines(
-                init_timeout=10000, read_timeout=300000
+                init_timeout=10000, read_timeout=30000
             ):
                 bareosfd.JobMessage(bareosfd.M_INFO, line)
                 if line.startswith("INFO: Starting Backup of VM"):
@@ -286,6 +286,7 @@ class BareosFdProxmox(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
                     # """INFO: sending archive to stdout"
                     write_started = True
                     bareosfd.DebugMessage(100, "start marker found\n")
+                    break
         except TimeoutError as e:
             bareosfd.JobMessage(bareosfd.M_FATAL, f"vzdump log output stalled: {e}\n")
             return bareosfd.bRC_Error
@@ -391,6 +392,7 @@ class BareosFdProxmox(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
             # other levels already caught at job start
             assert False
 
+        self._despool_log(init_timeout=0)
         return bareosfd.bRC_OK
 
     def plugin_io_close(self, iop):

--- a/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
+++ b/core/src/plugins/filed/python/proxmox/bareos-fd-proxmox.py
@@ -479,12 +479,32 @@ class BareosFdProxmox(BareosFdPluginBaseclass.BareosFdPluginBaseclass):
         )
         return False
 
-    def _wait_for_io_process(self, timeout=10):
+    def _wait_for_io_process(self, wait_interval=10):
         bareosfd.JobMessage(bareosfd.M_INFO, "waiting for command to finish\n")
+        wait_count = 0
         while self.io_process.returncode is None:
             self._despool_log()
             try:
-                self.io_process.wait(timeout=timeout)
+                wait_count += 1
+                self.io_process.wait(timeout=wait_interval)
             except subprocess.TimeoutExpired:
-                pass
+                if 3 < wait_count <= 6:
+                    bareosfd.JobMessage(
+                        bareosfd.M_WARNING,
+                        f"command did not exit within {wait_count * wait_interval}s, terminating\n",
+                    )
+                    self.io_process.terminate()
+                elif 6 < wait_count <= 7:
+                    bareosfd.JobMessage(
+                        bareosfd.M_WARNING,
+                        f"command did not exit within {wait_count * wait_interval}s, killing\n",
+                    )
+                    self.io_process.kill()
+                elif 7 < wait_count:
+                    bareosfd.JobMessage(
+                        bareosfd.M_WARNING,
+                        "giving up as command did not exit after kill signal.\n",
+                    )
+                    break
+
         return self._check_io_process()

--- a/webui-vue/package-lock.json
+++ b/webui-vue/package-lock.json
@@ -1874,16 +1874,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -2039,9 +2038,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -2056,9 +2055,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -2077,10 +2075,9 @@
       }
     },
     "node_modules/quasar": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.19.2.tgz",
-      "integrity": "sha512-I0f/4nTiumAs8dKs+d+eaqmyJOZJqxAfkNKhvgAH/h2dYlw792Gd6n/xCAHohhU4ro0QfvWE5ble+eyPxKJBMw==",
-      "license": "MIT",
+      "version": "2.23.2",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.23.2.tgz",
+      "integrity": "sha512-4MeD5/RIkXLVvDgrbhZgBsbwd/v8eJaEiLRkuv6nt0xKCoQ2l7TL2KvmOCs7zf/7uh+o3Y5EsM/59jFqnrVWaQ==",
       "engines": {
         "node": ">= 10.18.1",
         "npm": ">= 6.13.4",
@@ -4083,9 +4080,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="
     },
     "node-addon-api": {
       "version": "7.1.1",
@@ -4175,11 +4172,11 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "requires": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       }
@@ -4191,9 +4188,9 @@
       "dev": true
     },
     "quasar": {
-      "version": "2.19.2",
-      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.19.2.tgz",
-      "integrity": "sha512-I0f/4nTiumAs8dKs+d+eaqmyJOZJqxAfkNKhvgAH/h2dYlw792Gd6n/xCAHohhU4ro0QfvWE5ble+eyPxKJBMw=="
+      "version": "2.23.2",
+      "resolved": "https://registry.npmjs.org/quasar/-/quasar-2.23.2.tgz",
+      "integrity": "sha512-4MeD5/RIkXLVvDgrbhZgBsbwd/v8eJaEiLRkuv6nt0xKCoQ2l7TL2KvmOCs7zf/7uh+o3Y5EsM/59jFqnrVWaQ=="
     },
     "readdirp": {
       "version": "4.1.2",


### PR DESCRIPTION
When the proxmox plugin started backing up a virtual machine, it would wait for a 5 minute timeout before starting to consume the backup data stream. This will not only take way more time than needed, but will also stall the virtual machine being backed up.

This change makes the plugin read the backup data stream as soon as possible after vzdump announces it will start writing to stdout. It also reduces the 5 minute timeout down to 30 seconds, so in case anything goes wrong the plugin won't wait too long before canceling the job.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)

