### PR TITLE
stored: stop waiting forever for a device

### DIFF
--- a/core/src/stored/device_wait_policy.h
+++ b/core/src/stored/device_wait_policy.h
@@ -1,0 +1,75 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#ifndef BAREOS_STORED_DEVICE_WAIT_POLICY_H_
+#define BAREOS_STORED_DEVICE_WAIT_POLICY_H_
+
+#include <cstdint>
+
+namespace storagedaemon {
+
+/* Budget for waiting until a device becomes available.
+ *
+ * A job waits in rounds. Every round grants wait_sec seconds, of which
+ * rem_wait_sec are still left. When a round is used up the next one lasts
+ * twice as long, capped at max_wait, until max_num_wait rounds were spent. */
+struct DeviceWaitTimes {
+  int32_t min_wait{};
+  int32_t max_wait{};
+  int32_t max_num_wait{};
+  int32_t wait_sec{};
+  int32_t rem_wait_sec{};
+  int32_t num_wait{};
+};
+
+/* Start a new waiting round with twice the length of the previous one.
+ *
+ * Returns whether another round may be started, so a job that can never get
+ * a device stops waiting instead of retrying forever. */
+constexpr bool DoubleJobWaitTime(DeviceWaitTimes& times)
+{
+  times.wait_sec *= 2;
+  if (times.wait_sec > times.max_wait) { times.wait_sec = times.max_wait; }
+
+  times.num_wait++;
+  times.rem_wait_sec = times.wait_sec;
+
+  return times.num_wait < times.max_num_wait;
+}
+
+/* Account for seconds spent waiting for a device.
+ *
+ * Returns whether the job may keep waiting. Once the current round is used
+ * up the next one is started, and waiting ends when the budget is exhausted.
+ * A round that cannot make progress, because it grants no time at all, does
+ * not stall the budget either. */
+constexpr bool ConsumeDeviceWaitTime(DeviceWaitTimes& times, int32_t seconds)
+{
+  if (seconds > 0) { times.rem_wait_sec -= seconds; }
+
+  if (times.rem_wait_sec > 0) { return true; }
+
+  return DoubleJobWaitTime(times);
+}
+
+}  // namespace storagedaemon
+
+#endif  // BAREOS_STORED_DEVICE_WAIT_POLICY_H_

--- a/core/src/stored/reserve.cc
+++ b/core/src/stored/reserve.cc
@@ -36,6 +36,7 @@
 #include "stored/sd_device_control_record.h"
 #include "stored/acquire.h"
 #include "stored/autochanger.h"
+#include "stored/device_wait_policy.h"
 #include "stored/stored_jcr_impl.h"
 #include "stored/wait.h"
 #include "lib/berrno.h"
@@ -240,17 +241,28 @@ bool TryReserveAfterUse(JobControlRecord* jcr, bool append)
     // during WaitForDevice()
     reservation_lock.unlock();
 
-    /* The idea of looping on repeat a few times it to ensure
-     * that if there is some subtle timing problem between two
-     * jobs, we will simply try again, and most likely succeed.
-     * This can happen if one job reserves a drive or finishes using
-     * a drive at the same time a second job wants it. */
-    if (repeat++ > 1) {   /* try algorithm 3 times */
+    if (!rctx.suitable_device) {
+      /* Not a single configured device can ever serve this job, so waiting
+       * for one to be released cannot help. */
+      Dmsg0(debuglevel, "Fail. !suitable_device\n");
+      fail = true;
+    } else if (repeat++ > 1) {
+      /* The idea of looping on repeat a few times it to ensure
+       * that if there is some subtle timing problem between two
+       * jobs, we will simply try again, and most likely succeed.
+       * This can happen if one job reserves a drive or finishes using
+       * a drive at the same time a second job wants it. */
       Bmicrosleep(30, 0); /* wait a bit */
       Dmsg0(debuglevel, "repeat reserve algorithm\n");
-    } else if (!rctx.suitable_device
-               || !WaitForDevice(jcr, wait_for_device_retries)) {
-      Dmsg0(debuglevel, "Fail. !suitable_device || !WaitForDevice\n");
+
+      /* This sleep also counts against the wait budget, otherwise repeating
+       * the algorithm would keep the job here forever. */
+      if (!ConsumeDeviceWaitTime(jcr->sd_impl->device_wait_times, 30)) {
+        Dmsg0(debuglevel, "Fail. wait budget exhausted\n");
+        fail = true;
+      }
+    } else if (!WaitForDevice(jcr, wait_for_device_retries)) {
+      Dmsg0(debuglevel, "Fail. !WaitForDevice\n");
       fail = true;
     }
     dir->signal(BNET_HEARTBEAT); /* Inform Dir that we are alive */

--- a/core/src/stored/stored_jcr_impl.h
+++ b/core/src/stored/stored_jcr_impl.h
@@ -3,7 +3,7 @@
 
    Copyright (C) 2000-2012 Free Software Foundation Europe e.V.
    Copyright (C) 2011-2012 Planets Communications B.V.
-   Copyright (C) 2013-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2013-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -26,6 +26,7 @@
 
 #include "stored/read_ctx.h"
 #include "stored/stored_conf.h"
+#include "stored/device_wait_policy.h"
 #include "lib/thread_util.h"
 #include "stored/reserve.h"
 
@@ -49,15 +50,6 @@ struct ReadSession {
   uint32_t read_EndFile{};
   uint32_t read_StartBlock{};
   uint32_t read_EndBlock{};
-};
-
-struct DeviceWaitTimes {
-  int32_t min_wait{};
-  int32_t max_wait{};
-  int32_t max_num_wait{};
-  int32_t wait_sec{};
-  int32_t rem_wait_sec{};
-  int32_t num_wait{};
 };
 
 }  // namespace storagedaemon

--- a/core/src/stored/wait.cc
+++ b/core/src/stored/wait.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2000-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -32,6 +32,8 @@
 #include "stored/stored.h"  /* pull in Storage Daemon headers */
 #include "stored/stored_globals.h"
 #include "stored/device_control_record.h"
+#include "stored/device_wait_policy.h"
+#include "stored/stored_jcr_impl.h"
 #include "stored/wait.h"
 #include "lib/berrno.h"
 #include "lib/bsock.h"
@@ -235,12 +237,28 @@ bool WaitForDevice(JobControlRecord* jcr, int& retries)
 
   Dmsg0(debuglevel, "Going to wait for a device.\n");
 
+  time_t start = time(NULL);
+
   /* Wait required time */
   status = pthread_cond_timedwait(&wait_device_release, &device_release_mutex,
                                   &timeout);
   Dmsg1(debuglevel, "Wokeup from sleep on device status=%d\n", status);
 
   unlock_mutex(device_release_mutex);
+
+  /* Charge the time we actually spent here against the wait budget of the
+   * job, so a job that never gets a device gives up instead of waiting
+   * forever. */
+  time_t waited = time(NULL) - start;
+  ok = ConsumeDeviceWaitTime(jcr->sd_impl->device_wait_times,
+                             static_cast<int32_t>(waited));
+
+  if (!ok) {
+    Jmsg(jcr, M_FATAL, 0,
+         T_("JobId=%s, Job %s gave up waiting to reserve a device.\n"),
+         edit_uint64(jcr->JobId, ed1), jcr->Job);
+  }
+
   Dmsg1(debuglevel, "Return from wait_device ok=%d\n", ok);
   return ok;
 }

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -276,6 +276,9 @@ if(NOT client-only)
   )
   bareos_add_test(multiplied_device_test LINK_LIBRARIES ${LINK_LIBRARIES})
   bareos_add_test(
+    device_wait_policy_test LINK_LIBRARIES Bareos::Lib GTest::gtest_main
+  )
+  bareos_add_test(
     ndmp_address_translate_test
     ADDITIONAL_SOURCES ../dird/ndmp_slot2elemaddr.cc
     LINK_LIBRARIES ${LINK_LIBRARIES}

--- a/core/src/tests/device_wait_policy_test.cc
+++ b/core/src/tests/device_wait_policy_test.cc
@@ -1,0 +1,183 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "gtest/gtest.h"
+#include "stored/device_wait_policy.h"
+
+using namespace storagedaemon;
+
+namespace {
+// The values InitJcrDeviceWaitTimers() sets up for a job.
+constexpr DeviceWaitTimes DefaultTimes()
+{
+  DeviceWaitTimes times{};
+
+  times.min_wait = 60 * 60;
+  times.max_wait = 24 * 60 * 60;
+  times.max_num_wait = 9;
+  times.wait_sec = times.min_wait;
+  times.rem_wait_sec = times.wait_sec;
+  times.num_wait = 0;
+
+  return times;
+}
+
+// Waiting the given number of seconds, reports whether waiting may continue.
+constexpr bool WaitFor(DeviceWaitTimes& times, int32_t seconds)
+{
+  return ConsumeDeviceWaitTime(times, seconds);
+}
+
+// Total seconds a job may wait before it gives up.
+constexpr int32_t TotalBudget()
+{
+  DeviceWaitTimes times = DefaultTimes();
+  int32_t total = 0;
+
+  // Consume in whole rounds until the budget is exhausted.
+  while (true) {
+    int32_t round = times.rem_wait_sec;
+    total += round;
+    if (!ConsumeDeviceWaitTime(times, round)) { return total; }
+  }
+}
+}  // namespace
+
+// Time inside the current round does not end the wait.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  return WaitFor(times, 60);
+}());
+
+// Using up a round starts the next one, which is twice as long.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  WaitFor(times, times.rem_wait_sec);
+  return times.wait_sec == 2 * 60 * 60 && times.num_wait == 1;
+}());
+
+// Rounds never grow beyond max_wait.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  for (int i = 0; i < 8; ++i) { WaitFor(times, times.rem_wait_sec); }
+  return times.wait_sec == times.max_wait;
+}());
+
+// The budget is finite, so a job that never gets a device gives up.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  for (int i = 0; i < 1000; ++i) {
+    if (!WaitFor(times, times.rem_wait_sec)) { return true; }
+  }
+  return false;
+}());
+
+// Exactly max_num_wait rounds are granted.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  int rounds = 0;
+  while (WaitFor(times, times.rem_wait_sec)) { ++rounds; }
+  return rounds == times.max_num_wait - 1;
+}());
+
+/* A round that grants no time must not stall the budget, otherwise a wait
+ * that returns immediately would spin forever. */
+static_assert([] {
+  DeviceWaitTimes times{};
+  times.max_num_wait = 3;
+  for (int i = 0; i < 1000; ++i) {
+    if (!ConsumeDeviceWaitTime(times, 0)) { return true; }
+  }
+  return false;
+}());
+
+// Waiting longer than the round grants still only consumes one round.
+static_assert([] {
+  DeviceWaitTimes times = DefaultTimes();
+  WaitFor(times, times.rem_wait_sec * 100);
+  return times.num_wait == 1;
+}());
+
+// The default budget is finite and reaches into the range of days.
+static_assert(TotalBudget() > 0);
+static_assert(TotalBudget() < 7 * 24 * 60 * 60);
+
+TEST(DeviceWaitPolicy, WaitingWithinRoundContinues)
+{
+  DeviceWaitTimes times = DefaultTimes();
+
+  EXPECT_TRUE(ConsumeDeviceWaitTime(times, 60));
+  EXPECT_EQ(times.num_wait, 0);
+  EXPECT_EQ(times.rem_wait_sec, times.min_wait - 60);
+}
+
+TEST(DeviceWaitPolicy, RoundsDoubleUpToMaximum)
+{
+  DeviceWaitTimes times = DefaultTimes();
+
+  ConsumeDeviceWaitTime(times, times.rem_wait_sec);
+  EXPECT_EQ(times.wait_sec, 2 * 60 * 60);
+
+  ConsumeDeviceWaitTime(times, times.rem_wait_sec);
+  EXPECT_EQ(times.wait_sec, 4 * 60 * 60);
+
+  for (int i = 0; i < 10; ++i) {
+    ConsumeDeviceWaitTime(times, times.rem_wait_sec);
+  }
+  EXPECT_EQ(times.wait_sec, times.max_wait);
+}
+
+// The regression this guards: waiting used to never end.
+TEST(DeviceWaitPolicy, WaitingEventuallyGivesUp)
+{
+  DeviceWaitTimes times = DefaultTimes();
+
+  int rounds = 0;
+  while (ConsumeDeviceWaitTime(times, times.rem_wait_sec)) {
+    ++rounds;
+    ASSERT_LT(rounds, 1000) << "waiting for a device never ends";
+  }
+
+  EXPECT_EQ(rounds, times.max_num_wait - 1);
+}
+
+TEST(DeviceWaitPolicy, ZeroLengthWaitsStillExhaustBudget)
+{
+  DeviceWaitTimes times{};
+  times.max_num_wait = 3;
+
+  int rounds = 0;
+  while (ConsumeDeviceWaitTime(times, 0)) {
+    ++rounds;
+    ASSERT_LT(rounds, 1000) << "zero length waits never end";
+  }
+
+  EXPECT_EQ(rounds, times.max_num_wait - 1);
+}
+
+TEST(DeviceWaitPolicy, NegativeDurationDoesNotExtendBudget)
+{
+  DeviceWaitTimes times = DefaultTimes();
+
+  // A clock that appears to go backwards must not grant extra time.
+  ConsumeDeviceWaitTime(times, -100);
+  EXPECT_EQ(times.rem_wait_sec, times.min_wait);
+}


### PR DESCRIPTION
A job that could not reserve a device waited indefinitely. Three defects combined to that result.

WaitForDevice() promised to return false once the total wait time expired, but its result was hardcoded to true, so the caller never saw a timeout. TryReserveAfterUse() checked whether any device matching the job exists only during its first two passes. From the third pass on it only slept and retried, so a job asking for a media type no device provides kept retrying instead of failing. The wait budget in the job, set up by InitJcrDeviceWaitTimers(), was never read by anyone.

Use that budget now. Every wait is charged against it, including the sleep between repeats, and waiting ends once it is exhausted. A job for which no suitable device exists at all now fails immediately, as waiting cannot make such a device appear.

The budget itself is unchanged, it still grants doubling rounds from one hour up to a day. Jobs that legitimately wait for a busy drive are therefore not affected.

The wait budget arithmetic moved into its own header so it can be tested without a job, and is covered by compile time and unit tests.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
