### PR TITLE
lib: make socket bind failures fatal and syslog-visible

### DIFF
--- a/core/src/lib/bnet_server_tcp.cc
+++ b/core/src/lib/bnet_server_tcp.cc
@@ -53,6 +53,10 @@
 #  include <poll.h>
 #endif
 
+#ifndef HAVE_WIN32
+#  include <syslog.h>
+#endif
+
 #include <algorithm>
 #include <atomic>
 #include <array>
@@ -236,17 +240,37 @@ std::vector<s_sockfd> OpenAndBindSockets(dlist<IPADDR>* addr_list)
     if (sock.fd < 0) {
       BErrNo be;
       char tmp[1024];
+      /* Being unable to bind a configured address/port is a fatal
+       * startup condition: the daemon would otherwise silently skip
+       * starting its socket server (or, for the director, exit with a
+       * success status), leaving no trace of the failure in the
+       * journal/init script. M_ERROR_TERM guarantees the message is
+       * always dispatched (also via syslog) and terminates the daemon
+       * with a failure exit code. */
 #ifdef HAVE_WIN32
-      Emsg2(M_ERROR, 0, T_("Cannot bind address %s port %d: ERR=%u.\n"),
+      Emsg2(M_ERROR_TERM, 0, T_("Cannot bind address %s port %d: ERR=%u.\n"),
             ipaddr->GetAddress(tmp, sizeof(tmp) - 1), ntohs(sock.port),
             WSAGetLastError());
 #else
-      Emsg2(M_ERROR, 0, T_("Cannot bind address %s port %d: ERR=%s.\n"),
+      Emsg2(M_ERROR_TERM, 0, T_("Cannot bind address %s port %d: ERR=%s.\n"),
             ipaddr->GetAddress(tmp, sizeof(tmp) - 1), ntohs(sock.port),
             be.bstrerror());
 #endif
       return {};
     } else {
+      char tmp[1024];
+      /* Report each successfully bound address/port so that a running
+       * daemon leaves a positive trace of what it is listening on
+       * instead of just silence. Also written directly to syslog,
+       * since the M_INFO message may be filtered by the configured
+       * Messages resource and stdout is redirected to /dev/null once
+       * the daemon has detached (see daemon_start()). */
+      Emsg2(M_INFO, 0, T_("Listening on address %s port %d.\n"),
+            ipaddr->GetAddress(tmp, sizeof(tmp) - 1), ntohs(sock.port));
+#ifndef HAVE_WIN32
+      syslog(LOG_DAEMON | LOG_INFO, "Listening on address %s port %d.",
+             ipaddr->GetAddress(tmp, sizeof(tmp) - 1), ntohs(sock.port));
+#endif
       bound_sockets.emplace_back(std::move(sock));
     }
   }

--- a/core/src/lib/message.cc
+++ b/core/src/lib/message.cc
@@ -637,12 +637,21 @@ void DispatchMessage(JobControlRecord* jcr,
     return;
   }
 
-  // For serious errors make sure message is printed or logged
+  /* For serious errors make sure message is printed or logged.
+   * stdout is unreliable here: once the daemon has forked into the
+   * background (daemon_start()), stdin/stdout/stderr are redirected to
+   * /dev/null, so anything written to stdout after that point is lost.
+   * Always mirror these severities to syslog as well, so the failure is
+   * still visible (e.g. in the systemd journal or via classic syslog)
+   * regardless of whether the daemon runs in the foreground or has
+   * already daemonized. */
   if (type == M_ABORT || type == M_ERROR_TERM || type == M_CONFIG_ERROR) {
     fputs(dt, stdout);
     fputs(msg, stdout);
     fflush(stdout);
-    if (type == M_ABORT) { syslog(LOG_DAEMON | LOG_ERR, "%s", msg); }
+    if (type == M_ABORT || type == M_ERROR_TERM) {
+      syslog(LOG_DAEMON | LOG_ERR, "%s", msg);
+    }
   }
 
   // Now figure out where to send the message


### PR DESCRIPTION
Bind failures during OpenAndBindSockets() were reported with M_ERROR, a non-fatal severity that can be filtered out by the configured Messages resource. Daemons then silently skipped the socket or exited with status 0, leaving no trace in the systemd journal or classic init logs.

Change the bind-failure message to M_ERROR_TERM, which is always dispatched and terminates the daemon with a non-zero exit code.

Since daemons not started in the foreground redirect stdout to /dev/null before opening their listen sockets, also route M_ERROR_TERM through syslog in DispatchMessage(), the same as M_ABORT, so the failure remains visible regardless of how the daemon was started.

Additionally, log each successfully bound address/port, both as an M_INFO message and directly to syslog, so a running daemon also leaves a positive trace of what it is listening on.

### Thank you for contributing to the Bareos Project!

#### Please check

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
