### PR TITLE
stored: fix segfault on missing Changer Command"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - bvfs: fix stack buffer overflow in GetAllFileVersions [PR #2785]
 - dplcompat: fix SIGABRT when a chunk deletion fails during truncate [PR #2779]
 - core: script btraceback support environment variable [PR #2771]
+- stored: fix segfault on missing Changer Command" [PR #2763]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2378,6 +2379,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2757]: https://github.com/bareos/bareos/pull/2757
 [PR #2761]: https://github.com/bareos/bareos/pull/2761
 [PR #2762]: https://github.com/bareos/bareos/pull/2762
+[PR #2763]: https://github.com/bareos/bareos/pull/2763
 [PR #2764]: https://github.com/bareos/bareos/pull/2764
 [PR #2771]: https://github.com/bareos/bareos/pull/2771
 [PR #2772]: https://github.com/bareos/bareos/pull/2772

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -131,6 +131,7 @@ std::string AvailableDevicesListing()
   for (BareosResource* resource = nullptr;
        (resource = my_config->GetNextRes(R_DEVICE, resource));) {
     DeviceResource* device = dynamic_cast<DeviceResource*>(resource);
+
     std::string device_str;
     device_str += " \"";
     device_str += device->resource_name_;
@@ -292,6 +293,14 @@ static DeviceResource* find_device_res(char* archive_device_string,
   foreach_res (device_resource, R_DEVICE) {
     Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
           archive_device_string);
+
+    ASSERT(device_resource->resource_name_);
+
+    if (device_resource->resource_name_[0] == '$') {
+      // this is a dummy device, and is not to be used
+      continue;
+    }
+
     if (bstrcmp(device_resource->archive_device_string,
                 archive_device_string)) {
       found = true;
@@ -299,7 +308,8 @@ static DeviceResource* find_device_res(char* archive_device_string,
     }
   }
 
-  if (!found) {
+  // we cannot select devices starting with `$` as they are not real devices
+  if (!found && archive_device_string[0] != '$') {
     /* Search for name of Device resource rather than archive name */
     if (archive_device_string[0] == '"') {
       int len = strlen(archive_device_string);
@@ -310,6 +320,7 @@ static DeviceResource* find_device_res(char* archive_device_string,
     foreach_res (device_resource, R_DEVICE) {
       Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
             archive_device_string);
+
       if (bstrcmp(device_resource->resource_name_, archive_device_string)) {
         found = true;
         break;

--- a/core/src/stored/butil.cc
+++ b/core/src/stored/butil.cc
@@ -54,7 +54,7 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
                                    char* dev_name,
                                    const std::string& VolumeName,
                                    bool readonly);
-static DeviceResource* find_device_res(char* archive_device_string,
+static DeviceResource* find_device_res(std::string_view archive_device_string,
                                        bool readonly);
 static void MyFreeJcr(JobControlRecord* jcr);
 
@@ -132,6 +132,16 @@ std::string AvailableDevicesListing()
        (resource = my_config->GetNextRes(R_DEVICE, resource));) {
     DeviceResource* device = dynamic_cast<DeviceResource*>(resource);
 
+    if (!device) {
+      // this should not be possible
+      continue;
+    }
+
+    if (device->resource_name_[0] == '$') {
+      // these are not real device names
+      continue;
+    }
+
     std::string device_str;
     device_str += " \"";
     device_str += device->resource_name_;
@@ -190,6 +200,8 @@ static bool setup_to_access_device(DeviceControlRecord* dcr,
       }
     }
   }
+
+  if (!dev_name) { return false; }
 
   if ((device_resource = find_device_res(dev_name, readonly)) == NULL) {
     Jmsg2(jcr, M_FATAL, 0,
@@ -283,27 +295,26 @@ static void MyFreeJcr(JobControlRecord* jcr)
  * Returns: NULL on failure
  *          Device resource pointer on success
  */
-static DeviceResource* find_device_res(char* archive_device_string,
+static DeviceResource* find_device_res(std::string_view archive_device_string,
                                        bool readonly)
 {
-  bool found = false;
-  DeviceResource* device_resource;
+  DeviceResource* candidate;
+  DeviceResource* found = nullptr;
 
   Dmsg0(900, "Enter find_device_res\n");
-  foreach_res (device_resource, R_DEVICE) {
-    Dmsg2(900, "Compare %s and %s\n", device_resource->archive_device_string,
-          archive_device_string);
+  foreach_res (candidate, R_DEVICE) {
+    Dmsg2(900, "Compare %s and %.*s\n", candidate->archive_device_string,
+          (int)archive_device_string.size(), archive_device_string.data());
 
-    ASSERT(device_resource->resource_name_);
+    ASSERT(candidate->resource_name_);
 
-    if (device_resource->resource_name_[0] == '$') {
+    if (candidate->resource_name_[0] == '$') {
       // this is a dummy device, and is not to be used
       continue;
     }
 
-    if (bstrcmp(device_resource->archive_device_string,
-                archive_device_string)) {
-      found = true;
+    if (archive_device_string == candidate->archive_device_string) {
+      found = candidate;
       break;
     }
   }
@@ -311,36 +322,39 @@ static DeviceResource* find_device_res(char* archive_device_string,
   // we cannot select devices starting with `$` as they are not real devices
   if (!found && archive_device_string[0] != '$') {
     /* Search for name of Device resource rather than archive name */
-    if (archive_device_string[0] == '"') {
-      int len = strlen(archive_device_string);
-      bstrncpy(archive_device_string, archive_device_string + 1, len + 1);
-      len--;
-      if (len > 0) { archive_device_string[len - 1] = 0; /* zap trailing " */ }
-    }
-    foreach_res (device_resource, R_DEVICE) {
-      Dmsg2(900, "Compare %s and %s\n", device_resource->resource_name_,
-            archive_device_string);
 
-      if (bstrcmp(device_resource->resource_name_, archive_device_string)) {
-        found = true;
-        break;
+    if (archive_device_string.starts_with('"')
+        && archive_device_string.ends_with('"')) {
+      archive_device_string.remove_prefix(1);
+      archive_device_string.remove_suffix(1);
+    }
+
+    if (!archive_device_string.empty()
+        && !archive_device_string.starts_with('$')) {
+      foreach_res (candidate, R_DEVICE) {
+        Dmsg2(900, "Compare %s and %.*s\n", candidate->resource_name_,
+              (int)archive_device_string.size(), archive_device_string.data());
+
+        if (candidate->resource_name_ == archive_device_string) {
+          found = candidate;
+          break;
+        }
       }
     }
   }
 
   if (!found) {
-    Pmsg2(0, T_("Could not find device \"%s\" in config file %s.\n"),
-          archive_device_string, configfile);
+    Pmsg2(0, T_("Could not find device \"%.*s\" in config file %s.\n"),
+          (int)archive_device_string.size(), archive_device_string.data(),
+          configfile);
     return NULL;
   }
 
-  if (readonly) {
-    Pmsg1(0, T_("Using device: \"%s\" for reading.\n"), archive_device_string);
-  } else {
-    Pmsg1(0, T_("Using device: \"%s\" for writing.\n"), archive_device_string);
-  }
+  Pmsg1(0, T_("Using device: \"%.*s\" for %s.\n"),
+        (int)archive_device_string.size(), archive_device_string.data(),
+        readonly ? "reading" : "writing");
 
-  return device_resource;
+  return found;
 }
 
 // Device got an error, attempt to analyse it


### PR DESCRIPTION
Device::OpenDevice() checked device_resource->changer_res for NULL but then unconditionally dereferenced
device_resource->changer_command[0]. When a device has a Changer Resource configured but no Changer Command set for it (changer_command == NULL), this caused a segfault.

Add a NULL check for changer_command before dereferencing it.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
