### PR TITLE
hyper-v: fix preventing other jobs from starting because of bad ROP handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - dplcompat: fix SIGABRT when a chunk deletion fails during truncate [PR #2779]
 - core: script btraceback support environment variable [PR #2771]
 - stored: fix segfault on missing Changer Command" [PR #2763]
+- hyper-v: fix preventing other jobs from starting because of bad ROP handling [PR #2777]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2383,6 +2384,7 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2764]: https://github.com/bareos/bareos/pull/2764
 [PR #2771]: https://github.com/bareos/bareos/pull/2771
 [PR #2772]: https://github.com/bareos/bareos/pull/2772
+[PR #2777]: https://github.com/bareos/bareos/pull/2777
 [PR #2779]: https://github.com/bareos/bareos/pull/2779
 [PR #2785]: https://github.com/bareos/bareos/pull/2785
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/win32/plugins/filed/hyper-v.cc
+++ b/core/src/win32/plugins/filed/hyper-v.cc
@@ -2969,7 +2969,8 @@ static bool handle_restore_object(PluginContext* ctx,
                                   plugin_ctx* p_ctx,
                                   const filedaemon::restore_object_pkt* rop)
 {
-  switch (restore_object::name_to_type(rop->object_name)) {
+  switch (
+      restore_object::name_to_type(rop->object_name ? rop->object_name : "")) {
     case restore_object::Type::ReferencePoint: {
       json_error_t json_err;
 
@@ -3065,8 +3066,32 @@ static bool handle_restore_object(PluginContext* ctx,
       return true;
     }
     default: {
-      JFATAL(ctx, "unknown restore object with name '{}'", rop->object_name);
-      return false;
+      auto safe = [](char const* ptr) {
+        if (ptr) { return ptr; }
+        return "(null)";
+      };
+
+      std::string_view plugin_name = rop->plugin_name ? rop->plugin_name : "";
+
+      /* ROP with plugin_name set to *all* (e.g. VSS metadata) gets sent to
+       * every plugin; as we do not care about it, we just ignore it. */
+      if (plugin_name == "*all*") {
+        DBGC(ctx, "ignoring '{}' from *all*", safe(rop->object_name));
+        return true;
+        /* if we receive a ROP that we created ourselves, but that we do not
+         * recognize, then something really weird is going on, so we stop to
+         * be on the safe side. */
+      } else if (plugin_name.starts_with("hyper-v")) {
+        JFATAL(ctx, "unknown restore object with name '{}'",
+               safe(rop->object_name));
+        return false;
+        /* Bareos should not send us any other ROPs, so we log them just in
+         * case. */
+      } else {
+        JWARN(ctx, "unknown restore object with name '{}' from {}",
+              safe(rop->object_name), safe(rop->plugin_name));
+        return true;
+      }
     } break;
   }
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

When you load the hyper-v plugin on your client, then it gets loaded for every job regardless of whether it gets used or not.
As such we should be careful about sending M_FATAL messages for jobs we are not part of.  This PR makes sure that these messages are not sent because of (un)expected ROPs, as currently any VSS job gets stopped because of this.

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR



