### PR TITLE
hyper-v: fix preventing other jobs from starting because of bad ROP handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core: script btraceback support environment variable [PR #2782]
 - stored: fix segfault on missing Changer Command" [PR #2791]
 - dplcompat: fix SIGABRT when a chunk deletion fails during truncate [PR #2789]
+- hyper-v: fix preventing other jobs from starting because of bad ROP handling [PR #2794]
 
 ### Changed
 - cmake: fix add_alphabetic_requirements() no-op sort [PR #2758]
@@ -2356,4 +2357,5 @@ If you want to migrate from your manually configured disk autochanger to simply 
 [PR #2786]: https://github.com/bareos/bareos/pull/2786
 [PR #2789]: https://github.com/bareos/bareos/pull/2789
 [PR #2791]: https://github.com/bareos/bareos/pull/2791
+[PR #2794]: https://github.com/bareos/bareos/pull/2794
 [unreleased]: https://github.com/bareos/bareos/tree/master

--- a/core/src/win32/plugins/filed/hyper-v.cc
+++ b/core/src/win32/plugins/filed/hyper-v.cc
@@ -2969,7 +2969,8 @@ static bool handle_restore_object(PluginContext* ctx,
                                   plugin_ctx* p_ctx,
                                   const filedaemon::restore_object_pkt* rop)
 {
-  switch (restore_object::name_to_type(rop->object_name)) {
+  switch (
+      restore_object::name_to_type(rop->object_name ? rop->object_name : "")) {
     case restore_object::Type::ReferencePoint: {
       json_error_t json_err;
 
@@ -3065,8 +3066,32 @@ static bool handle_restore_object(PluginContext* ctx,
       return true;
     }
     default: {
-      JFATAL(ctx, "unknown restore object with name '{}'", rop->object_name);
-      return false;
+      auto safe = [](char const* ptr) {
+        if (ptr) { return ptr; }
+        return "(null)";
+      };
+
+      std::string_view plugin_name = rop->plugin_name ? rop->plugin_name : "";
+
+      /* ROP with plugin_name set to *all* (e.g. VSS metadata) gets sent to
+       * every plugin; as we do not care about it, we just ignore it. */
+      if (plugin_name == "*all*") {
+        DBGC(ctx, "ignoring '{}' from *all*", safe(rop->object_name));
+        return true;
+        /* if we receive a ROP that we created ourselves, but that we do not
+         * recognize, then something really weird is going on, so we stop to
+         * be on the safe side. */
+      } else if (plugin_name.starts_with("hyper-v")) {
+        JFATAL(ctx, "unknown restore object with name '{}'",
+               safe(rop->object_name));
+        return false;
+        /* Bareos should not send us any other ROPs, so we log them just in
+         * case. */
+      } else {
+        JWARN(ctx, "unknown restore object with name '{}' from {}",
+              safe(rop->object_name), safe(rop->plugin_name));
+        return true;
+      }
     } break;
   }
 }


### PR DESCRIPTION
**Backport of PR #2777 to bareos-25**

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [x] Correct milestone is set

##### Source code quality (if there were changes to the original PR)
- [x] Source code changes are understandable
- [x] Variable and function names are meaningful
- [x] Code comments are correct (logically and spelling)
- [x] Required documentation changes are present and part of the PR

#### Backport quality
- [x] Original PR #2777 is merged
- [x] All functional differences to the original PR are documented above
