### PR TITLE
cmake: fix alphabetic requirements when some tests are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix proxmox plugin stalling virtual machines [PR #2733]
 - logrotate: add minsize 100k [PR #2731]
 - libcloud plugin: fix error when backing up an empty bucket [PR #2717]
+- cmake: fix alphabetic requirements when some tests are disabled [PR #2762]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2363,4 +2364,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2738]: https://github.com/bareos/bareos/pull/2738
 [PR #2745]: https://github.com/bareos/bareos/pull/2745
 [PR #2756]: https://github.com/bareos/bareos/pull/2756
+[PR #2762]: https://github.com/bareos/bareos/pull/2762
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -1181,12 +1181,20 @@ function(systemtest_requires test required_test)
   )
 endfunction()
 
-function(add_requirement test_basename test requirement)
+function(add_requirements test_basename test)
   get_test_property("${test_basename}:${test}" FIXTURES_REQUIRED fixtures)
+  if(NOT fixtures)
+    # if no fixtures are defined yet, get_test_property returns NOTFOUND since
+    # list(APPEND) does not treat that value differently (but if does!) we need
+    # to empty it out, so that we do not add NOTFOUND to the list of fixtures
+    set(fixtures "")
+  endif()
+  foreach(req IN LISTS ARGN)
+    list(APPEND fixtures "${test_basename}/${req}-fixture")
+  endforeach()
+
   set_tests_properties(
-    "${test_basename}:${test}"
-    PROPERTIES FIXTURES_REQUIRED
-               "${fixtures};${test_basename}/${requirement}-fixture"
+    "${test_basename}:${test}" PROPERTIES FIXTURES_REQUIRED "${fixtures}"
   )
 endfunction()
 
@@ -1218,12 +1226,10 @@ function(add_alphabetic_requirements prefix test_subdir)
   endforeach()
 
   set(tests "${all_tests}")
-  set(prevs "${all_tests}")
+  set(prevs "")
 
-  list(POP_BACK prevs)
-  list(POP_FRONT tests)
-
-  foreach(iter IN ZIP_LISTS tests prevs)
-    add_requirement("${test_basename}" "${iter_0}" "${iter_1}")
+  foreach(test IN LISTS tests)
+    add_requirements("${test_basename}" "${test}" "${prevs}")
+    list(APPEND prevs "${test}")
   endforeach()
 endfunction()

--- a/systemtests/tests/virtualfull-basic/CMakeLists.txt
+++ b/systemtests/tests/virtualfull-basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -27,4 +27,4 @@ endif()
 
 create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
 
-add_requirement("${SYSTEMTEST_PREFIX}${BASENAME}" "failing-virtual" "simple")
+add_requirements("${SYSTEMTEST_PREFIX}${BASENAME}" "failing-virtual" "simple")

--- a/systemtests/tests/webui-vue-common/test-cleanup
+++ b/systemtests/tests/webui-vue-common/test-cleanup
@@ -29,6 +29,10 @@ export TestName
 . ./environment
 . "${BAREOS_SCRIPTS_DIR}/functions"
 
+if [ -f "${working}/bareos-dir.trace" ]; then
+  cat "${working}/bareos-dir.trace"
+fi
+
 for pid_file in "${tmp}/webui-vue-frontend.pid" "${tmp}/webui-vue-proxy.pid"; do
   if [[ -f "${pid_file}" ]]; then
     pid="$(<"${pid_file}")"

--- a/systemtests/tests/webui-vue-common/test-setup
+++ b/systemtests/tests/webui-vue-common/test-setup
@@ -133,6 +133,11 @@ bin/bareos start
 bin/bareos status
 print_debug "$(bin/bconsole <<<"status dir")"
 
+# Emsg emits a 10 debug level
+bin/bconsole <<EOF
+setdebug dir level=10 trace=1
+EOF
+
 proxy_tls_psk_disable=no
 if [[ "${BAREOS_WEBUI_PROXY_DISABLE_TLS_PSK}" = "1" ]]; then
   proxy_tls_psk_disable=yes


### PR DESCRIPTION
### cmake: fix bad alphabetic requirements

If I have three tests A, B, C, then C should depend on both A and B,
not just on B.  Otherwise C will run without waiting for A, if B is
e.g. disabled!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [X] Is the PR title usable as CHANGELOG entry?
- [X] Purpose of the PR is understood
- [X] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [X] Source code changes are understandable
- [X] Variable and function names are meaningful
- [X] Code comments are correct (logically and spelling)

