### PR TITLE
dplcompat: fix SIGABRT when a chunk deletion fails during truncate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - cmake: fix alphabetic requirements when some tests are disabled [PR #2762]
 - new webui: Simplify configuration and improve robustness [PR #2754]
 - bvfs: fix stack buffer overflow in GetAllFileVersions [PR #2785]
+- dplcompat: fix SIGABRT when a chunk deletion fails during truncate [PR #2779]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2378,5 +2379,6 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2762]: https://github.com/bareos/bareos/pull/2762
 [PR #2764]: https://github.com/bareos/bareos/pull/2764
 [PR #2772]: https://github.com/bareos/bareos/pull/2772
+[PR #2779]: https://github.com/bareos/bareos/pull/2779
 [PR #2785]: https://github.com/bareos/bareos/pull/2785
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -374,7 +374,7 @@ bool DropletCompatibleDevice::TruncateRemoteVolume(DeviceControlRecord*)
   for (const auto& [chunk_name, stat] : *chunk_map) {
     if (is_chunk_name(chunk_name)) {
       if (auto res = m_storage.remove(vol_name, chunk_name); !res) {
-        PmStrcpy(errmsg, chunk_map.error().c_str());
+        PmStrcpy(errmsg, res.error().c_str());
         dev_errno = EIO;
         return false;
       }


### PR DESCRIPTION
Fixes #2778

`TruncateRemoteVolume()` calls `chunk_map.error()` inside the chunk-deletion loop, but the object that actually failed is `res`. At that point `chunk_map` is engaged, so `tl::expected::error()` trips its `TL_ASSERT(!has_value())` and the storage daemon aborts with `SIGABRT` instead of reporting the error and returning `false`:

```
Assertion !has_value() failed at .../expected.hpp
  [T = std::map<std::string, CrudStorage::Stat>]
```

Any single failed chunk delete against the object store therefore kills the SD rather than failing the truncate. Since `label.cc` invokes `d_truncate()` on both relabel and recycle, normal volume reuse reaches this path — it is not limited to `Action On Purge = Truncate`.

This PR reports `res.error()` instead, so the failure surfaces as an `EIO` device error carrying the backend's own message in `errmsg`, which is what the surrounding code already expects. Verified against a Backblaze B2 backend: the crash was reproduced twice in production, and with the deletion succeeding a 1600-chunk / 107 GB volume truncated cleanly with the SD staying up.

The unrelated `RemoteVolumeSize()` return-type issue mentioned in #2778 is deliberately left out of scope; happy to follow up separately.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR
