### PR TITLE
dplcompat: fix SIGABRT when a chunk deletion fails during truncate

### DIFF
--- a/core/src/stored/backends/dplcompat_device.cc
+++ b/core/src/stored/backends/dplcompat_device.cc
@@ -381,7 +381,7 @@ bool DropletCompatibleDevice::TruncateRemoteVolume(DeviceControlRecord*)
   for (const auto& [chunk_name, stat] : *chunk_map) {
     if (is_chunk_name(chunk_name)) {
       if (auto res = m_storage.remove(vol_name, chunk_name); !res) {
-        PmStrcpy(errmsg, chunk_map.error().c_str());
+        PmStrcpy(errmsg, res.error().c_str());
         dev_errno = EIO;
         return false;
       }


### PR DESCRIPTION
**Backport of PR #2779 to bareos-24**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- If a release should wait for this PR to be finished, set that release's milestone.

#### Backport quality
- [ ] Original PR #2779 is merged
- [x] All functional differences to the original PR are documented above
