### PR TITLE
new windows version detection

### DIFF
--- a/core/src/lib/CMakeLists.txt
+++ b/core/src/lib/CMakeLists.txt
@@ -108,7 +108,7 @@ if(HAVE_WIN32)
     bareos PRIVATE ../win32/compat/compat.cc ../win32/compat/glob.cc
                    ../win32/compat/winapi.cc
   )
-  target_sources(bareos PRIVATE osinfo_win32.cc)
+  target_sources(bareos PRIVATE osinfo_win32.cc windows_version.cc)
   target_link_libraries(bareos PUBLIC ws2_32)
 
   find_package(pcre2 CONFIG REQUIRED)

--- a/core/src/lib/osinfo_win32.cc
+++ b/core/src/lib/osinfo_win32.cc
@@ -2,7 +2,7 @@
    BAREOS® - Backup Archiving REcovery Open Sourced
 
    Copyright (C) 2007-2011 Free Software Foundation Europe e.V.
-   Copyright (C) 2016-2025 Bareos GmbH & Co. KG
+   Copyright (C) 2016-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can redistribute it and/or
    modify it under the terms of version three of the GNU Affero General Public
@@ -36,13 +36,18 @@
  * #defines.
  */
 
+#include <cstdint>
+#include <cstring>
 #include <mutex>
+#include <string>
+#include <string_view>
 #include <windows.h>
 #include <tchar.h>
 #include <stdio.h>
 
 #include "fill_proc_address.h"
 #include "osinfo.h"
+#include "windows_version.h"
 
 static char win_os[300];
 static bool win_os_initialized = false;
@@ -62,156 +67,202 @@ const char* GetOsInfoString()
   return win_os;
 }
 
+namespace {
 
-#ifndef PRODUCT_UNLICENSED
-#  define PRODUCT_UNLICENSED 0xABCDABCD
-#  define PRODUCT_BUSINESS 0x00000006
-#  define PRODUCT_BUSINESS_N 0x00000010
-#  define PRODUCT_CLUSTER_SERVER 0x00000012
-#  define PRODUCT_DATACENTER_SERVER 0x00000008
-#  define PRODUCT_DATACENTER_SERVER_CORE 0x0000000C
-#  define PRODUCT_DATACENTER_SERVER_CORE_V 0x00000027
-#  define PRODUCT_DATACENTER_SERVER_V 0x00000025
-#  define PRODUCT_ENTERPRISE 0x00000004
-#  define PRODUCT_ENTERPRISE_E 0x00000046
-#  define PRODUCT_ENTERPRISE_N 0x0000001B
-#  define PRODUCT_ENTERPRISE_SERVER 0x0000000A
-#  define PRODUCT_ENTERPRISE_SERVER_CORE 0x0000000E
-#  define PRODUCT_ENTERPRISE_SERVER_CORE_V 0x00000029
-#  define PRODUCT_ENTERPRISE_SERVER_IA64 0x0000000F
-#  define PRODUCT_ENTERPRISE_SERVER_V 0x00000026
-#  define PRODUCT_HOME_BASIC 0x00000002
-#  define PRODUCT_HOME_BASIC_E 0x00000043
-#  define PRODUCT_HOME_BASIC_N 0x00000005
-#  define PRODUCT_HOME_PREMIUM 0x00000003
-#  define PRODUCT_HOME_PREMIUM_E 0x00000044
-#  define PRODUCT_HOME_PREMIUM_N 0x0000001A
-#  define PRODUCT_HYPERV 0x0000002A
-#  define PRODUCT_MEDIUMBUSINESS_SERVER_MANAGEMENT 0x0000001E
-#  define PRODUCT_MEDIUMBUSINESS_SERVER_MESSAGING 0x00000020
-#  define PRODUCT_MEDIUMBUSINESS_SERVER_SECURITY 0x0000001F
-#  define PRODUCT_PROFESSIONAL 0x00000030
-#  define PRODUCT_PROFESSIONAL_E 0x00000045
-#  define PRODUCT_PROFESSIONAL_N 0x00000031
-#  define PRODUCT_SERVER_FOR_SMALLBUSINESS 0x00000018
-#  define PRODUCT_SERVER_FOR_SMALLBUSINESS_V 0x00000023
-#  define PRODUCT_SERVER_FOUNDATION 0x00000021
-#  define PRODUCT_SMALLBUSINESS_SERVER 0x00000009
-#  define PRODUCT_SOLUTION_EMBEDDEDSERVER 0x00000038
-#  define PRODUCT_STANDARD_SERVER 0x00000007
-#  define PRODUCT_STANDARD_SERVER_CORE 0x0000000D
-#  define PRODUCT_STANDARD_SERVER_CORE_V 0x00000028
-#  define PRODUCT_STANDARD_SERVER_V 0x00000024
-#  define PRODUCT_STARTER 0x0000000B
-#  define PRODUCT_STARTER_E 0x00000042
-#  define PRODUCT_STARTER_N 0x0000002F
-#  define PRODUCT_STORAGE_ENTERPRISE_SERVER 0x00000017
-#  define PRODUCT_STORAGE_EXPRESS_SERVER 0x00000014
-#  define PRODUCT_STORAGE_STANDARD_SERVER 0x00000015
-#  define PRODUCT_STORAGE_WORKGROUP_SERVER 0x00000016
-#  define PRODUCT_UNDEFINED 0x00000000
-#  define PRODUCT_ULTIMATE 0x00000001
-#  define PRODUCT_ULTIMATE_E 0x00000047
-#  define PRODUCT_ULTIMATE_N 0x0000001C
-#  define PRODUCT_WEB_SERVER 0x00000011
-#  define PRODUCT_WEB_SERVER_CORE 0x0000001D
-
-#  define PRODUCT_SMALLBUSINESS_SERVER_PREMIUM 0x19
-#  define SM_SERVERR2 89
-#  define VER_SERVER_NT 0x80000000
-
-#endif
-
-#ifndef PRODUCT_PROFESSIONAL
-#  define PRODUCT_PROFESSIONAL 0x00000030
-#endif
-#ifndef VER_SUITE_STORAGE_SERVER
-#  define VER_SUITE_STORAGE_SERVER 0x00002000
-#endif
-#ifndef VER_SUITE_COMPUTE_SERVER
-#  define VER_SUITE_COMPUTE_SERVER 0x00004000
-#endif
-
-/* Unknown value */
-#undef VER_SUITE_WH_SERVER
-#define VER_SUITE_WH_SERVER -1
-
+using windows_version::Architecture;
+using windows_version::ProductType;
+using windows_version::VersionInfo;
 
 typedef void(WINAPI* PGNSI)(LPSYSTEM_INFO);
-typedef BOOL(WINAPI* PGPI)(DWORD, DWORD, DWORD, DWORD, PDWORD);
 
-static std::string Reg_GetStringValue(HKEY key, const char* value)
+/* RTL_OSVERSIONINFOEXW is not declared by every SDK/mingw header set, so the
+ * layout (which is ABI stable and matches OSVERSIONINFOEXW) is reproduced
+ * here. RtlGetVersion() is used instead of GetVersionEx()/VerifyVersionInfo()
+ * because those lie about the OS version unless the calling process carries
+ * an application manifest declaring compatibility with the running Windows
+ * release. */
+struct RtlOsVersionInfoExW {
+  ULONG dwOSVersionInfoSize;
+  ULONG dwMajorVersion;
+  ULONG dwMinorVersion;
+  ULONG dwBuildNumber;
+  ULONG dwPlatformId;
+  WCHAR szCSDVersion[128];
+  USHORT wServicePackMajor;
+  USHORT wServicePackMinor;
+  USHORT wSuiteMask;
+  UCHAR wProductType;
+  UCHAR wReserved;
+};
+
+using RtlGetVersionFn = LONG(WINAPI*)(RtlOsVersionInfoExW*);
+
+bool GetTrueOsVersion(RtlOsVersionInfoExW* info)
 {
-  DWORD Type;
-  DWORD Size;
-  if (auto ret
-      = RegGetValueA(key, "", value, RRF_RT_REG_SZ, &Type, nullptr, &Size);
-      ret != ERROR_SUCCESS) {
-    throw std::runtime_error{"cannot determine size"};
-  }
+  memset(info, 0, sizeof(*info));
+  info->dwOSVersionInfoSize = sizeof(*info);
 
-  if (Type != REG_SZ) { throw std::runtime_error{"bad type"}; }
+  RtlGetVersionFn RtlGetVersion;
+  if (!BareosFillProcAddress(RtlGetVersion, GetModuleHandle(TEXT("ntdll.dll")),
+                             "RtlGetVersion")) {
+    return false;
+  }
+  // STATUS_SUCCESS
+  return RtlGetVersion(info) == 0;
+}
+
+std::string RegGetString(HKEY key, const char* value)
+{
+  DWORD type;
+  DWORD size;
+  if (RegGetValueA(key, "", value, RRF_RT_REG_SZ, &type, nullptr, &size)
+      != ERROR_SUCCESS) {
+    return {};
+  }
+  if (type != REG_SZ || size == 0) { return {}; }
 
   // size includes the terminating 0
-  if (Size <= 0) { throw std::runtime_error{"bad size"}; }
   std::string result;
-  result.resize(Size - 1);
-
-  if (auto ret = RegGetValueA(key, "", value, RRF_RT_REG_SZ, &Type,
-                              result.data(), &Size);
-      ret != ERROR_SUCCESS) {
-    throw std::runtime_error{"could not get value"};
+  result.resize(size - 1);
+  if (RegGetValueA(key, "", value, RRF_RT_REG_SZ, &type, result.data(), &size)
+      != ERROR_SUCCESS) {
+    return {};
   }
-
   return result;
 }
 
-static bool GetVersionStringFromRegistry(LPTSTR osbuf, int maxsiz)
+std::uint32_t RegGetDword(HKEY key, const char* value)
 {
-  HKEY hKey;
+  DWORD type;
+  DWORD data = 0;
+  DWORD size = sizeof(data);
+  if (RegGetValueA(key, "", value, RRF_RT_REG_DWORD, &type, &data, &size)
+      != ERROR_SUCCESS) {
+    return 0;
+  }
+  return data;
+}
+
+std::uint32_t ParseUint32(std::string_view value)
+{
+  std::uint32_t result = 0;
+  for (char c : value) {
+    if (c < '0' || c > '9') { break; }
+    result = (result * 10) + static_cast<std::uint32_t>(c - '0');
+  }
+  return result;
+}
+
+Architecture ArchitectureFromProcessorArchitecture(WORD arch)
+{
+  switch (arch) {
+    case PROCESSOR_ARCHITECTURE_AMD64:
+      return Architecture::kX64;
+    case PROCESSOR_ARCHITECTURE_INTEL:
+      return Architecture::kX86;
+    case PROCESSOR_ARCHITECTURE_ARM64:
+      return Architecture::kArm64;
+    case PROCESSOR_ARCHITECTURE_IA64:
+      return Architecture::kIa64;
+    default:
+      return Architecture::kUnknown;
+  }
+}
+
+// Backing storage for the string_views referenced by VersionInfo; VersionInfo
+// itself only borrows these values, so they have to outlive its use.
+struct RegistryStrings {
+  std::string product_name;
+  std::string display_version;
+  std::string edition_id;
+  std::string installation_type;
+  std::string csd_version;
+  std::string current_version;
+};
+
+/* Reads HKLM\Software\Microsoft\Windows NT\CurrentVersion. Returns false if
+ * the key cannot be opened or no usable build number was found, in which
+ * case the caller falls back to RtlGetVersion() alone. */
+bool FillFromRegistry(RegistryStrings* strings, VersionInfo* info)
+{
+  HKEY key;
   auto ret = RegOpenKeyExA(HKEY_LOCAL_MACHINE,
                            "Software\\Microsoft\\Windows NT\\CurrentVersion", 0,
-                           KEY_READ, &hKey);
+                           KEY_READ, &key);
+  if (ret != ERROR_SUCCESS) { return false; }
 
-  if (ret != ERROR_SUCCESS) {
-    // Dmsg0(100, "could not open registry key\n");
-    return false;
+  strings->product_name = RegGetString(key, "ProductName");
+  // DisplayVersion (e.g. "24H2") replaced ReleaseId in Windows 10 1909+.
+  strings->display_version = RegGetString(key, "DisplayVersion");
+  if (strings->display_version.empty()) {
+    strings->display_version = RegGetString(key, "ReleaseId");
+  }
+  strings->edition_id = RegGetString(key, "EditionID");
+  strings->installation_type = RegGetString(key, "InstallationType");
+  strings->csd_version = RegGetString(key, "CSDVersion");
+  strings->current_version = RegGetString(key, "CurrentVersion");
+
+  info->build = ParseUint32(RegGetString(key, "CurrentBuildNumber"));
+  info->ubr = RegGetDword(key, "UBR");
+
+  // Windows 10+ exposes the version as separate DWORDs; older releases only
+  // have the "6.1"-style CurrentVersion string.
+  info->major = RegGetDword(key, "CurrentMajorVersionNumber");
+  info->minor = RegGetDword(key, "CurrentMinorVersionNumber");
+  if (info->major == 0 && !strings->current_version.empty()) {
+    std::string_view version = strings->current_version;
+    auto dot = version.find('.');
+    info->major = ParseUint32(version.substr(0, dot));
+    if (dot != std::string_view::npos) {
+      info->minor = ParseUint32(version.substr(dot + 1));
+    }
   }
 
-  bool ok = true;
-  try {
-    std::string product_name = Reg_GetStringValue(hKey, "ProductName");
-    std::string lcu_ver = Reg_GetStringValue(hKey, "LCUVer");
-
-    snprintf(osbuf, maxsiz, "%s (%s)", product_name.c_str(), lcu_ver.c_str());
-  } catch (const std::exception& e) {
-    (void)e;
-    // Dmsg0(100, "could not get some registry value: %s\n", e.what());
-    ok = false;
-  }
-
-  RegCloseKey(hKey);
-  return ok;
+  RegCloseKey(key);
+  return info->build != 0;
 }
+
+}  // namespace
 
 // Get Windows version display string
 static bool GetWindowsVersionString(LPTSTR osbuf, int maxsiz)
 {
-  if (GetVersionStringFromRegistry(osbuf, maxsiz)) { return true; }
-  OSVERSIONINFOEX osvi;
+  RegistryStrings strings;
+  VersionInfo info{};
+
+  bool have_registry_values = FillFromRegistry(&strings, &info);
+
+  RtlOsVersionInfoExW true_version;
+  bool have_true_version = GetTrueOsVersion(&true_version);
+
+  if (!have_registry_values && !have_true_version) {
+    strncpy(osbuf, "Unknown Windows version.", maxsiz);
+    osbuf[maxsiz - 1] = '\0';
+    return true;
+  }
+
+  info.product_name = strings.product_name;
+  info.display_version = strings.display_version;
+  info.edition_id = strings.edition_id;
+  info.installation_type = strings.installation_type;
+  info.csd_version = strings.csd_version;
+  info.is_winpe = strings.installation_type == "WindowsPE";
+
+  if (have_true_version) {
+    info.product_type = (true_version.wProductType == VER_NT_WORKSTATION)
+                            ? ProductType::kWorkstation
+                            : ProductType::kServer;
+    // RtlGetVersion() is authoritative; use it if the registry did not
+    // provide major/build values.
+    if (info.major == 0) { info.major = true_version.dwMajorVersion; }
+    if (info.minor == 0) { info.minor = true_version.dwMinorVersion; }
+    if (info.build == 0) { info.build = true_version.dwBuildNumber; }
+  } else {
+    info.product_type = ProductType::kWorkstation;
+  }
+
   SYSTEM_INFO si;
-  BOOL bOsVersionInfoEx;
-  DWORD dwType;
-
-  memset(&si, 0, sizeof(SYSTEM_INFO));
-  memset(&osvi, 0, sizeof(OSVERSIONINFOEX));
-
-  osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-
-  if (!(bOsVersionInfoEx = GetVersionEx((OSVERSIONINFO*)&osvi))) return 1;
-
-  // Call GetNativeSystemInfo if supported or GetSystemInfo otherwise.
-
+  memset(&si, 0, sizeof(si));
   if (PGNSI pGNSI;
       BareosFillProcAddress(pGNSI, GetModuleHandle(TEXT("kernel32.dll")),
                             "GetNativeSystemInfo")) {
@@ -219,213 +270,10 @@ static bool GetWindowsVersionString(LPTSTR osbuf, int maxsiz)
   } else {
     GetSystemInfo(&si);
   }
+  info.arch = ArchitectureFromProcessorArchitecture(si.wProcessorArchitecture);
 
-  if (osvi.dwPlatformId == VER_PLATFORM_WIN32_NT && osvi.dwMajorVersion > 4) {
-    strncpy(osbuf, TEXT("Microsoft "), maxsiz);
-
-    // Test for the specific product.
-    switch (osvi.dwMajorVersion) {
-      case 6:
-        switch (osvi.dwMinorVersion) {
-          case 0:
-            if (osvi.wProductType == VER_NT_WORKSTATION) {
-              strncat(osbuf, TEXT("Windows Vista "), maxsiz);
-            } else {
-              strncat(osbuf, TEXT("Windows Server 2008 "), maxsiz);
-            }
-            break;
-          case 1:
-            if (osvi.wProductType == VER_NT_WORKSTATION) {
-              strncat(osbuf, TEXT("Windows 7 "), maxsiz);
-            } else {
-              strncat(osbuf, TEXT("Windows Server 2008 R2 "), maxsiz);
-            }
-            break;
-          case 2:
-            if (osvi.wProductType == VER_NT_WORKSTATION) {
-              strncat(osbuf, TEXT("Windows 8 "), maxsiz);
-            } else {
-              strncat(osbuf, TEXT("Windows Server 2012 "), maxsiz);
-            }
-            break;
-          default:
-            strncat(osbuf, TEXT("Windows Unknown Release "), maxsiz);
-            break;
-        }
-
-        if (PGPI pGPI;
-            BareosFillProcAddress(pGPI, GetModuleHandle(TEXT("kernel32.dll")),
-                                  "GetProductInfo")) {
-          pGPI(osvi.dwMajorVersion, osvi.dwMinorVersion, 0, 0, &dwType);
-        } else {
-          dwType = PRODUCT_HOME_BASIC;
-        }
-
-        switch (dwType) {
-          case PRODUCT_ULTIMATE:
-            strncat(osbuf, TEXT("Ultimate Edition"), maxsiz);
-            break;
-          case PRODUCT_PROFESSIONAL:
-            strncat(osbuf, TEXT("Professional"), maxsiz);
-            break;
-          case PRODUCT_HOME_PREMIUM:
-            strncat(osbuf, TEXT("Home Premium Edition"), maxsiz);
-            break;
-          case PRODUCT_HOME_BASIC:
-            strncat(osbuf, TEXT("Home Basic Edition"), maxsiz);
-            break;
-          case PRODUCT_ENTERPRISE:
-            strncat(osbuf, TEXT("Enterprise Edition"), maxsiz);
-            break;
-          case PRODUCT_BUSINESS:
-            strncat(osbuf, TEXT("Business Edition"), maxsiz);
-            break;
-          case PRODUCT_STARTER:
-            strncat(osbuf, TEXT("Starter Edition"), maxsiz);
-            break;
-          case PRODUCT_CLUSTER_SERVER:
-            strncat(osbuf, TEXT("Cluster Server Edition"), maxsiz);
-            break;
-          case PRODUCT_DATACENTER_SERVER:
-            strncat(osbuf, TEXT("Datacenter Edition"), maxsiz);
-            break;
-          case PRODUCT_DATACENTER_SERVER_CORE:
-            strncat(osbuf, TEXT("Datacenter Edition (core installation)"),
-                    maxsiz);
-            break;
-          case PRODUCT_ENTERPRISE_SERVER:
-            strncat(osbuf, TEXT("Enterprise Edition"), maxsiz);
-            break;
-          case PRODUCT_ENTERPRISE_SERVER_CORE:
-            strncat(osbuf, TEXT("Enterprise Edition (core installation)"),
-                    maxsiz);
-            break;
-          case PRODUCT_ENTERPRISE_SERVER_IA64:
-            strncat(osbuf, TEXT("Enterprise Edition for Itanium-based Systems"),
-                    maxsiz);
-            break;
-          case PRODUCT_SMALLBUSINESS_SERVER:
-            strncat(osbuf, TEXT("Small Business Server"), maxsiz);
-            break;
-          case PRODUCT_SMALLBUSINESS_SERVER_PREMIUM:
-            strncat(osbuf, TEXT("Small Business Server Premium Edition"),
-                    maxsiz);
-            break;
-          case PRODUCT_STANDARD_SERVER:
-            strncat(osbuf, TEXT("Standard Edition"), maxsiz);
-            break;
-          case PRODUCT_STANDARD_SERVER_CORE:
-            strncat(osbuf, TEXT("Standard Edition (core installation)"),
-                    maxsiz);
-            break;
-          case PRODUCT_WEB_SERVER:
-            strncat(osbuf, TEXT("Web Server Edition"), maxsiz);
-            break;
-        }
-        break;
-      case 5:
-        switch (osvi.dwMinorVersion) {
-          case 2:
-            if (GetSystemMetrics(SM_SERVERR2)) {
-              strncat(osbuf, TEXT("Windows Server 2003 R2 "), maxsiz);
-            } else if (osvi.wSuiteMask & VER_SUITE_STORAGE_SERVER) {
-              strncat(osbuf, TEXT("Windows Storage Server 2003"), maxsiz);
-            } else if (osvi.wSuiteMask & VER_SUITE_WH_SERVER) {
-              strncat(osbuf, TEXT("Windows Home Server"), maxsiz);
-            } else if (osvi.wProductType == VER_NT_WORKSTATION
-                       && si.wProcessorArchitecture
-                              == PROCESSOR_ARCHITECTURE_AMD64) {
-              strncat(osbuf, TEXT("Windows XP Professional x64 Edition"),
-                      maxsiz);
-            } else {
-              strncat(osbuf, TEXT("Windows Server 2003 "), maxsiz);
-            }
-
-            // Test for the server type.
-            if (osvi.wProductType != VER_NT_WORKSTATION) {
-              if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64) {
-                if (osvi.wSuiteMask & VER_SUITE_DATACENTER) {
-                  strncat(osbuf,
-                          TEXT("Datacenter Edition for Itanium-based Systems"),
-                          maxsiz);
-                } else if (osvi.wSuiteMask & VER_SUITE_ENTERPRISE) {
-                  strncat(osbuf,
-                          TEXT("Enterprise Edition for Itanium-based Systems"),
-                          maxsiz);
-                }
-              } else if (si.wProcessorArchitecture
-                         == PROCESSOR_ARCHITECTURE_AMD64) {
-                if (osvi.wSuiteMask & VER_SUITE_DATACENTER) {
-                  strncat(osbuf, TEXT("Datacenter x64 Edition"), maxsiz);
-                } else if (osvi.wSuiteMask & VER_SUITE_ENTERPRISE) {
-                  strncat(osbuf, TEXT("Enterprise x64 Edition"), maxsiz);
-                } else {
-                  strncat(osbuf, TEXT("Standard x64 Edition"), maxsiz);
-                }
-              } else {
-                if (osvi.wSuiteMask & VER_SUITE_COMPUTE_SERVER) {
-                  strncat(osbuf, TEXT("Compute Cluster Edition"), maxsiz);
-                } else if (osvi.wSuiteMask & VER_SUITE_DATACENTER) {
-                  strncat(osbuf, TEXT("Datacenter Edition"), maxsiz);
-                } else if (osvi.wSuiteMask & VER_SUITE_ENTERPRISE) {
-                  strncat(osbuf, TEXT("Enterprise Edition"), maxsiz);
-                } else if (osvi.wSuiteMask & VER_SUITE_BLADE) {
-                  strncat(osbuf, TEXT("Web Edition"), maxsiz);
-                } else {
-                  strncat(osbuf, TEXT("Standard Edition"), maxsiz);
-                }
-              }
-            }
-            break;
-          case 1:
-            strncat(osbuf, TEXT("Windows XP "), maxsiz);
-            if (osvi.wSuiteMask & VER_SUITE_PERSONAL) {
-              strncat(osbuf, TEXT("Home Edition"), maxsiz);
-            } else {
-              strncat(osbuf, TEXT("Professional"), maxsiz);
-            }
-            break;
-          case 0:
-            strncat(osbuf, TEXT("Windows 2000 "), maxsiz);
-            if (osvi.wProductType == VER_NT_WORKSTATION) {
-              strncat(osbuf, TEXT("Professional"), maxsiz);
-            } else {
-              if (osvi.wSuiteMask & VER_SUITE_DATACENTER) {
-                strncat(osbuf, TEXT("Datacenter Server"), maxsiz);
-              } else if (osvi.wSuiteMask & VER_SUITE_ENTERPRISE) {
-                strncat(osbuf, TEXT("Advanced Server"), maxsiz);
-              } else {
-                strncat(osbuf, TEXT("Server"), maxsiz);
-              }
-            }
-            break;
-        }
-        break;
-      default:
-        break;
-    }
-
-    // Include service pack (if any) and build number.
-    if (_tcslen(osvi.szCSDVersion) > 0) {
-      strncat(osbuf, TEXT(" "), maxsiz);
-      strncat(osbuf, osvi.szCSDVersion, maxsiz);
-    }
-
-    char buf[80];
-
-    snprintf(buf, 80, " (build %d)", (int)osvi.dwBuildNumber);
-    strncat(osbuf, buf, maxsiz);
-
-    if (osvi.dwMajorVersion >= 6) {
-      if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64)
-        strncat(osbuf, TEXT(", 64-bit"), maxsiz);
-      else if (si.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL)
-        strncat(osbuf, TEXT(", 32-bit"), maxsiz);
-    }
-
-    return true;
-  } else {
-    strncpy(osbuf, "Unknown Windows version.", maxsiz);
-    return true;
-  }
+  std::string formatted = windows_version::FormatVersion(info);
+  strncpy(osbuf, formatted.c_str(), maxsiz);
+  osbuf[maxsiz - 1] = '\0';
+  return true;
 }

--- a/core/src/lib/osinfo_win32.cc
+++ b/core/src/lib/osinfo_win32.cc
@@ -50,26 +50,21 @@
 #include "windows_version.h"
 
 static char win_os[300];
-static bool win_os_initialized = false;
-static std::mutex init_mutex;
+static std::once_flag win_os_once;
 
 static bool GetWindowsVersionString(LPTSTR osbuf, int maxsiz);
 
 const char* GetOsInfoString()
 {
-  if (!win_os_initialized) {
-    const std::lock_guard<std::mutex> lock(init_mutex);
-    if (!win_os_initialized) {
-      GetWindowsVersionString(win_os, sizeof(win_os) - 1);
-      win_os_initialized = true;
-    }
-  }
+  std::call_once(win_os_once,
+                 [] { GetWindowsVersionString(win_os, sizeof(win_os) - 1); });
   return win_os;
 }
 
 namespace {
 
 using windows_version::Architecture;
+using windows_version::ParseUint32;
 using windows_version::ProductType;
 using windows_version::VersionInfo;
 
@@ -141,16 +136,6 @@ std::uint32_t RegGetDword(HKEY key, const char* value)
     return 0;
   }
   return data;
-}
-
-std::uint32_t ParseUint32(std::string_view value)
-{
-  std::uint32_t result = 0;
-  for (char c : value) {
-    if (c < '0' || c > '9') { break; }
-    result = (result * 10) + static_cast<std::uint32_t>(c - '0');
-  }
-  return result;
 }
 
 Architecture ArchitectureFromProcessorArchitecture(WORD arch)

--- a/core/src/lib/windows_version.cc
+++ b/core/src/lib/windows_version.cc
@@ -1,0 +1,136 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include "windows_version.h"
+
+namespace windows_version {
+
+namespace {
+
+constexpr std::string_view kWhitespace = " \t\r\n";
+
+std::string_view Trim(std::string_view value)
+{
+  auto begin = value.find_first_not_of(kWhitespace);
+  if (begin == std::string_view::npos) { return {}; }
+  auto end = value.find_last_not_of(kWhitespace);
+  return value.substr(begin, end - begin + 1);
+}
+
+bool Contains(std::string_view haystack, std::string_view needle)
+{
+  return haystack.find(needle) != std::string_view::npos;
+}
+
+void Append(std::string& out, std::string_view value)
+{
+  if (value.empty()) { return; }
+  if (!out.empty() && out.back() != ' ') { out += ' '; }
+  out += value;
+}
+
+std::string BuildString(const VersionInfo& info)
+{
+  std::string result = " (build " + std::to_string(info.build);
+  if (info.ubr != 0) { result += '.' + std::to_string(info.ubr); }
+  result += ')';
+  return result;
+}
+
+/* Windows 11 and Windows Server 2019 and later report a ProductName of
+ * "Windows 10 ..." resp. an outdated name, so the registry value cannot be
+ * trusted verbatim. */
+std::string BaseName(const VersionInfo& info)
+{
+  std::string_view product_name = Trim(info.product_name);
+  std::string_view marketing_name = MarketingName(info.major, info.minor,
+                                                  info.build, info.product_type);
+
+  if (product_name.empty()) {
+    std::string name{marketing_name};
+    Append(name, EditionDisplayName(Trim(info.edition_id)));
+    return name;
+  }
+
+  std::string name{product_name};
+  if (IsWindows11(info.major, info.build, info.product_type)) {
+    if (auto pos = name.find("Windows 10"); pos != std::string::npos) {
+      name.replace(pos, std::string_view{"Windows 10"}.size(), "Windows 11");
+    } else if (!Contains(name, "Windows 11")) {
+      name = std::string{marketing_name};
+      Append(name, EditionDisplayName(Trim(info.edition_id)));
+    }
+  }
+  return name;
+}
+
+}  // namespace
+
+std::string FormatVersion(const VersionInfo& info)
+{
+  if (info.is_winpe) {
+    std::string result = "Windows PE";
+    result += BuildString(info);
+    result += ArchitectureSuffix(info.arch);
+    return result;
+  }
+
+  std::string result = BaseName(info);
+  if (Trim(result).empty()) { return "Unknown Windows version"; }
+
+  std::string_view edition_id = Trim(info.edition_id);
+  if (IsLongTermServicingEdition(edition_id) && !Contains(result, "LTSC")
+      && !Contains(result, "LTSB")) {
+    Append(result, LtscDesignation(info.build));
+  }
+
+  if (IsServerCore(Trim(info.installation_type))
+      && !Contains(result, "Core installation")) {
+    Append(result, "(Core installation)");
+  }
+
+  if (std::string_view display_version = Trim(info.display_version);
+      !display_version.empty() && !Contains(result, display_version)) {
+    Append(result, display_version);
+  }
+
+  if (std::string_view csd_version = Trim(info.csd_version);
+      !csd_version.empty()) {
+    if (std::string_view number = ServicePackShortName(csd_version);
+        !number.empty()) {
+      Append(result, "SP");
+      result += number;
+    } else {
+      Append(result, csd_version);
+    }
+  }
+
+  result += BuildString(info);
+  result += ArchitectureSuffix(info.arch);
+
+  if (result.compare(0, 10, "Microsoft ") != 0) {
+    result.insert(0, "Microsoft ");
+  }
+
+  return result;
+}
+
+}  // namespace windows_version

--- a/core/src/lib/windows_version.h
+++ b/core/src/lib/windows_version.h
@@ -1,0 +1,200 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+/*
+ * Human readable description of a Windows installation.
+ *
+ * This header is deliberately free of any windows.h dependency so that the
+ * formatting logic can be unit tested on every platform.  The values that
+ * describe the machine are gathered in osinfo_win32.cc and passed in as a
+ * VersionInfo.
+ */
+
+#ifndef BAREOS_LIB_WINDOWS_VERSION_H_
+#define BAREOS_LIB_WINDOWS_VERSION_H_
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace windows_version {
+
+enum class ProductType
+{
+  kUnknown,
+  kWorkstation,
+  kServer,
+};
+
+enum class Architecture
+{
+  kUnknown,
+  kX86,
+  kX64,
+  kArm64,
+  kIa64,
+};
+
+// All string_views point into storage owned by the caller; they only have to
+// stay alive until FormatVersion() returns.
+struct VersionInfo {
+  std::uint32_t major{};
+  std::uint32_t minor{};
+  std::uint32_t build{};
+  std::uint32_t ubr{};
+
+  std::string_view product_name;       // registry ProductName
+  std::string_view display_version;    // DisplayVersion, else ReleaseId
+  std::string_view edition_id;         // EditionID
+  std::string_view installation_type;  // Client/Server/Server Core/WindowsPE
+  std::string_view csd_version;        // "Service Pack 1"
+
+  ProductType product_type{ProductType::kUnknown};
+  Architecture arch{Architecture::kUnknown};
+  bool is_winpe{false};
+};
+
+// The first Windows 10 build that is marketed as Windows 11.
+inline constexpr std::uint32_t kFirstWindows11Build = 22000;
+
+constexpr std::string_view ArchitectureSuffix(Architecture arch)
+{
+  switch (arch) {
+    case Architecture::kX86:
+      return ", 32-bit";
+    case Architecture::kX64:
+      return ", 64-bit";
+    case Architecture::kArm64:
+      return ", ARM64";
+    case Architecture::kIa64:
+      return ", IA64";
+    case Architecture::kUnknown:
+      break;
+  }
+  return {};
+}
+
+/* Windows 11 keeps reporting a ProductName of "Windows 10 ..." in the
+ * registry, so the marketing name has to be derived from the build number. */
+constexpr bool IsWindows11(std::uint32_t major,
+                           std::uint32_t build,
+                           ProductType type)
+{
+  return major >= 10 && build >= kFirstWindows11Build
+         && type != ProductType::kServer;
+}
+
+// Used when the registry does not provide a usable ProductName.
+constexpr std::string_view MarketingName(std::uint32_t major,
+                                         std::uint32_t minor,
+                                         std::uint32_t build,
+                                         ProductType type)
+{
+  bool server = type == ProductType::kServer;
+
+  if (major == 6) {
+    switch (minor) {
+      case 0:
+        return server ? "Windows Server 2008" : "Windows Vista";
+      case 1:
+        return server ? "Windows Server 2008 R2" : "Windows 7";
+      case 2:
+        return server ? "Windows Server 2012" : "Windows 8";
+      case 3:
+        return server ? "Windows Server 2012 R2" : "Windows 8.1";
+      default:
+        return server ? "Windows Server" : "Windows";
+    }
+  }
+
+  if (major >= 10) {
+    if (!server) {
+      return IsWindows11(major, build, type) ? "Windows 11" : "Windows 10";
+    }
+    if (build >= 26100) { return "Windows Server 2025"; }
+    if (build >= 25398) { return "Windows Server, version 23H2"; }
+    if (build >= 20348) { return "Windows Server 2022"; }
+    if (build >= 17763) { return "Windows Server 2019"; }
+    if (build >= 14393) { return "Windows Server 2016"; }
+    return "Windows Server";
+  }
+
+  return server ? "Windows Server" : "Windows";
+}
+
+/* The LTSC/LTSB editions are only distinguishable by their EditionID; the
+ * release year has to be derived from the build number. */
+constexpr bool IsLongTermServicingEdition(std::string_view edition_id)
+{
+  return edition_id == "EnterpriseS" || edition_id == "EnterpriseSN"
+         || edition_id == "IoTEnterpriseS" || edition_id == "IoTEnterpriseSK";
+}
+
+constexpr std::string_view LtscDesignation(std::uint32_t build)
+{
+  if (build >= 26100) { return "LTSC 2024"; }
+  if (build >= 19044) { return "LTSC 2021"; }
+  if (build >= 17763) { return "LTSC 2019"; }
+  if (build >= 14393) { return "LTSB 2016"; }
+  if (build >= 10240) { return "LTSB 2015"; }
+  return "LTSC";
+}
+
+/* "Service Pack 3" becomes "SP3"; anything else is used verbatim.  Returns an
+ * empty view when the input is not of the expected shape, in which case the
+ * caller uses the original string. */
+constexpr std::string_view ServicePackShortName(std::string_view csd_version)
+{
+  constexpr std::string_view prefix = "Service Pack ";
+  if (csd_version.size() <= prefix.size()) { return {}; }
+  if (csd_version.substr(0, prefix.size()) != prefix) { return {}; }
+
+  std::string_view number = csd_version.substr(prefix.size());
+  for (char c : number) {
+    if (c < '0' || c > '9') { return {}; }
+  }
+  return number;
+}
+
+/* EditionID is written as "ServerStandard"/"ServerDatacenter" on server
+ * systems; the redundant "Server" prefix is stripped when the edition is
+ * appended to a name that already contains "Windows Server". */
+constexpr std::string_view EditionDisplayName(std::string_view edition_id)
+{
+  constexpr std::string_view prefix = "Server";
+  if (edition_id.size() > prefix.size()
+      && edition_id.substr(0, prefix.size()) == prefix) {
+    return edition_id.substr(prefix.size());
+  }
+  return edition_id;
+}
+
+constexpr bool IsServerCore(std::string_view installation_type)
+{
+  return installation_type.find("Core") != std::string_view::npos;
+}
+
+// Build the human readable description, e.g.
+// "Microsoft Windows 11 Pro 24H2 (build 26100.4652), 64-bit"
+std::string FormatVersion(const VersionInfo& info);
+
+}  // namespace windows_version
+
+#endif  // BAREOS_LIB_WINDOWS_VERSION_H_

--- a/core/src/lib/windows_version.h
+++ b/core/src/lib/windows_version.h
@@ -191,6 +191,21 @@ constexpr bool IsServerCore(std::string_view installation_type)
   return installation_type.find("Core") != std::string_view::npos;
 }
 
+// Parses the leading run of ASCII digits in value, stopping at the first
+// non-digit character. Returns 0 if value does not start with a digit.
+// Used to turn registry string values such as CurrentBuildNumber or the
+// legacy "6.1"-style CurrentVersion into numbers without pulling in <charconv>
+// on platforms where it is unavailable.
+constexpr std::uint32_t ParseUint32(std::string_view value)
+{
+  std::uint32_t result = 0;
+  for (char c : value) {
+    if (c < '0' || c > '9') { break; }
+    result = (result * 10) + static_cast<std::uint32_t>(c - '0');
+  }
+  return result;
+}
+
 // Build the human readable description, e.g.
 // "Microsoft Windows 11 Pro 24H2 (build 26100.4652), 64-bit"
 std::string FormatVersion(const VersionInfo& info);

--- a/core/src/tests/CMakeLists.txt
+++ b/core/src/tests/CMakeLists.txt
@@ -494,6 +494,13 @@ bareos_add_test(
 
 bareos_add_test(version_strings LINK_LIBRARIES Bareos::Lib GTest::gtest_main)
 
+# the formatting logic is os independent, so it is tested on all platforms
+bareos_add_test(
+  windows_version_test
+  ADDITIONAL_SOURCES ../lib/windows_version.cc
+  LINK_LIBRARIES GTest::gtest_main
+)
+
 bareos_add_test(channel LINK_LIBRARIES Bareos::Lib GTest::gtest_main)
 
 bareos_add_test(

--- a/core/src/tests/windows_version_test.cc
+++ b/core/src/tests/windows_version_test.cc
@@ -87,6 +87,13 @@ static_assert(IsServerCore("Server Core"));
 static_assert(!IsServerCore("Server"));
 static_assert(!IsServerCore("Client"));
 
+static_assert(ParseUint32("14393") == 14393);
+static_assert(ParseUint32("0") == 0);
+static_assert(ParseUint32("1.2") == 1);
+static_assert(ParseUint32("") == 0);
+static_assert(ParseUint32("abc") == 0);
+static_assert(ParseUint32("007") == 7);
+
 static_assert(EditionDisplayName("ServerStandard") == "Standard");
 static_assert(EditionDisplayName("ServerDatacenter") == "Datacenter");
 static_assert(EditionDisplayName("Professional") == "Professional");
@@ -108,8 +115,10 @@ constexpr VersionInfo MakeVersionInfo(std::uint32_t major,
                                       std::string_view edition_id = {},
                                       std::string_view installation_type = {},
                                       std::string_view csd_version = {},
-                                      ProductType product_type = ProductType::kUnknown,
-                                      Architecture arch = Architecture::kUnknown,
+                                      ProductType product_type
+                                      = ProductType::kUnknown,
+                                      Architecture arch
+                                      = Architecture::kUnknown,
                                       bool is_winpe = false)
 {
   return VersionInfo{.major = major,

--- a/core/src/tests/windows_version_test.cc
+++ b/core/src/tests/windows_version_test.cc
@@ -1,0 +1,305 @@
+/*
+   BAREOS® - Backup Archiving REcovery Open Sourced
+
+   Copyright (C) 2026-2026 Bareos GmbH & Co. KG
+
+   This program is Free Software; you can redistribute it and/or
+   modify it under the terms of version three of the GNU Affero General Public
+   License as published by the Free Software Foundation and included
+   in the file LICENSE.
+
+   This program is distributed in the hope that it will be useful, but
+   WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+   Affero General Public License for more details.
+
+   You should have received a copy of the GNU Affero General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+   02110-1301, USA.
+*/
+
+#include <gtest/gtest.h>
+
+#include "lib/windows_version.h"
+
+using namespace windows_version;
+
+// compile time tests for the constexpr helpers
+static_assert(ArchitectureSuffix(Architecture::kX64) == ", 64-bit");
+static_assert(ArchitectureSuffix(Architecture::kX86) == ", 32-bit");
+static_assert(ArchitectureSuffix(Architecture::kArm64) == ", ARM64");
+static_assert(ArchitectureSuffix(Architecture::kUnknown).empty());
+
+static_assert(IsWindows11(10, 22000, ProductType::kWorkstation));
+static_assert(IsWindows11(10, 26100, ProductType::kWorkstation));
+static_assert(!IsWindows11(10, 19044, ProductType::kWorkstation));
+static_assert(!IsWindows11(10, 26100, ProductType::kServer));
+static_assert(!IsWindows11(6, 7601, ProductType::kWorkstation));
+
+static_assert(MarketingName(6, 0, 6002, ProductType::kWorkstation)
+              == "Windows Vista");
+static_assert(MarketingName(6, 0, 6002, ProductType::kServer)
+              == "Windows Server 2008");
+static_assert(MarketingName(6, 1, 7601, ProductType::kWorkstation)
+              == "Windows 7");
+static_assert(MarketingName(6, 1, 7601, ProductType::kServer)
+              == "Windows Server 2008 R2");
+static_assert(MarketingName(6, 2, 9200, ProductType::kServer)
+              == "Windows Server 2012");
+static_assert(MarketingName(6, 3, 9600, ProductType::kWorkstation)
+              == "Windows 8.1");
+static_assert(MarketingName(6, 3, 9600, ProductType::kServer)
+              == "Windows Server 2012 R2");
+static_assert(MarketingName(10, 0, 19044, ProductType::kWorkstation)
+              == "Windows 10");
+static_assert(MarketingName(10, 0, 22621, ProductType::kWorkstation)
+              == "Windows 11");
+static_assert(MarketingName(10, 0, 14393, ProductType::kServer)
+              == "Windows Server 2016");
+static_assert(MarketingName(10, 0, 17763, ProductType::kServer)
+              == "Windows Server 2019");
+static_assert(MarketingName(10, 0, 20348, ProductType::kServer)
+              == "Windows Server 2022");
+static_assert(MarketingName(10, 0, 25398, ProductType::kServer)
+              == "Windows Server, version 23H2");
+static_assert(MarketingName(10, 0, 26100, ProductType::kServer)
+              == "Windows Server 2025");
+
+static_assert(IsLongTermServicingEdition("EnterpriseS"));
+static_assert(IsLongTermServicingEdition("IoTEnterpriseS"));
+static_assert(!IsLongTermServicingEdition("Enterprise"));
+static_assert(!IsLongTermServicingEdition("Professional"));
+
+static_assert(LtscDesignation(10240) == "LTSB 2015");
+static_assert(LtscDesignation(14393) == "LTSB 2016");
+static_assert(LtscDesignation(17763) == "LTSC 2019");
+static_assert(LtscDesignation(19044) == "LTSC 2021");
+static_assert(LtscDesignation(26100) == "LTSC 2024");
+
+static_assert(ServicePackShortName("Service Pack 1") == "1");
+static_assert(ServicePackShortName("Service Pack 12") == "12");
+static_assert(ServicePackShortName("Service Pack ").empty());
+static_assert(ServicePackShortName("").empty());
+static_assert(ServicePackShortName("Update Rollup 1").empty());
+
+static_assert(IsServerCore("Server Core"));
+static_assert(!IsServerCore("Server"));
+static_assert(!IsServerCore("Client"));
+
+static_assert(EditionDisplayName("ServerStandard") == "Standard");
+static_assert(EditionDisplayName("ServerDatacenter") == "Datacenter");
+static_assert(EditionDisplayName("Professional") == "Professional");
+static_assert(EditionDisplayName("Server") == "Server");
+
+namespace {
+struct TestCase {
+  const char* name;
+  VersionInfo info;
+  const char* expected;
+};
+
+constexpr VersionInfo MakeVersionInfo(std::uint32_t major,
+                                      std::uint32_t minor,
+                                      std::uint32_t build,
+                                      std::uint32_t ubr = 0,
+                                      std::string_view product_name = {},
+                                      std::string_view display_version = {},
+                                      std::string_view edition_id = {},
+                                      std::string_view installation_type = {},
+                                      std::string_view csd_version = {},
+                                      ProductType product_type = ProductType::kUnknown,
+                                      Architecture arch = Architecture::kUnknown,
+                                      bool is_winpe = false)
+{
+  return VersionInfo{.major = major,
+                     .minor = minor,
+                     .build = build,
+                     .ubr = ubr,
+                     .product_name = product_name,
+                     .display_version = display_version,
+                     .edition_id = edition_id,
+                     .installation_type = installation_type,
+                     .csd_version = csd_version,
+                     .product_type = product_type,
+                     .arch = arch,
+                     .is_winpe = is_winpe};
+}
+
+// clang-format off
+const TestCase kCases[] = {
+    {"vista_sp2",
+     MakeVersionInfo(6, 0, 6002, 0, "Windows Vista (TM) Business", {},
+                     "Business", "Client", "Service Pack 2",
+                     ProductType::kWorkstation, Architecture::kX86),
+     "Microsoft Windows Vista (TM) Business SP2 (build 6002), 32-bit"},
+
+    {"server_2008_sp2",
+     MakeVersionInfo(6, 0, 6002, 0, "Windows Server (R) 2008 Standard", {},
+                     "ServerStandard", {}, "Service Pack 2",
+                     ProductType::kServer, Architecture::kX64),
+     "Microsoft Windows Server (R) 2008 Standard SP2 (build 6002), 64-bit"},
+
+    {"windows_7_sp1",
+     MakeVersionInfo(6, 1, 7601, 24545, "Windows 7 Professional", {},
+                     "Professional", "Client", "Service Pack 1",
+                     ProductType::kWorkstation, Architecture::kX64),
+     "Microsoft Windows 7 Professional SP1 (build 7601.24545), 64-bit"},
+
+    {"server_2008_r2_sp1",
+     MakeVersionInfo(6, 1, 7601, 0, "Windows Server 2008 R2 Standard", {},
+                     "ServerStandard", "Server", "Service Pack 1",
+                     ProductType::kServer, Architecture::kX64),
+     "Microsoft Windows Server 2008 R2 Standard SP1 (build 7601), 64-bit"},
+
+    {"server_2012",
+     MakeVersionInfo(6, 2, 9200, 0, "Windows Server 2012 Standard", {},
+                     "ServerStandard", "Server", {}, ProductType::kServer,
+                     Architecture::kX64),
+     "Microsoft Windows Server 2012 Standard (build 9200), 64-bit"},
+
+    {"windows_8_1",
+     MakeVersionInfo(6, 3, 9600, 20144, "Windows 8.1 Pro", {},
+                     "Professional", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 8.1 Pro (build 9600.20144), 64-bit"},
+
+    {"windows_10_1607",
+     MakeVersionInfo(10, 0, 14393, 7159, "Windows 10 Pro", "1607",
+                     "Professional", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 10 Pro 1607 (build 14393.7159), 64-bit"},
+
+    {"windows_10_21h2",
+     MakeVersionInfo(10, 0, 19044, 4529, "Windows 10 Pro", "21H2",
+                     "Professional", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 10 Pro 21H2 (build 19044.4529), 64-bit"},
+
+    // LTSC has no LCUVer and frequently no DisplayVersion either
+    {"windows_10_ltsc_2019",
+     MakeVersionInfo(10, 0, 17763, 5936, "Windows 10 Enterprise", {},
+                     "EnterpriseS", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 10 Enterprise LTSC 2019 (build 17763.5936), 64-bit"},
+
+    {"windows_10_ltsc_2021",
+     MakeVersionInfo(10, 0, 19044, 4529, "Windows 10 Enterprise LTSC 2021",
+                     "21H2", "EnterpriseS", "Client", {},
+                     ProductType::kWorkstation, Architecture::kX64),
+     "Microsoft Windows 10 Enterprise LTSC 2021 21H2 (build 19044.4529), "
+     "64-bit"},
+
+    {"windows_11_22h2",
+     MakeVersionInfo(10, 0, 22621, 3737, "Windows 10 Pro", "22H2",
+                     "Professional", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 11 Pro 22H2 (build 22621.3737), 64-bit"},
+
+    {"windows_11_24h2_arm64",
+     MakeVersionInfo(10, 0, 26100, 4652, "Windows 10 Pro", "24H2",
+                     "Professional", "Client", {}, ProductType::kWorkstation,
+                     Architecture::kArm64),
+     "Microsoft Windows 11 Pro 24H2 (build 26100.4652), ARM64"},
+
+    {"server_2016",
+     MakeVersionInfo(10, 0, 14393, 7159, "Windows Server 2016 Standard",
+                     "1607", "ServerStandard", "Server", {}, ProductType::kServer,
+                     Architecture::kX64),
+     "Microsoft Windows Server 2016 Standard 1607 (build 14393.7159), 64-bit"},
+
+    {"server_2019",
+     MakeVersionInfo(10, 0, 17763, 5936, "Windows Server 2019 Datacenter",
+                     "1809", "ServerDatacenter", "Server", {},
+                     ProductType::kServer, Architecture::kX64),
+     "Microsoft Windows Server 2019 Datacenter 1809 (build 17763.5936), "
+     "64-bit"},
+
+    {"server_2022_core",
+     MakeVersionInfo(10, 0, 20348, 2527, "Windows Server 2022 Standard",
+                     "21H2", "ServerStandard", "Server Core", {},
+                     ProductType::kServer, Architecture::kX64),
+     "Microsoft Windows Server 2022 Standard (Core installation) 21H2 "
+     "(build 20348.2527), 64-bit"},
+
+    {"server_2025",
+     MakeVersionInfo(10, 0, 26100, 1742, "Windows Server 2025 Standard",
+                     "24H2", "ServerStandard", "Server", {}, ProductType::kServer,
+                     Architecture::kX64),
+     "Microsoft Windows Server 2025 Standard 24H2 (build 26100.1742), 64-bit"},
+
+    {"winpe",
+     MakeVersionInfo(10, 0, 26100, 1, {}, {}, {}, "WindowsPE", {},
+                     ProductType::kWorkstation, Architecture::kX64, true),
+     "Windows PE (build 26100.1), 64-bit"},
+
+    // WinPE keeps a ProductName of the image it was built from; it must not
+    // be reported as a regular installation.
+    {"winpe_with_product_name",
+     MakeVersionInfo(6, 1, 7601, 0, "Windows 7 Enterprise", {}, {},
+                     "WindowsPE", {}, ProductType::kWorkstation,
+                     Architecture::kX86, true),
+     "Windows PE (build 7601), 32-bit"},
+
+    // registry unreadable: everything is derived from the version numbers
+    {"no_registry_values_workstation",
+     MakeVersionInfo(6, 1, 7601, 0, {}, {}, {}, {}, {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 7 (build 7601), 64-bit"},
+
+    {"no_registry_values_server",
+     MakeVersionInfo(10, 0, 20348, 0, {}, {}, {}, {}, {}, ProductType::kServer,
+                     Architecture::kX64),
+     "Microsoft Windows Server 2022 (build 20348), 64-bit"},
+
+    {"no_product_name_uses_edition",
+     MakeVersionInfo(10, 0, 22631, 4460, {}, "23H2", "Professional", {}, {},
+                     ProductType::kWorkstation, Architecture::kX64),
+     "Microsoft Windows 11 Professional 23H2 (build 22631.4460), 64-bit"},
+
+    {"unknown_architecture_is_omitted",
+     MakeVersionInfo(10, 0, 19045, 4529, "Windows 10 Pro", "22H2", {}, {}, {},
+                     ProductType::kWorkstation),
+     "Microsoft Windows 10 Pro 22H2 (build 19045.4529)"},
+
+    // registry strings arrive 0-padded/whitespace-padded on some systems
+    {"values_are_trimmed",
+     MakeVersionInfo(10, 0, 19045, 0, "  Windows 10 Pro  ", " 22H2 ",
+                     " Professional ", {}, {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 10 Pro 22H2 (build 19045), 64-bit"},
+
+    {"product_name_already_has_vendor_prefix",
+     MakeVersionInfo(10, 0, 19045, 0, "Microsoft Windows 10 Pro", {}, {}, {}, {},
+                     ProductType::kWorkstation, Architecture::kX64),
+     "Microsoft Windows 10 Pro (build 19045), 64-bit"},
+
+    {"display_version_not_duplicated",
+     MakeVersionInfo(10, 0, 19044, 0, "Windows 10 Enterprise LTSC 2021",
+                     "21H2", "EnterpriseS", {}, {}, ProductType::kWorkstation,
+                     Architecture::kX64),
+     "Microsoft Windows 10 Enterprise LTSC 2021 21H2 (build 19044), 64-bit"},
+};
+// clang-format on
+
+class WindowsVersionFormat : public ::testing::TestWithParam<TestCase> {};
+
+TEST_P(WindowsVersionFormat, MatchesExpectedString)
+{
+  EXPECT_EQ(FormatVersion(GetParam().info), GetParam().expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    Systems,
+    WindowsVersionFormat,
+    ::testing::ValuesIn(kCases),
+    [](const ::testing::TestParamInfo<TestCase>& test_info) {
+      return std::string{test_info.param.name};
+    });
+
+TEST(WindowsVersion, EmptyInfoDoesNotCrash)
+{
+  VersionInfo info{};
+  EXPECT_FALSE(FormatVersion(info).empty());
+}
+}  // namespace


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

The old code for windows version detection had support for long EOL versions and was not able to
differentiate between Windows 10 an 11. 
This PR now  intends to get rid of old unused code and allow a correct human-readable detection of the running OS.

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
