### PR TITLE
webui-vue: fix API/WS base URL when deep-linking or refreshing sub-routes

### DIFF
--- a/webui-vue/src/utils/directorCommandSocket.js
+++ b/webui-vue/src/utils/directorCommandSocket.js
@@ -20,8 +20,8 @@
  */
 
 export function getAppBasePath() {
-  const path = window.location.pathname || '/'
-  return path.endsWith('/') ? path : path + '/'
+  const base = import.meta.env.BASE_URL || '/'
+  return base.endsWith('/') ? base : base + '/'
 }
 
 export function defaultDirectorWsUrl() {


### PR DESCRIPTION
Fixes #2747

`getAppBasePath()` derived the app's base path from `window.location.pathname`, which reflects whatever route the user is currently on rather than the path the app is actually deployed under. When a user opened or refreshed a deep link (e.g. `/bareos-webui-new/dashboard`), the computed base became `/bareos-webui-new/dashboard/` instead of `/bareos-webui-new/`, so `API_BASE_URL` and the director WebSocket URL pointed at a non-existent proxy path (`/bareos-webui-new/dashboard/api`, `.../dashboard/ws`). The reverse proxy doesn't recognize that path and returns HTML instead of JSON, which surfaces as a persistent "Director list request failed" error and blocks login.

Since the app already uses `createWebHashHistory()`, the browser path never actually changes during in-app navigation, only routes reached via a fresh page load (deep link or refresh) hit this bug. The fix uses Vite's `import.meta.env.BASE_URL`, which is fixed at build time to the app's real deployment path, instead of the mutable current URL. `API_BASE_URL` and `DIRECTOR_WS_URL` are computed once from this in `directorCommandSocket.js` and consumed everywhere else, so the fix is centralized in a single function.

Testing:

`npx vitest run`: 275/276 tests pass; the one failure (`i18nGeneration.spec.js`) is a pre-existing, unrelated stale-generated-file issue with no dependency on this code.