### PR TITLE
webui-proxy: fix not bashing console name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bpipe-fd: add safety check against using usesuffix option together with Accurate flag [PR #2745]
 - webui-vue: update nanoid to patched version [PR #2772]
 - webui-vue: remove unneeded newlines in bareos-audit.log [PR #2761]
+- webui-proxy: fix not bashing console name [PR #2757]
 
 ### Removed
 - dird: deprecate Pool->FileRetention, Pool->JobRetention, WriteVerifyList [PR #2567]
@@ -2371,6 +2372,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2752]: https://github.com/bareos/bareos/pull/2752
 [PR #2754]: https://github.com/bareos/bareos/pull/2754
 [PR #2756]: https://github.com/bareos/bareos/pull/2756
+[PR #2757]: https://github.com/bareos/bareos/pull/2757
 [PR #2761]: https://github.com/bareos/bareos/pull/2761
 [PR #2762]: https://github.com/bareos/bareos/pull/2762
 [PR #2764]: https://github.com/bareos/bareos/pull/2764

--- a/core/src/webui-proxy/director_connection.cc
+++ b/core/src/webui-proxy/director_connection.cc
@@ -293,7 +293,27 @@ void DirectorConnection::Authenticate(const DirectorConfig& cfg)
   BashSpaces(bashed_username);
   const std::string hello = "Hello " + bashed_username + " calling version "
                             + kBareosVersionStrings.Full + "\n";
-  SendFrame(hello);
+
+  {
+    /* workaround for a bug in the director, where it does only a single peek
+     * to detect cleartext.
+     * Sending size + content separatly as SendFrame does can cause the director
+     * to misunderstand that we are trying to use cleartext, and as such
+     * fail the connection.
+     * This is only an issue for exactly this situation, so we simply workaround
+     * this by doing this manually once */
+    std::vector<char> data;
+    data.resize(sizeof(int32_t) + hello.size());
+
+    memcpy(data.data() + sizeof(int32_t), hello.data(), hello.size());
+
+    int32_t size = hello.size();
+    int32_t hdr = htonl(size);
+
+    memcpy(data.data(), &hdr, sizeof(int32_t));
+
+    WriteAll(data.data(), data.size());
+  }
 
   // Step 2: receive director's challenge
   int32_t challenge_signal = 0;

--- a/core/src/webui-proxy/director_connection.cc
+++ b/core/src/webui-proxy/director_connection.cc
@@ -24,6 +24,7 @@
 #include "lib/ascii_control_characters.h"
 #include "lib/bnet_protocol_signals.h"
 #include "proxy_log.h"
+#include "lib/util.h"
 #include "lib/version.h"
 #include "lib/scan.h"
 
@@ -288,7 +289,9 @@ void DirectorConnection::Authenticate(const DirectorConfig& cfg)
   const std::string key = MakeCramMd5Key(cfg.password);
 
   // Step 1: send Hello with version so the director uses the >= 18.2 protocol.
-  const std::string hello = "Hello " + cfg.username + " calling version "
+  std::string bashed_username = cfg.username;
+  BashSpaces(bashed_username);
+  const std::string hello = "Hello " + bashed_username + " calling version "
                             + kBareosVersionStrings.Full + "\n";
   SendFrame(hello);
 

--- a/core/src/webui-proxy/tests/test_director_connection.cc
+++ b/core/src/webui-proxy/tests/test_director_connection.cc
@@ -41,6 +41,49 @@
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 
+TEST(DirectorConnection, BashesSpacesInUsernameInHelloMessage)
+{
+  // Usernames containing spaces must have spaces encoded as \x01 so the
+  // director's space-splitting Hello parser reconstructs the full name.
+  int sockets[2] = {-1, -1};
+  ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, sockets), 0);
+
+  DirectorConnection connection;
+  connection.fd_ = sockets[0];
+
+  DirectorConfig cfg;
+  cfg.username = "my console";  // space in name
+  cfg.password = "secret";
+  cfg.json_mode = false;
+
+  std::thread director([peer = sockets[1]]() {
+    int32_t header = 0;
+    ASSERT_EQ(read(peer, &header, sizeof(header)), sizeof(header));
+    const auto hello_size = static_cast<size_t>(ntohl(header));
+    std::string hello(hello_size, '\0');
+    ASSERT_EQ(read(peer, hello.data(), hello.size()),
+              static_cast<ssize_t>(hello.size()));
+
+    // Space in username must be encoded as \x01, not a literal space.
+    const std::string bashed
+        = "my\x01"
+          "console";
+    EXPECT_NE(hello.find("Hello " + bashed + " calling version "),
+              std::string::npos)
+        << "Hello message was: " << hello;
+
+    // Close without completing auth — we only care about the Hello content.
+    close(peer);
+  });
+
+  // Authenticate will throw because we closed the socket early; that's fine.
+  EXPECT_THROW(connection.Authenticate(cfg), std::runtime_error);
+
+  director.join();
+  close(connection.fd_);
+  connection.fd_ = -1;
+}
+
 TEST(DirectorConnection, FormatsTlsPskIdentityAsQualifiedConsoleName)
 {
   // The proxy prepends the console resource name and the separator byte.


### PR DESCRIPTION
The director connection did not bash the console name, which means that the webui could not login if the console name contained spaces.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
~~Required backport PRs have been created~~
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
