### PR TITLE
dedup: enhance reliability

### DIFF
--- a/core/src/stored/backends/dedupable/fvec.h
+++ b/core/src/stored/backends/dedupable/fvec.h
@@ -1,7 +1,7 @@
 /*
    BAREOS® - Backup Archiving REcovery Open Sourced
 
-   Copyright (C) 2023-2024 Bareos GmbH & Co. KG
+   Copyright (C) 2023-2026 Bareos GmbH & Co. KG
 
    This program is Free Software; you can modify it under the terms of
    version three of the GNU Affero General Public License as published by the
@@ -291,9 +291,10 @@ template <typename T> class fvec : access {
   void flush()
   {
     auto size = useful_bytes();
-    if (msync(buffer, size, MS_SYNC) < 0) {
+    if (size > 0 && msync(buffer, size, MS_SYNC) < 0) {
       throw error("msync (size = " + std::to_string(size) + ")");
     }
+    if (fsync(fd) < 0) { throw error("fsync"); }
   }
 
   ~fvec()

--- a/core/src/stored/backends/dedupable/volume.cc
+++ b/core/src/stored/backends/dedupable/volume.cc
@@ -90,6 +90,15 @@ std::uint32_t SafeCast(std::size_t size)
   return size;
 }
 
+std::int32_t UnfinishedStreamKey(std::int32_t stream)
+{
+  if (stream == std::numeric_limits<std::int32_t>::min()) {
+    throw std::invalid_argument("Cannot normalize stream id.");
+  }
+
+  return stream < 0 ? -stream : stream;
+}
+
 std::vector<char> LoadFile(int fd)
 {
   std::vector<char> loaded;
@@ -350,7 +359,7 @@ auto volume::reserve_parts(record_header header) -> std::vector<reserved_part>
         .VolSessionId = current_block->VolSessionId,
         .VolSessionTime = current_block->VolSessionTime,
         .FileIndex = header.FileIndex,
-        .Stream = -header.Stream,
+        .Stream = UnfinishedStreamKey(header.Stream),
     };
 
     if (auto found = unfinished.find(rec_id); found != unfinished.end()) {
@@ -440,10 +449,14 @@ void volume::PushRecord(record_header header,
         .VolSessionId = current_block->VolSessionId,
         .VolSessionTime = current_block->VolSessionTime,
         .FileIndex = header.FileIndex,
-        .Stream = header.Stream,
+        .Stream = UnfinishedStreamKey(header.Stream),
     };
 
-    unfinished.emplace(rec_id, std::move(reserved_parts));
+    if (auto [_, inserted]
+        = unfinished.emplace(rec_id, std::move(reserved_parts));
+        !inserted) {
+      throw std::runtime_error("Duplicate unfinished record reservation.");
+    }
   }
 }
 

--- a/core/src/stored/backends/dedupable/volume.cc
+++ b/core/src/stored/backends/dedupable/volume.cc
@@ -141,6 +141,16 @@ void WriteFile(int fd, const std::vector<char>& written)
   }
 }
 
+void SyncFile(int fd, const char* name)
+{
+  if (fsync(fd) < 0) {
+    std::string errctx = "while syncing '";
+    errctx += name;
+    errctx += "'";
+    throw std::system_error(errno, std::generic_category(), errctx);
+  }
+}
+
 raii_fd OpenRelative(open_context ctx, const char* path)
 {
   int fd = openat(ctx.dird, path, ctx.flags);
@@ -555,9 +565,17 @@ void volume::truncate()
 
 void volume::flush()
 {
-  backing->blocks.flush();
-  backing->parts.flush();
   for (auto& vec : backing->datafiles) { vec.flush(); }
+  backing->parts.flush();
+  backing->blocks.flush();
+
+  raii_fd conf_fd{openat(dird.fileno(), "config", O_RDONLY)};
+  if (!conf_fd) {
+    std::string errctx = "Could not open dedup config file";
+    throw std::system_error(errno, std::generic_category(), errctx);
+  }
+  SyncFile(conf_fd.fileno(), "config");
+  SyncFile(dird.fileno(), sys_path.c_str());
 }
 
 std::size_t volume::ReadBlock(std::size_t blocknum,

--- a/core/src/tests/dedupable_volume_test.cc
+++ b/core/src/tests/dedupable_volume_test.cc
@@ -21,8 +21,13 @@
 
 #include "gtest/gtest.h"
 #include "stored/backends/dedupable/volume.h"
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
 #include <limits>
 #include <stdexcept>
+#include <unistd.h>
+#include <vector>
 
 using namespace dedup;
 
@@ -342,4 +347,101 @@ TEST(SaveStateTest, MoveAssignment)
   EXPECT_EQ(s2.block_size, 100u);
   EXPECT_EQ(s2.part_size, 200u);
   ASSERT_EQ(s2.data_sizes.size(), 3u);
+}
+
+namespace {
+constexpr std::size_t kDeviceBlockSize = 1024 * 1024;
+constexpr std::size_t kAlignedBlockSize = 128 * 1024;
+
+block_header MakeBlockHeader(std::uint32_t block_number, std::size_t block_size)
+{
+  block_header header;
+  header.CheckSum = 0;
+  header.BlockSize = SafeCast(block_size);
+  header.BlockNumber = block_number;
+  header.ID[0] = 'B';
+  header.ID[1] = 'B';
+  header.ID[2] = '0';
+  header.ID[3] = '2';
+  header.VolSessionId = 1;
+  header.VolSessionTime = 2;
+  return header;
+}
+
+record_header MakeRecordHeader(std::size_t offset, std::size_t remaining)
+{
+  record_header record;
+  record.FileIndex = 1;
+  record.Stream = offset == 0 ? 2 : -2;
+  record.DataSize = SafeCast(remaining);
+  return record;
+}
+
+std::vector<char> MakeData(std::size_t size)
+{
+  std::vector<char> data(size);
+  for (std::size_t i = 0; i < data.size(); ++i) {
+    data[i] = static_cast<char>(i * 17 + (i >> 7));
+  }
+  return data;
+}
+
+void WriteLargeRecord(volume& vol, const std::vector<char>& data)
+{
+  std::size_t offset = 0;
+  std::uint32_t block_number = 0;
+  while (offset < data.size()) {
+    const auto remaining = data.size() - offset;
+    const auto chunk_size
+        = std::min(remaining, kDeviceBlockSize - sizeof(block_header)
+                                  - sizeof(record_header));
+    const auto block_size
+        = sizeof(block_header) + sizeof(record_header) + chunk_size;
+    auto save = vol.BeginBlock(MakeBlockHeader(block_number, block_size));
+    auto record = MakeRecordHeader(offset, remaining);
+    vol.PushRecord(record, data.data() + offset, chunk_size);
+    vol.CommitBlock(std::move(save));
+    offset += chunk_size;
+    ++block_number;
+  }
+}
+
+config ReadConfig(const std::filesystem::path& volume_path)
+{
+  const auto config_path = volume_path / "config";
+  std::ifstream file(config_path, std::ios::binary | std::ios::ate);
+  if (!file) { throw std::runtime_error("Could not open config file."); }
+
+  const auto size = file.tellg();
+  std::vector<char> data(size);
+  file.seekg(0);
+  if (!file.read(data.data(), size)) {
+    throw std::runtime_error("Could not read config file.");
+  }
+
+  return config::deserialize(data.data(), data.size());
+}
+}  // namespace
+
+TEST(VolumeTest, ReusesUnfinishedReservationForRepeatedContinuation)
+{
+  const auto volume_path
+      = std::filesystem::temp_directory_path()
+        / ("dedupable-volume-test-" + std::to_string(getpid()));
+  std::filesystem::remove_all(volume_path);
+
+  volume::create_new(0700, volume_path.c_str(), kAlignedBlockSize);
+
+  const auto data = MakeData(3 * kDeviceBlockSize);
+  {
+    volume vol(volume::ReadWrite, volume_path.c_str());
+    WriteLargeRecord(vol, data);
+  }
+
+  const auto conf = ReadConfig(volume_path);
+  ASSERT_EQ(conf.dfiles.size(), 2u);
+  EXPECT_EQ(conf.dfiles[0].relpath, "aligned.data");
+  EXPECT_EQ(conf.dfiles[0].Size, data.size());
+
+  std::filesystem::remove_all(volume_path);
 }


### PR DESCRIPTION
### Thank you for contributing to the Bareos Project!

#### Please check

    A copied dedup volume showed two checksum mismatches caused by a
    referenced 128 KiB aligned.data extent that contained only zero bytes.
    The blocks and parts metadata were consistent and referenced that range.
    That means metadata was durable enough to point at the extent while the
    mapped data bytes were not the expected block payload.
    
    Make flush create a stronger durability boundary for dedup volumes.
    Flush mapped data files first, then parts and blocks, then fsync the
    config file and volume directory. This preserves the ordering from
    payload data to indexes and config at device release time without
    adding per-block verification overhead.

Fixes bareos/internal#768

- [ ] Short description and the purpose of this PR is present _above this paragraph_
- [ ] Your name is present in the AUTHORS file (optional)

If you have any questions or problems, please give a comment in the PR.

### Helpful documentation and best practices

- [Git Workflow](https://docs.bareos.org/DeveloperGuide/gitworkflow.html)
- [Automatic Sourcecode Formatting](https://docs.bareos.org/DeveloperGuide/generaldevel.html#automatic-sourcecode-formatting)
- [Check your commit messages](https://docs.bareos.org/DeveloperGuide/gitworkflow.html#commits)
- [Boy Scout Rule](https://docs.bareos.org/DeveloperGuide/generaldevel.html#boy-scout-rule)

### Checklist for the _reviewer_ of the PR (will be processed by the Bareos team)
Make sure you check/merge the PR using `devtools/pr-tool` to have some simple automated checks run and a proper changelog record added.

##### General
- [ ] Is the PR title usable as CHANGELOG entry?
- [ ] Purpose of the PR is understood
- [ ] Commit descriptions are understandable and well formatted
- [ ] Required backport PRs have been created
- If a release should wait for this PR to be finished, set that release's milestone.

##### Source code quality
- [ ] Source code changes are understandable
- [ ] Variable and function names are meaningful
- [ ] Code comments are correct (logically and spelling)
- [ ] Required documentation changes are present and part of the PR

##### Tests
- [ ] Decision taken that a test is required (if not, then remove this paragraph)
- [ ] The choice of the type of test (unit test or systemtest) is reasonable
- [ ] Testname matches exactly what is being tested
- [ ] On a fail, output of the test leads quickly to the origin of the fault
