### PR TITLE
bpipe-fd: add safety check against using usesuffix option together with Accurate flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Don't break the build when npm audit fails [PR #2737]
 - Matrix: rename xUbuntu to Ubuntu [PR #2735]
 - cmake: fix add_alphabetic_requirements() no-op sort [PR #2756]
+- bpipe-fd: add safety check against using usesuffix option together with Accurate flag [PR #2745]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2360,5 +2361,6 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2736]: https://github.com/bareos/bareos/pull/2736
 [PR #2737]: https://github.com/bareos/bareos/pull/2737
 [PR #2738]: https://github.com/bareos/bareos/pull/2738
+[PR #2745]: https://github.com/bareos/bareos/pull/2745
 [PR #2756]: https://github.com/bareos/bareos/pull/2756
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/plugins/filed/bpipe/bpipe-fd.cc
+++ b/core/src/plugins/filed/bpipe/bpipe-fd.cc
@@ -661,15 +661,22 @@ static bRC plugin_has_valid_arguments(PluginContext* ctx)
   }
 
   int is_accurate;
-  bRC rc = bareos_core_functions->getBareosValue(ctx, bVarAccurate, &is_accurate);
+  bRC rc
+      = bareos_core_functions->getBareosValue(ctx, bVarAccurate, &is_accurate);
   if (rc == bRC_Error) {
-    Jmsg(ctx, M_FATAL, T_("bpipe-fd: internal error getting accurate status.\n"));
-    Dmsg(ctx, debuglevel, "bpipe-fd: internal error getting accurate status.\n");
+    Jmsg(ctx, M_FATAL,
+         T_("bpipe-fd: internal error getting accurate status.\n"));
+    Dmsg(ctx, debuglevel,
+         "bpipe-fd: internal error getting accurate status.\n");
     retval = bRC_Error;
   } else {
     if (p_ctx->usesuffix && is_accurate != 0) {
-      Jmsg(ctx, M_FATAL, T_("bpipe-fd: Accurate not allowed with usesuffix, please disable in Job.\n"));
-      Dmsg(ctx, debuglevel, "bpipe-fd: Accurate not allowed with usesuffix, please disable in Job.\n");
+      Jmsg(ctx, M_FATAL,
+           T_("bpipe-fd: Accurate not allowed with usesuffix, "
+              "please disable in Job.\n"));
+      Dmsg(ctx, debuglevel,
+           "bpipe-fd: Accurate not allowed with usesuffix, "
+           "please disable in Job.\n");
       retval = bRC_Error;
     }
   }

--- a/core/src/plugins/filed/bpipe/bpipe-fd.cc
+++ b/core/src/plugins/filed/bpipe/bpipe-fd.cc
@@ -660,6 +660,20 @@ static bRC plugin_has_valid_arguments(PluginContext* ctx)
     retval = bRC_Error;
   }
 
+  int is_accurate;
+  bRC rc = bareos_core_functions->getBareosValue(ctx, bVarAccurate, &is_accurate);
+  if (rc == bRC_Error) {
+    Jmsg(ctx, M_FATAL, T_("bpipe-fd: internal error getting accurate status.\n"));
+    Dmsg(ctx, debuglevel, "bpipe-fd: internal error getting accurate status.\n");
+    retval = bRC_Error;
+  } else {
+    if (p_ctx->usesuffix && is_accurate != 0) {
+      Jmsg(ctx, M_FATAL, T_("bpipe-fd: Accurate not allowed with usesuffix, please disable in Job.\n"));
+      Dmsg(ctx, debuglevel, "bpipe-fd: Accurate not allowed with usesuffix, please disable in Job.\n");
+      retval = bRC_Error;
+    }
+  }
+
   return retval;
 }
 } /* namespace filedaemon */

--- a/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/BpipePlugin.rst.inc
+++ b/docs/manuals/source/TasksAndConcepts/Plugins/FileDaemonPlugins/BpipePlugin.rst.inc
@@ -50,7 +50,7 @@ usesuffix
    Optional boolean argument that enables the automatic creation of a unique pseudo filename.
    If **usesuffix** is :code:`true`, a unique suffix is appended to **filepath**, containing the job name, the backup level and the job id. This makes incremental backups with the bpipe plugin possible. Otherwise, on a restore the plugin would just be called once with the data from the latest job, and earlier incremental and full backup jobs would be ignored.
    The full filename will have the following form: :code:`<filepath>.<job_name>.<level_letter>.<job_id>`
-
+   **usesuffix** cannot be used in a job that has **Accurate** enabled.
 readprogram
    for the bpipe plugin specifies the "reader" program that is called by the plugin during backup to read the data. bpipe will call this program by doing a popen on it.
 

--- a/systemtests/tests/bpipe-fd/testrunner-fail-with-accurate
+++ b/systemtests/tests/bpipe-fd/testrunner-fail-with-accurate
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+#   BAREOS® - Backup Archiving REcovery Open Sourced
+#
+#   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+#
+#   This program is Free Software; you can redistribute it and/or
+#   modify it under the terms of version three of the GNU Affero General Public
+#   License as published by the Free Software Foundation and included
+#   in the file LICENSE.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+#   02110-1301, USA.
+
+set -e
+set -o pipefail
+set -u
+#
+# Check that having usesuffix=true and running an accurate job
+# results in a failure
+
+TestName="$(basename "$(pwd)")"
+export TestName
+
+#shellcheck source=../environment.in
+. ./environment
+
+#shellcheck source=../scripts/functions
+. "${BAREOS_SCRIPTS_DIR}"/functions
+
+start_test
+
+run_bconsole - <<END_OF_DATA
+@$out ${NULL_DEV}
+messages
+
+@$out ${runner_tmp}/full.out
+run job=backup-bareos-fd fileset=bpipe-unique level=Full accurate=yes yes
+wait
+messages
+END_OF_DATA
+
+check_log "${runner_tmp}/full.out"
+
+run_bconsole - <<EOF
+@$out ${runner_tmp}/incr.out
+run job=backup-bareos-fd fileset=bpipe-unique level=Incremental accurate=yes yes
+wait
+messages
+quit
+EOF
+
+expect_grep "Backup Error." \
+  "${runner_tmp}/incr.out" \
+  "backup should have failed but did not"
+
+end_test

--- a/systemtests/tests/bpipe-fd/testrunner-fail-with-accurate
+++ b/systemtests/tests/bpipe-fd/testrunner-fail-with-accurate
@@ -61,4 +61,8 @@ expect_grep "Backup Error." \
   "${runner_tmp}/incr.out" \
   "backup should have failed but did not"
 
+expect_grep "Accurate not allowed with usesuffix" \
+  "${runner_tmp}/incr.out" \
+  "expected error message about Accurate job not found"
+
 end_test


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

bpipe-fd: add safety check against using usesuffix option together with Accurate flag

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
