### PR TITLE
docs: update volume add warning about delete rotate key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - docs: fix sphinx-linkcheck warnings in our docs [PR #2706]
 - docs: promote eval subscription in release docs [PR #2712]
 - docs: update readme file and image [PR #2719]
+- docs: update volume add warning about delete rotate key [PR #2738]
 
 ## [25.0.0] - 2025-12-01
 
@@ -2357,4 +2358,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2735]: https://github.com/bareos/bareos/pull/2735
 [PR #2736]: https://github.com/bareos/bareos/pull/2736
 [PR #2737]: https://github.com/bareos/bareos/pull/2737
+[PR #2738]: https://github.com/bareos/bareos/pull/2738
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/docs/manuals/source/IntroductionAndTutorial/InstallingBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/InstallingBareos.rst
@@ -48,7 +48,7 @@ There are different types of Bareos repositories:
 .. note::
 
    Interested in the subscription repositories? Start with a Bareos Evaluation Subscription at
-   https://bareos.com/try.
+   https://www.bareos.com/try/ .
 
 2. Bareos Community repositories on https://download.bareos.org/ with
 

--- a/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
+++ b/docs/manuals/source/IntroductionAndTutorial/WhatIsBareos.rst
@@ -244,7 +244,7 @@ There are different types of Bareos binaries:
 .. note::
 
    Interested in the subscription repositories? Start with a Bareos Evaluation Subscription at
-   https://bareos.com/try.
+   https://www.bareos.com/try/ .
 
 2. Bareos Community binaries on https://download.bareos.org/:
 
@@ -309,7 +309,7 @@ For a simple comparison of the two editions, please see the following table:
 +-------------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Issue tracker           | `GitHub Issues <https://github.com/bareos/bareos/issues/>`_                                                                                                   |
 +-------------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------+
-| New features            | `Co-Funding         <https://www.bareos.com/funded-development>`_            | `Join in <https://www.bareos.com/community/join-in/>`_                         |
+| New features            | `Co-Funding <https://www.bareos.com/services/#development-hint>`_            | `Join in <https://www.bareos.com/community/join-in/>`_                         |
 +-------------------------+------------------------------------------------------------------------------+--------------------------------------------------------------------------------+
 
 This binary release policy is in place since Bareos >= 22.

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1972,8 +1972,10 @@ update
    volume=<volume-name> encrypt=<yes/no/rotate>` for :ref:`scsicrypto-sd`.
 
    .. warning::
-      As a new encryption key will only be loaded on volume mount, make sure you
-      re-mount any currently mounted volume when changing the encryption key!
+      - As a new encryption key will only be loaded on volume mount, make sure you
+        re-mount any currently mounted volume when changing the encryption key!
+      - Removing or rotating a key need purging the volume first.
+
 
    For slots :bcommand:`update slots`, Bareos will obtain a list of slots and their barcodes from
    the Storage daemon, and for each barcode found, it will automatically update the slot in the

--- a/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
+++ b/docs/manuals/source/TasksAndConcepts/BareosConsole.rst
@@ -1974,7 +1974,7 @@ update
    .. warning::
       - As a new encryption key will only be loaded on volume mount, make sure you
         re-mount any currently mounted volume when changing the encryption key!
-      - Removing or rotating a key need purging the volume first.
+      - Removing or rotating a key requires the volume to be purged.
 
 
    For slots :bcommand:`update slots`, Bareos will obtain a list of slots and their barcodes from

--- a/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
@@ -50,10 +50,9 @@ The basic algorithm used for each backup session (Job) is:
 
 .. warning::
 
-   PKI Encryption disables Parallel Send code path, as such the configuration option
-   :config:option:`fd/client/MaximumWorkersPerJob` will not be used.
-   With PKI enabled, the FD has to handle compression, digests, transport encryption,
-   data encryption, and sending all in a single thread per job.
+   PKI Encryption disables Parallel Send code path, as such whatever the configuration option
+   :config:option:`fd/client/MaximumWorkersPerJob` is set, the FD has to handle compression, digests,
+   transport encryption, data encryption, and data sending all in a single thread per job.
 
 
 Encryption Technical Details

--- a/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
+++ b/docs/manuals/source/TasksAndConcepts/DataEncryption.rst
@@ -7,19 +7,31 @@ Data Encryption
    single: Data Encryption
    single: Encryption; Data
 
-Bareos permits file data encryption and signing within the File Daemon (or Client) prior to sending data to the Storage Daemon. Upon restoration, file signatures are validated and any mismatches are reported. At no time does the Director or the Storage Daemon have access to unencrypted file contents.
+Bareos permits file data encryption and signing within the File Daemon (or Client) prior to sending
+data to the Storage Daemon. Upon restoration, file signatures are validated and any mismatches are
+reported. At no time does the Director or the Storage Daemon have access to unencrypted file contents.
 
 It is very important to specify what this implementation does NOT do:
 
--  The implementation does not encrypt file metadata such as file path names, permissions, ownership and extended attributes. However, Mac OS X resource forks are encrypted.
+-  The implementation does not encrypt file metadata such as file path names, permissions,
+   ownership and extended attributes. However, Mac OS X resource forks are encrypted.
 
-Encryption and signing are implemented using RSA private keys coupled with self-signed x509 public certificates. This is also sometimes known as PKI or Public Key Infrastructure.
+Encryption and signing are implemented using RSA private keys coupled with self-signed x509 public
+certificates. This is also sometimes known as PKI or Public Key Infrastructure.
 
-Each File Daemon should be given its own unique private/public key pair. In addition to this key pair, any number of "Master Keys" may be specified – these are key pairs that may be used to decrypt any backups should the File Daemon key be lost. Only the Master Key’s public certificate should be made available to the File Daemon. Under no circumstances should the Master Private Key be shared or stored on the Client machine.
+Each File Daemon should be given its own unique private/public key pair. In addition to this key
+pair, any number of "Master Keys" may be specified – these are key pairs that may be used to
+decrypt any backups should the File Daemon key be lost. Only the Master Key’s public certificate
+should be made available to the File Daemon. Under no circumstances should the Master Private Key
+be shared or stored on the Client machine.
 
-The Master Keys should be backed up to a secure location, such as a CD placed in a in a fire-proof safe or bank safety deposit box. The Master Keys should never be kept on the same machine as the Storage Daemon or Director if you are worried about an unauthorized party compromising either machine and accessing your encrypted backups.
+The Master Keys should be backed up to a secure location, such as a CD placed in a in a fire-proof
+safe or bank safety deposit box. The Master Keys should never be kept on the same machine as the
+Storage Daemon or Director if you are worried about an unauthorized party compromising either
+machine and accessing your encrypted backups.
 
-While less critical than the Master Keys, File Daemon Keys are also a prime candidate for off-site backups; burn the key pair to a CD and send the CD home with the owner of the machine.
+While less critical than the Master Keys, File Daemon Keys are also a prime candidate for off-site
+backups; burn the key pair to a CD and send the CD home with the owner of the machine.
 
 
 
@@ -36,14 +48,27 @@ The basic algorithm used for each backup session (Job) is:
 
 #. The FD uses that session key to perform symmetric encryption on the data.
 
+.. warning::
+
+   PKI Encryption disables Parallel Send code path, as such the configuration option
+   :config:option:`fd/client/MaximumWorkersPerJob` will not be used.
+   With PKI enabled, the FD has to handle compression, digests, transport encryption,
+   data encryption, and sending all in a single thread per job.
+
+
 Encryption Technical Details
 ----------------------------
 
-:index:`\ <single: Encryption; Technical Details>`
+.. index::
+   single: Encryption; Technical Details
 
-The implementation uses 128bit AES-CBC, with RSA encrypted symmetric session keys. The RSA key is user supplied. If you are running OpenSSL >= 0.9.8, the signed file hash uses SHA-256, otherwise SHA-1 is used.
+The implementation uses 128bit AES-CBC, with RSA encrypted symmetric session keys. The RSA key is
+user supplied. If you are running OpenSSL >= 0.9.8, the signed file hash uses SHA-256, otherwise
+SHA-1 is used.
 
-End-user configuration settings for the algorithms are not currently exposed, only the algorithms listed above are used. However, the data written to Volume supports arbitrary symmetric, asymmetric, and digest algorithms for future extensibility, and the back-end implementation currently supports:
+End-user configuration settings for the algorithms are not currently exposed, only the algorithms
+listed above are used. However, the data written to Volume supports arbitrary symmetric, asymmetric,
+and digest algorithms for future extensibility, and the back-end implementation currently supports:
 
 ::
 
@@ -60,12 +85,18 @@ End-user configuration settings for the algorithms are not currently exposed, on
        - SHA256
        - SHA512
 
-The various algorithms are exposed via an entirely reusable, OpenSSL-agnostic API (ie, it is possible to drop in a new encryption backend). The Volume format is DER-encoded ASN.1, modeled after the Cryptographic Message Syntax from RFC 3852. Unfortunately, using CMS directly was not possible, as at the time of coding a free software streaming DER decoder/encoder was not available.
+The various algorithms are exposed via an entirely reusable, OpenSSL-agnostic API (ie, it is
+possible to drop in a new encryption backend). The Volume format is DER-encoded ASN.1, modeled
+after the Cryptographic Message Syntax from RFC 3852.
+Unfortunately, using CMS directly was not possible, as at the time of coding a free software
+streaming DER decoder/encoder was not available.
+
 
 Generating Private/Public Encryption Keys
 -----------------------------------------
 
-:index:`\ <single: Encryption; Generating Private/Public Encryption Keypairs>`\
+.. index::
+   single: Encryption; Generating Private/Public Encryption Keypairs
 
 Generate a Master public/private key-pair with:
 
@@ -90,15 +121,24 @@ Generate the File Daemon public/private key-pairs for each FD with:
 
 
 
-Please note the extensions given to these key-files. For example, a .pem file can contain all the following: private keys (RSA and DSA), public keys (RSA and DSA) and (x509) certificates. It is the default format for OpenSSL. It stores data Base64 encoded DER format, surrounded by ASCII headers, so is suitable for text mode transfers between systems. A .pem file may contain any number of keys either public or private. We use it in cases where there is both, a public and a private key.
+Please note the extensions given to these key-files. For example, a .pem file can contain all the
+following: private keys (RSA and DSA), public keys (RSA and DSA) and (x509) certificates. It is the
+default format for OpenSSL. It stores data Base64 encoded DER format, surrounded by ASCII headers,
+so is suitable for text mode transfers between systems.
+A .pem file may contain any number of keys either public or private.
+We use it in cases where there is both, a public and a private key.
 
-Above we have used the .pub.key extension to refer to X509 certificate encoding that contains only a single public key.
+Above we have used the .pub.key extension to refer to X509 certificate encoding that contains only
+a single public key.
 
 Example Data Encryption Configurations (bareos-fd.conf)
 -------------------------------------------------------
 
-:index:`\ <single: Example; Data Encryption Configuration File>`\
+.. index::
+   single: Example; Data Encryption Configuration File
 
+
+a sample configuration:
 
 
    .. literalinclude:: /include/config/FdClientPki.conf
@@ -109,9 +149,12 @@ Example Data Encryption Configurations (bareos-fd.conf)
 Decrypting with a Master Key
 ----------------------------
 
-:index:`\ <single: Decrypting with a Master Key>`\  :index:`\ <single: Encryption; Decrypting with a Master Key>`\
+.. index::
+   single: Decrypting with a Master Key
+   single: Encryption; Decrypting with a Master Key
 
-It is preferable to retain a secure, non-encrypted copy of the client’s own encryption keypair. However, should you lose the client’s keypair, recovery with the master keypair is possible.
+It is preferable to retain a secure, non-encrypted copy of the client’s own encryption keypair.
+However, should you lose the client’s keypair, recovery with the master keypair is possible.
 
 You must:
 

--- a/docs/manuals/source/conf.py
+++ b/docs/manuals/source/conf.py
@@ -343,6 +343,8 @@ linkcheck_ignore = [
     "http://127.0.0.1:8000/docs",
     "http://127.0.0.1:8000/redoc",
     r"https://github\.com/bareos/bareos/pull/\d+",
+    r"https://download.bareos.com/bareos/release/\d+/\w+/add_bareos_repositories.sh",  # login protected
+    r"https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/\d+/html/security_hardening/switching-rhel-to-fips-mode",  # bot crawl protected
     "https://www.sphinx-doc.org/en/1.7/intro.html#",
     "https://www.snia.org/ndmp",  # cloudflare protected
     "https://www.dell.com/support.*",  # client protected

--- a/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumWorkersPerJob.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumWorkersPerJob.rst.inc
@@ -1,6 +1,4 @@
 .. note::
-   These worker threads are mostly used to compute checksums, and to compress & encrypt data.
+   When PKI Encryption is not enabled, these worker threads are mostly used to compute checksums, and to compress & encrypt data.
    If this is set to at least 1, bareos will use a separate thread for sending data.
-
-.. warning::
-   As PKI Encryption disables Parallel Send code path, the value will not be used.
+   When PKI Encryption is enabled, it disables Parallel Send code path, and all tasks happens in a single thread.

--- a/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumWorkersPerJob.rst.inc
+++ b/docs/manuals/source/manually_added_config_directive_descriptions/fd-client-MaximumWorkersPerJob.rst.inc
@@ -1,3 +1,6 @@
 .. note::
    These worker threads are mostly used to compute checksums, and to compress & encrypt data.
    If this is set to at least 1, bareos will use a separate thread for sending data.
+
+.. warning::
+   As PKI Encryption disables Parallel Send code path, the value will not be used.


### PR DESCRIPTION
This PR add a warning into bconsole update volume encrypt delete or rotate key.
The volume needs to be pruned first.

Fix bareos/internal#725

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

