### PR TITLE
cmake: fix add_alphabetic_requirements() no-op sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - logrotate: add minsize 100k [PR #2746]
 
+### Changed
+- cmake: fix add_alphabetic_requirements() no-op sort [PR #2758]
+
 ## [25.1.0] - 2026-08-03
 
 ### Added
@@ -2336,4 +2339,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2741]: https://github.com/bareos/bareos/pull/2741
 [PR #2742]: https://github.com/bareos/bareos/pull/2742
 [PR #2746]: https://github.com/bareos/bareos/pull/2746
+[PR #2758]: https://github.com/bareos/bareos/pull/2758
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -992,7 +992,11 @@ function(add_alphabetic_requirements prefix test_subdir)
     CONFIGURE_DEPENDS "${test_dir}/testrunner-*"
   )
 
-  list(SORT "${all_test_files}")
+  # Use natural sort, so e.g. testrunner-9-... sorts before testrunner-10-...,
+  # not just testrunner-01-.../testrunner-02-... Pass the variable name (not its
+  # dereferenced value), otherwise list(SORT) silently does nothing and
+  # all_test_files keeps whatever order file(GLOB ...) happened to return it in.
+  list(SORT all_test_files COMPARE NATURAL)
 
   set(all_tests "")
   foreach(file ${all_test_files})


### PR DESCRIPTION
**Backport of PR #2756 to bareos-25**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2756 is merged
- [x] All functional differences to the original PR are documented above
