### PR TITLE
cmake: fix add_alphabetic_requirements() no-op sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - devtools: pip-tools: update dependencies [PR #2736]
 - Don't break the build when npm audit fails [PR #2737]
 - Matrix: rename xUbuntu to Ubuntu [PR #2735]
+- cmake: fix add_alphabetic_requirements() no-op sort [PR #2756]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2359,4 +2360,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2736]: https://github.com/bareos/bareos/pull/2736
 [PR #2737]: https://github.com/bareos/bareos/pull/2737
 [PR #2738]: https://github.com/bareos/bareos/pull/2738
+[PR #2756]: https://github.com/bareos/bareos/pull/2756
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -1205,7 +1205,11 @@ function(add_alphabetic_requirements prefix test_subdir)
     CONFIGURE_DEPENDS "${test_dir}/testrunner-*"
   )
 
-  list(SORT "${all_test_files}")
+  # Use natural sort, so e.g. testrunner-9-... sorts before testrunner-10-...,
+  # not just testrunner-01-.../testrunner-02-... Pass the variable name (not its
+  # dereferenced value), otherwise list(SORT) silently does nothing and
+  # all_test_files keeps whatever order file(GLOB ...) happened to return it in.
+  list(SORT all_test_files COMPARE NATURAL)
 
   set(all_tests "")
   foreach(file ${all_test_files})


### PR DESCRIPTION
list(SORT ${all_test_files}) dereferences the variable before
passing it, so list(SORT) receives the expanded file list instead
of the variable name and silently does nothing. The dependency
chain built afterwards is therefore wired in whatever order
file(GLOB ...) happened to return, which is filesystem-dependent
and not guaranteed to match the numeric testrunner-NN order.

This could let e.g. testrunner-03 (and any later test) of a
systemtest suite start before testrunner-01/02 finished, since
the ordering requirement ends up attached to the wrong
predecessor.

Pass the variable name instead of its value, and use natural sort
so testrunner-9-... correctly sorts before testrunner-10-...,
not just zero-padded testrunner-01-.../testrunner-02-... This
fixes the dependency chain for every systemtest suite using
add_alphabetic_requirements().

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
