### PR TITLE
bvfs: fix stack buffer overflow in GetAllFileVersions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - libcloud plugin: fix error when backing up an empty bucket [PR #2717]
 - cmake: fix alphabetic requirements when some tests are disabled [PR #2762]
 - new webui: Simplify configuration and improve robustness [PR #2754]
+- bvfs: fix stack buffer overflow in GetAllFileVersions [PR #2785]
 
 ### Documentation
 - update bareos-github-banner.png to 13th anniversary [PR #2483]
@@ -2377,4 +2378,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2762]: https://github.com/bareos/bareos/pull/2762
 [PR #2764]: https://github.com/bareos/bareos/pull/2764
 [PR #2772]: https://github.com/bareos/bareos/pull/2772
+[PR #2785]: https://github.com/bareos/bareos/pull/2785
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -32,6 +32,7 @@
 #include "cats/bvfs.h"
 #include "lib/edit.h"
 
+#include <string>
 #include <unordered_set>
 
 #define dbglevel 10
@@ -481,10 +482,12 @@ void Bvfs::GetAllFileVersions(const char* path,
                               const char* client)
 {
   DBId_t pathid = 0;
-  char path_esc[MAX_ESCAPE_NAME_LENGTH];
+  std::string path_esc;
+  size_t path_len = strlen(path);
 
-  db->EscapeString(jcr, path_esc, path, strlen(path));
-  pathid = db->GetPathRecord(jcr, path_esc);
+  path_esc.resize(path_len * 2 + 1);
+  db->EscapeString(jcr, path_esc.data(), path, path_len);
+  pathid = db->GetPathRecord(jcr, path_esc.c_str());
   GetAllFileVersions(pathid, fname, client);
 }
 
@@ -497,10 +500,12 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
                               const char* client)
 {
   char ed1[50];
-  char fname_esc[MAX_ESCAPE_NAME_LENGTH];
-  char client_esc[MAX_ESCAPE_NAME_LENGTH];
+  std::string fname_esc;
+  std::string client_esc;
   PoolMem query(PM_MESSAGE);
   PoolMem filter(PM_MESSAGE);
+  size_t fname_len = strlen(fname);
+  size_t client_len = strlen(client);
 
   Dmsg3(dbglevel, "GetAllFileVersions(%" PRIdbid ", %s, %s)\n", pathid, fname,
         client);
@@ -511,12 +516,14 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
     Mmsg(filter, " AND Job.Type IN ('B', 'A', 'a') ");
   }
 
-  db->EscapeString(jcr, fname_esc, fname, strlen(fname));
-  db->EscapeString(jcr, client_esc, client, strlen(client));
+  fname_esc.resize(fname_len * 2 + 1);
+  client_esc.resize(client_len * 2 + 1);
+  db->EscapeString(jcr, fname_esc.data(), fname, fname_len);
+  db->EscapeString(jcr, client_esc.data(), client, client_len);
 
   db->FillQuery<BareosDb::SQL_QUERY::bvfs_versions_6>(
-      query, fname_esc, edit_uint64(pathid, ed1), client_esc, filter.c_str(),
-      limit, offset);
+      query, fname_esc.c_str(), edit_uint64(pathid, ed1), client_esc.c_str(),
+      filter.c_str(), limit, offset);
   db->SqlQuery(query.c_str(), list_entries, user_data);
 }
 


### PR DESCRIPTION
Bvfs::GetAllFileVersions used fixed 257-byte stack buffers (MAX_ESCAPE_NAME_LENGTH) to hold SQL-escaped copies of the fname, path and client arguments. These arguments are raw console command values bounded only by the socket's 1MB max packet size, not by MAX_NAME_LENGTH.

EscapeString()/PQescapeStringConn() can write up to 2*len+1 bytes with no bounds checking, so an argument longer than ~128 bytes overflows the stack buffer. Any authenticated console user with .bvfs_versions access, including the read-only webui profile shipped by default, could crash bareos-dir with a single command.

Fix by sizing the escape buffers dynamically with PoolMem and check_size(), matching the pattern already used by Bvfs::SetPattern.

### Thank you for contributing to the Bareos Project!

#### Please check

- [x] Short description and the purpose of this PR is present _above this paragraph_
- [x] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Is the PR title usable as CHANGELOG entry?
- [x] Purpose of the PR is understood
- [x] Commit descriptions are understandable and well formatted
- [x] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

##### Tests
- [x] Decision taken that a test is required (if not, then remove this paragraph)
- [x] The choice of the type of test (unit test or systemtest) is reasonable
- [x] Testname matches exactly what is being tested
- [x] On a fail, output of the test leads quickly to the origin of the fault
