### PR TITLE
cmake: fix alphabetic requirements when some tests are disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - logrotate: add minsize 100k [PR #2746]
+- cmake: fix alphabetic requirements when some tests are disabled [PR #2766]
 
 ### Changed
 - cmake: fix add_alphabetic_requirements() no-op sort [PR #2758]
@@ -2340,4 +2341,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2742]: https://github.com/bareos/bareos/pull/2742
 [PR #2746]: https://github.com/bareos/bareos/pull/2746
 [PR #2758]: https://github.com/bareos/bareos/pull/2758
+[PR #2766]: https://github.com/bareos/bareos/pull/2766
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/systemtests/cmake/BareosSystemtestFunctions.cmake
+++ b/systemtests/cmake/BareosSystemtestFunctions.cmake
@@ -968,12 +968,20 @@ function(systemtest_requires test required_test)
   )
 endfunction()
 
-function(add_requirement test_basename test requirement)
+function(add_requirements test_basename test)
   get_test_property("${test_basename}:${test}" FIXTURES_REQUIRED fixtures)
+  if(NOT fixtures)
+    # if no fixtures are defined yet, get_test_property returns NOTFOUND since
+    # list(APPEND) does not treat that value differently (but if does!) we need
+    # to empty it out, so that we do not add NOTFOUND to the list of fixtures
+    set(fixtures "")
+  endif()
+  foreach(req IN LISTS ARGN)
+    list(APPEND fixtures "${test_basename}/${req}-fixture")
+  endforeach()
+
   set_tests_properties(
-    "${test_basename}:${test}"
-    PROPERTIES FIXTURES_REQUIRED
-               "${fixtures};${test_basename}/${requirement}-fixture"
+    "${test_basename}:${test}" PROPERTIES FIXTURES_REQUIRED "${fixtures}"
   )
 endfunction()
 
@@ -1005,12 +1013,10 @@ function(add_alphabetic_requirements prefix test_subdir)
   endforeach()
 
   set(tests "${all_tests}")
-  set(prevs "${all_tests}")
+  set(prevs "")
 
-  list(POP_BACK prevs)
-  list(POP_FRONT tests)
-
-  foreach(iter IN ZIP_LISTS tests prevs)
-    add_requirement("${test_basename}" "${iter_0}" "${iter_1}")
+  foreach(test IN LISTS tests)
+    add_requirements("${test_basename}" "${test}" "${prevs}")
+    list(APPEND prevs "${test}")
   endforeach()
 endfunction()

--- a/systemtests/tests/virtualfull-basic/CMakeLists.txt
+++ b/systemtests/tests/virtualfull-basic/CMakeLists.txt
@@ -1,6 +1,6 @@
 #   BAREOS® - Backup Archiving REcovery Open Sourced
 #
-#   Copyright (C) 2021-2025 Bareos GmbH & Co. KG
+#   Copyright (C) 2021-2026 Bareos GmbH & Co. KG
 #
 #   This program is Free Software; you can redistribute it and/or
 #   modify it under the terms of version three of the GNU Affero General Public
@@ -27,4 +27,4 @@ endif()
 
 create_systemtest(${SYSTEMTEST_PREFIX} ${BASENAME})
 
-add_requirement("${SYSTEMTEST_PREFIX}${BASENAME}" "failing-virtual" "simple")
+add_requirements("${SYSTEMTEST_PREFIX}${BASENAME}" "failing-virtual" "simple")

--- a/systemtests/tests/webui-vue-common/test-cleanup
+++ b/systemtests/tests/webui-vue-common/test-cleanup
@@ -29,6 +29,10 @@ export TestName
 . ./environment
 . "${BAREOS_SCRIPTS_DIR}/functions"
 
+if [ -f "${working}/bareos-dir.trace" ]; then
+  cat "${working}/bareos-dir.trace"
+fi
+
 for pid_file in "${tmp}/webui-vue-frontend.pid" "${tmp}/webui-vue-proxy.pid"; do
   if [[ -f "${pid_file}" ]]; then
     pid="$(<"${pid_file}")"

--- a/systemtests/tests/webui-vue-common/test-setup
+++ b/systemtests/tests/webui-vue-common/test-setup
@@ -133,6 +133,11 @@ bin/bareos start
 bin/bareos status
 print_debug "$(bin/bconsole <<<"status dir")"
 
+# Emsg emits a 10 debug level
+bin/bconsole <<EOF
+setdebug dir level=10 trace=1
+EOF
+
 proxy_tls_psk_disable=no
 if [[ "${BAREOS_WEBUI_PROXY_DISABLE_TLS_PSK}" = "1" ]]; then
   proxy_tls_psk_disable=yes


### PR DESCRIPTION
**Backport of PR #2762 to bareos-25**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

#### Backport quality
- [x] Original PR #2762 is merged
- [x] All functional differences to the original PR are documented above
