### PR TITLE
bvfs: fix stack buffer overflow in GetAllFileVersions

### DIFF
--- a/.matrix.yml
+++ b/.matrix.yml
@@ -92,7 +92,7 @@ OS:
     "7":
       TYPE: rpm
       IMAGE: rhel7
-      CUSTOM_TEST_IMAGES: [ CentOS, RHEL ]
+      CUSTOM_TEST_IMAGES: [ CentOS ]
       ARCH:
         - x86_64
   FreeBSD:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and since Bareos version 20 this project adheres to [Semantic Versioning](https:
 ### Changed
 - spec: use gcc-15 for rhel builds [PR #2709]
 
+### Fixed
+- bvfs: fix stack buffer overflow in GetAllFileVersions [PR #2788]
+
 ## [23.1.7] - 2026-04-01
 
 ### Changed
@@ -1780,4 +1783,5 @@ It is therefore strongly suggested to immediately schedule a full backup of your
 [PR #2551]: https://github.com/bareos/bareos/pull/2551
 [PR #2675]: https://github.com/bareos/bareos/pull/2675
 [PR #2709]: https://github.com/bareos/bareos/pull/2709
+[PR #2788]: https://github.com/bareos/bareos/pull/2788
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -3,7 +3,7 @@
 
    Copyright (C) 2009-2010 Free Software Foundation Europe e.V.
    Copyright (C) 2016-2016 Planets Communications B.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public

--- a/core/src/cats/bvfs.cc
+++ b/core/src/cats/bvfs.cc
@@ -34,6 +34,7 @@
 #  include "cats/bvfs.h"
 #  include "lib/edit.h"
 
+#  include <string>
 #  include <unordered_set>
 
 #  define dbglevel 10
@@ -479,10 +480,12 @@ void Bvfs::GetAllFileVersions(const char* path,
                               const char* client)
 {
   DBId_t pathid = 0;
-  char path_esc[MAX_ESCAPE_NAME_LENGTH];
+  std::string path_esc;
+  size_t path_len = strlen(path);
 
-  db->EscapeString(jcr, path_esc, path, strlen(path));
-  pathid = db->GetPathRecord(jcr, path_esc);
+  path_esc.resize(path_len * 2 + 1);
+  db->EscapeString(jcr, path_esc.data(), path, path_len);
+  pathid = db->GetPathRecord(jcr, path_esc.c_str());
   GetAllFileVersions(pathid, fname, client);
 }
 
@@ -495,10 +498,12 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
                               const char* client)
 {
   char ed1[50];
-  char fname_esc[MAX_ESCAPE_NAME_LENGTH];
-  char client_esc[MAX_ESCAPE_NAME_LENGTH];
+  std::string fname_esc;
+  std::string client_esc;
   PoolMem query(PM_MESSAGE);
   PoolMem filter(PM_MESSAGE);
+  size_t fname_len = strlen(fname);
+  size_t client_len = strlen(client);
 
   Dmsg3(dbglevel, "GetAllFileVersions(%lld, %s, %s)\n", (uint64_t)pathid, fname,
         client);
@@ -509,12 +514,14 @@ void Bvfs::GetAllFileVersions(DBId_t pathid,
     Mmsg(filter, " AND Job.Type IN ('B', 'A', 'a') ");
   }
 
-  db->EscapeString(jcr, fname_esc, fname, strlen(fname));
-  db->EscapeString(jcr, client_esc, client, strlen(client));
+  fname_esc.resize(fname_len * 2 + 1);
+  client_esc.resize(client_len * 2 + 1);
+  db->EscapeString(jcr, fname_esc.data(), fname, fname_len);
+  db->EscapeString(jcr, client_esc.data(), client, client_len);
 
-  db->FillQuery(query, BareosDb::SQL_QUERY::bvfs_versions_6, fname_esc,
-                edit_uint64(pathid, ed1), client_esc, filter.c_str(), limit,
-                offset);
+  db->FillQuery(query, BareosDb::SQL_QUERY::bvfs_versions_6, fname_esc.c_str(),
+                edit_uint64(pathid, ed1), client_esc.c_str(), filter.c_str(),
+                limit, offset);
   db->SqlQuery(query.c_str(), list_entries, user_data);
 }
 


### PR DESCRIPTION
**Backport of PR #2785 to bareos-23**

Also disables RHEL variant of the CI-test for EL 7 to fix the build.

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2785 is merged
- [x] All functional differences to the original PR are documented above
