### PR TITLE
cmake: fix add_alphabetic_requirements() no-op sort

### DIFF
--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2024 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -667,4 +667,51 @@ function(systemtest_requires test required_test)
     "${SYSTEMTEST_PREFIX}${basename}:${test}" PROPERTIES FIXTURES_REQUIRED
                                                          "${_fixtures}"
   )
+endfunction()
+
+function(add_requirement test_basename test requirement)
+  get_test_property("${test_basename}:${test}" FIXTURES_REQUIRED fixtures)
+  set_tests_properties(
+    "${test_basename}:${test}"
+    PROPERTIES FIXTURES_REQUIRED
+               "${fixtures};${test_basename}/${requirement}-fixture"
+  )
+endfunction()
+
+function(add_alphabetic_requirements prefix test_subdir)
+  set(test_dir "${tests_dir}/${test_subdir}")
+  set(test_basename "${prefix}${test_subdir}")
+
+  if(EXISTS ${test_dir}/testrunner)
+    return()
+  endif()
+
+  file(
+    GLOB all_test_files
+    LIST_DIRECTORIES false
+    RELATIVE "${test_dir}"
+    CONFIGURE_DEPENDS "${test_dir}/testrunner-*"
+  )
+
+  # Use natural sort, so e.g. testrunner-9-... sorts before testrunner-10-...,
+  # not just testrunner-01-.../testrunner-02-... Pass the variable name (not its
+  # dereferenced value), otherwise list(SORT) silently does nothing and
+  # all_test_files keeps whatever order file(GLOB ...) happened to return it in.
+  list(SORT all_test_files COMPARE NATURAL)
+
+  set(all_tests "")
+  foreach(file ${all_test_files})
+    string(REPLACE "testrunner-" "" test ${file})
+    list(APPEND all_tests "${test}")
+  endforeach()
+
+  set(tests "${all_tests}")
+  set(prevs "${all_tests}")
+
+  list(POP_BACK prevs)
+  list(POP_FRONT tests)
+
+  foreach(iter IN ZIP_LISTS tests prevs)
+    add_requirement("${test_basename}" "${iter_0}" "${iter_1}")
+  endforeach()
 endfunction()


### PR DESCRIPTION
**Backport of PR #2756 to bareos-23**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality (if there were changes to the original PR)
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

#### Backport quality
- [ ] Original PR #2756 is merged
- [ ] All functional differences to the original PR are documented above
