### PR TITLE
Don't break the build when npm audit fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: make sure to cross check tls-psk with claimed identity in auth [PR #2721]
 - speedup cmake checks [PR #2379]
 - devtools: pip-tools: update dependencies [PR #2736]
+- Don't break the build when npm audit fails [PR #2737]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2349,4 +2350,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2725]: https://github.com/bareos/bareos/pull/2725
 [PR #2733]: https://github.com/bareos/bareos/pull/2733
 [PR #2736]: https://github.com/bareos/bareos/pull/2736
+[PR #2737]: https://github.com/bareos/bareos/pull/2737
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/CMakeLists.txt
+++ b/systemtests/CMakeLists.txt
@@ -691,6 +691,15 @@ else()
                  "${WEBUI_VUE_TEST_PREFIX}${TEST_NAME}-fixture" TIMEOUT 60 COST
                  1.0
     )
+    # Each profile starts a Director, proxy, frontend, and Chromium instance.
+    # Keep the complete profile lifecycle exclusive on shared CI workers.
+    set_tests_properties(
+      "${WEBUI_VUE_TEST_PREFIX}${TEST_NAME}:setup"
+      "${WEBUI_VUE_TEST_PREFIX}${TEST_NAME}:create-backup"
+      "${WEBUI_VUE_TEST_PREFIX}${TEST_NAME}"
+      "${WEBUI_VUE_TEST_PREFIX}${TEST_NAME}:cleanup"
+      PROPERTIES RESOURCE_LOCK webui_vue_playwright_resource
+    )
     math(EXPR BASEPORT "${BASEPORT} + 10")
   endforeach()
   set(BAREOS_WEBUI_PROFILE "")

--- a/systemtests/tests/webui-vue-common/testrunner
+++ b/systemtests/tests/webui-vue-common/testrunner
@@ -30,6 +30,7 @@ export TestName
 . "${BAREOS_SCRIPTS_DIR}/functions"
 
 proxy_log="${tmp}/webui-vue-proxy.out"
+frontend_log="${tmp}/webui-vue-frontend.out"
 playwright_log="${tmp}/webui-vue-playwright.out"
 
 start_test
@@ -42,7 +43,13 @@ if ! PLAYWRIGHT_BASE_URL="${BAREOS_WEBUI_BASE_URL}" \
   GOOGLE_CHROME_EXECUTABLE="${GOOGLE_CHROME_EXECUTABLE}" \
   "${WEBUI_VUE_PLAYWRIGHT_EXECUTABLE}" test --reporter=line \
   >"${playwright_log}" 2>&1; then
-  set_error "$(cat "${playwright_log}")"
+  set_error "$(cat "${playwright_log}")
+
+=== webui-vue proxy log ===
+$(cat "${proxy_log}")
+
+=== webui-vue frontend log ===
+$(cat "${frontend_log}")"
 fi
 popd >/dev/null
 

--- a/webui-vue/build-dist.cmake
+++ b/webui-vue/build-dist.cmake
@@ -97,7 +97,7 @@ execute_process(
   RESULT_VARIABLE npm_audit_result
 )
 if(NOT npm_audit_result EQUAL 0)
-  message(FATAL_ERROR "npm audit failed with exit code ${npm_audit_result}")
+  message(WARNING "npm audit failed with exit code ${npm_audit_result}")
 endif()
 
 message(STATUS "Building webui-vue dist in ${DIST_DIR}")

--- a/webui-vue/build-dist.cmake
+++ b/webui-vue/build-dist.cmake
@@ -47,18 +47,8 @@ set(CMAKE_MODULE_PATH "${REPO_ROOT_DIR}/cmake" "${REPO_ROOT_DIR}/core/cmake"
                       "${REPO_ROOT_DIR}/webui/cmake"
 )
 
-execute_process(
-  COMMAND "${CMAKE_COMMAND}" -P "${REPO_ROOT_DIR}/write_version_files.cmake"
-  WORKING_DIRECTORY "${REPO_ROOT_DIR}"
-  RESULT_VARIABLE write_version_result
-)
-if(NOT write_version_result EQUAL 0)
-  message(
-    FATAL_ERROR
-      "write_version_files.cmake failed with exit code ${write_version_result}"
-  )
-endif()
-
+find_package(Git QUIET)
+include(BareosVersionFromGit)
 include(BareosExtractVersionInfo)
 
 file(READ "${VERSION_TEMPLATE_FILE}" VERSION_FILE_TEMPLATE)

--- a/webui-vue/tests/e2e/full-stack.spec.js
+++ b/webui-vue/tests/e2e/full-stack.spec.js
@@ -29,6 +29,8 @@ const expectedDirectorTransport
 const isReadonlyProfile = profile === 'readonly'
 const isMultiDirectorProfile
   = process.env.BAREOS_WEBUI_PROXY_ENABLE_MULTI_DIRECTOR === '1'
+const LOGIN_ATTEMPTS = 3
+const LOGIN_RESULT_TIMEOUT_MS = 10_000
 
 async function expectConnected(page) {
   await expect(page.locator('[data-testid="director-status-label"]')).toContainText(
@@ -54,26 +56,38 @@ async function login(
 ) {
   const loginError = page.locator('[data-testid="login-error"]')
 
-  await page.goto('/')
-  await expect(page.locator('[data-testid="login-form"]')).toBeVisible()
-  await page.getByLabel('Username').fill(loginUsername)
-  await page.getByLabel('Password').fill(loginPassword)
-  await page.getByRole('button', { name: 'Login' }).click()
+  for (let attempt = 1; attempt <= LOGIN_ATTEMPTS; attempt += 1) {
+    await page.goto('/')
+    await expect(page.locator('[data-testid="login-form"]')).toBeVisible()
+    await page.getByLabel('Username').fill(loginUsername)
+    await page.getByLabel('Password').fill(loginPassword)
+    await page.getByRole('button', { name: 'Login' }).click()
 
-  if (!shouldSucceed) {
-    await expect(page.locator('[data-testid="login-error"]')).toBeVisible()
-    await expect(page).toHaveURL(/#\/login$/)
-    return
+    await page.waitForFunction(() => (
+      window.location.hash === '#/dashboard'
+      || document.querySelector('[data-testid="login-error"]')?.textContent?.trim()
+    ), { timeout: LOGIN_RESULT_TIMEOUT_MS })
+
+    if (!shouldSucceed) {
+      await expect(loginError).toBeVisible()
+      await expect(page).toHaveURL(/#\/login$/)
+      return
+    }
+
+    if (page.url().endsWith('/#/dashboard')) {
+      await expectConnected(page)
+      return
+    }
+
+    const message = (await loginError.textContent())?.trim() || 'Unknown error'
+    const transientConnectionError
+      = /connection error|websocket connection failed|could not connect to director/i.test(message)
+    if (!transientConnectionError || attempt === LOGIN_ATTEMPTS) {
+      throw new Error(`Login failed: ${message}`)
+    }
+
+    await page.waitForTimeout(1_000)
   }
-
-  await Promise.race([
-    page.waitForURL(/#\/dashboard$/),
-    loginError.waitFor({ state: 'visible' }).then(async () => {
-      const message = (await loginError.textContent())?.trim()
-      throw new Error(`Login failed: ${message || 'Unknown error'}`)
-    }),
-  ])
-  await expectConnected(page)
 }
 
 async function openNav(page, testId, urlPattern) {

--- a/webui-vue/tests/e2e/full-stack.spec.js
+++ b/webui-vue/tests/e2e/full-stack.spec.js
@@ -81,22 +81,33 @@ async function openNav(page, testId, urlPattern) {
   await page.waitForURL(urlPattern)
 }
 
-async function selectFirstQOption(page, testId, { optionTimeoutMs = 5000 } = {}) {
+async function selectFirstQOption(
+  page,
+  testId,
+  {
+    optionTimeoutMs = 5000,
+    selected,
+  } = {}
+) {
   const field = page.locator(`[data-testid="${testId}"]`)
     .locator('xpath=ancestor::*[contains(@class,"q-field")]')
     .first()
+  const combobox = field.getByRole('combobox')
   await expect(field).toBeVisible({ timeout: 20000 })
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
-    await field.click({ force: true })
-    await page.keyboard.press('ArrowDown')
-    const option = page.locator(
-      '.q-menu:visible [role="option"], .q-menu:visible .q-item, .q-menu:visible .q-virtual-scroll__content .q-item, .q-popup-proxy:visible .q-item'
-    ).first()
-
     try {
+      await combobox.click()
+      const listboxId = await combobox.getAttribute('aria-controls')
+      if (!listboxId) {
+        throw new Error(`Could not find the option list for ${testId}`)
+      }
+      const option = page.locator(`[id="${listboxId}"]`).getByRole('option').first()
       await expect(option).toBeVisible({ timeout: optionTimeoutMs })
       await option.click()
+      if (selected) {
+        await selected()
+      }
       return
     } catch {
       await page.keyboard.press('Escape')
@@ -227,7 +238,9 @@ test('loads the restore workflow selections', async ({ page }) => {
   await openNav(page, 'nav-restore', /#\/restore/)
 
   await waitForQSelectReady(page, 'restore-source-client')
-  await selectFirstQOption(page, 'restore-source-client')
+  await selectFirstQOption(page, 'restore-source-client', {
+    selected: () => waitForQSelectReady(page, 'restore-backup-job'),
+  })
   await expect(page.locator('[data-testid="restore-backup-job"]')).toBeVisible()
   await waitForQSelectReady(page, 'restore-backup-job')
   await selectFirstQOption(page, 'restore-backup-job', { optionTimeoutMs: 8000 })

--- a/webui-vue/tests/e2e/full-stack.spec.js
+++ b/webui-vue/tests/e2e/full-stack.spec.js
@@ -54,11 +54,25 @@ async function login(
     shouldSucceed = true,
   } = {}
 ) {
+  const loginForm = page.locator('[data-testid="login-form"]')
   const loginError = page.locator('[data-testid="login-error"]')
 
   for (let attempt = 1; attempt <= LOGIN_ATTEMPTS; attempt += 1) {
     await page.goto('/')
-    await expect(page.locator('[data-testid="login-form"]')).toBeVisible()
+    await page.waitForFunction(() => (
+      window.location.hash === '#/dashboard'
+      || document.querySelector('[data-testid="login-form"]')
+    ), { timeout: LOGIN_RESULT_TIMEOUT_MS })
+
+    if (page.url().endsWith('/#/dashboard')) {
+      if (!shouldSucceed) {
+        throw new Error('Invalid credentials unexpectedly restored a session')
+      }
+      await expectConnected(page)
+      return
+    }
+
+    await expect(loginForm).toBeVisible()
     await page.getByLabel('Username').fill(loginUsername)
     await page.getByLabel('Password').fill(loginPassword)
     await page.getByRole('button', { name: 'Login' }).click()
@@ -93,6 +107,26 @@ async function login(
 async function openNav(page, testId, urlPattern) {
   await page.locator(`[data-testid="${testId}"]`).click()
   await page.waitForURL(urlPattern)
+}
+
+async function openConsole(page) {
+  const consoleOutput = page.locator('[data-testid="console-output"]')
+  await page.goto('/#/console-popup')
+  await expect(consoleOutput).toBeVisible()
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await expect(consoleOutput).toContainText('Connected to bareos-dir', {
+        timeout: 5000,
+      })
+      return consoleOutput
+    } catch {
+      await page.getByTitle('Reconnect').click()
+    }
+  }
+
+  await expect(consoleOutput).toContainText('Connected to bareos-dir')
+  return consoleOutput
 }
 
 async function selectFirstQOption(
@@ -196,9 +230,7 @@ test('shows all configured directors in multi-director login mode', async ({
 test('reconnects the console session on demand', async ({ page }) => {
   await login(page)
 
-  await page.goto('/#/console-popup')
-  const consoleOutput = page.locator('[data-testid="console-output"]')
-  await expect(consoleOutput).toContainText('Connected to bareos-dir')
+  const consoleOutput = await openConsole(page)
 
   await page.getByTitle('Reconnect').click()
   await expect(consoleOutput).toContainText('Console disconnected.')
@@ -208,9 +240,7 @@ test('reconnects the console session on demand', async ({ page }) => {
 test('reconnects the console after typing exit', async ({ page }) => {
   await login(page)
 
-  await page.goto('/#/console-popup')
-  const consoleOutput = page.locator('[data-testid="console-output"]')
-  await expect(consoleOutput).toContainText('Connected to bareos-dir')
+  const consoleOutput = await openConsole(page)
 
   await consoleOutput.click()
   await page.keyboard.type('exit')
@@ -346,9 +376,7 @@ test('keeps the console session when navigating away and back', async ({
 }) => {
   await login(page)
 
-  await page.goto('/#/console-popup')
-  const consoleOutput = page.locator('[data-testid="console-output"]')
-  await expect(consoleOutput).toContainText('Connected to bareos-dir')
+  const consoleOutput = await openConsole(page)
 
   await page.getByText('status director', { exact: true }).click()
   await expect(consoleOutput).toContainText('Terminated Jobs:')
@@ -374,12 +402,7 @@ test('opens the console and runs a raw command through the proxied director conn
 }) => {
   await login(page)
 
-  await page.goto('/#/console-popup')
-  await expect(page.locator('[data-testid="console-output"]')).toContainText(
-    'Connected to bareos-dir'
-  )
+  const consoleOutput = await openConsole(page)
   await page.getByText('status director', { exact: true }).click()
-  await expect(page.locator('[data-testid="console-output"]')).toContainText(
-    'Terminated Jobs:'
-  )
+  await expect(consoleOutput).toContainText('Terminated Jobs:')
 })


### PR DESCRIPTION
This PR changes the webui-vue build steps to not break the build even if there are problems reported by `npm audit`.

It also fixes the version number generation in webui-vue and improves the robustness of the tests.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
