### PR TITLE
core: script btraceback support environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - new webui: Simplify configuration and improve robustness [PR #2754]
 - bvfs: fix stack buffer overflow in GetAllFileVersions [PR #2785]
 - dplcompat: fix SIGABRT when a chunk deletion fails during truncate [PR #2779]
+- core: script btraceback support environment variable [PR #2771]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2378,6 +2379,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2761]: https://github.com/bareos/bareos/pull/2761
 [PR #2762]: https://github.com/bareos/bareos/pull/2762
 [PR #2764]: https://github.com/bareos/bareos/pull/2764
+[PR #2771]: https://github.com/bareos/bareos/pull/2771
 [PR #2772]: https://github.com/bareos/bareos/pull/2772
 [PR #2779]: https://github.com/bareos/bareos/pull/2779
 [PR #2785]: https://github.com/bareos/bareos/pull/2785

--- a/contrib/misc/media_vault/media_vault.py
+++ b/contrib/misc/media_vault/media_vault.py
@@ -885,11 +885,14 @@ class MediaVault():
                     raise ValueError(msg)
 
                 ctime = datetime.datetime.fromtimestamp(
-                    f_stats.st_ctime,datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
+                    f_stats.st_ctime,
+                    datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
                 atime = datetime.datetime.fromtimestamp(
-                    f_stats.st_atime,datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
+                    f_stats.st_atime,
+                    datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
                 mtime = datetime.datetime.fromtimestamp(
-                    f_stats.st_mtime,datetime.UTC).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
+                    f_stats.st_mtime,
+                    datetime.timezone.utc).strftime('%Y-%m-%dT%H:%M:%S.%f%z')
                 t_stat = (
                             f"{'----------' : <10} {' ' : <15}\n"
                             f"{'os stats ' : <10}{self.ftp_file : <15}\n"

--- a/core/platforms/packaging/bareos-aix.spec
+++ b/core/platforms/packaging/bareos-aix.spec
@@ -97,6 +97,7 @@ Provides:   %{name}-fd
 Summary:    Common files, required by multiple Bareos packages
 Group:      Productivity/Archiving/Backup
 Provides:   %{name}-libs
+Requires:   coreutils
 Requires:   libstdc++
 Requires:   libgcc
 Requires:   zlib

--- a/core/scripts/btraceback.in
+++ b/core/scripts/btraceback.in
@@ -102,5 +102,12 @@ esac
 # Send the stack trace info to someone for analyzing or at least letting someone know we crashed.
 #
 PNAME="${PNAME} on $(hostname)"
-cat ${WD}/bareos.$2.traceback \
-  | @sbindir@/bsmtp -h @smtp_host@ -f @dump_email@ -s "Bareos ${DEBUGGER} traceback of ${PNAME}" @dump_email@
+# Environment variable:
+#   BAREOS_BTRACEBACK_SMTP_CMD is a shell expression that is used to notify
+#     you about the crash.  It evaluated via sh, and receives the title as its
+#     first argument ($0).  Its stdin is mapped to the content of the traceback.
+#     By default it uses bsmtp to sent the content to @dump_email@.
+#     You can set this to e.g. /bin/true to disable the send, or set it to
+#     'cat >> mylog' to append it to some log.
+: "${BAREOS_BTRACEBACK_SMTP_CMD:=timeout -k 5s 30 \"@sbindir@/bsmtp\" -h \"@smtp_host@\" -f \"@dump_email@\" -s \"\$0\" \"@dump_email@\"}"
+/bin/sh -c "${BAREOS_BTRACEBACK_SMTP_CMD}" "Bareos ${DEBUGGER} traceback of ${PNAME}" <"${WD}/bareos.$2.traceback"


### PR DESCRIPTION
We add the support of environement variables to allow user to adjust
btraceback exit.

Fix #2770

### Thank you for contributing to the Bareos Project!

#### Please check

- [X] Short description and the purpose of this PR is present _above this paragraph_
- [X] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
