### PR TITLE
Reject external post-login redirects

### DIFF
--- a/webui/module/Auth/src/Auth/Controller/AuthController.php
+++ b/webui/module/Auth/src/Auth/Controller/AuthController.php
@@ -167,12 +167,12 @@ class AuthController extends AbstractActionController
             $session->offsetSet('commands', $aclcheck);
         }
 
-        if ($this->params()->fromQuery('req')) {
-            $redirect = $this->params()->fromQuery('req');
+        $redirect = $this->params()->fromQuery('req');
+        if ($this->isLocalRedirect($redirect)) {
             $request = $this->getRequest();
             $request->setUri($redirect);
             if ($routeToBeMatched = $this->getServiceLocator()->get('Router')->match($request)) {
-                return $this->redirect()->toUrl($this->params()->fromQuery('req'));
+                return $this->redirect()->toUrl($redirect);
             }
         }
 
@@ -241,6 +241,15 @@ class AuthController extends AbstractActionController
         ) as $key) {
             $session->offsetUnset($key);
         }
+    }
+
+    private function isLocalRedirect($redirect)
+    {
+        return is_string($redirect)
+            && substr($redirect, 0, 1) === '/'
+            && substr($redirect, 0, 2) !== '//'
+            && strpos($redirect, '\\') === false
+            && !preg_match('/%(2f|5c)/i', $redirect);
     }
 
     /**


### PR DESCRIPTION
The WebUI login return path accepted an absolute req URL. The route check
validated only its path, while the subsequent redirect used the original
absolute URL.

This allowed a URL such as https://attacker.example/dashboard to pass the
local /dashboard route check and redirect users off-site after login.

Require an origin-relative path and reject network-path, backslash, and
encoded path-separator forms before route matching and redirecting.